### PR TITLE
Improved server class names

### DIFF
--- a/integration_test/music_streaming/music_streaming_test/pubspec.lock
+++ b/integration_test/music_streaming/music_streaming_test/pubspec.lock
@@ -388,10 +388,10 @@ packages:
     dependency: "direct main"
     description:
       name: tonik_util
-      sha256: f16c86d5349fac40893d1d8ae87f6507192d8886f16ba6acefeabef4a61ae3ef
+      sha256: d1fc175e99d440d654d4be8b78f008d2d0614820fb8d9f40507cd3e5ee34fcca
       url: "https://pub.dev"
     source: hosted
-    version: "0.0.5"
+    version: "0.0.6"
   typed_data:
     dependency: transitive
     description:

--- a/packages/tonik/README.md
+++ b/packages/tonik/README.md
@@ -97,7 +97,6 @@ For a full list of changes of each release, refer to [release notes](https://git
 ### Short term goals
 - `allowReserved` support for query parameters
 - `format: uri` mapping to Dart `Uri`
-- Add custom `Date` model in util package to handle `format: date` properly
 - More E2E tests
 - Full decoding and encoding support for any of and one of
 - Support for `x-dart-name`, `x-dart-type` and `x-dart-enums`

--- a/packages/tonik_generate/lib/src/naming/name_generator.dart
+++ b/packages/tonik_generate/lib/src/naming/name_generator.dart
@@ -376,7 +376,7 @@ class NameGenerator {
 
   ({String baseName, Map<Server, String> serverMap, String customName})
   _generateServerNames(List<Server> servers, List<String> uniqueNames) {
-    final baseName = _makeUnique('ApiServer', '');
+    final baseName = _makeUnique('Server', '');
 
     final resultMap = <Server, String>{};
     for (var index = 0; index < servers.length; index++) {
@@ -398,7 +398,7 @@ class NameGenerator {
 
   ({String baseName, Map<Server, String> serverMap, String customName})
   _generateFallbackServerNames(List<Server> servers) {
-    final baseName = _makeUnique('ApiServer', '');
+    final baseName = _makeUnique('Server', '');
 
     final resultMap = <Server, String>{};
     for (final server in servers) {

--- a/packages/tonik_generate/test/src/naming/name_generator_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_generator_test.dart
@@ -1075,11 +1075,11 @@ void main() {
         final result = generator.generateServerNames(servers);
 
         expect(result.serverMap.length, 3);
-        expect(result.serverMap[servers[0]], 'ApiServer2');
+        expect(result.serverMap[servers[0]], 'ApiServer');
         expect(result.serverMap[servers[1]], 'StagingServer');
         expect(result.serverMap[servers[2]], 'DevServer');
         expect(result.customName, 'CustomServer');
-        expect(result.baseName, 'ApiServer');
+        expect(result.baseName, 'Server');
       });
 
       test('generates names based on multi-level subdomain differences', () {
@@ -1100,7 +1100,7 @@ void main() {
         expect(result.serverMap[servers[1]], 'ApiStagingServer');
         expect(result.serverMap[servers[2]], 'ApiProdServer');
         expect(result.customName, 'CustomServer');
-        expect(result.baseName, 'ApiServer');
+        expect(result.baseName, 'Server');
       });
 
       test(
@@ -1120,7 +1120,7 @@ void main() {
           expect(result.serverMap[servers[1]], 'AcmeServer');
           expect(result.serverMap[servers[2]], 'TestServer');
           expect(result.customName, 'CustomServer');
-          expect(result.baseName, 'ApiServer');
+          expect(result.baseName, 'Server');
         },
       );
 
@@ -1140,7 +1140,7 @@ void main() {
         expect(result.serverMap[servers[1]], 'V2Server');
         expect(result.serverMap[servers[2]], 'BetaServer');
         expect(result.customName, 'CustomServer');
-        expect(result.baseName, 'ApiServer');
+        expect(result.baseName, 'Server');
       });
 
       test(
@@ -1156,11 +1156,11 @@ void main() {
           final result = generator.generateServerNames(servers);
 
           expect(result.serverMap.length, 3);
-          expect(result.serverMap[servers[0]], 'Server');
-          expect(result.serverMap[servers[1]], 'Server2');
-          expect(result.serverMap[servers[2]], 'Server3');
+          expect(result.serverMap[servers[0]], 'Server2');
+          expect(result.serverMap[servers[1]], 'Server3');
+          expect(result.serverMap[servers[2]], 'Server4');
           expect(result.customName, 'CustomServer');
-          expect(result.baseName, 'ApiServer');
+          expect(result.baseName, 'Server');
         },
       );
 
@@ -1180,7 +1180,7 @@ void main() {
           expect(result.serverMap.length, 1);
           expect(result.serverMap[servers[0]], 'CustomServer');
           expect(result.customName, r'CustomServer$');
-          expect(result.baseName, 'ApiServer');
+          expect(result.baseName, 'Server');
         },
       );
 
@@ -1199,12 +1199,12 @@ void main() {
         final result = generator.generateServerNames(servers);
 
         expect(result.serverMap.length, 4);
-        expect(result.serverMap[servers[0]], 'Server');
-        expect(result.serverMap[servers[1]], 'Server2');
-        expect(result.serverMap[servers[2]], 'Server3');
-        expect(result.serverMap[servers[3]], 'Server4');
+        expect(result.serverMap[servers[0]], 'Server2');
+        expect(result.serverMap[servers[1]], 'Server3');
+        expect(result.serverMap[servers[2]], 'Server4');
+        expect(result.serverMap[servers[3]], 'Server5');
         expect(result.customName, 'CustomServer');
-        expect(result.baseName, 'ApiServer');
+        expect(result.baseName, 'Server');
       });
     });
   });

--- a/packages/tonik_generate/test/src/server/server_file_generator_test.dart
+++ b/packages/tonik_generate/test/src/server/server_file_generator_test.dart
@@ -109,10 +109,10 @@ void main() {
       final fileContent = File(generatedFile.path).readAsStringSync();
 
       // Check file name
-      expect(actualFileName, equals('api_server.dart'));
+      expect(actualFileName, equals('server.dart'));
 
       // Check file content
-      expect(fileContent, contains('sealed class ApiServer'));
+      expect(fileContent, contains('sealed class Server'));
       expect(fileContent, contains('class ProductionServer'));
       expect(fileContent, contains('class StagingServer'));
       expect(fileContent, contains('class CustomServer'));
@@ -154,7 +154,7 @@ void main() {
       final fileContent = File(generatedFile.path).readAsStringSync();
 
       // Expect base class and custom class to be generated
-      expect(fileContent, contains('sealed class ApiServer'));
+      expect(fileContent, contains('sealed class Server'));
       expect(fileContent, contains('class CustomServer'));
 
       // No server-specific classes should be present

--- a/packages/tonik_generate/test/src/server/server_generator_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_test.dart
@@ -110,7 +110,7 @@ void main() {
       final productionClass = generatedClasses[1];
 
       expect(productionClass.name, 'ProductionServer');
-      expect(productionClass.extend?.accept(emitter).toString(), 'ApiServer');
+      expect(productionClass.extend?.accept(emitter).toString(), 'Server');
       expect(
         productionClass.docs.first,
         '/// Production server - https://production.example.com',
@@ -144,7 +144,7 @@ void main() {
       final stagingClass = generatedClasses[2];
 
       expect(stagingClass.name, 'StagingServer');
-      expect(stagingClass.extend?.accept(emitter).toString(), 'ApiServer');
+      expect(stagingClass.extend?.accept(emitter).toString(), 'Server');
       expect(
         stagingClass.docs.first,
         '/// Staging server - https://staging.example.com',
@@ -180,7 +180,7 @@ void main() {
       final customClass = generatedClasses.last;
 
       expect(customClass.name, 'CustomServer');
-      expect(customClass.extend?.accept(emitter).toString(), 'ApiServer');
+      expect(customClass.extend?.accept(emitter).toString(), 'Server');
       expect(
         customClass.docs.first,
         '/// Custom server with user-defined base URL',


### PR DESCRIPTION
Many APIs use an `api` subdomain. This results in `ApiServer` and `ApiServer2` getting generated. With this change we this will become `Server` and `ApiServer` and much better user experience.