### PR TITLE
fix: resolve alias-to-primitive types in OneOf code generation

### DIFF
--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -28,6 +28,12 @@ sealed class Model {
   final Context context;
   EncodingShape get encodingShape;
 
+  /// The terminal model after resolving through any [AliasModel] chains.
+  ///
+  /// For non-alias models this returns `this`. For [AliasModel] it walks
+  /// the chain until a non-alias model is reached.
+  Model get resolved => this;
+
   /// Whether this model produces a nullable Dart type, including through
   /// typedef/alias chains.
   bool get isEffectivelyNullable => switch (this) {
@@ -170,6 +176,7 @@ class AliasModel extends Model with NamedModel {
   bool isReadOnly;
   bool isWriteOnly;
 
+  @override
   Model get resolved => switch (model) {
     final AliasModel alias => alias.resolved,
     _ => model,

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1116,9 +1116,7 @@ class AllOfGenerator {
     final ap = model.additionalProperties;
     if (ap is UnrestrictedAdditionalProperties) return true;
     if (ap is TypedAdditionalProperties) {
-      final resolved = ap.valueModel is AliasModel
-          ? (ap.valueModel as AliasModel).resolved
-          : ap.valueModel;
+      final resolved = ap.valueModel.resolved;
       return resolved is StringModel;
     }
     return false;

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -92,7 +92,7 @@ class AnyOfGenerator {
       properties: normalized.map(
         (n) {
           final model = n.property.model;
-          final resolvedModel = model is AliasModel ? model.resolved : model;
+          final resolvedModel = model.resolved;
           return (
             normalizedName: n.normalizedName,
             typeRef: typeReference(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -282,9 +282,7 @@ class ClassGenerator {
     final copyWithProps = properties.map(
       (prop) {
         final propModel = prop.property.model;
-        final resolvedModel = propModel is AliasModel
-            ? propModel.resolved
-            : propModel;
+        final resolvedModel = propModel.resolved;
         return (
           normalizedName: prop.normalizedName,
           typeRef: _getSchemaAwareTypeReference(prop.property, model),
@@ -1104,7 +1102,7 @@ for (final _\$e in $apFieldName.entries) {
           prop.property.isNullable || prop.property.model.isEffectivelyNullable;
       final isFieldNullable = isNullable || prop.property.isWriteOnly;
       final model = prop.property.model;
-      final resolvedModel = model is AliasModel ? model.resolved : model;
+      final resolvedModel = model.resolved;
 
       if (resolvedModel is NeverModel) {
         propertyAssignments.addAll([
@@ -1369,7 +1367,7 @@ if ($name != null) {
           prop.property.isNullable || prop.property.model.isEffectivelyNullable;
       final isFieldNullable = isNullable || prop.property.isWriteOnly;
       final model = prop.property.model;
-      final resolvedModel = model is AliasModel ? model.resolved : model;
+      final resolvedModel = model.resolved;
 
       if (resolvedModel is AnyModel) {
         propertyAssignments.add(
@@ -1870,9 +1868,7 @@ if ($name != null) {
     final ap = model.additionalProperties;
     if (ap is UnrestrictedAdditionalProperties) return true;
     if (ap is TypedAdditionalProperties) {
-      final resolved = ap.valueModel is AliasModel
-          ? (ap.valueModel as AliasModel).resolved
-          : ap.valueModel;
+      final resolved = ap.valueModel.resolved;
       return resolved is StringModel ||
           resolved is IntegerModel ||
           resolved is NumberModel ||

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -215,8 +215,8 @@ class OneOfGenerator {
       );
 
       final hasCollectionValue = !useImmutableCollections &&
-          (_resolveForClassification(discriminatedModel.model) is ListModel ||
-              _resolveForClassification(discriminatedModel.model) is MapModel);
+          (discriminatedModel.model.resolved is ListModel ||
+              discriminatedModel.model.resolved is MapModel);
 
       classes.add(
         Class(
@@ -351,9 +351,9 @@ class OneOfGenerator {
               .where(
                 (m) =>
                     m.discriminatorValue != null &&
-                    _resolveForClassification(m.model) is! PrimitiveModel &&
-                    _resolveForClassification(m.model) is! ListModel &&
-                    _resolveForClassification(m.model) is! MapModel &&
+                    m.model.resolved is! PrimitiveModel &&
+                    m.model.resolved is! ListModel &&
+                    m.model.resolved is! MapModel &&
                     model is! EnumModel,
               )) {
         final variantName = variantNames[m]!;
@@ -388,10 +388,10 @@ class OneOfGenerator {
     }
 
     final hasPrimitives = model.models.any(
-      (m) => _resolveForClassification(m.model) is PrimitiveModel,
+      (m) => m.model.resolved is PrimitiveModel,
     );
     final hasOnlyPrimitives = !model.models.any(
-      (m) => _resolveForClassification(m.model) is! PrimitiveModel,
+      (m) => m.model.resolved is! PrimitiveModel,
     );
 
     if (hasPrimitives && hasOnlyPrimitives) {
@@ -402,13 +402,13 @@ class OneOfGenerator {
               .sortDiscriminatedModels(model.models)
               .where(
                 (m) =>
-                    _resolveForClassification(m.model) is PrimitiveModel,
+                    m.model.resolved is PrimitiveModel,
               )) {
         final variantName = variantNames[m]!;
 
         cases.addAll([
           typeReference(
-            _resolveForClassification(m.model),
+            m.model.resolved,
             nameManager,
             package,
             useImmutableCollections: useImmutableCollections,
@@ -438,10 +438,10 @@ class OneOfGenerator {
             .sortDiscriminatedModels(model.models)
             .where(
               (m) =>
-                  _resolveForClassification(m.model) is PrimitiveModel,
+                  m.model.resolved is PrimitiveModel,
             )) {
       final typeRef = typeReference(
-        _resolveForClassification(m.model),
+        m.model.resolved,
         nameManager,
         package,
       );
@@ -462,10 +462,10 @@ class OneOfGenerator {
             .sortDiscriminatedModels(model.models)
             .where(
               (m) =>
-                  _resolveForClassification(m.model) is! PrimitiveModel,
+                  m.model.resolved is! PrimitiveModel,
             )) {
       final modelType = m.model;
-      final resolvedType = _resolveForClassification(modelType);
+      final resolvedType = modelType.resolved;
       final modelName = nameManager.modelName(modelType);
       final variantName = variantNames[m]!;
 
@@ -529,9 +529,9 @@ class OneOfGenerator {
       final hasDiscriminatedComplexTypes = model.models.any(
         (m) =>
             m.discriminatorValue != null &&
-            _resolveForClassification(m.model) is! PrimitiveModel &&
-            _resolveForClassification(m.model) is! ListModel &&
-            _resolveForClassification(m.model) is! MapModel,
+            m.model.resolved is! PrimitiveModel &&
+            m.model.resolved is! ListModel &&
+            m.model.resolved is! MapModel,
       );
 
       if (hasDiscriminatedComplexTypes) {
@@ -564,9 +564,9 @@ class OneOfGenerator {
                 .where(
                   (m) =>
                       m.discriminatorValue != null &&
-                      _resolveForClassification(m.model) is! PrimitiveModel &&
-                      _resolveForClassification(m.model) is! ListModel &&
-                      _resolveForClassification(m.model) is! MapModel,
+                      m.model.resolved is! PrimitiveModel &&
+                      m.model.resolved is! ListModel &&
+                      m.model.resolved is! MapModel,
                 )) {
           final variantName = variantNames[m]!;
           final modelType = m.model;
@@ -606,7 +606,7 @@ class OneOfGenerator {
 
       final tryBody = <Code>[];
 
-      final resolvedType = _resolveForClassification(modelType);
+      final resolvedType = modelType.resolved;
 
       if (resolvedType is PrimitiveModel) {
         final decodeExpr = isForm
@@ -747,8 +747,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          _resolveForClassification(m.model) is! ListModel &&
-          _resolveForClassification(m.model) is! MapModel) {
+          m.model.resolved is! ListModel &&
+          m.model.resolved is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -821,8 +821,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (_resolveForClassification(m.model) is ListModel &&
-          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
+      } else if (m.model.resolved is ListModel &&
+          (m.model.resolved as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -833,13 +833,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildSimpleParameterExpression(
             refer('value'),
-            _resolveForClassification(m.model) as ListModel,
+            m.model.resolved as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is ListModel) {
+      } else if (m.model.resolved is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -855,7 +855,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is BinaryModel) {
+      } else if (m.model.resolved is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -865,7 +865,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is MapModel) {
+      } else if (m.model.resolved is MapModel) {
         // Map types cannot be simple-encoded
         caseCodes.addAll([
           Code.scope(
@@ -934,8 +934,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          _resolveForClassification(m.model) is! ListModel &&
-          _resolveForClassification(m.model) is! MapModel) {
+          m.model.resolved is! ListModel &&
+          m.model.resolved is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -1010,8 +1010,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (_resolveForClassification(m.model) is ListModel &&
-          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
+      } else if (m.model.resolved is ListModel &&
+          (m.model.resolved as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1022,13 +1022,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildFormParameterExpression(
             refer('value'),
-            _resolveForClassification(m.model) as ListModel,
+            m.model.resolved as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is ListModel) {
+      } else if (m.model.resolved is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -1044,7 +1044,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is BinaryModel) {
+      } else if (m.model.resolved is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -1054,7 +1054,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is MapModel) {
+      } else if (m.model.resolved is MapModel) {
         // Map types cannot be form-encoded
         caseCodes.addAll([
           Code.scope(
@@ -1125,8 +1125,8 @@ class OneOfGenerator {
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
       final isSimple = m.model.encodingShape == EncodingShape.simple;
-      final isList = _resolveForClassification(m.model) is ListModel;
-      final isMap = _resolveForClassification(m.model) is MapModel;
+      final isList = m.model.resolved is ListModel;
+      final isMap = m.model.resolved is MapModel;
 
       if (isSimple) {
         caseCodes.addAll([
@@ -1194,7 +1194,7 @@ class OneOfGenerator {
     Map<DiscriminatedModel, String> variantNames,
   ) {
     final hasOnlyPrimitives = !model.models.any(
-      (m) => _resolveForClassification(m.model) is! PrimitiveModel,
+      (m) => m.model.resolved is! PrimitiveModel,
     );
 
     if (hasOnlyPrimitives) {
@@ -1290,7 +1290,7 @@ class OneOfGenerator {
           ]);
         }
       } else {
-        if (_resolveForClassification(m.model) is ListModel) {
+        if (m.model.resolved is ListModel) {
           caseCodes
             ..add(Code('$variantName() => '))
             ..add(
@@ -1298,7 +1298,7 @@ class OneOfGenerator {
                 'Lists are not supported in parameterProperties',
               ).code,
             );
-        } else if (_resolveForClassification(m.model) is MapModel) {
+        } else if (m.model.resolved is MapModel) {
           caseCodes
             ..add(Code('$variantName() => '))
             ..add(
@@ -1382,8 +1382,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          _resolveForClassification(m.model) is! ListModel &&
-          _resolveForClassification(m.model) is! MapModel) {
+          m.model.resolved is! ListModel &&
+          m.model.resolved is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -1455,8 +1455,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (_resolveForClassification(m.model) is ListModel &&
-          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
+      } else if (m.model.resolved is ListModel &&
+          (m.model.resolved as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1467,13 +1467,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildLabelParameterExpression(
             refer('value'),
-            _resolveForClassification(m.model) as ListModel,
+            m.model.resolved as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is ListModel) {
+      } else if (m.model.resolved is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -1489,7 +1489,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is BinaryModel) {
+      } else if (m.model.resolved is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -1499,7 +1499,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (_resolveForClassification(m.model) is MapModel) {
+      } else if (m.model.resolved is MapModel) {
         // Map types cannot be label-encoded
         caseCodes.addAll([
           Code.scope(
@@ -1697,12 +1697,3 @@ class OneOfGenerator {
   }
 }
 
-/// Resolves through [AliasModel] chains for type classification.
-///
-/// Needed because `AliasModel(model: StringModel())` must be treated
-/// as a primitive in code generation dispatch, but
-/// `AliasModel is PrimitiveModel` is false.
-Model _resolveForClassification(Model model) => switch (model) {
-  AliasModel(:final resolved) => resolved,
-  _ => model,
-};

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -215,8 +215,8 @@ class OneOfGenerator {
       );
 
       final hasCollectionValue = !useImmutableCollections &&
-          (discriminatedModel.model is ListModel ||
-              discriminatedModel.model is MapModel);
+          (_resolveForClassification(discriminatedModel.model) is ListModel ||
+              _resolveForClassification(discriminatedModel.model) is MapModel);
 
       classes.add(
         Class(
@@ -351,9 +351,9 @@ class OneOfGenerator {
               .where(
                 (m) =>
                     m.discriminatorValue != null &&
-                    m.model is! PrimitiveModel &&
-                    m.model is! ListModel &&
-                    m.model is! MapModel &&
+                    _resolveForClassification(m.model) is! PrimitiveModel &&
+                    _resolveForClassification(m.model) is! ListModel &&
+                    _resolveForClassification(m.model) is! MapModel &&
                     model is! EnumModel,
               )) {
         final variantName = variantNames[m]!;
@@ -387,9 +387,11 @@ class OneOfGenerator {
       ]);
     }
 
-    final hasPrimitives = model.models.any((m) => m.model is PrimitiveModel);
+    final hasPrimitives = model.models.any(
+      (m) => _resolveForClassification(m.model) is PrimitiveModel,
+    );
     final hasOnlyPrimitives = !model.models.any(
-      (m) => m.model is! PrimitiveModel,
+      (m) => _resolveForClassification(m.model) is! PrimitiveModel,
     );
 
     if (hasPrimitives && hasOnlyPrimitives) {
@@ -399,13 +401,14 @@ class OneOfGenerator {
           in stableModelSorter
               .sortDiscriminatedModels(model.models)
               .where(
-                (m) => m.model is PrimitiveModel,
+                (m) =>
+                    _resolveForClassification(m.model) is PrimitiveModel,
               )) {
         final variantName = variantNames[m]!;
 
         cases.addAll([
           typeReference(
-            m.model,
+            _resolveForClassification(m.model),
             nameManager,
             package,
             useImmutableCollections: useImmutableCollections,
@@ -434,9 +437,14 @@ class OneOfGenerator {
         in stableModelSorter
             .sortDiscriminatedModels(model.models)
             .where(
-              (m) => m.model is PrimitiveModel,
+              (m) =>
+                  _resolveForClassification(m.model) is PrimitiveModel,
             )) {
-      final typeRef = typeReference(m.model, nameManager, package);
+      final typeRef = typeReference(
+        _resolveForClassification(m.model),
+        nameManager,
+        package,
+      );
       final variantName = variantNames[m]!;
 
       blocks.addAll([
@@ -453,13 +461,15 @@ class OneOfGenerator {
         in stableModelSorter
             .sortDiscriminatedModels(model.models)
             .where(
-              (m) => m.model is! PrimitiveModel,
+              (m) =>
+                  _resolveForClassification(m.model) is! PrimitiveModel,
             )) {
       final modelType = m.model;
+      final resolvedType = _resolveForClassification(modelType);
       final modelName = nameManager.modelName(modelType);
       final variantName = variantNames[m]!;
 
-      if (modelType is ListModel || modelType is MapModel) {
+      if (resolvedType is ListModel || resolvedType is MapModel) {
         final decodeExpr = buildFromJsonValueExpression(
           'json',
           model: modelType,
@@ -519,9 +529,9 @@ class OneOfGenerator {
       final hasDiscriminatedComplexTypes = model.models.any(
         (m) =>
             m.discriminatorValue != null &&
-            m.model is! PrimitiveModel &&
-            m.model is! ListModel &&
-            m.model is! MapModel,
+            _resolveForClassification(m.model) is! PrimitiveModel &&
+            _resolveForClassification(m.model) is! ListModel &&
+            _resolveForClassification(m.model) is! MapModel,
       );
 
       if (hasDiscriminatedComplexTypes) {
@@ -554,9 +564,9 @@ class OneOfGenerator {
                 .where(
                   (m) =>
                       m.discriminatorValue != null &&
-                      m.model is! PrimitiveModel &&
-                      m.model is! ListModel &&
-                      m.model is! MapModel,
+                      _resolveForClassification(m.model) is! PrimitiveModel &&
+                      _resolveForClassification(m.model) is! ListModel &&
+                      _resolveForClassification(m.model) is! MapModel,
                 )) {
           final variantName = variantNames[m]!;
           final modelType = m.model;
@@ -596,11 +606,13 @@ class OneOfGenerator {
 
       final tryBody = <Code>[];
 
-      if (modelType is PrimitiveModel) {
+      final resolvedType = _resolveForClassification(modelType);
+
+      if (resolvedType is PrimitiveModel) {
         final decodeExpr = isForm
             ? buildFromFormValueExpression(
                 refer('value'),
-                model: modelType,
+                model: resolvedType,
                 isRequired: true,
                 nameManager: nameManager,
                 package: package,
@@ -610,7 +622,7 @@ class OneOfGenerator {
               )
             : buildSimpleValueExpression(
                 refer('value'),
-                model: modelType,
+                model: resolvedType,
                 isRequired: true,
                 nameManager: nameManager,
                 package: package,
@@ -618,11 +630,11 @@ class OneOfGenerator {
                 explode: refer('explode'),
               );
         tryBody.add(refer(variantName).call([decodeExpr]).returned.statement);
-      } else if (modelType is ListModel && modelType.hasSimpleContent) {
+      } else if (resolvedType is ListModel && resolvedType.hasSimpleContent) {
         final decodeExpr = isForm
             ? buildFromFormValueExpression(
                 refer('value'),
-                model: modelType,
+                model: resolvedType,
                 isRequired: true,
                 nameManager: nameManager,
                 package: package,
@@ -632,7 +644,7 @@ class OneOfGenerator {
               )
             : buildSimpleValueExpression(
                 refer('value'),
-                model: modelType,
+                model: resolvedType,
                 isRequired: true,
                 nameManager: nameManager,
                 package: package,
@@ -642,10 +654,10 @@ class OneOfGenerator {
         tryBody.add(
           refer(variantName).call([decodeExpr]).returned.statement,
         );
-      } else if (modelType is ListModel) {
+      } else if (resolvedType is ListModel) {
         // Add throw directly to bodyBlocks (not tryBody) so it is NOT
         // wrapped in the try/catch that swallows DecodingException.
-        final message = modelType.hasSimpleContent
+        final message = resolvedType.hasSimpleContent
             ? 'List decoding from $encodingStyleName encoding '
                 'is not supported in $className'
             : 'List types with complex content cannot be decoded '
@@ -657,7 +669,7 @@ class OneOfGenerator {
           ).statement,
         );
         continue;
-      } else if (modelType is MapModel) {
+      } else if (resolvedType is MapModel) {
         bodyBlocks.add(
           generateSimpleDecodingExceptionExpression(
             'Map types cannot be decoded from '
@@ -735,8 +747,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model is! ListModel &&
-          m.model is! MapModel) {
+          _resolveForClassification(m.model) is! ListModel &&
+          _resolveForClassification(m.model) is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -809,8 +821,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model is ListModel &&
-          (m.model as ListModel).hasSimpleContent) {
+      } else if (_resolveForClassification(m.model) is ListModel &&
+          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -821,13 +833,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildSimpleParameterExpression(
             refer('value'),
-            m.model as ListModel,
+            _resolveForClassification(m.model) as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is ListModel) {
+      } else if (_resolveForClassification(m.model) is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -843,7 +855,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (m.model is BinaryModel) {
+      } else if (_resolveForClassification(m.model) is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -853,7 +865,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is MapModel) {
+      } else if (_resolveForClassification(m.model) is MapModel) {
         // Map types cannot be simple-encoded
         caseCodes.addAll([
           Code.scope(
@@ -922,8 +934,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model is! ListModel &&
-          m.model is! MapModel) {
+          _resolveForClassification(m.model) is! ListModel &&
+          _resolveForClassification(m.model) is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -998,8 +1010,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model is ListModel &&
-          (m.model as ListModel).hasSimpleContent) {
+      } else if (_resolveForClassification(m.model) is ListModel &&
+          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1010,13 +1022,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildFormParameterExpression(
             refer('value'),
-            m.model as ListModel,
+            _resolveForClassification(m.model) as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is ListModel) {
+      } else if (_resolveForClassification(m.model) is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -1032,7 +1044,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (m.model is BinaryModel) {
+      } else if (_resolveForClassification(m.model) is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -1042,7 +1054,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is MapModel) {
+      } else if (_resolveForClassification(m.model) is MapModel) {
         // Map types cannot be form-encoded
         caseCodes.addAll([
           Code.scope(
@@ -1113,8 +1125,8 @@ class OneOfGenerator {
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
       final isSimple = m.model.encodingShape == EncodingShape.simple;
-      final isList = m.model is ListModel;
-      final isMap = m.model is MapModel;
+      final isList = _resolveForClassification(m.model) is ListModel;
+      final isMap = _resolveForClassification(m.model) is MapModel;
 
       if (isSimple) {
         caseCodes.addAll([
@@ -1182,7 +1194,7 @@ class OneOfGenerator {
     Map<DiscriminatedModel, String> variantNames,
   ) {
     final hasOnlyPrimitives = !model.models.any(
-      (m) => m.model is! PrimitiveModel,
+      (m) => _resolveForClassification(m.model) is! PrimitiveModel,
     );
 
     if (hasOnlyPrimitives) {
@@ -1278,7 +1290,7 @@ class OneOfGenerator {
           ]);
         }
       } else {
-        if (m.model is ListModel) {
+        if (_resolveForClassification(m.model) is ListModel) {
           caseCodes
             ..add(Code('$variantName() => '))
             ..add(
@@ -1286,7 +1298,7 @@ class OneOfGenerator {
                 'Lists are not supported in parameterProperties',
               ).code,
             );
-        } else if (m.model is MapModel) {
+        } else if (_resolveForClassification(m.model) is MapModel) {
           caseCodes
             ..add(Code('$variantName() => '))
             ..add(
@@ -1370,8 +1382,8 @@ class OneOfGenerator {
       if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model is! ListModel &&
-          m.model is! MapModel) {
+          _resolveForClassification(m.model) is! ListModel &&
+          _resolveForClassification(m.model) is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -1443,8 +1455,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model is ListModel &&
-          (m.model as ListModel).hasSimpleContent) {
+      } else if (_resolveForClassification(m.model) is ListModel &&
+          (_resolveForClassification(m.model) as ListModel).hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1455,13 +1467,13 @@ class OneOfGenerator {
           if (isNullableList) const Code("value == null ? '' : "),
           buildLabelParameterExpression(
             refer('value'),
-            m.model as ListModel,
+            _resolveForClassification(m.model) as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is ListModel) {
+      } else if (_resolveForClassification(m.model) is ListModel) {
         // Lists with complex content cannot be encoded
         caseCodes.addAll([
           Code.scope(
@@ -1477,7 +1489,7 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
-      } else if (m.model is BinaryModel) {
+      } else if (_resolveForClassification(m.model) is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
             (allocate) => '${allocate(refer(variantName))}() => ',
@@ -1487,7 +1499,7 @@ class OneOfGenerator {
           ).code,
           const Code(','),
         ]);
-      } else if (m.model is MapModel) {
+      } else if (_resolveForClassification(m.model) is MapModel) {
         // Map types cannot be label-encoded
         caseCodes.addAll([
           Code.scope(
@@ -1683,5 +1695,14 @@ class OneOfGenerator {
         ..body = body,
     );
   }
-
 }
+
+/// Resolves through [AliasModel] chains for type classification.
+///
+/// Needed because `AliasModel(model: StringModel())` must be treated
+/// as a primitive in code generation dispatch, but
+/// `AliasModel is PrimitiveModel` is false.
+Model _resolveForClassification(Model model) => switch (model) {
+  AliasModel(:final resolved) => resolved,
+  _ => model,
+};

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -408,9 +408,7 @@ class OptionsGenerator {
     final explode = cookie.parameter.explode;
 
     if (model is ListModel) {
-      final contentModel = model.content is AliasModel
-          ? (model.content as AliasModel).resolved
-          : model.content;
+      final contentModel = model.content.resolved;
 
       if (contentModel is StringModel) {
         final encodedValue = refer(paramName).property('toForm').call([], {

--- a/packages/tonik_generate/lib/src/response/response_generator.dart
+++ b/packages/tonik_generate/lib/src/response/response_generator.dart
@@ -102,7 +102,7 @@ class ResponseGenerator {
       properties: properties.map(
         (prop) {
           final model = prop.property.model;
-          final resolvedModel = model is AliasModel ? model.resolved : model;
+          final resolvedModel = model.resolved;
           return (
             normalizedName: prop.normalizedName,
             typeRef: typeReference(

--- a/packages/tonik_generate/lib/src/util/additional_properties_helpers.dart
+++ b/packages/tonik_generate/lib/src/util/additional_properties_helpers.dart
@@ -5,9 +5,8 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 /// Whether the given [model] resolves to a collection type (list or map).
 bool isCollectionModel(Model model) {
-  if (model is ListModel || model is MapModel) return true;
-  if (model is AliasModel) return isCollectionModel(model.resolved);
-  return false;
+  final resolved = model.resolved;
+  return resolved is ListModel || resolved is MapModel;
 }
 
 /// Whether the given [additionalProperties] specification is active, meaning

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -215,10 +215,7 @@ void _addMultipartHeaderParameters({
     if (encoding == null) continue;
 
     // Resolve the model to get properties.
-    var model = content.model;
-    if (model is AliasModel) {
-      model = model.resolved;
-    }
+    final model = content.model.resolved;
     if (model is! ClassModel) continue;
 
     final writeProperties = model.properties

--- a/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
@@ -36,7 +36,7 @@ Code buildToDeepObjectQueryParameterCode(
   // Handle MapModel (including aliases to MapModel) before the general
   // object path, since maps are typedefs and don't implement
   // ParameterEncodable.
-  final resolvedModel = _resolveModel(model);
+  final resolvedModel = model.resolved;
   if (resolvedModel is MapModel) {
     return _buildMapDeepObjectCode(
       parameterName,
@@ -89,7 +89,7 @@ Code _buildMapDeepObjectCode(
   required bool allowEmpty,
 }) {
   final valueModel = model.valueModel;
-  final resolvedValueModel = _resolveModel(valueModel);
+  final resolvedValueModel = valueModel.resolved;
 
   // For Map<String, String>, the extension handles encoding directly.
   if (resolvedValueModel is StringModel) {
@@ -169,15 +169,9 @@ bool _isSimpleMapValueModel(Model model) {
     Base64Model() ||
     EnumModel() => true,
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() => true,
-    AliasModel() => _isSimpleMapValueModel(model.model),
+    AliasModel() => _isSimpleMapValueModel(model.resolved),
     _ => false,
   };
-}
-
-/// Unwraps [AliasModel] layers to find the underlying model.
-Model _resolveModel(Model model) {
-  if (model is AliasModel) return _resolveModel(model.model);
-  return model;
 }
 
 bool _isValidDeepObjectModel(Model model) {
@@ -186,7 +180,7 @@ bool _isValidDeepObjectModel(Model model) {
     AllOfModel() => true,
     OneOfModel() => true,
     AnyOfModel() => true,
-    AliasModel() => _isValidDeepObjectModel(model.model),
+    AliasModel() => _isValidDeepObjectModel(model.resolved),
     _ => false,
   };
 }

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -59,9 +59,7 @@ List<Code> buildToFormQueryParameterCode(
   }
 
   if (model is ListModel) {
-    final contentModel = model.content is AliasModel
-        ? (model.content as AliasModel).resolved
-        : model.content;
+    final contentModel = model.content.resolved;
     final contentShape = contentModel.encodingShape;
 
     // Binary/Base64 content cannot be form-encoded.

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -32,7 +32,7 @@ Expression buildToLabelPathParameterExpression(
 
   if (model is ListModel) {
     final content = model.content;
-    final contentModel = content is AliasModel ? content.resolved : content;
+    final contentModel = content.resolved;
 
     if (contentModel is StringModel) {
       return valueRef.property('toLabel').call([], {

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -40,10 +40,7 @@ Expression buildMultipartBodyExpression(
   // Only add `return formData;` when the model resolved to a ClassModel
   // (i.e., formData was actually declared). For non-ClassModel bodies,
   // the statements contain only a throw.
-  var model = content.model;
-  if (model is AliasModel) {
-    model = model.resolved;
-  }
+  final model = content.model.resolved;
   final bodyStatements = [
     ...statements,
     if (model is ClassModel) refer(r'_$formData').returned.statement,
@@ -66,10 +63,7 @@ List<Code> _buildMultipartFields(
   final statements = <Code>[];
 
   // Resolve through alias chains.
-  var model = content.model;
-  if (model is AliasModel) {
-    model = model.resolved;
-  }
+  final model = content.model.resolved;
 
   // Non-ClassModel: generate runtime UnsupportedError.
   if (model is! ClassModel) {
@@ -1261,10 +1255,7 @@ List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
   final encoding = content.encoding;
   if (encoding == null) return const [];
 
-  var model = content.model;
-  if (model is AliasModel) {
-    model = model.resolved;
-  }
+  final model = content.model.resolved;
   if (model is! ClassModel) return const [];
 
   final writeProperties = model.properties.where((p) => !p.isReadOnly).toList();

--- a/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
@@ -619,4 +619,45 @@ void main() {
       );
     });
   });
+
+  group('with alias-to-primitive types', () {
+    test('fromForm uses decode extension for alias-to-primitive', () {
+      final aliasModel = AliasModel(
+        name: 'ErrorCode',
+        model: StringModel(context: context),
+        context: context,
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Result',
+        models: {
+          (discriminatorValue: null, model: aliasModel),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Result');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+        factory Result.fromForm(String? value, {required bool explode}) {
+          try {
+            return ResultErrorCode(value.decodeFormString(context: r'Result'));
+          } on DecodingException catch (_) { } on FormatException catch (_) {}
+          try {
+            return ResultInt(value.decodeFormInt(context: r'Result'));
+          } on DecodingException catch (_) { } on FormatException catch (_) {}
+          throw SimpleDecodingException(r'Invalid form value for Result');
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -743,6 +743,42 @@ void main() {
       );
     });
 
+    test('throws for alias-to-primitive-only oneOf', () {
+      final aliasModel = AliasModel(
+        name: 'ErrorCode',
+        model: StringModel(context: context),
+        context: context,
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: aliasModel),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+
+      const expectedMethod = '''
+        Map<String, String> parameterProperties({
+          bool allowEmpty = true,
+          bool allowLists = true,
+        }) =>
+          throw EncodingException(
+            r'parameterProperties not supported for Value: only contains primitive types',
+          );
+      ''';
+
+      expect(
+        collapseWhitespace(format(baseClass.accept(emitter).toString())),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
     test('delegates to value for complex variant without discriminator', () {
       final userModel = ClassModel(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1056,5 +1056,103 @@ void main() {
         );
       },
     );
+
+    group('with alias-to-primitive types', () {
+      test('fromJson uses primitive switch for only alias-to-primitive types',
+          () {
+        final aliasModel = AliasModel(
+          name: 'ErrorCode',
+          model: StringModel(context: context),
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Result',
+          models: {
+            (discriminatorValue: null, model: aliasModel),
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Result');
+        final generatedCode = format(baseClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+          factory Result.fromJson(Object? json) {
+            return switch (json) {
+              String s => ResultErrorCode(s),
+              int s => ResultInt(s),
+              _ => throw JsonDecodingException(
+                r'Invalid JSON type for Result: ${json.runtimeType}',
+              ),
+            };
+          }''';
+
+        expect(
+          collapseWhitespace(generatedCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      });
+
+      test('fromJson uses type check for alias-to-primitive mixed with class',
+          () {
+        final aliasModel = AliasModel(
+          name: 'ErrorCode',
+          model: StringModel(context: context),
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Result',
+          models: {
+            (discriminatorValue: null, model: aliasModel),
+            (
+              discriminatorValue: null,
+              model: ClassModel(
+                isDeprecated: false,
+                name: 'TestClass',
+                properties: [
+                  Property(
+                    name: 'value',
+                    model: StringModel(context: context),
+                    isRequired: true,
+                    isNullable: false,
+                    isDeprecated: false,
+                  ),
+                ],
+                context: context,
+              ),
+            ),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Result');
+        final generatedCode = format(baseClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+          factory Result.fromJson(Object? json) {
+            if (json is String) {
+              return ResultErrorCode(json);
+            }
+
+            try {
+              return ResultTestClass(TestClass.fromJson(json));
+            } on Object catch (_) {}
+
+            throw JsonDecodingException(r'Invalid JSON for Result');
+          }''';
+
+        expect(
+          collapseWhitespace(generatedCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
@@ -918,4 +918,45 @@ void main() {
       },
     );
   });
+
+  group('with alias-to-primitive types', () {
+    test('fromSimple uses decode extension for alias-to-primitive', () {
+      final aliasModel = AliasModel(
+        name: 'ErrorCode',
+        model: StringModel(context: context),
+        context: context,
+      );
+
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Result',
+        models: {
+          (discriminatorValue: null, model: aliasModel),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Result');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+        factory Result.fromSimple(String? value, {required bool explode}) {
+          try {
+            return ResultErrorCode(value.decodeSimpleString(context: r'Result'));
+          } on DecodingException catch (_) { } on FormatException catch (_) {}
+          try {
+            return ResultInt(value.decodeSimpleInt(context: r'Result'));
+          } on DecodingException catch (_) { } on FormatException catch (_) {}
+          throw SimpleDecodingException(r'Invalid simple value for Result');
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
 }

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -186,7 +186,7 @@ class RequestBodyImporter {
     required Map<String, core.MultipartPropertyEncoding>? explicitEncoding,
   }) {
     // Resolve through aliases to find the underlying model
-    final resolved = model is core.AliasModel ? model.resolved : model;
+    final resolved = model.resolved;
 
     // Only populate per-property defaults for ClassModel
     if (resolved is! core.ClassModel) {


### PR DESCRIPTION
## Summary

- Fix OneOf generator treating `AliasModel(model: PrimitiveModel)` as a complex type, causing it to emit non-existent static factory calls like `String.fromJson()`, `String.fromSimple()`, `String.fromForm()`
- Add `_resolveForClassification()` helper that unwraps `AliasModel` via `.resolved` and update all ~30 type-classification checks in the OneOf generator

## Test plan

- [x] New tests for `fromJson` with alias-to-primitive (only-primitives and mixed-with-class scenarios)
- [x] New tests for `fromSimple` with alias-to-primitive
- [x] New tests for `fromForm` with alias-to-primitive
- [x] New test for `parameterProperties` with alias-to-primitive-only OneOf
- [x] All 2035 existing `tonik_generate` tests pass