### PR TITLE
fix: handle newline characters in specLiteralStringCode

### DIFF
--- a/packages/tonik_generate/lib/src/util/spec_literal_string.dart
+++ b/packages/tonik_generate/lib/src/util/spec_literal_string.dart
@@ -3,14 +3,18 @@ import 'package:code_builder/code_builder.dart';
 /// Generates a string literal [Expression] for a value from an OpenAPI spec.
 ///
 /// Prefers raw strings to prevent `$` from being interpreted as Dart
-/// interpolation. Falls back to an escaped non-raw string when the value
-/// contains both quote styles and triple-double-quotes (or ends with `"`).
+/// interpolation. When the value contains newline characters (`\n` or `\r`),
+/// single-line raw strings are avoided because they cannot represent literal
+/// newlines. Falls back to an escaped non-raw string when no raw quoting style
+/// is viable.
 ///
 /// Quoting strategy:
-/// - No single quotes → `r'value'`
-/// - Has `'` but no `"` → `r"value"`
-/// - Has both `'` and `"` (not ending in `"`, no `"""`) → `r"""value"""`
-/// - Otherwise → `'escaped value'` (non-raw, with `\`, `'`, `$` escaped)
+/// - No newlines, no single quotes → `r'value'`
+/// - No newlines, has `'` but no `"` → `r"value"`
+/// - Can use triple-double-quotes (no `"""`, doesn't end with `"`) →
+///   `r"""value"""`
+/// - Otherwise → `'escaped value'` (non-raw, with `\`, `'`, `$`, `\n`, `\r`
+///   escaped)
 Expression specLiteralString(String value) {
   return CodeExpression(Code(specLiteralStringCode(value)));
 }

--- a/packages/tonik_generate/lib/src/util/spec_literal_string.dart
+++ b/packages/tonik_generate/lib/src/util/spec_literal_string.dart
@@ -11,7 +11,7 @@ import 'package:code_builder/code_builder.dart';
 /// Quoting strategy:
 /// - No newlines, no single quotes → `r'value'`
 /// - No newlines, has `'` but no `"` → `r"value"`
-/// - Can use triple-double-quotes (no `"""`, doesn't end with `"`) →
+/// - No `\r`, can use triple-double-quotes (no `"""`, doesn't end with `"`) →
 ///   `r"""value"""`
 /// - Otherwise → `'escaped value'` (non-raw, with `\`, `'`, `$`, `\n`, `\r`
 ///   escaped)
@@ -26,11 +26,13 @@ Expression specLiteralString(String value) {
 /// but falls back to an escaped non-raw string for edge cases.
 ///
 /// When [value] contains newline characters (`\n` or `\r`), single-line raw
-/// strings are avoided because they cannot contain literal newlines. Instead
-/// a triple-quoted raw string is used when possible, or the escaped fallback
-/// path handles the newlines.
+/// strings are avoided because they cannot contain literal newlines.
+/// Values with `\n` (but no `\r`) use triple-quoted raw strings.
+/// Values with `\r` always use the escaped fallback to avoid embedding
+/// literal carriage-return bytes in generated source files.
 String specLiteralStringCode(String value) {
   final hasNewline = value.contains('\n') || value.contains('\r');
+  final hasCarriageReturn = value.contains('\r');
 
   if (!hasNewline) {
     // Single-line raw strings are safe when there are no newlines.
@@ -42,10 +44,10 @@ String specLiteralStringCode(String value) {
     }
   }
 
-  // Use raw triple-double-quoted string when possible.
-  // This handles both newline and non-newline cases where single-line raw
-  // strings were not viable.
-  if (!value.contains('"""') && !value.endsWith('"')) {
+  // Use raw triple-double-quoted string when possible. Avoid this for values
+  // containing \r — literal CR bytes in source files cause issues with
+  // formatters, diffs, and editors.
+  if (!hasCarriageReturn && !value.contains('"""') && !value.endsWith('"')) {
     return 'r"""$value"""';
   }
 

--- a/packages/tonik_generate/lib/src/util/spec_literal_string.dart
+++ b/packages/tonik_generate/lib/src/util/spec_literal_string.dart
@@ -20,17 +20,31 @@ Expression specLiteralString(String value) {
 /// Same quoting logic as [specLiteralString] but returns a plain [String]
 /// that can be embedded directly in [Code] templates. Prefers raw strings
 /// but falls back to an escaped non-raw string for edge cases.
+///
+/// When [value] contains newline characters (`\n` or `\r`), single-line raw
+/// strings are avoided because they cannot contain literal newlines. Instead
+/// a triple-quoted raw string is used when possible, or the escaped fallback
+/// path handles the newlines.
 String specLiteralStringCode(String value) {
-  if (!value.contains("'")) {
-    return "r'$value'";
+  final hasNewline = value.contains('\n') || value.contains('\r');
+
+  if (!hasNewline) {
+    // Single-line raw strings are safe when there are no newlines.
+    if (!value.contains("'")) {
+      return "r'$value'";
+    }
+    if (!value.contains('"')) {
+      return 'r"$value"';
+    }
   }
-  if (!value.contains('"')) {
-    return 'r"$value"';
-  }
+
+  // Use raw triple-double-quoted string when possible.
+  // This handles both newline and non-newline cases where single-line raw
+  // strings were not viable.
   if (!value.contains('"""') && !value.endsWith('"')) {
     return 'r"""$value"""';
   }
-  // Value contains both quote styles and triple-double-quotes.
+
   // Fall back to a regular single-quoted string with escaping.
   final escaped = escapeForSingleQuotedDartString(value);
   return "'$escaped'";
@@ -38,13 +52,15 @@ String specLiteralStringCode(String value) {
 
 /// Escapes a string for embedding inside a Dart single-quoted (non-raw) string.
 ///
-/// Handles `\`, `'`, and `$` — the three characters that are special inside
-/// single-quoted Dart strings. This is useful both for the fallback path in
-/// [specLiteralStringCode] and for building interpolated strings like
-/// templated server URLs.
+/// Handles `\`, `'`, `$`, `\n`, and `\r` — the characters that are special
+/// or invalid inside single-quoted Dart strings. This is useful both for the
+/// fallback path in [specLiteralStringCode] and for building interpolated
+/// strings like templated server URLs.
 String escapeForSingleQuotedDartString(String value) {
   return value
       .replaceAll(r'\', r'\\')
       .replaceAll("'", r"\'")
-      .replaceAll(r'$', r'\$');
+      .replaceAll(r'$', r'\$')
+      .replaceAll('\n', r'\n')
+      .replaceAll('\r', r'\r');
 }

--- a/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
+++ b/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
@@ -137,18 +137,18 @@ world''';
         expect(result, 'r"""hello\nworld"""');
       });
 
-      test(r'value with \r uses raw triple-quoted string', () {
+      test(r'value with \r uses escaped fallback to avoid literal CR', () {
         final result = specLiteralStringCode('hello\rworld');
-        expect(result, startsWith('r"""'));
-        expect(result, endsWith('"""'));
-        expect(result, 'r"""hello\rworld"""');
+        expect(result, isNot(startsWith('r')));
+        expect(result, startsWith("'"));
+        expect(result, endsWith("'"));
+        expect(result, r"'hello\rworld'");
       });
 
-      test(r'value with \r\n uses raw triple-quoted string', () {
+      test(r'value with \r\n uses escaped fallback to avoid literal CR', () {
         final result = specLiteralStringCode('hello\r\nworld');
-        expect(result, startsWith('r"""'));
-        expect(result, endsWith('"""'));
-        expect(result, 'r"""hello\r\nworld"""');
+        expect(result, isNot(startsWith('r')));
+        expect(result, r"'hello\r\nworld'");
       });
 
       test(

--- a/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
+++ b/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
@@ -125,5 +125,99 @@ void main() {
       final result = specLiteralStringCode(value);
       expect(result, contains(r'\$'));
     });
+
+    group('newline handling', () {
+      test(r'value with \n uses raw triple-quoted string', () {
+        final result = specLiteralStringCode('hello\nworld');
+        expect(result, startsWith('r"""'));
+        expect(result, endsWith('"""'));
+        expect(result, 'r"""hello\nworld"""');
+      });
+
+      test(r'value with \r uses raw triple-quoted string', () {
+        final result = specLiteralStringCode('hello\rworld');
+        expect(result, startsWith('r"""'));
+        expect(result, endsWith('"""'));
+        expect(result, 'r"""hello\rworld"""');
+      });
+
+      test(r'value with \r\n uses raw triple-quoted string', () {
+        final result = specLiteralStringCode('hello\r\nworld');
+        expect(result, startsWith('r"""'));
+        expect(result, endsWith('"""'));
+        expect(result, 'r"""hello\r\nworld"""');
+      });
+
+      test(
+        r'value with \n and single quotes uses raw triple-quoted string',
+        () {
+          final result = specLiteralStringCode("it's\nnew");
+          expect(result, startsWith('r"""'));
+          expect(result, endsWith('"""'));
+          expect(result, 'r"""it\'s\nnew"""');
+        },
+      );
+
+      test(
+        r'value with \n and double quotes uses raw triple-quoted string',
+        () {
+          final result = specLiteralStringCode('say "hi"\nthere');
+          expect(result, startsWith('r"""'));
+          expect(result, endsWith('"""'));
+          expect(result, 'r"""say "hi"\nthere"""');
+        },
+      );
+
+      test(
+        r'value with \n and both quotes uses raw triple-quoted string',
+        () {
+          final result = specLiteralStringCode('it\'s "here"\nok');
+          expect(result, startsWith('r"""'));
+          expect(result, endsWith('"""'));
+          expect(result, 'r"""it\'s "here"\nok"""');
+        },
+      );
+
+      test(
+        r'value with \n and triple-double-quotes falls back to escaped '
+        'single-quoted string with escaped newline',
+        () {
+          // Contains ', ", """, and \n — must use escaped fallback
+          const value = "it's\"\"\"\ntest";
+          final result = specLiteralStringCode(value);
+          expect(result, isNot(startsWith('r')));
+          expect(result, startsWith("'"));
+          expect(result, endsWith("'"));
+          // \n must be escaped as literal \n in the output
+          expect(result, contains(r'\n'));
+          // single quote must be escaped
+          expect(result, contains(r"\'"));
+        },
+      );
+
+      test(
+        r'value with \r in fallback path is escaped as literal \r',
+        () {
+          // Contains ', ", """, and \r — must use escaped fallback
+          const value = "it's\"\"\"\rtest";
+          final result = specLiteralStringCode(value);
+          expect(result, isNot(startsWith('r')));
+          expect(result, contains(r'\r'));
+        },
+      );
+
+      test(
+        r'value with \n ending in double quote uses escaped '
+        'single-quoted string',
+        () {
+          // Has both quotes, ends in ", and has \n
+          final result = specLiteralStringCode('it\'s "here"\n"end"');
+          expect(result, isNot(startsWith('r')));
+          expect(result, startsWith("'"));
+          expect(result, endsWith("'"));
+          expect(result, contains(r'\n'));
+        },
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
+++ b/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
@@ -127,8 +127,11 @@ void main() {
     });
 
     group('newline handling', () {
-      test(r'value with \n uses raw triple-quoted string', () {
-        final result = specLiteralStringCode('hello\nworld');
+      test('multiline value uses raw triple-quoted string', () {
+        const value = '''
+hello
+world''';
+        final result = specLiteralStringCode(value);
         expect(result, startsWith('r"""'));
         expect(result, endsWith('"""'));
         expect(result, 'r"""hello\nworld"""');
@@ -149,9 +152,12 @@ void main() {
       });
 
       test(
-        r'value with \n and single quotes uses raw triple-quoted string',
+        'multiline value with single quotes uses raw triple-quoted string',
         () {
-          final result = specLiteralStringCode("it's\nnew");
+          const value = '''
+it's
+new''';
+          final result = specLiteralStringCode(value);
           expect(result, startsWith('r"""'));
           expect(result, endsWith('"""'));
           expect(result, 'r"""it\'s\nnew"""');
@@ -159,9 +165,12 @@ void main() {
       );
 
       test(
-        r'value with \n and double quotes uses raw triple-quoted string',
+        'multiline value with double quotes uses raw triple-quoted string',
         () {
-          final result = specLiteralStringCode('say "hi"\nthere');
+          const value = '''
+say "hi"
+there''';
+          final result = specLiteralStringCode(value);
           expect(result, startsWith('r"""'));
           expect(result, endsWith('"""'));
           expect(result, 'r"""say "hi"\nthere"""');
@@ -169,9 +178,12 @@ void main() {
       );
 
       test(
-        r'value with \n and both quotes uses raw triple-quoted string',
+        'multiline value with both quotes uses raw triple-quoted string',
         () {
-          final result = specLiteralStringCode('it\'s "here"\nok');
+          const value = '''
+it's "here"
+ok''';
+          final result = specLiteralStringCode(value);
           expect(result, startsWith('r"""'));
           expect(result, endsWith('"""'));
           expect(result, 'r"""it\'s "here"\nok"""');
@@ -179,18 +191,16 @@ void main() {
       );
 
       test(
-        r'value with \n and triple-double-quotes falls back to escaped '
+        'multiline value with triple-double-quotes falls back to escaped '
         'single-quoted string with escaped newline',
         () {
-          // Contains ', ", """, and \n — must use escaped fallback
+          // Contains ', ", """, and a newline — must use escaped fallback
           const value = "it's\"\"\"\ntest";
           final result = specLiteralStringCode(value);
           expect(result, isNot(startsWith('r')));
           expect(result, startsWith("'"));
           expect(result, endsWith("'"));
-          // \n must be escaped as literal \n in the output
           expect(result, contains(r'\n'));
-          // single quote must be escaped
           expect(result, contains(r"\'"));
         },
       );
@@ -207,11 +217,14 @@ void main() {
       );
 
       test(
-        r'value with \n ending in double quote uses escaped '
+        'multiline value ending in double quote uses escaped '
         'single-quoted string',
         () {
-          // Has both quotes, ends in ", and has \n
-          final result = specLiteralStringCode('it\'s "here"\n"end"');
+          // Has both quotes, ends in ", and has a newline
+          const value = '''
+it's "here"
+"end"''';
+          final result = specLiteralStringCode(value);
           expect(result, isNot(startsWith('r')));
           expect(result, startsWith("'"));
           expect(result, endsWith("'"));
@@ -222,16 +235,22 @@ void main() {
   });
 
   group('escapeForSingleQuotedDartString', () {
-    test(r'escapes \n to literal \n', () {
-      expect(escapeForSingleQuotedDartString('hello\nworld'), r'hello\nworld');
+    test('escapes newline to literal backslash-n', () {
+      const input = '''
+hello
+world''';
+      expect(
+        escapeForSingleQuotedDartString(input),
+        r'hello\nworld',
+      );
     });
 
-    test(r'escapes \r to literal \r', () {
+    test(r'escapes \r to literal backslash-r', () {
       expect(escapeForSingleQuotedDartString('hello\rworld'), r'hello\rworld');
     });
 
     test(
-      r'escapes combined \n, \r, single quote, dollar, and backslash',
+      'escapes combined newlines, single quote, dollar, and backslash',
       () {
         const input = "a\\b'c\$d\ne\rf";
         final result = escapeForSingleQuotedDartString(input);

--- a/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
+++ b/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
@@ -220,4 +220,25 @@ void main() {
       );
     });
   });
+
+  group('escapeForSingleQuotedDartString', () {
+    test(r'escapes \n to literal \n', () {
+      expect(escapeForSingleQuotedDartString('hello\nworld'), r'hello\nworld');
+    });
+
+    test(r'escapes \r to literal \r', () {
+      expect(escapeForSingleQuotedDartString('hello\rworld'), r'hello\rworld');
+    });
+
+    test(
+      r'escapes combined \n, \r, single quote, dollar, and backslash',
+      () {
+        const input = "a\\b'c\$d\ne\rf";
+        final result = escapeForSingleQuotedDartString(input);
+        // Backslash must be escaped first to avoid double-escaping.
+        // Then single quote, dollar, \n, and \r.
+        expect(result, r"a\\b\'c\$d\ne\rf");
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- `specLiteralStringCode()` now skips single-line raw strings (`r'...'`, `r"..."`) when the value contains `\n` or `\r`, using triple-quoted raw strings or the escaped fallback path instead
- `escapeForSingleQuotedDartString()` now escapes `\n` and `\r` so the fallback path produces valid Dart
- Added 9 new tests covering `\n`, `\r`, `\r\n`, and combinations with quotes

## Test plan
- [x] All 1,899 tonik_generate unit tests pass (including 9 new newline tests)
- [x] All 3,727 unit tests pass across all packages
- [x] All 3,450 integration tests pass across 27 suites
- [x] `fvm dart analyze` clean

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)