### PR TITLE
fix: preserve trailing slash in OpenAPI path segments

### DIFF
--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -28,12 +28,21 @@ class PathGenerator {
     List<({String normalizedName, PathParameterObject parameter})>
     pathParameters,
   ) {
+    final hasTrailingSlash =
+        operation.path.endsWith('/') && operation.path.length > 1;
+
     if (pathParameters.isEmpty) {
-      final pathSegments = operation.path
+      final segments = operation.path
           .split('/')
           .where((s) => s.isNotEmpty)
           .map(specLiteralStringCode)
-          .join(', ');
+          .toList();
+
+      if (hasTrailingSlash) {
+        segments.add("r''");
+      }
+
+      final pathSegments = segments.join(', ');
 
       return Method(
         (b) => b
@@ -153,6 +162,10 @@ class PathGenerator {
         );
         pathPartExpressions.add(matrixExpression);
       }
+    }
+
+    if (hasTrailingSlash) {
+      pathPartExpressions.add(specLiteralString(''));
     }
 
     final listExpr = literalList(pathPartExpressions);

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -39,7 +39,7 @@ class PathGenerator {
           .toList();
 
       if (hasTrailingSlash) {
-        segments.add("r''");
+        segments.add(specLiteralStringCode(''));
       }
 
       final pathSegments = segments.join(', ');

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1393,4 +1393,180 @@ void main() {
       collapseWhitespace(expectedMethod),
     );
   });
+
+  group('trailing slash preservation', () {
+    test(
+        'preserves trailing slash for path without parameters '
+        'by adding empty segment', () {
+      final operation = Operation(
+        operationId: 'listSpaces',
+        context: context,
+        summary: 'List spaces',
+        description: 'Lists all spaces',
+        tags: const {},
+        isDeprecated: false,
+        path: '/api/mobile/protected/spaces/',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+          List<String> _path() {
+            return [r'api', r'mobile', r'protected', r'spaces', r''];
+          }
+        ''';
+
+      final method = generator.generatePathMethod(operation, []);
+
+      expect(method, isA<Method>());
+      expect(
+        collapseWhitespace(method.accept(emitter).toString()),
+        collapseWhitespace(expectedMethod),
+      );
+    });
+
+    test(
+        'preserves trailing slash for path with parameters '
+        'by adding empty segment after parameter', () {
+      final pathParam = PathParameterObject(
+        name: 'slug',
+        rawName: 'slug',
+        description: 'Keeper slug',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getKeeperBySlug',
+        context: context,
+        summary: 'Get keeper by slug',
+        description: 'Gets a keeper by slug',
+        tags: const {},
+        isDeprecated: false,
+        path: '/api/mobile/protected/spaces/keeper/{slug}/',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+          List<String> _path({required String slug}) {
+            return [r'api', r'mobile', r'protected', r'spaces', r'keeper', slug.toSimple(explode: false, allowEmpty: false, ), r'', ];
+          }
+        ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'slug', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expect(method, isA<Method>());
+      expect(
+        collapseWhitespace(method.accept(emitter).toString()),
+        collapseWhitespace(expectedMethod),
+      );
+    });
+
+    test('does not add trailing segment for path without trailing slash '
+        'and no parameters', () {
+      final operation = Operation(
+        operationId: 'getUsers',
+        context: context,
+        summary: 'Get users',
+        description: 'Gets a list of users',
+        tags: const {},
+        isDeprecated: false,
+        path: '/users',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+          List<String> _path() {
+            return [r'users'];
+          }
+        ''';
+
+      final method = generator.generatePathMethod(operation, []);
+
+      expect(method, isA<Method>());
+      expect(
+        collapseWhitespace(method.accept(emitter).toString()),
+        collapseWhitespace(expectedMethod),
+      );
+    });
+
+    test('does not add trailing segment for path without trailing slash '
+        'and with parameters', () {
+      final pathParam = PathParameterObject(
+        name: 'userId',
+        rawName: 'userId',
+        description: 'User ID',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getUser',
+        context: context,
+        summary: 'Get user',
+        description: 'Gets a user by ID',
+        tags: const {},
+        isDeprecated: false,
+        path: '/users/{userId}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+          List<String> _path({required String userId}) {
+            return [r'users', userId.toSimple(explode: false, allowEmpty: false, ), ];
+          }
+        ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'userId', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expect(method, isA<Method>());
+      expect(
+        collapseWhitespace(method.accept(emitter).toString()),
+        collapseWhitespace(expectedMethod),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Paths with trailing slashes (e.g. `/api/spaces/`) were silently dropping the slash in generated code, producing different URLs than specified
- Root cause: `split('/').where(isNotEmpty)` filtered the empty trailing segment
- Fix: append an empty string segment (`''`) when path ends with `/`, so `join('/')` at runtime reproduces the trailing slash
- Handles both parameterized and non-parameterized paths

## Test plan

- [x] Path without parameters and trailing slash generates correct segments
- [x] Path with parameters and trailing slash generates correct segments  
- [x] No regression for paths without trailing slashes
- [x] All 3822 unit tests pass
- [x] All 20 integration test suites pass
- [x] Patch coverage: 100%