### PR TITLE
fix: generate runtime throw for ClassModel in list simple encoding

### DIFF
--- a/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
@@ -314,8 +314,8 @@ Expression _buildListFromSimpleExpression(
       isRequired,
       contextParam: contextParam,
     ),
-    ClassModel() => throw UnimplementedError(
-      'ClassModel is not supported in lists for simple encoding',
+    ClassModel() => generateSimpleDecodingExceptionExpression(
+      'Lists of objects are not supported in simple encoding.',
     ),
     EnumModel() ||
     OneOfModel() ||

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -714,6 +714,66 @@ void main() {
       });
     });
 
+    group('List<ClassModel>', () {
+      test(
+        'generates SimpleDecodingException throw for required '
+        'List<ClassModel>',
+        () {
+          final value = refer('value');
+          final classModel = ClassModel(
+            isDeprecated: false,
+            context: context,
+            name: 'User',
+            properties: const [],
+          );
+          final listModel = ListModel(
+            content: classModel,
+            context: context,
+          );
+          expect(
+            buildSimpleValueExpression(
+              value,
+              model: listModel,
+              isRequired: true,
+              nameManager: nameManager,
+              package: 'package:my_package/my_package.dart',
+              explode: literalBool(false),
+            ).accept(scopedEmitter).toString(),
+            """throw  _i1.SimpleDecodingException('Lists of objects are not supported in simple encoding.')""",
+          );
+        },
+      );
+
+      test(
+        'generates SimpleDecodingException throw for nullable '
+        'List<ClassModel>',
+        () {
+          final value = refer('value');
+          final classModel = ClassModel(
+            isDeprecated: false,
+            context: context,
+            name: 'User',
+            properties: const [],
+          );
+          final listModel = ListModel(
+            content: classModel,
+            context: context,
+          );
+          expect(
+            buildSimpleValueExpression(
+              value,
+              model: listModel,
+              isRequired: false,
+              nameManager: nameManager,
+              package: 'package:my_package/my_package.dart',
+              explode: literalBool(false),
+            ).accept(scopedEmitter).toString(),
+            """throw  _i1.SimpleDecodingException('Lists of objects are not supported in simple encoding.')""",
+          );
+        },
+      );
+    });
+
     group('NeverModel', () {
       test('generates throw for required NeverModel', () {
         final value = refer('value');


### PR DESCRIPTION
## Summary

- Instead of crashing the code generator with `UnimplementedError` when encountering `List<ClassModel>` in simple encoding, generate code that throws `SimpleDecodingException` at runtime
- Follows the established pattern used for `MapModel` (line 171) and `NeverModel` — unsupported combinations produce generated code that throws at runtime rather than blocking the entire spec generation
- Per RFC 6570, simple-style serialization does not support arrays of objects, so a runtime throw is the correct behavior

## Test plan

- [x] Unit tests for required and nullable `List<ClassModel>` verify the generated throw expression
- [x] All 3848 unit tests pass
- [x] All 33 integration test suites pass (including Cloudflare)
- [x] `fvm dart analyze` clean
- [x] 100% patch coverage