### PR TITLE
fix: resolve adjacent-string lint warnings in tests

### DIFF
--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2264,8 +2264,7 @@ String _parseResponse(Response<List<int>> response) {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace(
-              "throw ResponseDecodingException( "
-              "'Multipart response body decoding is not supported.', );",
+              '''throw ResponseDecodingException( 'Multipart response body decoding is not supported.', );''',
             ),
           ),
         );

--- a/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
@@ -830,8 +830,7 @@ void main() {
 
         expect(
           expression.accept(scopedEmitter).toString(),
-          "throw  _i1.FormDecodingException("
-          "'ClassModel is not supported in lists for form decoding.')",
+          '''throw  _i1.FormDecodingException('ClassModel is not supported in lists for form decoding.')''',
         );
       });
 
@@ -852,8 +851,7 @@ void main() {
 
         expect(
           expression.accept(scopedEmitter).toString(),
-          "throw  _i1.FormDecodingException("
-          "'Nested lists are not supported in form decoding.')",
+          '''throw  _i1.FormDecodingException('Nested lists are not supported in form decoding.')''',
         );
       });
 
@@ -876,8 +874,7 @@ void main() {
 
           expect(
             expression.accept(scopedEmitter).toString(),
-            "throw  _i1.FormDecodingException("
-            "'Unsupported model type for form decoding.')",
+            '''throw  _i1.FormDecodingException('Unsupported model type for form decoding.')''',
           );
         },
       );

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -827,9 +827,7 @@ void main() {
             package: 'my_package',
             explode: literalBool(false),
           ).accept(scopedEmitter).toString(),
-          "throw  _i1.SimpleDecodingException("
-          "'ClassModel is not supported in lists"
-          " for simple decoding.')",
+          '''throw  _i1.SimpleDecodingException('ClassModel is not supported in lists for simple decoding.')''',
         );
       });
 
@@ -851,9 +849,7 @@ void main() {
             package: 'my_package',
             explode: literalBool(false),
           ).accept(scopedEmitter).toString(),
-          "throw  _i1.SimpleDecodingException("
-          "'Nested lists are not supported"
-          " in simple decoding.')",
+          '''throw  _i1.SimpleDecodingException('Nested lists are not supported in simple decoding.')''',
         );
       });
 
@@ -877,8 +873,7 @@ void main() {
               package: 'my_package',
               explode: literalBool(false),
             ).accept(scopedEmitter).toString(),
-            "throw  _i1.SimpleDecodingException("
-            "'Unsupported model type for simple decoding.')",
+            '''throw  _i1.SimpleDecodingException('Unsupported model type for simple decoding.')''',
           );
         },
       );

--- a/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
@@ -262,9 +262,7 @@ void main() {
 
       expect(
         code,
-        "throw  _i1.EncodingException("
-        "r'deepObject encoding only supports object types."
-        ' Parameter "count" is not supported.\')',
+        '''throw  _i1.EncodingException(r'deepObject encoding only supports object types. Parameter "count" is not supported.')''',
       );
     });
 
@@ -288,9 +286,7 @@ void main() {
 
       expect(
         code,
-        "throw  _i1.EncodingException("
-        "r'deepObject encoding only supports object types."
-        ' Parameter "items" is not supported.\')',
+        '''throw  _i1.EncodingException(r'deepObject encoding only supports object types. Parameter "items" is not supported.')''',
       );
     });
 
@@ -320,9 +316,7 @@ void main() {
 
       expect(
         code,
-        "throw  _i1.EncodingException("
-        "r'deepObject encoding only supports object types."
-        ' Parameter "status" is not supported.\')',
+        '''throw  _i1.EncodingException(r'deepObject encoding only supports object types. Parameter "status" is not supported.')''',
       );
     });
 

--- a/packages/tonik_generate/test/src/util/to_form_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_parameter_expression_generator_test.dart
@@ -424,8 +424,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported model type for form encoding.')",
+        '''throw  _i1.EncodingException('Unsupported model type for form encoding.')''',
       );
     });
 
@@ -443,8 +442,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported list content type for form encoding.')",
+        '''throw  _i1.EncodingException('Unsupported list content type for form encoding.')''',
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -131,8 +131,7 @@ void main() {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace(
-              "throw _i1.EncodingException("
-              "'Map types cannot be form query encoded.')",
+              '''throw _i1.EncodingException('Map types cannot be form query encoded.')''',
             ),
           ),
         );
@@ -160,8 +159,7 @@ void main() {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace(
-              "throw _i1.EncodingException("
-              "'Binary data cannot be form-encoded.')",
+              '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
             ),
           ),
         );
@@ -187,8 +185,7 @@ void main() {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace(
-              "throw _i1.EncodingException("
-              "'Binary data cannot be form-encoded.')",
+              '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
             ),
           ),
         );
@@ -214,9 +211,7 @@ void main() {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace(
-              "throw _i1.EncodingException( "
-              "'Cannot encode NeverModel"
-              " - this type does not permit any value.', );",
+              '''throw _i1.EncodingException( 'Cannot encode NeverModel - this type does not permit any value.', );''',
             ),
           ),
         );
@@ -247,8 +242,7 @@ void main() {
             collapseWhitespace(generated),
             contains(
               collapseWhitespace(
-                "throw _i1.EncodingException("
-                "'Binary data cannot be form-encoded.')",
+                '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
               ),
             ),
           );
@@ -280,8 +274,7 @@ void main() {
             collapseWhitespace(generated),
             contains(
               collapseWhitespace(
-                "throw _i1.EncodingException("
-                "'Binary data cannot be form-encoded.')",
+                '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
               ),
             ),
           );
@@ -313,9 +306,7 @@ void main() {
             collapseWhitespace(generated),
             contains(
               collapseWhitespace(
-                "throw _i1.EncodingException( "
-                "'Cannot encode List<NeverModel>"
-                " - this type does not permit any value.', );",
+                '''throw _i1.EncodingException( 'Cannot encode List<NeverModel> - this type does not permit any value.', );''',
               ),
             ),
           );
@@ -348,8 +339,7 @@ void main() {
             collapseWhitespace(generated),
             contains(
               collapseWhitespace(
-                "throw _i1.EncodingException( "
-                "'Unsupported model type for form query encoding.', );",
+                '''throw _i1.EncodingException( 'Unsupported model type for form query encoding.', );''',
               ),
             ),
           );
@@ -386,8 +376,7 @@ void main() {
             collapseWhitespace(generated),
             contains(
               collapseWhitespace(
-                "throw _i1.EncodingException( "
-                "'Unsupported model type for form query encoding.', );",
+                '''throw _i1.EncodingException( 'Unsupported model type for form query encoding.', );''',
               ),
             ),
           );

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -768,8 +768,7 @@ void main() {
 
         expect(
           scopedEmit(result),
-          "throw  _i1.EncodingException("
-          "'Form encoding not supported for binary types.')",
+          '''throw  _i1.EncodingException('Form encoding not supported for binary types.')''',
         );
       });
 
@@ -789,8 +788,7 @@ void main() {
 
         expect(
           scopedEmit(result),
-          "throw  _i1.EncodingException("
-          "'Form encoding not supported for binary types.')",
+          '''throw  _i1.EncodingException('Form encoding not supported for binary types.')''',
         );
       });
     });

--- a/packages/tonik_generate/test/src/util/to_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_json_value_expression_generator_test.dart
@@ -20,8 +20,7 @@ void main() {
 
   String emit(Expression expr) => expr.accept(emitter).toString();
 
-  String scopedEmit(Expression expr) =>
-      expr.accept(scopedEmitter).toString();
+  String scopedEmit(Expression expr) => expr.accept(scopedEmitter).toString();
 
   group('buildToJsonValueExpression', () {
     test('for String property', () {
@@ -1258,9 +1257,7 @@ void main() {
         scopedEmit(
           buildToJsonPropertyExpression('forbidden', property),
         ),
-        "throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')",
+        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
 
@@ -1276,9 +1273,7 @@ void main() {
         scopedEmit(
           buildToJsonPropertyExpression('forbidden', property),
         ),
-        "throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')",
+        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
 
@@ -1298,9 +1293,7 @@ void main() {
         scopedEmit(
           buildToJsonPropertyExpression('forbiddenList', property),
         ),
-        "forbiddenList.map((e) => throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')).toList()",
+        '''forbiddenList.map((e) => throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')).toList()''',
       );
     });
 
@@ -1321,9 +1314,7 @@ void main() {
         scopedEmit(
           buildToJsonPropertyExpression('forbiddenAlias', property),
         ),
-        "throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')",
+        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
   });
@@ -1346,9 +1337,7 @@ void main() {
         scopedEmit(
           buildToJsonPathParameterExpression('forbidden', parameter),
         ),
-        "throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')",
+        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
   });
@@ -1372,9 +1361,7 @@ void main() {
         scopedEmit(
           buildToJsonQueryParameterExpression('forbidden', parameter),
         ),
-        "throw  _i1.EncodingException("
-        "'Cannot encode NeverModel"
-        " - this type does not permit any value.')",
+        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
   });
@@ -1836,5 +1823,4 @@ void main() {
       );
     });
   });
-
 }

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -424,8 +424,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported model type for label encoding.')",
+        '''throw  _i1.EncodingException('Unsupported model type for label encoding.')''',
       );
     });
 
@@ -443,8 +442,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported list content type for label encoding.')",
+        '''throw  _i1.EncodingException('Unsupported list content type for label encoding.')''',
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -440,8 +440,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported model type for matrix encoding.')",
+        '''throw  _i1.EncodingException('Unsupported model type for matrix encoding.')''',
       );
     });
 
@@ -460,8 +459,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported list content type for matrix encoding.')",
+        '''throw  _i1.EncodingException('Unsupported list content type for matrix encoding.')''',
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -424,8 +424,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported model type for simple encoding.')",
+        '''throw  _i1.EncodingException('Unsupported model type for simple encoding.')''',
       );
     });
 
@@ -443,8 +442,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported list content type for simple encoding.')",
+        '''throw  _i1.EncodingException('Unsupported list content type for simple encoding.')''',
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -345,9 +345,7 @@ void main() {
             explode: false,
             allowEmpty: true,
           ).accept(scopedEmitter).toString(),
-          "throw  _i1.EncodingException("
-          "'Nested lists are not supported"
-          " for simple encoding.')",
+          '''throw  _i1.EncodingException('Nested lists are not supported for simple encoding.')''',
         );
       });
 
@@ -359,8 +357,7 @@ void main() {
             explode: false,
             allowEmpty: true,
           ).accept(scopedEmitter).toString(),
-          "throw  _i1.EncodingException("
-          "'Unsupported model type for simple encoding.')",
+          '''throw  _i1.EncodingException('Unsupported model type for simple encoding.')''',
         );
       });
 
@@ -380,8 +377,7 @@ void main() {
             explode: false,
             allowEmpty: true,
           ).accept(scopedEmitter).toString(),
-          "throw  _i1.EncodingException("
-          "'Unsupported content model for simple encoding.')",
+          '''throw  _i1.EncodingException('Unsupported content model for simple encoding.')''',
         );
       });
     });

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -295,8 +295,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported model type for URI encoding.')",
+        '''throw  _i1.EncodingException('Unsupported model type for URI encoding.')''',
       );
     });
   });
@@ -596,8 +595,7 @@ void main() {
 
       expect(
         expression.accept(scopedEmitter).toString(),
-        "throw  _i1.EncodingException("
-        "'Unsupported list content type for URI encoding.')",
+        '''throw  _i1.EncodingException('Unsupported list content type for URI encoding.')''',
       );
     });
   });


### PR DESCRIPTION
## Summary
- Replace implicit string concatenation with triple-quoted (`'''...'''`) single-line strings across 13 test files
- Fixes `missing_whitespace_between_adjacent_strings` and `prefer_single_quotes` lint warnings

## Test plan
- [x] `dart analyze` reports no errors on all modified files
- [x] Existing tests still pass (no string content changes, only quoting style)