### PR TITLE
fix: correct toJson serialization for additional properties with collection values

### DIFF
--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -805,14 +805,17 @@ class AllOfGenerator {
         final apAccess = useImmutableCollections
             ? '$apFieldName.unlock'
             : apFieldName;
-        if (ap is TypedAdditionalProperties &&
-            ap.valueModel.encodingShape == EncodingShape.complex) {
-          bodyCode.add(
-            Code(
-              'for (final _\$e in $apAccess.entries) '
-              r'{ _$map[_$e.key] = _$e.value.toJson(); }',
-            ),
+        if (ap is TypedAdditionalProperties) {
+          final apExpr = buildToJsonAdditionalPropertiesExpression(
+            apFieldName,
+            ap.valueModel,
+            useImmutableCollections: useImmutableCollections,
           );
+          bodyCode.addAll([
+            const Code(r'_$map.addAll('),
+            apExpr.code,
+            const Code(');'),
+          ]);
         } else {
           bodyCode.add(
             Code(
@@ -923,13 +926,16 @@ class AllOfGenerator {
           final apAccess = useImmutableCollections
               ? '$apFieldName.unlock'
               : apFieldName;
-          if (ap is TypedAdditionalProperties &&
-              ap.valueModel.encodingShape == EncodingShape.complex) {
+          if (ap is TypedAdditionalProperties) {
+            final apExpr = buildToJsonAdditionalPropertiesExpression(
+              apFieldName,
+              ap.valueModel,
+              useImmutableCollections: useImmutableCollections,
+            );
             mapParts.addAll([
-              Code(
-                'for (final _\$e in $apAccess.entries) '
-                r'{ _$map[_$e.key] = _$e.value.toJson(); }',
-              ),
+              const Code(r'_$map.addAll('),
+              apExpr.code,
+              const Code(');'),
             ]);
           } else {
             mapParts.add(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -801,21 +801,16 @@ class ClassGenerator {
           ? '$apFieldName.unlock'
           : apFieldName;
       if (ap is TypedAdditionalProperties) {
-        final valueModel = ap.valueModel;
-        // For complex types, encode each value via toJson.
-        // For simple/primitive types, pass through.
-        if (valueModel.encodingShape == EncodingShape.complex) {
-          mapEntries.add(
-            Code.scope(
-              (a) =>
-                  '...$apAccess.map('
-                  '(k, v) => ${a(refer('MapEntry', 'dart:core'))}'
-                  '(k, v.toJson())),',
-            ),
-          );
-        } else {
-          mapEntries.add(Code('...$apAccess,'));
-        }
+        final apExpr = buildToJsonAdditionalPropertiesExpression(
+          apFieldName,
+          ap.valueModel,
+          useImmutableCollections: useImmutableCollections,
+        );
+        mapEntries.addAll([
+          const Code('...'),
+          apExpr.code,
+          const Code(','),
+        ]);
       } else {
         // Unrestricted: values are already Object?
         mapEntries.add(Code('...$apAccess,'));

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -49,6 +49,48 @@ Expression buildToJsonQueryParameterExpression(
   );
 }
 
+/// Builds the serialization expression for typed additional properties.
+///
+/// Returns an expression suitable for spreading into a map literal
+/// (class generator) or passing to `addAll` (allOf generator).
+/// Handles unlock for immutable collections internally.
+Expression buildToJsonAdditionalPropertiesExpression(
+  String fieldName,
+  Model valueModel, {
+  bool useImmutableCollections = false,
+}) {
+  final receiver = useImmutableCollections
+      ? refer(fieldName).property('unlock')
+      : refer(fieldName);
+
+  if (!_needsTransformation(
+    valueModel,
+    useImmutableCollections: useImmutableCollections,
+  )) {
+    return receiver;
+  }
+
+  final innerExpr = _buildSerializationExpression(
+    refer('v'),
+    valueModel,
+    false,
+    useImmutableCollections: useImmutableCollections,
+  );
+
+  final mapClosure = Method(
+    (b) => b
+      ..requiredParameters.addAll([
+        Parameter((p) => p..name = 'k'),
+        Parameter((p) => p..name = 'v'),
+      ])
+      ..body = refer('MapEntry', 'dart:core')
+          .call([refer('k'), innerExpr])
+          .code,
+  ).closure;
+
+  return receiver.property('map').call([mapClosure]);
+}
+
 Expression _buildSerializationExpression(
   Expression receiver,
   Model model,

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -2247,9 +2247,7 @@ void main() {
       );
     }
     _$map.addAll(_$$baseJson);
-    for (final _$e in additionalProperties.entries) {
-      _$map[_$e.key] = _$e.value.toJson();
-    }
+    _$map.addAll(additionalProperties.map((k, v) => MapEntry(k, v.toJson())));
     return _$map;
   }''';
 

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -1339,6 +1339,102 @@ void main() {
       });
     });
 
+    group('typed additionalProperties with list-of-string values', () {
+      late ClassModel model;
+
+      setUp(() {
+        model = ClassModel(
+          isDeprecated: false,
+          name: 'Serie0',
+          properties: [
+            Property(
+              name: 'timestamps',
+              model: ListModel(
+                content: DateTimeModel(context: context),
+                context: context,
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+          additionalProperties: TypedAdditionalProperties(
+            valueModel: ListModel(
+              content: StringModel(context: context),
+              context: context,
+            ),
+          ),
+        );
+      });
+
+      test('generates toJson spreading list-of-string AP directly', () {
+        const expectedMethod = '''
+  Object? toJson() => {
+    r'timestamps': timestamps.map((e) => e.toTimeZonedIso8601String()).toList(),
+    ...additionalProperties,
+  };''';
+
+        final generatedClass = generator.generateClass(model);
+        expect(
+          collapseWhitespace(
+            format(generatedClass.accept(emitter).toString()),
+          ),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      });
+    });
+
+    group('typed additionalProperties with list-of-complex values', () {
+      late ClassModel model;
+
+      setUp(() {
+        model = ClassModel(
+          isDeprecated: false,
+          name: 'WidgetGroups',
+          properties: [
+            Property(
+              name: 'version',
+              model: IntegerModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+          additionalProperties: TypedAdditionalProperties(
+            valueModel: ListModel(
+              content: ClassModel(
+                isDeprecated: false,
+                name: 'Widget',
+                properties: const [],
+                context: context,
+              ),
+              context: context,
+            ),
+          ),
+        );
+      });
+
+      test('generates toJson mapping list-of-complex AP values', () {
+        const expectedMethod = '''
+  Object? toJson() => {
+    r'version': version,
+    ...additionalProperties.map(
+      (k, v) => MapEntry(k, v.map((e) => e.toJson()).toList()),
+    ),
+  };''';
+
+        final generatedClass = generator.generateClass(model);
+        expect(
+          collapseWhitespace(
+            format(generatedClass.accept(emitter).toString()),
+          ),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      });
+    });
+
     group('NoAdditionalProperties', () {
       test('generates fromJson without AP logic', () {
         final model = ClassModel(


### PR DESCRIPTION
## Summary

- Fixes `.toJson()` being called on `List<String>`, `Map<String, num>`, and other collection types that don't have that method
- The additional properties handling in `class_generator` and `all_of_generator` used `encodingShape == EncodingShape.complex` as a proxy for needing `.toJson()`, but `ListModel` and `MapModel` always return `complex` regardless of content type
- Adds `buildToJsonAdditionalPropertiesExpression` to the expression generator, which correctly checks whether transformation is needed and generates the right expression for each value type
- Both generators now delegate to this function instead of hand-rolling serialization logic

## Test plan

- [x] New test: typed AP with `List<String>` values spreads directly (no `.toJson()`)
- [x] New test: typed AP with `List<ClassModel>` values generates `.map((e) => e.toJson()).toList()`
- [x] Updated test: allOf typed AP uses `_$map.addAll(expr)` instead of for-loop
- [x] All 210 existing tests pass (class_json, all_of, to_json_expression, immutable_collections)