### PR TITLE
fix: address correctness and safety issues from comprehensive audit

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -16,6 +16,8 @@ tags:
     description: Operations testing label-style path parameters (RFC 6570 Section 3.2.5)
   - name: matrix
     description: Operations testing matrix-style path parameters (RFC 6570 Section 3.2.7)
+  - name: simple
+    description: Operations testing simple-style path parameters (RFC 6570 Section 3.2.2)
 
 paths:
   /label/primitive/string/{value}:
@@ -342,6 +344,48 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  /label/special-keys/{value}:
+    get:
+      operationId: testLabelSpecialKeys
+      tags: [label]
+      summary: Label-style object with special characters in property names (explode=false)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: label
+          explode: false
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /label/special-keys/explode/{value}:
+    get:
+      operationId: testLabelSpecialKeysExplode
+      tags: [label]
+      summary: Label-style object with special characters in property names (explode=true)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: label
+          explode: true
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
   /matrix/primitive/string/{value}:
     get:
       operationId: testMatrixPrimitiveString
@@ -655,6 +699,90 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/ComplexObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/special-keys/{value}:
+    get:
+      operationId: testMatrixSpecialKeys
+      tags: [matrix]
+      summary: Matrix-style object with special characters in property names (explode=false)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: matrix
+          explode: false
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/special-keys/explode/{value}:
+    get:
+      operationId: testMatrixSpecialKeysExplode
+      tags: [matrix]
+      summary: Matrix-style object with special characters in property names (explode=true)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: matrix
+          explode: true
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/special-keys/{value}:
+    get:
+      operationId: testSimpleSpecialKeys
+      tags: [simple]
+      summary: Simple-style object with special characters in property names (explode=false)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/special-keys/explode/{value}:
+    get:
+      operationId: testSimpleSpecialKeysExplode
+      tags: [simple]
+      summary: Simple-style object with special characters in property names (explode=true)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: simple
+          explode: true
+          schema:
+            $ref: '#/components/schemas/SpecialKeyObject'
       responses:
         '200':
           description: OK
@@ -1069,6 +1197,17 @@ components:
           properties:
             extra:
               type: string
+
+    SpecialKeyObject:
+      type: object
+      required:
+        - 'my.field'
+        - 'a=b'
+      properties:
+        'my.field':
+          type: string
+        'a=b':
+          type: integer
 
     EchoResponse:
       type: object

--- a/integration_test/path_encoding/path_encoding_test/test/label_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/label_test.dart
@@ -338,4 +338,43 @@ void main() {
       expect(error.type, TonikErrorType.encoding);
     });
   });
+
+  group('Label style - Special character property names', () {
+    test('special keys (explode=false) encodes keys with URI encoding',
+        () async {
+      final api = buildLabelApi();
+      final response = await api.testLabelSpecialKeys(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // my.field is unreserved so not encoded; a=b becomes a%3Db
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/label/special-keys/.my.field,hello,a%3Db,42',
+      );
+    });
+
+    test('special keys (explode=true) encodes keys with URI encoding',
+        () async {
+      final api = buildLabelApi();
+      final response = await api.testLabelSpecialKeysExplode(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // With explode=true, each key=value is dot-prefixed
+      // a=b key must be encoded as a%3Db to avoid ambiguity
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/label/special-keys/explode/.my.field=hello.a%3Db=42',
+      );
+    });
+  });
 }

--- a/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
@@ -341,4 +341,42 @@ void main() {
       expect(error.type, TonikErrorType.encoding);
     });
   });
+
+  group('Matrix style - Special character property names', () {
+    test('special keys (explode=false) encodes keys with URI encoding',
+        () async {
+      final api = buildMatrixApi();
+      final response = await api.testMatrixSpecialKeys(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // explode=false: ;paramName=k1,v1,k2,v2
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/matrix/special-keys/;value=my.field,hello,a%3Db,42',
+      );
+    });
+
+    test('special keys (explode=true) encodes keys with URI encoding',
+        () async {
+      final api = buildMatrixApi();
+      final response = await api.testMatrixSpecialKeysExplode(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // explode=true: ;k1=v1;k2=v2 — a=b must be encoded as a%3Db
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/matrix/special-keys/explode/;my.field=hello;a%3Db=42',
+      );
+    });
+  });
 }

--- a/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
@@ -1,0 +1,62 @@
+import 'package:dio/dio.dart';
+import 'package:path_encoding_api/path_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  SimpleApi buildSimpleApi() {
+    return SimpleApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(baseOptions: BaseOptions()),
+      ),
+    );
+  }
+
+  group('Simple style - Special character property names', () {
+    test('special keys (explode=false) encodes keys with URI encoding',
+        () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleSpecialKeys(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // explode=false: k1,v1,k2,v2
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/simple/special-keys/my.field,hello,a%3Db,42',
+      );
+    });
+
+    test('special keys (explode=true) encodes keys with URI encoding',
+        () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleSpecialKeysExplode(
+        value: const SpecialKeyObject(myField: 'hello', aEqualsB: 42),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      // explode=true: k1=v1,k2=v2 — a=b must be encoded as a%3Db
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/simple/special-keys/explode/my.field=hello,a%3Db=42',
+      );
+    });
+  });
+}

--- a/packages/tonik/lib/src/config/config_loader.dart
+++ b/packages/tonik/lib/src/config/config_loader.dart
@@ -43,9 +43,9 @@ extension ConfigLoader on CliConfig {
 
   static CliConfig _parseConfig(YamlMap yaml) {
     return CliConfig(
-      spec: yaml['spec'] as String?,
-      outputDir: yaml['outputDir'] as String?,
-      packageName: yaml['packageName'] as String?,
+      spec: _parseString(yaml['spec'], 'spec'),
+      outputDir: _parseString(yaml['outputDir'], 'outputDir'),
+      packageName: _parseString(yaml['packageName'], 'packageName'),
       logLevel: _parseLogLevel(yaml['logLevel']),
       nameOverrides: _parseNameOverrides(yaml['nameOverrides']),
       contentTypes: _parseContentTypes(yaml['contentTypes']),
@@ -54,6 +54,16 @@ extension ConfigLoader on CliConfig {
       deprecated: _parseDeprecated(yaml['deprecated']),
       enums: _parseEnums(yaml['enums']),
     );
+  }
+
+  static String? _parseString(dynamic value, String fieldName) {
+    if (value == null) return null;
+    if (value is! String) {
+      throw ConfigLoaderException(
+        'Invalid config: "$fieldName" must be a string',
+      );
+    }
+    return value;
   }
 
   static NameOverridesConfig _parseNameOverrides(dynamic value) {

--- a/packages/tonik/test/src/config/config_loader_test.dart
+++ b/packages/tonik/test/src/config/config_loader_test.dart
@@ -613,5 +613,61 @@ nameOverrides:
         expect(merged.enums.generateUnknownCase, isTrue);
       });
     });
+
+    group('type validation for string fields', () {
+      test('throws meaningful error when spec is not a string', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+spec:
+  - a
+  - b
+''');
+
+        expect(
+          () => ConfigLoader.load('${tempDir.path}/tonik.yaml'),
+          throwsA(
+            isA<ConfigLoaderException>().having(
+              (e) => e.message,
+              'message',
+              contains('"spec" must be a string'),
+            ),
+          ),
+        );
+      });
+
+      test('throws meaningful error when outputDir is not a string', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+outputDir:
+  nested: value
+''');
+
+        expect(
+          () => ConfigLoader.load('${tempDir.path}/tonik.yaml'),
+          throwsA(
+            isA<ConfigLoaderException>().having(
+              (e) => e.message,
+              'message',
+              contains('"outputDir" must be a string'),
+            ),
+          ),
+        );
+      });
+
+      test('throws meaningful error when packageName is not a string', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+packageName: 42
+''');
+
+        expect(
+          () => ConfigLoader.load('${tempDir.path}/tonik.yaml'),
+          throwsA(
+            isA<ConfigLoaderException>().having(
+              (e) => e.message,
+              'message',
+              contains('"packageName" must be a string'),
+            ),
+          ),
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -615,8 +615,26 @@ class OneOfGenerator {
         tryBody.add(
           refer(variantName).call([decodeExpr]).returned.statement,
         );
-      } else if (modelType is ListModel || modelType is MapModel) {
-        continue;
+      } else if (modelType is ListModel) {
+        final message = modelType.hasSimpleContent
+            ? 'List decoding from $encodingStyleName encoding '
+                'is not supported in $className'
+            : 'List types with complex content cannot be decoded '
+                'from $encodingStyleName encoding in $className';
+        tryBody.add(
+          generateSimpleDecodingExceptionExpression(
+            message,
+            raw: true,
+          ).statement,
+        );
+      } else if (modelType is MapModel) {
+        tryBody.add(
+          generateSimpleDecodingExceptionExpression(
+            'Map types cannot be decoded from '
+            '$encodingStyleName encoding in $className',
+            raw: true,
+          ).statement,
+        );
       } else {
         final innerDecode =
             refer(

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -616,25 +616,29 @@ class OneOfGenerator {
           refer(variantName).call([decodeExpr]).returned.statement,
         );
       } else if (modelType is ListModel) {
+        // Add throw directly to bodyBlocks (not tryBody) so it is NOT
+        // wrapped in the try/catch that swallows DecodingException.
         final message = modelType.hasSimpleContent
             ? 'List decoding from $encodingStyleName encoding '
                 'is not supported in $className'
             : 'List types with complex content cannot be decoded '
                 'from $encodingStyleName encoding in $className';
-        tryBody.add(
+        bodyBlocks.add(
           generateSimpleDecodingExceptionExpression(
             message,
             raw: true,
           ).statement,
         );
+        continue;
       } else if (modelType is MapModel) {
-        tryBody.add(
+        bodyBlocks.add(
           generateSimpleDecodingExceptionExpression(
             'Map types cannot be decoded from '
             '$encodingStyleName encoding in $className',
             raw: true,
           ).statement,
         );
+        continue;
       } else {
         final innerDecode =
             refer(

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -27,7 +27,7 @@ class PathGenerator {
       final pathSegments = operation.path
           .split('/')
           .where((s) => s.isNotEmpty)
-          .map((s) => "r'$s'")
+          .map(specLiteralStringCode)
           .join(', ');
 
       return Method(

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 /// Creates code blocks that serialize a query parameter to its form-encoded
@@ -40,7 +41,7 @@ List<Code> buildToFormQueryParameterCode(
   if (model is AnyModel) {
     return [
       const Code(r'_$entries.add(('),
-      Code("name: r'${parameter.rawName}', "),
+      Code('name: ${specLiteralStringCode(parameter.rawName)}, '),
       const Code('value: '),
       refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart')
           .call(
@@ -79,7 +80,7 @@ List<Code> buildToFormQueryParameterCode(
         contentModel is AnyOfModel) {
       return [
         const Code(r'_$entries.add(('),
-        Code("name: r'${parameter.rawName}', "),
+        Code('name: ${specLiteralStringCode(parameter.rawName)}, '),
         const Code('value: '),
         refer(parameterName).code,
         const Code('.map((e) => '),
@@ -105,7 +106,7 @@ List<Code> buildToFormQueryParameterCode(
         const Code('}'),
         Code(
           r'_$entries'
-          ".add((name: r'${parameter.rawName}', value: <",
+          '.add((name: ${specLiteralStringCode(parameter.rawName)}, value: <',
         ),
         refer('String', 'dart:core').code,
         Code(
@@ -137,7 +138,7 @@ List<Code> buildToFormQueryParameterCode(
         Code(
           r'_$entries'
           '.add(('
-          "name: r'${parameter.rawName}', "
+          'name: ${specLiteralStringCode(parameter.rawName)}, '
           'value: $valueExpression, '
           '),);',
         ),
@@ -159,7 +160,7 @@ List<Code> buildToFormQueryParameterCode(
     Code(
       r'_$entries'
       '.add(('
-      "name: r'${parameter.rawName}', "
+      'name: ${specLiteralStringCode(parameter.rawName)}, '
       'value: $valueExpression, '
       '),);',
     ),
@@ -279,7 +280,7 @@ List<Code> _buildExplodedListCode(
   EncodingShape contentShape, {
   required bool allowEmpty,
 }) {
-  final rawName = parameter.rawName;
+  final nameCode = specLiteralStringCode(parameter.rawName);
 
   if (contentShape == EncodingShape.complex) {
     return [
@@ -300,7 +301,7 @@ List<Code> _buildExplodedListCode(
         r'_$entries'
         '.addAll($parameterName.map((e) => (',
       ),
-      Code("name: r'$rawName', "),
+      Code('name: $nameCode, '),
       const Code('value: '),
       refer(
         'encodeAnyToUri',
@@ -325,7 +326,7 @@ List<Code> _buildExplodedListCode(
         r'_$entries'
         '.addAll($parameterName.map((e) => (',
       ),
-      Code("name: r'$rawName', "),
+      Code('name: $nameCode, '),
       Code(
         'value: e.toForm(explode: true, allowEmpty: $allowEmpty),),),);',
       ),
@@ -337,7 +338,7 @@ List<Code> _buildExplodedListCode(
       r'_$entries'
       '.addAll($parameterName.map((e) => (',
     ),
-    Code("name: r'$rawName', "),
+    Code('name: $nameCode, '),
     Code('value: e.toForm(explode: true, allowEmpty: $allowEmpty),),),);'),
   ];
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -1620,7 +1620,7 @@ void main() {
       );
     });
 
-    test('excludes ListModel with complex content from simple encoding', () {
+    test('throws for ListModel with complex content in simple encoding', () {
       final model = OneOfModel(
         isDeprecated: false,
         name: 'Value',
@@ -1646,18 +1646,16 @@ void main() {
 
       final generated = format(baseClass.accept(emitter).toString());
 
+      // Complex ListModel variant should throw SimpleDecodingException
+      // instead of being silently excluded
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace('''
-            factory Value.fromSimple(String? value, {required bool explode}) {
-              try {
-                return ValueString(value.decodeSimpleString(context: r'Value'));
-              } on DecodingException catch (_) {
-              } on FormatException catch (_) {}
-              throw SimpleDecodingException(r'Invalid simple value for Value');
-            }
-          '''),
+          collapseWhitespace(
+            'throw SimpleDecodingException(\n'
+            "r'List types with complex content cannot be decoded "
+            "from simple encoding in Value',\n);",
+          ),
         ),
       );
     });

--- a/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
@@ -749,5 +749,41 @@ void main() {
         ),
       );
     });
+
+    test('fromSimple throws for simple-content ListModel variant '
+        'that is not decodable', () {
+      // A ListModel with simple content that is NOT a list of primitives
+      // (e.g. list of enums) — the hasSimpleContent branch
+      final listVariant = ListModel(
+        content: StringModel(context: context),
+        context: context,
+        name: 'Tags',
+        isNullable: true,
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Payload',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: listVariant),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Payload');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // Simple-content list should be decodable via try/catch path
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            'return PayloadTags(value.decodeSimpleStringList(',
+          ),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
@@ -663,4 +663,91 @@ void main() {
       );
     });
   });
+
+  group('fromSimple with List/Map variants', () {
+    test('fromSimple throws for MapModel variant', () {
+      final mapVariant = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+        name: 'Tags',
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Payload',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: mapVariant),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Payload');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // Map variant should throw SimpleDecodingException, not be silently
+      // skipped
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            'throw SimpleDecodingException(\n'
+            "r'Map types cannot be decoded from simple encoding "
+            "in Payload',\n);",
+          ),
+        ),
+      );
+    });
+
+    test('fromSimple throws for complex ListModel variant', () {
+      final innerClass = ClassModel(
+        isDeprecated: false,
+        name: 'Item',
+        properties: [
+          Property(
+            name: 'id',
+            model: IntegerModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+          ),
+        ],
+        context: context,
+      );
+
+      final listVariant = ListModel(
+        content: innerClass,
+        context: context,
+        name: 'Items',
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Payload',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: listVariant),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Payload');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // Complex List variant should throw SimpleDecodingException, not be
+      // silently skipped
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            'throw SimpleDecodingException(\n'
+            "r'List types with complex content cannot be decoded "
+            "from simple encoding in Payload',\n);",
+          ),
+        ),
+      );
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1359,4 +1359,38 @@ void main() {
       collapseWhitespace(expectedMethod),
     );
   });
+
+  test(
+      'generates valid code when path segment contains single quote '
+      'and no path parameters exist', () {
+    final operation = Operation(
+      operationId: 'getQuoted',
+      context: context,
+      summary: 'Get quoted',
+      description: 'Path with single quote',
+      tags: const {},
+      isDeprecated: false,
+      path: "/it's/here",
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: const {},
+      cookieParameters: const {},
+      responses: const {},
+      securitySchemes: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path() {
+          return [r"it's", r'here'];
+        }
+      ''';
+
+    final method = generator.generatePathMethod(operation, []);
+
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
 }

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -40,6 +40,57 @@ void main() {
       );
     }
 
+    group('rawName with special characters', () {
+      test('generates valid code when rawName contains single quote', () {
+        final parameter = createParameter(
+          name: 'filterParam',
+          rawName: "filter's",
+          model: StringModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToFormQueryParameterCode(
+          'filterParam',
+          parameter,
+        );
+
+        final method = Method(
+          (b) => b
+            ..name = 'test'
+            ..body = Block.of(codes),
+        );
+
+        // Should not throw when formatting (valid Dart syntax)
+        final generated = format(method.accept(emitter).toString());
+        expect(generated, contains("filter's"));
+      });
+
+      test('generates valid code when rawName contains double quote', () {
+        final parameter = createParameter(
+          name: 'filterParam',
+          rawName: 'filter"s',
+          model: StringModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToFormQueryParameterCode(
+          'filterParam',
+          parameter,
+        );
+
+        final method = Method(
+          (b) => b
+            ..name = 'test'
+            ..body = Block.of(codes),
+        );
+
+        final generated = format(method.accept(emitter).toString());
+        expect(generated, contains('filter"s'));
+      });
+    });
+
     group('MapModel', () {
       test('generates encoding exception for MapModel', () {
         final parameter = createParameter(

--- a/packages/tonik_parse/lib/src/content_type_resolver.dart
+++ b/packages/tonik_parse/lib/src/content_type_resolver.dart
@@ -10,11 +10,16 @@ core.ContentType resolveContentType(
   required Map<String, core.ContentType> contentTypes,
   required Logger log,
 }) {
+  final lowerMediaType = mediaType.toLowerCase().split(';').first.trim();
+
+  // Check config overrides with both the raw media type and the
+  // normalized (parameter-stripped) form.
   if (contentTypes.containsKey(mediaType)) {
     return contentTypes[mediaType]!;
   }
-
-  final lowerMediaType = mediaType.toLowerCase().split(';').first.trim();
+  if (contentTypes.containsKey(lowerMediaType)) {
+    return contentTypes[lowerMediaType]!;
+  }
   switch (lowerMediaType) {
     case 'application/json':
       return core.ContentType.json;

--- a/packages/tonik_parse/lib/src/content_type_resolver.dart
+++ b/packages/tonik_parse/lib/src/content_type_resolver.dart
@@ -14,7 +14,7 @@ core.ContentType resolveContentType(
     return contentTypes[mediaType]!;
   }
 
-  final lowerMediaType = mediaType.toLowerCase();
+  final lowerMediaType = mediaType.toLowerCase().split(';').first.trim();
   switch (lowerMediaType) {
     case 'application/json':
       return core.ContentType.json;

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -15,6 +15,7 @@ class ModelImporter {
   final Map<String, Schema> _schemas;
   final Map<String, SchemaContentType> _contentMediaTypes;
   final Map<String, Schema> _defs = {};
+  final Set<String> _resolving = {};
 
   late Set<Model> models;
   final log = Logger('ModelImporter');
@@ -192,8 +193,22 @@ class ModelImporter {
     }
 
     final defName = ref.split('/').last;
-    final defsContext = _contextFromDefsPath(ref);
-    final refModel = _resolveSchemaRef(defName, defSchema, defsContext);
+    final isBareRef = defSchema.ref != null;
+
+    if (isBareRef && _resolving.contains(ref)) {
+      throw ArgumentError(
+        'Circular reference detected: $ref is part of a reference cycle',
+      );
+    }
+
+    if (isBareRef) _resolving.add(ref);
+    final Model refModel;
+    try {
+      final defsContext = _contextFromDefsPath(ref);
+      refModel = _resolveSchemaRef(defName, defSchema, defsContext);
+    } finally {
+      if (isBareRef) _resolving.remove(ref);
+    }
 
     if (_hasStructuralSiblings(schema)) {
       return _mergeRefWithStructuralSiblings(name, refModel, schema, context);
@@ -215,7 +230,7 @@ class ModelImporter {
         context: context,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
-        isNullable: schema.type.contains('null'),
+        isNullable: schema.isNullable ?? schema.type.contains('null'),
       );
 
       _logModelAdded(aliasModel);
@@ -232,9 +247,37 @@ class ModelImporter {
     return Context.initial().pushAll(parts);
   }
 
+  /// Resolves a schema ref with cycle detection for pure alias chains.
+  ///
+  /// Only detects cycles when the target schema is itself a bare `$ref`
+  /// (creating an alias chain like A→B→C→A). Schemas with structural content
+  /// (type, properties, oneOf, etc.) are allowed to recurse because
+  /// [_parseClassModel] registers models early to break recursion.
+  Model _resolveWithCycleCheck(String refName, Schema refSchema) {
+    // Only track cycles for schemas that are bare $ref aliases.
+    // Schemas with structural content handle recursion via early
+    // model registration in _parseClassModel.
+    final isBareRef = refSchema.ref != null;
+
+    if (isBareRef && _resolving.contains(refName)) {
+      throw ArgumentError(
+        'Circular reference detected: '
+        '$refName is part of a reference cycle',
+      );
+    }
+
+    if (isBareRef) _resolving.add(refName);
+    try {
+      return _resolveSchemaRef(refName, refSchema, rootContext);
+    } finally {
+      if (isBareRef) _resolving.remove(refName);
+    }
+  }
+
   bool _hasAnnotationSiblings(Schema schema) {
     return schema.description != null ||
         (schema.isDeprecated ?? false) ||
+        (schema.isNullable ?? false) ||
         schema.type.contains('null');
   }
 
@@ -277,7 +320,7 @@ class ModelImporter {
         models.firstWhereOrNull(
           (model) => model is NamedModel && model.name == refName,
         ) ??
-        _resolveSchemaRef(refName, refSchema, rootContext);
+        _resolveWithCycleCheck(refName, refSchema);
 
     if (_hasStructuralSiblings(schema)) {
       return _mergeRefWithStructuralSiblings(
@@ -304,7 +347,7 @@ class ModelImporter {
         context: context,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
-        isNullable: schema.type.contains('null'),
+        isNullable: schema.isNullable ?? schema.type.contains('null'),
       );
 
       _logModelAdded(aliasModel);
@@ -352,7 +395,9 @@ class ModelImporter {
       context: modelContext,
       description: schema.description,
       isDeprecated: schema.isDeprecated ?? false,
-      isNullable: schema.type.contains('null'),
+      isNullable: schema.isNullable ?? schema.type.contains('null'),
+      isReadOnly: schema.isReadOnly ?? false,
+      isWriteOnly: schema.isWriteOnly ?? false,
     );
 
     _addModelToSet(allOfModel);
@@ -724,6 +769,9 @@ class ModelImporter {
   }
 
   /// Walks an allOf chain to find a parent schema with a discriminator.
+  ///
+  /// Recursively descends into allOf members so that discriminators on
+  /// grandparent (or deeper) schemas are found.
   parse.Discriminator? _findDiscriminatorInAllOfChain(Schema schema) {
     final resolvedSchema = _resolveSchemaToSchema(schema);
     if (resolvedSchema == null) return null;
@@ -738,6 +786,10 @@ class ModelImporter {
       if (memberSchema.discriminator != null) {
         return memberSchema.discriminator;
       }
+
+      // Recurse into the member's own allOf chain.
+      final inherited = _findDiscriminatorInAllOfChain(memberSchema);
+      if (inherited != null) return inherited;
     }
 
     return null;

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -247,12 +247,11 @@ class ModelImporter {
     return Context.initial().pushAll(parts);
   }
 
-  /// Resolves a schema ref with cycle detection for pure alias chains.
+  /// Resolves a schema ref with cycle detection.
   ///
-  /// Only detects cycles when the target schema is itself a bare `$ref`
-  /// (creating an alias chain like A→B→C→A). Schemas with structural content
-  /// (type, properties, oneOf, etc.) are allowed to recurse because
-  /// [_parseClassModel] registers models early to break recursion.
+  /// Only tracks resolution for schemas whose definition is itself a `$ref`
+  /// (i.e. alias chains like A→B→C→A). Schemas with structural content
+  /// handle recursion via early model registration in [_parseClassModel].
   Model _resolveWithCycleCheck(String refName, Schema refSchema) {
     // Only track cycles for schemas that are bare $ref aliases.
     // Schemas with structural content handle recursion via early

--- a/packages/tonik_parse/test/content_type_resolver_test.dart
+++ b/packages/tonik_parse/test/content_type_resolver_test.dart
@@ -43,7 +43,7 @@ void main() {
       expect(result, core.ContentType.text);
     });
 
-    test('config override matches with parameters stripped', () {
+    test('config override matches when input has parameters', () {
       final result = resolveContentType(
         'application/vnd.custom+json; charset=utf-8',
         contentTypes: {
@@ -54,7 +54,7 @@ void main() {
       expect(result, core.ContentType.json);
     });
 
-    test('config override matches raw media type exactly', () {
+    test('config override matches when input has no parameters', () {
       final result = resolveContentType(
         'application/vnd.custom+json',
         contentTypes: {

--- a/packages/tonik_parse/test/content_type_resolver_test.dart
+++ b/packages/tonik_parse/test/content_type_resolver_test.dart
@@ -43,6 +43,28 @@ void main() {
       expect(result, core.ContentType.text);
     });
 
+    test('config override matches with parameters stripped', () {
+      final result = resolveContentType(
+        'application/vnd.custom+json; charset=utf-8',
+        contentTypes: {
+          'application/vnd.custom+json': core.ContentType.json,
+        },
+        log: log,
+      );
+      expect(result, core.ContentType.json);
+    });
+
+    test('config override matches raw media type exactly', () {
+      final result = resolveContentType(
+        'application/vnd.custom+json',
+        contentTypes: {
+          'application/vnd.custom+json': core.ContentType.json,
+        },
+        log: log,
+      );
+      expect(result, core.ContentType.json);
+    });
+
     test('resolves plain media types without parameters', () {
       expect(
         resolveContentType('application/json', contentTypes: {}, log: log),

--- a/packages/tonik_parse/test/content_type_resolver_test.dart
+++ b/packages/tonik_parse/test/content_type_resolver_test.dart
@@ -1,0 +1,65 @@
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart' as core;
+import 'package:tonik_parse/src/content_type_resolver.dart';
+
+void main() {
+  final log = Logger('test');
+
+  group('resolveContentType', () {
+    test('resolves application/json with charset parameter', () {
+      final result = resolveContentType(
+        'application/json; charset=utf-8',
+        contentTypes: {},
+        log: log,
+      );
+      expect(result, core.ContentType.json);
+    });
+
+    test('resolves multipart/form-data with boundary parameter', () {
+      final result = resolveContentType(
+        'multipart/form-data; boundary=something',
+        contentTypes: {},
+        log: log,
+      );
+      expect(result, core.ContentType.multipart);
+    });
+
+    test('resolves application/x-www-form-urlencoded with parameter', () {
+      final result = resolveContentType(
+        'application/x-www-form-urlencoded; charset=utf-8',
+        contentTypes: {},
+        log: log,
+      );
+      expect(result, core.ContentType.form);
+    });
+
+    test('resolves text/plain with parameter', () {
+      final result = resolveContentType(
+        'text/plain; charset=us-ascii',
+        contentTypes: {},
+        log: log,
+      );
+      expect(result, core.ContentType.text);
+    });
+
+    test('resolves plain media types without parameters', () {
+      expect(
+        resolveContentType('application/json', contentTypes: {}, log: log),
+        core.ContentType.json,
+      );
+      expect(
+        resolveContentType('text/plain', contentTypes: {}, log: log),
+        core.ContentType.text,
+      );
+      expect(
+        resolveContentType(
+          'application/octet-stream',
+          contentTypes: {},
+          log: log,
+        ),
+        core.ContentType.bytes,
+      );
+    });
+  });
+}

--- a/packages/tonik_parse/test/model/inherited_discriminator_test.dart
+++ b/packages/tonik_parse/test/model/inherited_discriminator_test.dart
@@ -454,4 +454,78 @@ void main() {
       },
     );
   });
+
+  group('Grandparent discriminator via nested allOf', () {
+    const fileContent = {
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          // Grandparent with discriminator
+          'Vehicle': {
+            'type': 'object',
+            'required': ['vehicleType'],
+            'properties': {
+              'vehicleType': {'type': 'string'},
+            },
+            'discriminator': {
+              'propertyName': 'vehicleType',
+            },
+          },
+          // Intermediate parent (no discriminator)
+          'MotorVehicle': {
+            'allOf': [
+              {r'$ref': '#/components/schemas/Vehicle'},
+              {
+                'type': 'object',
+                'properties': {
+                  'engineSize': {'type': 'integer'},
+                },
+              },
+            ],
+          },
+          // Children inherit from MotorVehicle (2 levels deep)
+          'Car': {
+            'allOf': [
+              {r'$ref': '#/components/schemas/MotorVehicle'},
+              {
+                'type': 'object',
+                'properties': {
+                  'doors': {'type': 'integer'},
+                },
+              },
+            ],
+          },
+          'Truck': {
+            'allOf': [
+              {r'$ref': '#/components/schemas/MotorVehicle'},
+              {
+                'type': 'object',
+                'properties': {
+                  'payload': {'type': 'integer'},
+                },
+              },
+            ],
+          },
+          // oneOf references children — should find grandparent discriminator
+          'VehicleChoice': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Car'},
+              {r'$ref': '#/components/schemas/Truck'},
+            ],
+          },
+        },
+      },
+    };
+
+    test('finds discriminator from grandparent allOf chain', () {
+      final api = Importer().import(fileContent);
+      final vehicleChoice = api.models.whereType<OneOfModel>().firstWhere(
+            (m) => m.name == 'VehicleChoice',
+          );
+
+      expect(vehicleChoice.discriminator, 'vehicleType');
+    });
+  });
 }

--- a/packages/tonik_parse/test/model/model_nullable_test.dart
+++ b/packages/tonik_parse/test/model/model_nullable_test.dart
@@ -770,4 +770,99 @@ void main() {
       expect(refModel.isNullable, isTrue);
     });
   });
+
+  group(r'nullable $ref with annotation siblings (OAS 3.0)', () {
+    const spec = {
+      'openapi': '3.0.0',
+      'info': {'title': 'Test', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Base': {
+            'type': 'object',
+            'properties': {
+              'id': {'type': 'integer'},
+            },
+          },
+          'NullableRefWithDescription': {
+            r'$ref': '#/components/schemas/Base',
+            'nullable': true,
+            'description': 'A nullable reference with description',
+          },
+        },
+      },
+    };
+
+    test('parses nullable flag on ref with description sibling', () {
+      final api = Importer().import(spec);
+      final model = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'NullableRefWithDescription',
+      );
+      expect(model, isA<AliasModel>());
+      expect((model as AliasModel).isNullable, isTrue);
+    });
+
+    test('parses nullable flag as sole annotation sibling on ref', () {
+      const soloNullableSpec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'Base': {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'integer'},
+              },
+            },
+            'NullableRefOnly': {
+              r'$ref': '#/components/schemas/Base',
+              'nullable': true,
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(soloNullableSpec);
+      final model = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'NullableRefOnly',
+      );
+      expect(model, isA<AliasModel>());
+      expect((model as AliasModel).isNullable, isTrue);
+    });
+  });
+
+  group(r'nullable $ref with structural siblings (OAS 3.0)', () {
+    const spec = {
+      'openapi': '3.0.0',
+      'info': {'title': 'Test', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Base': {
+            'type': 'object',
+            'properties': {
+              'id': {'type': 'integer'},
+            },
+          },
+          'NullableRefWithAllOf': {
+            r'$ref': '#/components/schemas/Base',
+            'nullable': true,
+            'properties': {
+              'extra': {'type': 'string'},
+            },
+          },
+        },
+      },
+    };
+
+    test('parses nullable flag on ref with structural siblings', () {
+      final api = Importer().import(spec);
+      final model = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'NullableRefWithAllOf',
+      );
+      expect(model, isA<AllOfModel>());
+      expect((model as AllOfModel).isNullable, isTrue);
+    });
+  });
 }

--- a/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
+++ b/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
@@ -1144,5 +1144,44 @@ void main() {
         throwsArgumentError,
       );
     });
+
+    test('indirect circular reference (A -> B -> C -> A) throws', () {
+      const fileContent = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'A': {r'$ref': '#/components/schemas/B'},
+            'B': {r'$ref': '#/components/schemas/C'},
+            'C': {r'$ref': '#/components/schemas/A'},
+          },
+        },
+      };
+
+      expect(
+        () => Importer().import(fileContent),
+        throwsArgumentError,
+      );
+    });
+
+    test('indirect circular reference (A -> B -> A) throws', () {
+      const fileContent = {
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'A': {r'$ref': '#/components/schemas/B'},
+            'B': {r'$ref': '#/components/schemas/A'},
+          },
+        },
+      };
+
+      expect(
+        () => Importer().import(fileContent),
+        throwsArgumentError,
+      );
+    });
   });
 }

--- a/packages/tonik_parse/test/model/schema_level_read_write_only_test.dart
+++ b/packages/tonik_parse/test/model/schema_level_read_write_only_test.dart
@@ -377,4 +377,72 @@ void main() {
       expect(secretProp.isReadOnly, isFalse);
     });
   });
+
+  group(r'readOnly/writeOnly on $ref with structural siblings', () {
+    test('readOnly propagated through ref with properties sibling', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'Base': {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'integer'},
+              },
+            },
+            'ReadOnlyExtended': {
+              r'$ref': '#/components/schemas/Base',
+              'readOnly': true,
+              'properties': {
+                'extra': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+      final model = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'ReadOnlyExtended',
+      );
+      expect(model, isA<AllOfModel>());
+      expect((model as AllOfModel).isReadOnly, isTrue);
+      expect(model.isWriteOnly, isFalse);
+    });
+
+    test('writeOnly propagated through ref with properties sibling', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'Base': {
+              'type': 'object',
+              'properties': {
+                'id': {'type': 'integer'},
+              },
+            },
+            'WriteOnlyExtended': {
+              r'$ref': '#/components/schemas/Base',
+              'writeOnly': true,
+              'properties': {
+                'secret': {'type': 'string'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+      final model = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'WriteOnlyExtended',
+      );
+      expect(model, isA<AllOfModel>());
+      expect((model as AllOfModel).isWriteOnly, isTrue);
+      expect(model.isReadOnly, isFalse);
+    });
+  });
 }

--- a/packages/tonik_util/lib/src/decoding/form_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/form_decoder.dart
@@ -388,11 +388,6 @@ extension FormDecoder on String? {
       throw ArgumentError('Cannot decode null string');
     }
 
-    // For numeric values with scientific notation, preserve + signs
-    if (this!.contains('e+') || this!.contains('E+')) {
-      return Uri.decodeComponent(this!);
-    } else {
-      return Uri.decodeQueryComponent(this!);
-    }
+    return Uri.decodeQueryComponent(this!);
   }
 }

--- a/packages/tonik_util/lib/src/decoding/json_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/json_decoder.dart
@@ -220,14 +220,14 @@ extension JsonDecoder on Object? {
         context: context,
       );
     }
-    if (this is! double) {
+    if (this is! num) {
       throw InvalidTypeException(
         value: toString(),
         targetType: double,
         context: context,
       );
     }
-    return this! as double;
+    return (this! as num).toDouble();
   }
 
   /// Decodes a JSON value to a nullable double.
@@ -238,14 +238,14 @@ extension JsonDecoder on Object? {
     if (this == null) {
       return null;
     }
-    if (this is! double) {
+    if (this is! num) {
       throw InvalidTypeException(
         value: toString(),
         targetType: double,
         context: context,
       );
     }
-    return this! as double;
+    return (this! as num).toDouble();
   }
 
   /// Decodes a JSON value to a List of type [T].

--- a/packages/tonik_util/lib/src/encoding/datetime_extension.dart
+++ b/packages/tonik_util/lib/src/encoding/datetime_extension.dart
@@ -24,13 +24,16 @@ extension DateTimeEncodingExtension on DateTime {
     final minute = _twoDigits(this.minute);
     final second = _twoDigits(this.second);
 
-    // Add milliseconds if present
-    final millisecondString = millisecond > 0
-        ? '.${_threeDigits(millisecond)}'
-        : '';
-
-    // Add microseconds if present
-    final microsecondString = microsecond > 0 ? _threeDigits(microsecond) : '';
+    // Combine milliseconds and microseconds into a single fractional part
+    final String fractionalString;
+    if (millisecond == 0 && microsecond == 0) {
+      fractionalString = '';
+    } else if (microsecond == 0) {
+      fractionalString = '.${_threeDigits(millisecond)}';
+    } else {
+      fractionalString =
+          '.${_threeDigits(millisecond)}${_threeDigits(microsecond)}';
+    }
 
     // Get the timezone offset in hours and minutes
     final offset = timeZoneOffset;
@@ -44,7 +47,7 @@ extension DateTimeEncodingExtension on DateTime {
         '${_twoDigits(offsetHours)}:${_twoDigits(offsetMinutes)}';
 
     return '$year-$month-${day}T$hour:$minute:$second'
-        '$millisecondString$microsecondString$offsetString';
+        '$fractionalString$offsetString';
   }
 
   /// Formats a number as two digits with leading zero if needed.

--- a/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
@@ -125,7 +125,7 @@ extension LabelStringMapEncoder on Map<String, String> {
           final value = alreadyEncoded
               ? entry.value
               : entry.value.uriEncode(allowEmpty: allowEmpty);
-          return '.${entry.key}=$value';
+          return '.${Uri.encodeComponent(entry.key)}=$value';
         },
       ).join();
     } else {

--- a/packages/tonik_util/test/src/decoding/form_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/form_decoder_test.dart
@@ -140,6 +140,58 @@ void main() {
           throwsA(isA<InvalidTypeException>()),
         );
       });
+
+      test('decodes scientific notation doubles', () {
+        expect('1.5e%2B10'.decodeFormDouble(), 1.5e+10);
+        expect('2E%2B3'.decodeFormDouble(), 2e+3);
+      });
+    });
+
+    group('form decoding with e+ in value', () {
+      test(
+          'decodeFormDouble decodes properly form-encoded '
+          'scientific notation', () {
+        // Properly encoded 1.5e+10: the + is encoded as %2B
+        expect('1.5e%2B10'.decodeFormDouble(), 1.5e+10);
+      });
+
+      test(
+          'decodeFormDouble decodes properly percent-encoded '
+          'scientific notation', () {
+        // Properly encoded: + is %2B in scientific notation
+        expect('1e%2B100'.decodeFormDouble(), 1e+100);
+        expect('1.5E%2B10'.decodeFormDouble(), 1.5e+10);
+        expect('-2.5e%2B3'.decodeFormDouble(), -2.5e+3);
+      });
+
+      test(
+          'decodeFormDouble treats + as space in '
+          'non-numeric values containing e+', () {
+        // 'e+notation' is not a valid numeric pattern,
+        // so + should be decoded as space
+        expect(
+          () => 'e+notation'.decodeFormDouble(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        // 'some+value+with+e+inside' has multiple +'s; not numeric
+        expect(
+          () => 'some+value+with+e+inside'.decodeFormDouble(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test(
+          'decodeFormDouble rejects ambiguous form-encoded value '
+          'where + means space', () {
+        // In form encoding, '5e+7' means '5e 7' (+ is space).
+        // Without the fix, the code incorrectly parses this as 5e+7 = 50000000.
+        // The correct behavior is to decode '+' as space, producing '5e 7',
+        // which is not a valid double and should throw.
+        expect(
+          () => '5e+7'.decodeFormDouble(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
     });
 
     group('decodeFormNullableDouble', () {

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -215,6 +215,15 @@ void main() {
           throwsA(isA<InvalidTypeException>()),
         );
       });
+
+      test('decodes integer JSON value as double', () {
+        // Use Object? to simulate jsonDecode returning int for whole numbers
+        expect((5 as Object?).decodeJsonDouble(), 5.0);
+      });
+
+      test('decodes nullable integer JSON value as double', () {
+        expect((42 as Object?).decodeJsonNullableDouble(), 42.0);
+      });
     });
 
     group('bool', () {

--- a/packages/tonik_util/test/src/encoding/datetime_extension_test.dart
+++ b/packages/tonik_util/test/src/encoding/datetime_extension_test.dart
@@ -148,6 +148,26 @@ void main() {
         expect(result, '2023-12-25T18:30:45.123456-08:00');
       });
 
+      test('encodes with only microseconds (no milliseconds) in timezone', () {
+        final estLocation = tz.getLocation('America/New_York');
+        final estDateTime = tz.TZDateTime(
+          estLocation,
+          2023,
+          1,
+          1,
+          12,
+          0,
+          0,
+          0, // milliseconds = 0
+          456, // microseconds = 456
+        );
+
+        final result = estDateTime.toTimeZonedIso8601String();
+
+        // Must include decimal point before fractional digits
+        expect(result, '2023-01-01T12:00:00.000456-05:00');
+      });
+
       test('encodes in JST (UTC+9:00)', () {
         final jstLocation = tz.getLocation('Asia/Tokyo');
         final jstDateTime = tz.TZDateTime(jstLocation, 2009, 6, 30, 18, 30);

--- a/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
@@ -245,6 +245,16 @@ void main() {
       );
     });
 
+    test('encodes special characters in map keys with explode=true', () {
+      expect(
+        {'a=b': '1', 'c&d': '2'}.toLabel(
+          explode: true,
+          allowEmpty: true,
+        ),
+        '.a%3Db=1.c%26d=2',
+      );
+    });
+
     test('encodes empty object when allowEmpty is true', () {
       expect(
         <String, String>{}.toLabel(explode: false, allowEmpty: true),

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -206,19 +206,17 @@ add_dependency_overrides_recursive "multipart/multipart_api"
 $TONIK_BINARY --config multipart/tonik_3_1.yaml
 add_dependency_overrides_recursive "multipart/multipart_3_1_api"
 
-# Figma generation may fail due to a known bug (circular model references).
-# See docs/integration-test-plans/bugs/figma-bugs.md for details.
-$TONIK_BINARY --config figma/tonik.yaml || echo "WARNING: Figma generation failed (known bug - circular model references). See docs/integration-test-plans/bugs/figma-bugs.md"
+$TONIK_BINARY --config figma/tonik.yaml || echo "WARNING: Figma generation failed."
 if [ -d "figma/figma_api" ]; then
     add_dependency_overrides_recursive "figma/figma_api"
 fi
 
-$TONIK_BINARY --config stripe/tonik.yaml || echo "WARNING: Stripe generation failed. See docs/integration-test-plans/bugs/stripe-bugs.md"
+$TONIK_BINARY --config stripe/tonik.yaml || echo "WARNING: Stripe generation failed."
 if [ -d "stripe/stripe_api" ]; then
     add_dependency_overrides_recursive "stripe/stripe_api"
 fi
 
-$TONIK_BINARY --config github/tonik.yaml || echo "WARNING: GitHub generation failed. See docs/integration-test-plans/bugs/github-bugs.md"
+$TONIK_BINARY --config github/tonik.yaml || echo "WARNING: GitHub generation failed."
 if [ -d "github/github_api" ]; then
     add_dependency_overrides_recursive "github/github_api"
 fi


### PR DESCRIPTION
## Summary

Fixes 13 bugs found during a correctness and security audit, with full TDD coverage and integration tests.

### Critical
- **DateTime encoding**: missing decimal point when `millisecond == 0` but `microsecond > 0` produced invalid ISO 8601
- **JSON double decoding**: `decodeJsonDouble` rejected `int` values from `jsonDecode`, violating RFC 8259
- **Nullable $ref**: OAS 3.0 `nullable: true` ignored on `$ref` schemas with annotation/structural siblings (3 sites)
- **Circular references**: indirect cycles (A→B→C→A) caused StackOverflow; now detected with clear error

### High
- **Label encoder**: map keys not URI-encoded in explode mode (inconsistent with simple/matrix encoders)
- **Content-Type resolver**: exact string match failed for media types with parameters (e.g. `charset=utf-8`)
- **Form decoder**: `e+` heuristic too broad — any value containing `e+` silently bypassed space decoding
- **readOnly/writeOnly**: flags lost when `$ref` has structural siblings (`_mergeRefWithStructuralSiblings`)
- **Code injection**: `rawName` and path segments interpolated into raw strings without escaping (5+ sites)
- **OneOf List/Map variants**: silently skipped in `fromSimple`/`fromForm` → now throw `SimpleDecodingException`

### Medium/Low
- **Discriminator inheritance**: only checked 1 level of allOf; now recurses into nested chains
- **Config loader**: `as String?` casts throw generic TypeError; now validates with helpful messages

### Integration tests
- Added `SpecialKeyObject` schema with special-character property names (`my.field`, `a=b`)
- Full HTTP request tests for label, matrix, and simple encoding styles (explode=true and false)
- Validates no double-encoding through the full Dart URI-building pipeline

## Test plan

- [x] All unit tests pass (3432 across 4 packages)
- [x] All integration tests pass (0 analysis issues)
- [x] New integration tests make real HTTP requests validating URI encoding end-to-end
- [x] Figma and Stripe specs generate successfully