### PR TITLE
fix: keep literal suffixes in same path segment as parameters

### DIFF
--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -116,61 +116,64 @@ class PathGenerator {
           continue;
         }
 
-        if (param.parameter.encoding == PathParameterEncoding.simple) {
-          final model = param.parameter.model;
-          if (model is ListModel &&
-              model.content.encodingShape != EncodingShape.simple) {
-            body.add(
-              generateEncodingExceptionExpression(
-                'Simple encoding does not support list with complex elements '
-                'for path parameter ${param.parameter.rawName}',
-              ).statement,
+        switch (param.parameter.encoding) {
+          case PathParameterEncoding.simple:
+            final model = param.parameter.model;
+            if (model is ListModel &&
+                model.content.encodingShape != EncodingShape.simple) {
+              currentConcatParts.clear();
+              body.add(
+                generateEncodingExceptionExpression(
+                  'Simple encoding does not support list with complex elements '
+                  'for path parameter ${param.parameter.rawName}',
+                ).statement,
+              );
+
+              continue;
+            }
+
+            final valueExpression = buildToSimplePathParameterExpression(
+              param.normalizedName,
+              param.parameter,
+              explode: param.parameter.explode,
+              allowEmpty: param.parameter.allowEmptyValue,
             );
+            // Simple parameters concatenate with adjacent literals.
+            currentConcatParts.add(valueExpression);
+          case PathParameterEncoding.label:
+            // Flush any accumulated concat parts before the label parameter.
+            _flushConcatParts(currentConcatParts, pathPartExpressions);
 
-            continue;
-          }
-
-          final valueExpression = buildToSimplePathParameterExpression(
-            param.normalizedName,
-            param.parameter,
-            explode: param.parameter.explode,
-            allowEmpty: param.parameter.allowEmptyValue,
-          );
-          // Simple parameters concatenate with adjacent literals.
-          currentConcatParts.add(valueExpression);
-        } else if (param.parameter.encoding == PathParameterEncoding.label) {
-          // Flush any accumulated concat parts before the label parameter.
-          _flushConcatParts(currentConcatParts, pathPartExpressions);
-
-          final valueExpression = buildToLabelPathParameterExpression(
-            param.normalizedName,
-            param.parameter,
-          );
-          pathPartExpressions.add(valueExpression);
-        } else if (param.parameter.encoding == PathParameterEncoding.matrix) {
-          // Flush any accumulated concat parts before the matrix parameter.
-          _flushConcatParts(currentConcatParts, pathPartExpressions);
-
-          final model = param.parameter.model;
-          if (model is ListModel && model.content is ListModel) {
-            body.add(
-              generateEncodingExceptionExpression(
-                'Matrix encoding does not support arrays of objects or '
-                'nested arrays',
-              ).statement,
+            final valueExpression = buildToLabelPathParameterExpression(
+              param.normalizedName,
+              param.parameter,
             );
+            pathPartExpressions.add(valueExpression);
+          case PathParameterEncoding.matrix:
+            // Flush any accumulated concat parts before the matrix parameter.
+            _flushConcatParts(currentConcatParts, pathPartExpressions);
 
-            continue;
-          }
+            final model = param.parameter.model;
+            if (model is ListModel && model.content is ListModel) {
+              currentConcatParts.clear();
+              body.add(
+                generateEncodingExceptionExpression(
+                  'Matrix encoding does not support arrays of objects or '
+                  'nested arrays',
+                ).statement,
+              );
 
-          final matrixExpression = buildMatrixParameterExpression(
-            refer(param.normalizedName),
-            param.parameter.model,
-            paramName: specLiteralString(param.parameter.rawName),
-            explode: literalBool(param.parameter.explode),
-            allowEmpty: literalBool(param.parameter.allowEmptyValue),
-          );
-          pathPartExpressions.add(matrixExpression);
+              continue;
+            }
+
+            final matrixExpression = buildMatrixParameterExpression(
+              refer(param.normalizedName),
+              param.parameter.model,
+              paramName: specLiteralString(param.parameter.rawName),
+              explode: literalBool(param.parameter.explode),
+              allowEmpty: literalBool(param.parameter.allowEmptyValue),
+            );
+            pathPartExpressions.add(matrixExpression);
         }
       }
 

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -77,82 +77,106 @@ class PathGenerator {
 
     final pathPartExpressions = <Expression>[];
 
-    for (final pathComponent
-        in operation.path
-            .splitAndKeep(RegExp(r'\{[^}]+\}'))
-            .where((pathComponent) => pathComponent.isNotEmpty)) {
-      if (!pathComponent.startsWith('{') || !pathComponent.endsWith('}')) {
-        final segments = pathComponent
-            .split('/')
-            .where((s) => s.isNotEmpty)
-            .map(specLiteralString);
-        pathPartExpressions.addAll(segments);
+    // Split by '/' first to get proper URL segments, then handle parameters
+    // within each segment. This ensures that suffixes like '.json' after a
+    // parameter (e.g. '{Sid}.json') stay in the same segment rather than
+    // becoming a separate path entry.
+    final segments = operation.path.split('/').where((s) => s.isNotEmpty);
+
+    for (final segment in segments) {
+      final parts = segment.splitAndKeep(RegExp(r'\{[^}]+\}'));
+
+      // Pure literal segment — no parameters at all.
+      if (!parts.any((p) => p.startsWith('{') && p.endsWith('}'))) {
+        pathPartExpressions.add(specLiteralString(segment));
         continue;
       }
 
-      final paramName = pathComponent.substring(1, pathComponent.length - 1);
-      final param = pathParameters.firstWhereOrNull(
-        (p) => p.parameter.rawName == paramName,
-      );
+      // Process parts within the segment. Simple-encoded parameters and
+      // adjacent literals are concatenated into a single list entry. Label
+      // and matrix parameters always become their own list entries because
+      // they produce their own prefix (. or ;).
+      final currentConcatParts = <Expression>[];
 
-      if (param == null) {
-        final segments = pathComponent
-            .split('/')
-            .where((s) => s.isNotEmpty)
-            .map(specLiteralString);
-        pathPartExpressions.addAll(segments);
-        continue;
-      }
-
-      if (param.parameter.encoding == PathParameterEncoding.simple) {
-        final model = param.parameter.model;
-        if (model is ListModel &&
-            model.content.encodingShape != EncodingShape.simple) {
-          body.add(
-            generateEncodingExceptionExpression(
-              'Simple encoding does not support list with complex elements for '
-              'path parameter ${param.parameter.rawName}',
-            ).statement,
-          );
-
+      for (final part in parts.where((p) => p.isNotEmpty)) {
+        if (!part.startsWith('{') || !part.endsWith('}')) {
+          // Literal text within the segment — accumulate for concatenation.
+          currentConcatParts.add(specLiteralString(part));
           continue;
         }
 
-        final valueExpression = buildToSimplePathParameterExpression(
-          param.normalizedName,
-          param.parameter,
-          explode: param.parameter.explode,
-          allowEmpty: param.parameter.allowEmptyValue,
+        final paramName = part.substring(1, part.length - 1);
+        final param = pathParameters.firstWhereOrNull(
+          (p) => p.parameter.rawName == paramName,
         );
-        pathPartExpressions.add(valueExpression);
-      } else if (param.parameter.encoding == PathParameterEncoding.label) {
-        final valueExpression = buildToLabelPathParameterExpression(
-          param.normalizedName,
-          param.parameter,
-        );
-        pathPartExpressions.add(valueExpression);
-      } else if (param.parameter.encoding == PathParameterEncoding.matrix) {
-        final model = param.parameter.model;
-        if (model is ListModel && model.content is ListModel) {
-          body.add(
-            generateEncodingExceptionExpression(
-              'Matrix encoding does not support arrays of objects or '
-              'nested arrays',
-            ).statement,
-          );
 
+        if (param == null) {
+          // Unknown parameter reference — treat as literal.
+          currentConcatParts.add(specLiteralString(part));
           continue;
         }
 
-        final matrixExpression = buildMatrixParameterExpression(
-          refer(param.normalizedName),
-          param.parameter.model,
-          paramName: specLiteralString(param.parameter.rawName),
-          explode: literalBool(param.parameter.explode),
-          allowEmpty: literalBool(param.parameter.allowEmptyValue),
-        );
-        pathPartExpressions.add(matrixExpression);
+        if (param.parameter.encoding == PathParameterEncoding.simple) {
+          final model = param.parameter.model;
+          if (model is ListModel &&
+              model.content.encodingShape != EncodingShape.simple) {
+            body.add(
+              generateEncodingExceptionExpression(
+                'Simple encoding does not support list with complex elements '
+                'for path parameter ${param.parameter.rawName}',
+              ).statement,
+            );
+
+            continue;
+          }
+
+          final valueExpression = buildToSimplePathParameterExpression(
+            param.normalizedName,
+            param.parameter,
+            explode: param.parameter.explode,
+            allowEmpty: param.parameter.allowEmptyValue,
+          );
+          // Simple parameters concatenate with adjacent literals.
+          currentConcatParts.add(valueExpression);
+        } else if (param.parameter.encoding == PathParameterEncoding.label) {
+          // Flush any accumulated concat parts before the label parameter.
+          _flushConcatParts(currentConcatParts, pathPartExpressions);
+
+          final valueExpression = buildToLabelPathParameterExpression(
+            param.normalizedName,
+            param.parameter,
+          );
+          pathPartExpressions.add(valueExpression);
+        } else if (param.parameter.encoding == PathParameterEncoding.matrix) {
+          // Flush any accumulated concat parts before the matrix parameter.
+          _flushConcatParts(currentConcatParts, pathPartExpressions);
+
+          final model = param.parameter.model;
+          if (model is ListModel && model.content is ListModel) {
+            body.add(
+              generateEncodingExceptionExpression(
+                'Matrix encoding does not support arrays of objects or '
+                'nested arrays',
+              ).statement,
+            );
+
+            continue;
+          }
+
+          final matrixExpression = buildMatrixParameterExpression(
+            refer(param.normalizedName),
+            param.parameter.model,
+            paramName: specLiteralString(param.parameter.rawName),
+            explode: literalBool(param.parameter.explode),
+            allowEmpty: literalBool(param.parameter.allowEmptyValue),
+          );
+          pathPartExpressions.add(matrixExpression);
+        }
       }
+
+      // Flush any remaining concat parts after the last parameter in the
+      // segment.
+      _flushConcatParts(currentConcatParts, pathPartExpressions);
     }
 
     final listExpr = literalList(pathPartExpressions);
@@ -171,6 +195,29 @@ class PathGenerator {
         ..lambda = false
         ..body = Block.of(body),
     );
+  }
+
+  /// Flushes accumulated concatenation parts into a single expression and
+  /// adds it to [target]. If there is exactly one part, it is added directly.
+  /// If there are multiple parts, they are joined with '+' to form a single
+  /// concatenated expression. After flushing, [parts] is cleared.
+  void _flushConcatParts(List<Expression> parts, List<Expression> target) {
+    if (parts.isEmpty) return;
+
+    if (parts.length == 1) {
+      target.add(parts.first);
+    } else {
+      final codes = <Code>[];
+      for (var i = 0; i < parts.length; i++) {
+        if (i > 0) {
+          codes.add(const Code(' + '));
+        }
+        codes.add(parts[i].code);
+      }
+      target.add(CodeExpression(Block.of(codes)));
+    }
+
+    parts.clear();
   }
 }
 

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1393,4 +1393,381 @@ void main() {
       collapseWhitespace(expectedMethod),
     );
   });
+
+  test('concatenates literal suffix with simple parameter in same segment', () {
+    final sidParam = PathParameterObject(
+      name: 'Sid',
+      rawName: 'Sid',
+      description: 'Account SID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'fetchAccount',
+      context: context,
+      summary: 'Fetch account',
+      description: 'Fetches an account by SID',
+      tags: const {},
+      isDeprecated: false,
+      path: '/2010-04-01/Accounts/{Sid}.json',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {sidParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String sid}) {
+          return [r'2010-04-01', r'Accounts', sid.toSimple(explode: false, allowEmpty: false, ) + r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'sid', parameter: sidParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test('concatenates literal prefix with simple parameter in same segment',
+      () {
+    final idParam = PathParameterObject(
+      name: 'id',
+      rawName: 'id',
+      description: 'Resource ID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getResource',
+      context: context,
+      summary: 'Get resource',
+      description: 'Gets a resource by prefixed ID',
+      tags: const {},
+      isDeprecated: false,
+      path: '/resources/v1{id}',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {idParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String id}) {
+          return [r'resources', r'v1' + id.toSimple(explode: false, allowEmpty: false, ), ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'id', parameter: idParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test(
+      'concatenates literal prefix and suffix with simple parameter in same '
+      'segment', () {
+    final idParam = PathParameterObject(
+      name: 'id',
+      rawName: 'id',
+      description: 'Resource ID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getResource',
+      context: context,
+      summary: 'Get resource',
+      description: 'Gets a resource with prefix and suffix',
+      tags: const {},
+      isDeprecated: false,
+      path: '/resources/pre{id}suf',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {idParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String id}) {
+          return [r'resources', r'pre' + id.toSimple(explode: false, allowEmpty: false, ) + r'suf', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'id', parameter: idParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test(
+      'concatenates multiple simple parameters and literals in same segment',
+      () {
+    final aParam = PathParameterObject(
+      name: 'a',
+      rawName: 'a',
+      description: 'First part',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final bParam = PathParameterObject(
+      name: 'b',
+      rawName: 'b',
+      description: 'Second part',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getComposite',
+      context: context,
+      summary: 'Get composite',
+      description: 'Gets a resource with multi-param mixed segment',
+      tags: const {},
+      isDeprecated: false,
+      path: '/resources/{a}-{b}.json',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {aParam, bParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String a, required String b, }) {
+          return [r'resources', a.toSimple(explode: false, allowEmpty: false, ) + r'-' + b.toSimple(explode: false, allowEmpty: false, ) + r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'a', parameter: aParam),
+          (normalizedName: 'b', parameter: bParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test('Twilio example: /2010-04-01/Accounts/{Sid}.json', () {
+    final sidParam = PathParameterObject(
+      name: 'Sid',
+      rawName: 'Sid',
+      description: 'Account SID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'fetchAccount',
+      context: context,
+      summary: 'Fetch account',
+      description: 'Fetches an account by SID',
+      tags: const {},
+      isDeprecated: false,
+      path: '/2010-04-01/Accounts/{Sid}.json',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {sidParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String sid}) {
+          return [r'2010-04-01', r'Accounts', sid.toSimple(explode: false, allowEmpty: false, ) + r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'sid', parameter: sidParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test(
+      'Shopify example: /admin/api/2020-10/products/{product_id}.json', () {
+    final productIdParam = PathParameterObject(
+      name: 'product_id',
+      rawName: 'product_id',
+      description: 'Product ID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'deleteProduct',
+      context: context,
+      summary: 'Delete product',
+      description: 'Deletes a product by ID',
+      tags: const {},
+      isDeprecated: false,
+      path: '/admin/api/2020-10/products/{product_id}.json',
+      method: HttpMethod.delete,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {productIdParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String productId}) {
+          return [r'admin', r'api', r'2020-10', r'products', productId.toSimple(explode: false, allowEmpty: false, ) + r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'productId', parameter: productIdParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test('pure literal segments are unchanged with parameters present', () {
+    final idParam = PathParameterObject(
+      name: 'id',
+      rawName: 'id',
+      description: 'User ID',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.simple,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getUser',
+      context: context,
+      summary: 'Get user',
+      description: 'Gets a user',
+      tags: const {},
+      isDeprecated: false,
+      path: '/Accounts.json/users/{id}',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {idParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String id}) {
+          return [r'Accounts.json', r'users', id.toSimple(explode: false, allowEmpty: false, ), ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'id', parameter: idParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
 }

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1720,6 +1720,108 @@ void main() {
     );
   });
 
+  test('label parameter with literal suffix emits separate list entries', () {
+    final typeParam = PathParameterObject(
+      name: 'type',
+      rawName: 'type',
+      description: 'Resource type',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.label,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getResource',
+      context: context,
+      summary: 'Get resource',
+      description: 'Gets a resource by type',
+      tags: const {},
+      isDeprecated: false,
+      path: '/resources/{type}.json',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {typeParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String type}) {
+          return [r'resources', type.toLabel(explode: false, allowEmpty: false, ), r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'type', parameter: typeParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
+  test('matrix parameter with literal suffix emits separate list entries', () {
+    final rolesParam = PathParameterObject(
+      name: 'roles',
+      rawName: 'roles',
+      description: 'User roles',
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: PathParameterEncoding.matrix,
+      context: context,
+    );
+
+    final operation = Operation(
+      operationId: 'getResource',
+      context: context,
+      summary: 'Get resource',
+      description: 'Gets a resource by roles',
+      tags: const {},
+      isDeprecated: false,
+      path: '/resources/{roles}.json',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: {rolesParam},
+      responses: const {},
+      securitySchemes: const {},
+      cookieParameters: const {},
+    );
+
+    const expectedMethod = '''
+        List<String> _path({required String roles}) {
+          return [r'resources', roles.toMatrix(r'roles', explode: false, allowEmpty: false, ), r'.json', ];
+        }
+      ''';
+
+    final pathParameters =
+        <({String normalizedName, PathParameterObject parameter})>[
+          (normalizedName: 'roles', parameter: rolesParam),
+        ];
+
+    final method = generator.generatePathMethod(operation, pathParameters);
+
+    expect(method, isA<Method>());
+    expect(
+      collapseWhitespace(method.accept(emitter).toString()),
+      collapseWhitespace(expectedMethod),
+    );
+  });
+
   test('pure literal segments are unchanged with parameters present', () {
     final idParam = PathParameterObject(
       name: 'id',


### PR DESCRIPTION
## Summary

- When an OpenAPI path has a parameter immediately followed by a literal suffix (e.g. `/Accounts/{Sid}.json`), the suffix was split into a separate path segment, producing incorrect URLs like `/Accounts/AC123/.json` instead of `/Accounts/AC123.json`
- Reversed the splitting order in path_generator: split by `/` first to get proper URL segments, then split within each segment by `{param}` patterns
- Mixed segments now produce concatenated expressions (e.g. `sid.toSimple(...) + r'.json'`) as a single list entry

## Test plan

- [x] New tests for suffix after parameter (`{Sid}.json`)
- [x] New tests for prefix before parameter (`v1{id}`)
- [x] New tests for prefix + suffix (`pre{id}suf`)
- [x] New tests for multi-param mixed segment (`{a}-{b}.json`)
- [x] New tests for Twilio and Shopify examples from bug report
- [x] All 3825 existing unit tests pass (zero regressions)
- [x] All integration tests pass after regeneration
- [x] `fvm dart analyze` clean
- [x] Patch coverage 98%