### PR TITLE
fix: resolve stack overflow on circular schema references

### DIFF
--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -112,7 +112,7 @@ class ModelImporter {
         models.firstWhereOrNull(
           (model) => model is NamedModel && model.name == refName,
         ) ??
-        _resolveSchemaRef(refName, refSchema, rootContext);
+        _resolveWithCycleCheck(refName, refSchema);
 
     final modelContext = context.push('allOf');
     final modelsToMerge = <Model>[refModel];
@@ -169,7 +169,7 @@ class ModelImporter {
     return models.firstWhereOrNull(
           (model) => model is NamedModel && model.name == refName,
         ) ??
-        _resolveSchemaRef(refName, refSchema, rootContext);
+        _resolveWithCycleCheck(refName, refSchema);
   }
 
   Model _resolveDefsReferenceForProperty(String ref, Context context) {
@@ -193,21 +193,38 @@ class ModelImporter {
     }
 
     final defName = ref.split('/').last;
-    final isBareRef = defSchema.ref != null;
 
-    if (isBareRef && _resolving.contains(ref)) {
-      throw ArgumentError(
-        'Circular reference detected: $ref is part of a reference cycle',
+    if (_resolving.contains(ref)) {
+      final existing = models.firstWhereOrNull(
+        (model) => model is NamedModel && model.name == defName,
       );
+      if (existing != null) {
+        return existing;
+      }
+
+      // No early-registered model found (e.g. bare $ref alias cycles in
+      // $defs). Create and register a placeholder so the other side of the
+      // cycle can resolve to it when it unwinds.
+      log.warning(
+        'Circular reference to $ref detected but no '
+        'early-registered model found. Registering AliasModel placeholder.',
+      );
+      final placeholder = AliasModel(
+        name: defName,
+        model: AnyModel(context: _contextFromDefsPath(ref)),
+        context: _contextFromDefsPath(ref),
+      );
+      models.add(placeholder);
+      return placeholder;
     }
 
-    if (isBareRef) _resolving.add(ref);
+    _resolving.add(ref);
     final Model refModel;
     try {
       final defsContext = _contextFromDefsPath(ref);
       refModel = _resolveSchemaRef(defName, defSchema, defsContext);
     } finally {
-      if (isBareRef) _resolving.remove(ref);
+      _resolving.remove(ref);
     }
 
     if (_hasStructuralSiblings(schema)) {
@@ -249,27 +266,43 @@ class ModelImporter {
 
   /// Resolves a schema ref with cycle detection.
   ///
-  /// Only tracks resolution for schemas whose definition is itself a `$ref`
-  /// (i.e. alias chains like A→B→C→A). Schemas with structural content
-  /// handle recursion via early model registration in [_parseClassModel].
+  /// Tracks all named schema resolutions to detect circular references.
+  /// When a cycle is detected the method first checks for an
+  /// early-registered model (structural schemas register before resolving
+  /// members). If none is found it creates and registers an [AliasModel]
+  /// placeholder wrapping [AnyModel] so that resolution can unwind safely.
   Model _resolveWithCycleCheck(String refName, Schema refSchema) {
-    // Only track cycles for schemas that are bare $ref aliases.
-    // Schemas with structural content handle recursion via early
-    // model registration in _parseClassModel.
-    final isBareRef = refSchema.ref != null;
-
-    if (isBareRef && _resolving.contains(refName)) {
-      throw ArgumentError(
-        'Circular reference detected: '
-        '$refName is part of a reference cycle',
+    if (_resolving.contains(refName)) {
+      // Look up a partially-constructed model that was registered early
+      // by one of the parse methods (_parseClassModel, _parseAllOf, etc.).
+      final existing = models.firstWhereOrNull(
+        (model) => model is NamedModel && model.name == refName,
       );
+      if (existing != null) {
+        return existing;
+      }
+
+      // No early-registered model found (e.g. bare $ref alias cycles).
+      // Create and register a placeholder so the other side of the cycle
+      // can resolve to it when it unwinds.
+      log.warning(
+        'Circular reference to $refName detected but no '
+        'early-registered model found. Registering AliasModel placeholder.',
+      );
+      final placeholder = AliasModel(
+        name: refName,
+        model: AnyModel(context: rootContext),
+        context: rootContext,
+      );
+      models.add(placeholder);
+      return placeholder;
     }
 
-    if (isBareRef) _resolving.add(refName);
+    _resolving.add(refName);
     try {
       return _resolveSchemaRef(refName, refSchema, rootContext);
     } finally {
-      if (isBareRef) _resolving.remove(refName);
+      _resolving.remove(refName);
     }
   }
 
@@ -628,15 +661,12 @@ class ModelImporter {
 
   AllOfModel _parseAllOf(String? name, Schema schema, Context context) {
     final modelContext = context.push(name ?? 'allOf');
-    final models = schema.allOf!
-        .map(
-          (allOfSchema) => _resolveSchemaRef(null, allOfSchema, modelContext),
-        )
-        .toList();
 
+    // Register the model early (with an empty models set) so that
+    // circular references can find it during member resolution.
     final allOfModel = AllOfModel(
       isDeprecated: schema.isDeprecated ?? false,
-      models: models.toSet(),
+      models: <Model>{},
       context: modelContext,
       name: name,
       description: schema.description,
@@ -646,7 +676,20 @@ class ModelImporter {
       isWriteOnly: schema.isWriteOnly ?? false,
     );
 
-    _addModelToSet(allOfModel);
+    if (name == null ||
+        models.none((m) => m is NamedModel && m.name == name)) {
+      _logModelAdded(allOfModel);
+      models.add(allOfModel);
+    }
+
+    final resolvedModels = schema.allOf!
+        .map(
+          (allOfSchema) => _resolveSchemaRef(null, allOfSchema, modelContext),
+        )
+        .toSet();
+
+    allOfModel.models = resolvedModels;
+
     return allOfModel;
   }
 
@@ -670,19 +713,11 @@ class ModelImporter {
     final effectiveDiscriminator =
         schema.discriminator ?? _findInheritedDiscriminator(alternatives);
 
-    final models = alternatives.map(
-      (oneOfSchema) => (
-        discriminatorValue: _getDiscriminatorValue(
-          discriminator: effectiveDiscriminator,
-          innerSchema: oneOfSchema,
-        ),
-        model: _resolveSchemaRef(null, oneOfSchema, modelContext),
-      ),
-    );
-
+    // Register the model early (with an empty models set) so that
+    // circular references can find it during member resolution.
     final oneOfModel = OneOfModel(
       isDeprecated: schema.isDeprecated ?? false,
-      models: models.toSet(),
+      models: <DiscriminatedModel>{},
       context: context,
       name: name,
       discriminator: effectiveDiscriminator?.propertyName,
@@ -692,7 +727,29 @@ class ModelImporter {
       isWriteOnly: schema.isWriteOnly ?? false,
     );
 
-    _addModelToSet(oneOfModel);
+    if (name == null ||
+        models.none((m) => m is NamedModel && m.name == name)) {
+      _logModelAdded(oneOfModel);
+      models.add(oneOfModel);
+    }
+
+    final resolvedModels = alternatives.map(
+      (oneOfSchema) => (
+        discriminatorValue: _getDiscriminatorValue(
+          discriminator: effectiveDiscriminator,
+          innerSchema: oneOfSchema,
+        ),
+        model: _resolveSchemaRef(null, oneOfSchema, modelContext),
+      ),
+    );
+
+    oneOfModel.models = resolvedModels.toSet();
+
+    // Add nested models to the model set now that members are resolved.
+    for (final nestedModel in oneOfModel.models) {
+      _addModelToSet(nestedModel.model);
+    }
+
     return oneOfModel;
   }
 
@@ -703,18 +760,11 @@ class ModelImporter {
     final effectiveDiscriminator =
         schema.discriminator ?? _findInheritedDiscriminator(alternatives);
 
-    final models = alternatives.map(
-      (anyOfSchema) => (
-        discriminatorValue: _getDiscriminatorValue(
-          discriminator: effectiveDiscriminator,
-          innerSchema: anyOfSchema,
-        ),
-        model: _resolveSchemaRef(null, anyOfSchema, modelContext),
-      ),
-    );
+    // Register the model early (with an empty models set) so that
+    // circular references can find it during member resolution.
     final anyOfModel = AnyOfModel(
       isDeprecated: schema.isDeprecated ?? false,
-      models: models.toSet(),
+      models: <DiscriminatedModel>{},
       context: context,
       name: name,
       discriminator: effectiveDiscriminator?.propertyName,
@@ -724,7 +774,24 @@ class ModelImporter {
       isWriteOnly: schema.isWriteOnly ?? false,
     );
 
-    _addModelToSet(anyOfModel);
+    if (name == null ||
+        models.none((m) => m is NamedModel && m.name == name)) {
+      _logModelAdded(anyOfModel);
+      models.add(anyOfModel);
+    }
+
+    final resolvedModels = alternatives.map(
+      (anyOfSchema) => (
+        discriminatorValue: _getDiscriminatorValue(
+          discriminator: effectiveDiscriminator,
+          innerSchema: anyOfSchema,
+        ),
+        model: _resolveSchemaRef(null, anyOfSchema, modelContext),
+      ),
+    );
+
+    anyOfModel.models = resolvedModels.toSet();
+
     return anyOfModel;
   }
 

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -16,6 +16,7 @@ class ModelImporter {
   final Map<String, SchemaContentType> _contentMediaTypes;
   final Map<String, Schema> _defs = {};
   final Set<String> _resolving = {};
+  final Map<String, AliasModel> _placeholders = {};
 
   late Set<Model> models;
   final log = Logger('ModelImporter');
@@ -25,6 +26,7 @@ class ModelImporter {
 
   void import() {
     models = <Model>{};
+    _placeholders.clear();
     _collectAllDefs();
 
     final context = rootContext;
@@ -202,19 +204,18 @@ class ModelImporter {
         return existing;
       }
 
-      // No early-registered model found (e.g. bare $ref alias cycles in
-      // $defs). Create and register a placeholder so the other side of the
-      // cycle can resolve to it when it unwinds.
-      log.warning(
-        'Circular reference to $ref detected but no '
-        'early-registered model found. Registering AliasModel placeholder.',
+      // Create placeholder but do NOT add to models -- this prevents
+      // shadowing the real model that will be built when resolution unwinds.
+      log.fine(
+        'Circular reference to $ref detected. '
+        'Using placeholder until resolution completes.',
       );
       final placeholder = AliasModel(
         name: defName,
         model: AnyModel(context: _contextFromDefsPath(ref)),
         context: _contextFromDefsPath(ref),
       );
-      models.add(placeholder);
+      _placeholders[ref] = placeholder;
       return placeholder;
     }
 
@@ -223,6 +224,18 @@ class ModelImporter {
     try {
       final defsContext = _contextFromDefsPath(ref);
       refModel = _resolveSchemaRef(defName, defSchema, defsContext);
+
+      // If a placeholder was created during resolution, update it to
+      // point to the real model so back-edge references resolve correctly.
+      // Skip AliasModel results to avoid infinite loops in resolved getter.
+      final placeholder = _placeholders.remove(ref);
+      if (placeholder != null) {
+        if (refModel is! AliasModel) {
+          placeholder.model = refModel;
+        } else {
+          models.add(placeholder);
+        }
+      }
     } finally {
       _resolving.remove(ref);
     }
@@ -269,8 +282,9 @@ class ModelImporter {
   /// Tracks all named schema resolutions to detect circular references.
   /// When a cycle is detected the method first checks for an
   /// early-registered model (structural schemas register before resolving
-  /// members). If none is found it creates and registers an [AliasModel]
-  /// placeholder wrapping [AnyModel] so that resolution can unwind safely.
+  /// members). If none is found it creates an [AliasModel] placeholder
+  /// wrapping [AnyModel] (tracked in [_placeholders], NOT added to [models])
+  /// so that resolution can unwind safely without shadowing the real model.
   Model _resolveWithCycleCheck(String refName, Schema refSchema) {
     if (_resolving.contains(refName)) {
       // Look up a partially-constructed model that was registered early
@@ -282,25 +296,41 @@ class ModelImporter {
         return existing;
       }
 
-      // No early-registered model found (e.g. bare $ref alias cycles).
-      // Create and register a placeholder so the other side of the cycle
-      // can resolve to it when it unwinds.
-      log.warning(
-        'Circular reference to $refName detected but no '
-        'early-registered model found. Registering AliasModel placeholder.',
+      // Create placeholder but do NOT add to models -- this prevents
+      // shadowing the real model that will be built when resolution unwinds.
+      log.fine(
+        'Circular reference to $refName detected. '
+        'Using placeholder until resolution completes.',
       );
       final placeholder = AliasModel(
         name: refName,
         model: AnyModel(context: rootContext),
         context: rootContext,
       );
-      models.add(placeholder);
+      _placeholders[refName] = placeholder;
       return placeholder;
     }
 
     _resolving.add(refName);
     try {
-      return _resolveSchemaRef(refName, refSchema, rootContext);
+      final result = _resolveSchemaRef(refName, refSchema, rootContext);
+
+      // If a placeholder was created during resolution, update it to
+      // point to the real model so back-edge references resolve correctly.
+      // Skip AliasModel results to avoid infinite loops in resolved getter
+      // for bare $ref cycles (A->B->A).
+      final placeholder = _placeholders.remove(refName);
+      if (placeholder != null) {
+        if (result is! AliasModel) {
+          placeholder.model = result;
+        } else {
+          // Bare ref cycle -- add placeholder to models as the final model.
+          // AnyModel terminal is correct since there's no concrete type.
+          models.add(placeholder);
+        }
+      }
+
+      return result;
     } finally {
       _resolving.remove(refName);
     }

--- a/packages/tonik_parse/test/model/circular_reference_test.dart
+++ b/packages/tonik_parse/test/model/circular_reference_test.dart
@@ -1,0 +1,677 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+void main() {
+  group('circular reference cycle detection', () {
+    test('cycle through array and class: A -> array of B -> ref A', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'type': 'object',
+              'properties': {
+                'children': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/SchemaB'},
+                },
+              },
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'parent': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      ) as ClassModel;
+      expect(schemaA.name, 'SchemaA');
+
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      expect(schemaB.name, 'SchemaB');
+
+      // SchemaA.children is a list of SchemaB
+      final childrenProp =
+          schemaA.properties.firstWhere((p) => p.name == 'children');
+      expect(childrenProp.model, isA<ListModel>());
+      final listModel = childrenProp.model as ListModel;
+      expect(listModel.content, isA<ClassModel>());
+      expect((listModel.content as ClassModel).name, 'SchemaB');
+
+      // SchemaB.parent is SchemaA
+      final parentProp =
+          schemaB.properties.firstWhere((p) => p.name == 'parent');
+      expect(parentProp.model, isA<ClassModel>());
+      expect((parentProp.model as ClassModel).name, 'SchemaA');
+    });
+
+    test('cycle through allOf: A -> allOf [ref B], B -> property ref A', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'allOf': [
+                {r'$ref': '#/components/schemas/SchemaB'},
+                {
+                  'type': 'object',
+                  'properties': {
+                    'extra': {'type': 'string'},
+                  },
+                },
+              ],
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'back': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      );
+      expect(schemaA, isA<AllOfModel>());
+
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      expect(schemaB.name, 'SchemaB');
+
+      // SchemaB.back should reference SchemaA (the AllOfModel)
+      final backProp =
+          schemaB.properties.firstWhere((p) => p.name == 'back');
+      expect(backProp.model, isA<AllOfModel>());
+      expect((backProp.model as AllOfModel).name, 'SchemaA');
+    });
+
+    test('longer cycle: A -> B -> C -> A through properties', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'type': 'object',
+              'properties': {
+                'b': {r'$ref': '#/components/schemas/SchemaB'},
+              },
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'c': {r'$ref': '#/components/schemas/SchemaC'},
+              },
+            },
+            'SchemaC': {
+              'type': 'object',
+              'properties': {
+                'a': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      ) as ClassModel;
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      final schemaC = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaC',
+      ) as ClassModel;
+
+      expect(schemaA.name, 'SchemaA');
+      expect(schemaB.name, 'SchemaB');
+      expect(schemaC.name, 'SchemaC');
+
+      // A.b -> SchemaB
+      final bProp = schemaA.properties.firstWhere((p) => p.name == 'b');
+      expect(bProp.model, isA<ClassModel>());
+      expect((bProp.model as ClassModel).name, 'SchemaB');
+
+      // B.c -> SchemaC
+      final cProp = schemaB.properties.firstWhere((p) => p.name == 'c');
+      expect(cProp.model, isA<ClassModel>());
+      expect((cProp.model as ClassModel).name, 'SchemaC');
+
+      // C.a -> SchemaA
+      final aProp = schemaC.properties.firstWhere((p) => p.name == 'a');
+      expect(aProp.model, isA<ClassModel>());
+      expect((aProp.model as ClassModel).name, 'SchemaA');
+    });
+
+    test('cycle through array in longer chain: A -> array of B -> C -> ref A',
+        () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'type': 'object',
+              'properties': {
+                'items': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/SchemaB'},
+                },
+              },
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'next': {r'$ref': '#/components/schemas/SchemaC'},
+              },
+            },
+            'SchemaC': {
+              'type': 'object',
+              'properties': {
+                'root': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      ) as ClassModel;
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      final schemaC = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaC',
+      ) as ClassModel;
+
+      // A.items is array of B
+      final itemsProp =
+          schemaA.properties.firstWhere((p) => p.name == 'items');
+      expect(itemsProp.model, isA<ListModel>());
+      expect((itemsProp.model as ListModel).content, isA<ClassModel>());
+      expect(
+        ((itemsProp.model as ListModel).content as ClassModel).name,
+        'SchemaB',
+      );
+
+      // B.next is C
+      final nextProp = schemaB.properties.firstWhere((p) => p.name == 'next');
+      expect(nextProp.model, isA<ClassModel>());
+      expect((nextProp.model as ClassModel).name, 'SchemaC');
+
+      // C.root is A
+      final rootProp = schemaC.properties.firstWhere((p) => p.name == 'root');
+      expect(rootProp.model, isA<ClassModel>());
+      expect((rootProp.model as ClassModel).name, 'SchemaA');
+    });
+
+    test('cycle through oneOf: A has oneOf [ref B], B has property ref A', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'oneOf': [
+                {r'$ref': '#/components/schemas/SchemaB'},
+                {'type': 'string'},
+              ],
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'back': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      );
+      expect(schemaA, isA<OneOfModel>());
+
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      expect(schemaB.name, 'SchemaB');
+
+      // SchemaB.back should reference SchemaA
+      final backProp =
+          schemaB.properties.firstWhere((p) => p.name == 'back');
+      expect(backProp.model, isA<OneOfModel>());
+      expect((backProp.model as OneOfModel).name, 'SchemaA');
+    });
+
+    test('cycle through anyOf: A has anyOf [ref B], B has property ref A', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'anyOf': [
+                {r'$ref': '#/components/schemas/SchemaB'},
+                {'type': 'string'},
+              ],
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'back': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      );
+      expect(schemaA, isA<AnyOfModel>());
+
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+      expect(schemaB.name, 'SchemaB');
+
+      // SchemaB.back should reference SchemaA
+      final backProp =
+          schemaB.properties.firstWhere((p) => p.name == 'back');
+      expect(backProp.model, isA<AnyOfModel>());
+      expect((backProp.model as AnyOfModel).name, 'SchemaA');
+    });
+
+    test('self-referencing through array: A has property that is array of A',
+        () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'TreeNode': {
+              'type': 'object',
+              'properties': {
+                'value': {'type': 'string'},
+                'children': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/TreeNode'},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final treeNode = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'TreeNode',
+      ) as ClassModel;
+      expect(treeNode.name, 'TreeNode');
+
+      final valueProp =
+          treeNode.properties.firstWhere((p) => p.name == 'value');
+      expect(valueProp.model, isA<StringModel>());
+
+      final childrenProp =
+          treeNode.properties.firstWhere((p) => p.name == 'children');
+      expect(childrenProp.model, isA<ListModel>());
+      final listModel = childrenProp.model as ListModel;
+      expect(listModel.content, isA<ClassModel>());
+      expect((listModel.content as ClassModel).name, 'TreeNode');
+      // The content should be the same TreeNode object
+      expect(identical(listModel.content, treeNode), isTrue);
+    });
+
+    test('mutual reference through arrays: A has array of B, B has array of A',
+        () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SchemaA': {
+              'type': 'object',
+              'properties': {
+                'bList': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/SchemaB'},
+                },
+              },
+            },
+            'SchemaB': {
+              'type': 'object',
+              'properties': {
+                'aList': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/SchemaA'},
+                },
+              },
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      final schemaA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaA',
+      ) as ClassModel;
+      final schemaB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'SchemaB',
+      ) as ClassModel;
+
+      // A.bList is array of B
+      final bListProp =
+          schemaA.properties.firstWhere((p) => p.name == 'bList');
+      expect(bListProp.model, isA<ListModel>());
+      expect(
+        ((bListProp.model as ListModel).content as ClassModel).name,
+        'SchemaB',
+      );
+
+      // B.aList is array of A
+      final aListProp =
+          schemaB.properties.firstWhere((p) => p.name == 'aList');
+      expect(aListProp.model, isA<ListModel>());
+      expect(
+        ((aListProp.model as ListModel).content as ClassModel).name,
+        'SchemaA',
+      );
+    });
+
+    test(
+      'cycle through top-level array schemas: '
+      'A(array of B) and B(array of A)',
+      () {
+        const spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': <String, dynamic>{},
+          'components': {
+            'schemas': {
+              'SchemaA': {
+                'type': 'array',
+                'items': {r'$ref': '#/components/schemas/SchemaB'},
+              },
+              'SchemaB': {
+                'type': 'array',
+                'items': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        };
+
+        final api = Importer().import(spec);
+
+        // Both schemas should be parsed as ListModel (wrapped in AliasModel)
+        // without causing a stack overflow.
+        expect(api.models.length, greaterThanOrEqualTo(2));
+      },
+    );
+
+    test(
+      'deep cycle: class -> array(named) -> class -> array(named) -> first',
+      () {
+        // SchemaA: object with property refs ArrayB
+        // ArrayB: array of SchemaC
+        // SchemaC: object with property refs ArrayD
+        // ArrayD: array of SchemaA
+        const spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': <String, dynamic>{},
+          'components': {
+            'schemas': {
+              'SchemaA': {
+                'type': 'object',
+                'properties': {
+                  'list': {r'$ref': '#/components/schemas/ArrayB'},
+                },
+              },
+              'ArrayB': {
+                'type': 'array',
+                'items': {r'$ref': '#/components/schemas/SchemaC'},
+              },
+              'SchemaC': {
+                'type': 'object',
+                'properties': {
+                  'list': {r'$ref': '#/components/schemas/ArrayD'},
+                },
+              },
+              'ArrayD': {
+                'type': 'array',
+                'items': {r'$ref': '#/components/schemas/SchemaA'},
+              },
+            },
+          },
+        };
+
+        final api = Importer().import(spec);
+
+        final schemaA = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaA',
+        ) as ClassModel;
+        expect(schemaA.name, 'SchemaA');
+
+        final schemaC = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaC',
+        ) as ClassModel;
+        expect(schemaC.name, 'SchemaC');
+      },
+    );
+
+    test('existing direct self-reference still throws', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'SelfRef': {
+              r'$ref': '#/components/schemas/SelfRef',
+            },
+          },
+        },
+      };
+
+      expect(
+        () => Importer().import(spec),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test(
+      'cycle through chained allOfs: '
+      'A(allOf) -> B(allOf) -> C(class) -> ref A',
+      () {
+        const spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': <String, dynamic>{},
+          'components': {
+            'schemas': {
+              'SchemaA': {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/SchemaB'},
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'extraA': {'type': 'string'},
+                    },
+                  },
+                ],
+              },
+              'SchemaB': {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/SchemaC'},
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'extraB': {'type': 'string'},
+                    },
+                  },
+                ],
+              },
+              'SchemaC': {
+                'type': 'object',
+                'properties': {
+                  'back': {r'$ref': '#/components/schemas/SchemaA'},
+                },
+              },
+            },
+          },
+        };
+
+        final api = Importer().import(spec);
+
+        final schemaA = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaA',
+        );
+        expect(schemaA, isA<AllOfModel>());
+
+        final schemaB = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaB',
+        );
+        expect(schemaB, isA<AllOfModel>());
+
+        final schemaC = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaC',
+        ) as ClassModel;
+        expect(schemaC.name, 'SchemaC');
+
+        // SchemaC.back should reference SchemaA
+        final backProp =
+            schemaC.properties.firstWhere((p) => p.name == 'back');
+        expect(backProp.model, isA<AllOfModel>());
+        expect((backProp.model as AllOfModel).name, 'SchemaA');
+      },
+    );
+
+    test(
+      'cycle through allOf and array: '
+      'A(allOf) -> B(class with array of C) -> C(class) -> ref A',
+      () {
+        const spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': <String, dynamic>{},
+          'components': {
+            'schemas': {
+              'SchemaA': {
+                'allOf': [
+                  {r'$ref': '#/components/schemas/SchemaB'},
+                  {
+                    'type': 'object',
+                    'properties': {
+                      'extraA': {'type': 'string'},
+                    },
+                  },
+                ],
+              },
+              'SchemaB': {
+                'type': 'object',
+                'properties': {
+                  'items': {
+                    'type': 'array',
+                    'items': {r'$ref': '#/components/schemas/SchemaC'},
+                  },
+                },
+              },
+              'SchemaC': {
+                'type': 'object',
+                'properties': {
+                  'root': {r'$ref': '#/components/schemas/SchemaA'},
+                },
+              },
+            },
+          },
+        };
+
+        final api = Importer().import(spec);
+
+        final schemaA = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaA',
+        );
+        expect(schemaA, isA<AllOfModel>());
+
+        final schemaC = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaC',
+        ) as ClassModel;
+
+        // SchemaC.root should reference SchemaA
+        final rootProp =
+            schemaC.properties.firstWhere((p) => p.name == 'root');
+        expect(rootProp.model, isA<AllOfModel>());
+        expect((rootProp.model as AllOfModel).name, 'SchemaA');
+      },
+    );
+
+    test('bare ref cycle produces valid AliasModels', () {
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'AliasA': {
+              r'$ref': '#/components/schemas/AliasB',
+            },
+            'AliasB': {
+              r'$ref': '#/components/schemas/AliasA',
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+
+      // Both schemas should be present as AliasModel instances.
+      final aliasA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'AliasA',
+      );
+      final aliasB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'AliasB',
+      );
+
+      expect(aliasA, isA<AliasModel>());
+      expect(aliasB, isA<AliasModel>());
+    });
+  });
+}

--- a/packages/tonik_parse/test/model/circular_reference_test.dart
+++ b/packages/tonik_parse/test/model/circular_reference_test.dart
@@ -440,9 +440,26 @@ void main() {
 
         final api = Importer().import(spec);
 
-        // Both schemas should be parsed as ListModel (wrapped in AliasModel)
-        // without causing a stack overflow.
-        expect(api.models.length, greaterThanOrEqualTo(2));
+        // Both schemas should be present and parsed as ListModel without
+        // causing a stack overflow.
+        final schemaA = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaA',
+        );
+        final schemaB = api.models.firstWhere(
+          (m) => m is NamedModel && m.name == 'SchemaB',
+        );
+
+        // Top-level array schemas become ListModel instances.
+        expect(schemaA, isA<ListModel>());
+        expect(schemaB, isA<ListModel>());
+
+        // Each list's content should reference the other list model.
+        final listA = schemaA as ListModel;
+        final listB = schemaB as ListModel;
+        expect(listA.content, isA<ListModel>());
+        expect(listB.content, isA<ListModel>());
+        expect((listA.content as ListModel).name, 'SchemaB');
+        expect((listB.content as ListModel).name, 'SchemaA');
       },
     );
 
@@ -672,6 +689,20 @@ void main() {
 
       expect(aliasA, isA<AliasModel>());
       expect(aliasB, isA<AliasModel>());
+
+      // For bare ref cycles, one alias wraps the other and the chain
+      // terminates at AnyModel (since bare ref cycles have no concrete type).
+      final aliasAModel = aliasA as AliasModel;
+      final aliasBModel = aliasB as AliasModel;
+
+      // AliasB wraps AliasA.
+      expect(aliasBModel.model, isA<AliasModel>());
+      expect((aliasBModel.model as AliasModel).name, 'AliasA');
+
+      // AliasA wraps a placeholder whose inner model is AnyModel,
+      // confirming the cycle terminates rather than looping infinitely.
+      expect(aliasAModel.model, isA<AliasModel>());
+      expect((aliasAModel.model as AliasModel).model, isA<AnyModel>());
     });
   });
 }

--- a/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
+++ b/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
@@ -1145,7 +1145,7 @@ void main() {
       );
     });
 
-    test('indirect circular reference (A -> B -> C -> A) throws', () {
+    test('indirect circular reference (A -> B -> C -> A) produces models', () {
       const fileContent = {
         'openapi': '3.1.0',
         'info': {'title': 'Test API', 'version': '1.0.0'},
@@ -1159,13 +1159,24 @@ void main() {
         },
       };
 
-      expect(
-        () => Importer().import(fileContent),
-        throwsArgumentError,
+      final api = Importer().import(fileContent);
+
+      final modelA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'A',
       );
+      final modelB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'B',
+      );
+      final modelC = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'C',
+      );
+
+      expect(modelA, isA<AliasModel>());
+      expect(modelB, isA<AliasModel>());
+      expect(modelC, isA<AliasModel>());
     });
 
-    test('indirect circular reference (A -> B -> A) throws', () {
+    test('indirect circular reference (A -> B -> A) produces models', () {
       const fileContent = {
         'openapi': '3.1.0',
         'info': {'title': 'Test API', 'version': '1.0.0'},
@@ -1178,10 +1189,17 @@ void main() {
         },
       };
 
-      expect(
-        () => Importer().import(fileContent),
-        throwsArgumentError,
+      final api = Importer().import(fileContent);
+
+      final modelA = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'A',
       );
+      final modelB = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'B',
+      );
+
+      expect(modelA, isA<AliasModel>());
+      expect(modelB, isA<AliasModel>());
     });
   });
 }

--- a/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
+++ b/packages/tonik_parse/test/model/ref_siblings_resolution_test.dart
@@ -1174,6 +1174,18 @@ void main() {
       expect(modelA, isA<AliasModel>());
       expect(modelB, isA<AliasModel>());
       expect(modelC, isA<AliasModel>());
+
+      // Verify the alias chain is wired (not all AnyModel terminals).
+      // At least one alias should wrap another alias (not AnyModel).
+      final aliasModels = [modelA, modelB, modelC].cast<AliasModel>();
+      final wrapsAlias =
+          aliasModels.where((a) => a.model is AliasModel).toList();
+      expect(
+        wrapsAlias,
+        isNotEmpty,
+        reason: 'At least one alias should wrap another alias, '
+            'not all terminate at AnyModel',
+      );
     });
 
     test('indirect circular reference (A -> B -> A) produces models', () {
@@ -1200,6 +1212,17 @@ void main() {
 
       expect(modelA, isA<AliasModel>());
       expect(modelB, isA<AliasModel>());
+
+      // One alias wraps the other, and the chain terminates at AnyModel
+      // (bare ref cycles have no concrete type).
+      final aliasA = modelA as AliasModel;
+      final aliasB = modelB as AliasModel;
+      expect(aliasB.model, isA<AliasModel>());
+      expect((aliasB.model as AliasModel).name, 'A');
+
+      // A wraps a placeholder whose inner model is AnyModel.
+      expect(aliasA.model, isA<AliasModel>());
+      expect((aliasA.model as AliasModel).model, isA<AnyModel>());
     });
   });
 }


### PR DESCRIPTION
## Summary

- Fixes stack overflow when parsing OpenAPI specs with circular schema references (e.g. Cloudflare's 9.2MB spec with 1780 paths)
- Generalizes cycle detection in the model importer to track all named schemas, not just bare `$ref` aliases
- Adds early registration for `allOf`, `oneOf`, and `anyOf` models (matching the existing `_parseClassModel` pattern)
- Mutual bare `$ref` aliases (A→B→A) are now supported instead of throwing `ArgumentError`

## Test plan

- [x] 13 new circular reference tests covering: array cycles, allOf cycles, oneOf cycles, anyOf cycles, longer chains (A→B→C→A), bare ref cycles, self-referencing arrays, mutual arrays, chained allOfs, mixed allOf+array
- [x] Existing ref_siblings_resolution tests updated (indirect circular refs now produce models instead of throwing)
- [x] All 3,836 unit tests pass
- [x] All integration tests pass
- [x] `fvm dart analyze` clean