### PR TITLE
fix: escape reserved enum member names and spell out numeric property names

### DIFF
--- a/packages/tonik_generate/lib/src/naming/name_utils.dart
+++ b/packages/tonik_generate/lib/src/naming/name_utils.dart
@@ -113,6 +113,13 @@ const generatedClassTokens = {
 
 const Set<String> allKeywords = {...dartKeywords, ...generatedClassTokens};
 
+/// Names that conflict with members inherited by all Dart enums.
+/// These are only reserved for enum values, not class properties.
+const reservedEnumMemberNames = {
+  'index', // Enum.index — ordinal position
+  'values', // Enum.values — static list of all values
+};
+
 /// Converts a number to its English word representation.
 /// Supports numbers up to trillions.
 String _numberToWords(int number) {
@@ -357,9 +364,11 @@ String normalizeSingle(String name, {bool preserveNumbers = false}) {
   var processedName = name.replaceAll(RegExp('^_+'), '');
   if (processedName.isEmpty) return '';
 
-  // If preserving numbers and it's just a number, return as-is
-  if (preserveNumbers && RegExp(r'^\d+$').hasMatch(processedName)) {
-    return processedName;
+  // If it's just a number, spell it out (e.g. "600" -> "sixHundred")
+  if (RegExp(r'^\d+$').hasMatch(processedName)) {
+    final number = int.parse(processedName);
+    final words = _numberToWords(number);
+    return _normalizeText(words).toCamelCase();
   }
 
   processedName = _normalizeText(
@@ -420,6 +429,10 @@ String normalizeEnumValueName(String value) {
 
   // Safety net: if the result still starts with a digit, prefix with $
   if (RegExp(r'^\d').hasMatch(result)) {
+    return '\$$result';
+  }
+
+  if (reservedEnumMemberNames.contains(result)) {
     return '\$$result';
   }
 

--- a/packages/tonik_generate/test/src/naming/name_utils_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_utils_test.dart
@@ -195,6 +195,53 @@ void main() {
         expect(normalizeEnumValueName('123_456'), r'$123456');
       });
     });
+
+    group('reserved enum member names', () {
+      test('escapes index which conflicts with Enum.index', () {
+        expect(normalizeEnumValueName('index'), r'$index');
+        expect(normalizeEnumValueName('INDEX'), r'$index');
+        expect(normalizeEnumValueName('Index'), r'$index');
+      });
+
+      test('escapes values which conflicts with Enum.values', () {
+        expect(normalizeEnumValueName('values'), r'$values');
+        expect(normalizeEnumValueName('VALUES'), r'$values');
+      });
+
+      test('does not escape words that contain reserved names', () {
+        expect(normalizeEnumValueName('reindex'), 'reindex');
+        expect(normalizeEnumValueName('indexing'), 'indexing');
+        expect(normalizeEnumValueName('INDEX_TYPE'), 'indexType');
+      });
+    });
+  });
+
+  group('normalizeSingle with purely numeric names', () {
+    test('spells out pure numbers when preserveNumbers is true', () {
+      expect(normalizeSingle('1', preserveNumbers: true), 'one');
+      expect(normalizeSingle('42', preserveNumbers: true), 'fortyTwo');
+      expect(normalizeSingle('100', preserveNumbers: true), 'oneHundred');
+      expect(normalizeSingle('600', preserveNumbers: true), 'sixHundred');
+      expect(normalizeSingle('1000', preserveNumbers: true), 'oneThousand');
+    });
+
+    test('spells out pure numbers when preserveNumbers is false', () {
+      expect(normalizeSingle('1'), 'one');
+      expect(normalizeSingle('600'), 'sixHundred');
+      expect(normalizeSingle('1000'), 'oneThousand');
+    });
+  });
+
+  group('normalizeSingle does not escape enum-specific reserved names', () {
+    test('allows index as a class property name', () {
+      expect(normalizeSingle('index'), 'index');
+      expect(normalizeSingle('INDEX'), 'index');
+    });
+
+    test('allows values as a class property name', () {
+      expect(normalizeSingle('values'), 'values');
+      expect(normalizeSingle('VALUES'), 'values');
+    });
   });
 
   group('normalizeSingle with special character property names', () {

--- a/packages/tonik_generate/test/src/naming/property_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/property_name_normalizer_test.dart
@@ -266,6 +266,52 @@ void main() {
     });
   });
 
+  group('purely numeric property names', () {
+    test('spells out single-digit numeric property names', () {
+      final result = normalizeProperties([
+        createProperty('1'),
+        createProperty('2'),
+        createProperty('3'),
+      ]);
+
+      expect(result.map((r) => r.normalizedName).toList(), [
+        'one',
+        'two',
+        'three',
+      ]);
+    });
+
+    test('spells out multi-digit numeric property names', () {
+      final result = normalizeProperties([
+        createProperty('600'),
+        createProperty('700'),
+        createProperty('800'),
+        createProperty('900'),
+        createProperty('1000'),
+      ]);
+
+      expect(result.map((r) => r.normalizedName).toList(), [
+        'sixHundred',
+        'sevenHundred',
+        'eightHundred',
+        'nineHundred',
+        'oneThousand',
+      ]);
+    });
+
+    test('makes duplicate spelled-out numeric names unique', () {
+      final result = normalizeProperties([
+        createProperty('1'),
+        createProperty('one'),
+      ]);
+
+      expect(result.map((r) => r.normalizedName).toList(), [
+        'one',
+        'one2',
+      ]);
+    });
+  });
+
   group('special character property names', () {
     test('replaces special characters with word equivalents', () {
       final result = normalizeProperties([


### PR DESCRIPTION
## Summary
- Enum values that normalize to `index` or `values` now get a `$` prefix to avoid conflicts with Dart's built-in `Enum.index` and `Enum.values` (fixes 7 compile errors in the Cloudflare spec)
- `normalizeSingle` now spells out purely numeric property names (e.g. `600` → `sixHundred`) regardless of the `preserveNumbers` flag, matching the existing enum value behavior

## Test plan
- [x] New tests for `index`, `INDEX`, `Index` → `$index`
- [x] New tests for `values`, `VALUES` → `$values`
- [x] Compound words like `reindex`, `indexing`, `INDEX_TYPE` pass through unescaped
- [x] `normalizeSingle('index')` remains `index` (valid for class properties)
- [x] Numeric property name tests for spelled-out conversion
- [x] All 37 name_utils tests pass