### PR TITLE
fix: prevent parameterProperties calls on List and Map types in allOf

### DIFF
--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1148,12 +1148,12 @@ class AllOfGenerator {
 
     // Check if we have any list properties FIRST (before simple types check)
     final hasListProperties = normalizedProperties.any(
-      (prop) => prop.property.model is ListModel,
+      (prop) => prop.property.model.resolved is ListModel,
     );
     final allListProperties =
         hasListProperties &&
         normalizedProperties.every(
-          (prop) => prop.property.model is ListModel,
+          (prop) => prop.property.model.resolved is ListModel,
         );
 
     // If we have lists (either all or mixed), throw exception
@@ -1174,6 +1174,29 @@ class AllOfGenerator {
           ])
           ..lambda = true
           ..body = generateEncodingExceptionExpression(message, raw: true).code,
+      );
+    }
+
+    // Check if we have any map properties
+    final hasMapProperties = normalizedProperties.any(
+      (prop) => prop.property.model.resolved is MapModel,
+    );
+
+    if (hasMapProperties) {
+      return Method(
+        (b) => b
+          ..name = 'parameterProperties'
+          ..returns = buildMapStringStringType()
+          ..optionalParameters.addAll([
+            buildBoolParameter('allowEmpty', defaultValue: true),
+            buildBoolParameter('allowLists', defaultValue: true),
+          ])
+          ..lambda = true
+          ..body = generateEncodingExceptionExpression(
+            'parameterProperties not supported for $className: '
+            'contains map types',
+            raw: true,
+          ).code,
       );
     }
 
@@ -1626,7 +1649,7 @@ for (final _\$e in $apFieldName.entries) {
       }
 
       // No direct primitives, only dynamic models that could be mixed at
-      // runtime. Generate runtime check.
+      // runtime. Generate runtime check and delegate to parameterProperties.
       final encodingShapeType = refer(
         'EncodingShape',
         'package:tonik_util/tonik_util.dart',
@@ -1641,39 +1664,17 @@ for (final _\$e in $apFieldName.entries) {
           raw: true,
         ).statement,
         const Code('}'),
-        const Code(r'final _$map = <'),
-        refer('String', 'dart:core').code,
-        const Code(', '),
-        refer('String', 'dart:core').code,
-        const Code('>{};'),
+        refer('parameterProperties')
+            .call([], {'allowEmpty': refer('allowEmpty')})
+            .property('toForm')
+            .call([], {
+              'explode': refer('explode'),
+              'allowEmpty': refer('allowEmpty'),
+              'alreadyEncoded': literalBool(true),
+            })
+            .returned
+            .statement,
       ];
-
-      for (final prop in normalizedProperties) {
-        if (prop.property.model.isEffectivelyNullable) {
-          bodyCode.addAll([
-            Code('if (${prop.normalizedName} != null) {'),
-            Code(
-              '  _\$map.addAll(${prop.normalizedName}! '
-              '.parameterProperties(allowEmpty: allowEmpty));',
-            ),
-            const Code('}'),
-          ]);
-        } else {
-          bodyCode.add(
-            Code(
-              '_\$map.addAll(${prop.normalizedName} '
-              '.parameterProperties(allowEmpty: allowEmpty));',
-            ),
-          );
-        }
-      }
-
-      bodyCode.addAll([
-        const Code(
-          r'return _$map.toForm( '
-          'explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);',
-        ),
-      ]);
 
       return Method(
         (b) => b
@@ -1855,7 +1856,8 @@ for (final _\$e in $apFieldName.entries) {
         );
       }
 
-      // If we have dynamic models, we need to validate and manually merge.
+      // If we have dynamic models, validate and delegate to
+      // parameterProperties.
       final bodyCode = <Code>[];
 
       // Validate that all dynamic models (anyOf/oneOf) are in complex state.
@@ -1877,41 +1879,18 @@ for (final _\$e in $apFieldName.entries) {
         ]);
       }
 
-      // Manually merge all parameterProperties.
-      bodyCode.addAll([
-        const Code(r'final _$map = <'),
-        refer('String', 'dart:core').code,
-        const Code(', '),
-        refer('String', 'dart:core').code,
-        const Code('>{};'),
-      ]);
-
-      for (final prop in normalizedProperties) {
-        if (prop.property.model.isEffectivelyNullable) {
-          bodyCode.addAll([
-            Code('if (${prop.normalizedName} != null) {'),
-            Code(
-              '  _\$map.addAll(${prop.normalizedName}! '
-              '.parameterProperties(allowEmpty: allowEmpty));',
-            ),
-            const Code('}'),
-          ]);
-        } else {
-          bodyCode.add(
-            Code(
-              '_\$map.addAll(${prop.normalizedName} '
-              '.parameterProperties(allowEmpty: allowEmpty));',
-            ),
-          );
-        }
-      }
-
-      bodyCode.addAll([
-        const Code(
-          r'return _$map.toForm( '
-          'explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);',
-        ),
-      ]);
+      bodyCode.add(
+        refer('parameterProperties')
+            .call([], {'allowEmpty': refer('allowEmpty')})
+            .property('toForm')
+            .call([], {
+              'explode': refer('explode'),
+              'allowEmpty': refer('allowEmpty'),
+              'alreadyEncoded': literalBool(true),
+            })
+            .returned
+            .statement,
+      );
 
       return Method(
         (b) => b
@@ -2216,45 +2195,17 @@ for (final _\$e in $apFieldName.entries) {
           'Simple encoding not supported: contains complex types',
         ).statement,
         const Code('}'),
-        const Code(r'final _$mergedProperties = '),
-        buildEmptyMapStringString().statement,
+        refer('parameterProperties')
+            .call([], {'allowEmpty': refer('allowEmpty')})
+            .property('toMatrix')
+            .call([refer('paramName')], {
+              'explode': refer('explode'),
+              'allowEmpty': refer('allowEmpty'),
+              'alreadyEncoded': literalBool(true),
+            })
+            .returned
+            .statement,
       ];
-
-      for (final prop in normalizedProperties) {
-        final isNullable = prop.property.model.isEffectivelyNullable;
-        if (isNullable) {
-          bodyCode.addAll([
-            Code('if (${prop.normalizedName} != null) {'),
-            refer(r'_$mergedProperties').property('addAll').call([
-              refer(prop.normalizedName).nullChecked
-                  .property(
-                    'parameterProperties',
-                  )
-                  .call([], {'allowEmpty': refer('allowEmpty')}),
-            ]).statement,
-            const Code('}'),
-          ]);
-        } else {
-          bodyCode.add(
-            refer(r'_$mergedProperties').property('addAll').call([
-              refer(prop.normalizedName).property('parameterProperties').call(
-                [],
-                {
-                  'allowEmpty': refer('allowEmpty'),
-                },
-              ),
-            ]).statement,
-          );
-        }
-      }
-
-      bodyCode.addAll([
-        const Code(
-          r'return _$mergedProperties.toMatrix( '
-          'paramName, explode: explode, allowEmpty: allowEmpty, '
-          'alreadyEncoded: true);',
-        ),
-      ]);
 
       return Method(
         (b) => b
@@ -2361,48 +2312,7 @@ for (final _\$e in $apFieldName.entries) {
         );
       }
 
-      // For non-list complex types, use parameterProperties
-      final propertyMergingLines = [
-        declareFinal(
-          r'_$mergedProperties',
-        ).assign(buildEmptyMapStringString()).statement,
-      ];
-
-      for (final normalized in normalizedProperties) {
-        final isNullable = normalized.property.model.isEffectivelyNullable;
-        if (isNullable) {
-          propertyMergingLines.addAll([
-            Code('if (${normalized.normalizedName} != null) {'),
-            refer(r'_$mergedProperties').property('addAll').call([
-              refer(normalized.normalizedName).nullChecked
-                  .property(
-                    'parameterProperties',
-                  )
-                  .call([], {'allowEmpty': refer('allowEmpty')}),
-            ]).statement,
-            const Code('}'),
-          ]);
-        } else {
-          propertyMergingLines.add(
-            refer(r'_$mergedProperties').property('addAll').call([
-              refer(
-                normalized.normalizedName,
-              ).property('parameterProperties').call([], {
-                'allowEmpty': refer('allowEmpty'),
-              }),
-            ]).statement,
-          );
-        }
-      }
-
-      propertyMergingLines.add(
-        const Code(
-          r'return _$mergedProperties.toMatrix( '
-          'paramName, explode: explode, allowEmpty: allowEmpty, '
-          'alreadyEncoded: true);',
-        ),
-      );
-
+      // For non-list complex types, delegate to parameterProperties
       return Method(
         (b) => b
           ..annotations.add(refer('override', 'dart:core'))
@@ -2417,7 +2327,16 @@ for (final _\$e in $apFieldName.entries) {
           )
           ..optionalParameters.addAll(buildEncodingParameters())
           ..lambda = false
-          ..body = Block.of(propertyMergingLines),
+          ..body = refer('parameterProperties')
+              .call([], {'allowEmpty': refer('allowEmpty')})
+              .property('toMatrix')
+              .call([refer('paramName')], {
+                'explode': refer('explode'),
+                'allowEmpty': refer('allowEmpty'),
+                'alreadyEncoded': literalBool(true),
+              })
+              .returned
+              .statement,
       );
     }
 

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -644,12 +644,12 @@ class AllOfGenerator {
   ) {
     // Check for list properties first (before any other logic)
     final hasListProperties = normalizedProperties.any(
-      (prop) => prop.property.model is ListModel,
+      (prop) => prop.property.model.resolved is ListModel,
     );
     final allListProperties =
         hasListProperties &&
         normalizedProperties.every(
-          (prop) => prop.property.model is ListModel,
+          (prop) => prop.property.model.resolved is ListModel,
         );
 
     // If we have lists mixed with other types, throw exception
@@ -1449,8 +1449,8 @@ for (final _\$e in $apFieldName.entries) {
           .where((p) => p.property.model.encodingShape == EncodingShape.complex)
           .every(
             (p) =>
-                p.property.model is ListModel &&
-                (p.property.model as ListModel).hasSimpleContent,
+                p.property.model.resolved is ListModel &&
+                (p.property.model.resolved as ListModel).hasSimpleContent,
           );
 
       if (allComplexAreSimpleLists) {
@@ -1783,8 +1783,8 @@ for (final _\$e in $apFieldName.entries) {
             )
             .every(
               (p) =>
-                  p.property.model is ListModel &&
-                  (p.property.model as ListModel).hasSimpleContent,
+                  p.property.model.resolved is ListModel &&
+                  (p.property.model.resolved as ListModel).hasSimpleContent,
             );
 
         if (allComplexAreSimpleLists) {
@@ -2064,8 +2064,8 @@ for (final _\$e in $apFieldName.entries) {
           .where((p) => p.property.model.encodingShape == EncodingShape.complex)
           .every(
             (p) =>
-                p.property.model is ListModel &&
-                (p.property.model as ListModel).hasSimpleContent,
+                p.property.model.resolved is ListModel &&
+                (p.property.model.resolved as ListModel).hasSimpleContent,
           );
 
       if (allComplexAreSimpleLists) {
@@ -2252,8 +2252,8 @@ for (final _\$e in $apFieldName.entries) {
           .where((p) => p.property.model.encodingShape == EncodingShape.complex)
           .every(
             (p) =>
-                p.property.model is ListModel &&
-                (p.property.model as ListModel).hasSimpleContent,
+                p.property.model.resolved is ListModel &&
+                (p.property.model.resolved as ListModel).hasSimpleContent,
           );
 
       if (allComplexAreSimpleLists) {

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -353,8 +353,7 @@ class OneOfGenerator {
                     m.discriminatorValue != null &&
                     m.model.resolved is! PrimitiveModel &&
                     m.model.resolved is! ListModel &&
-                    m.model.resolved is! MapModel &&
-                    model is! EnumModel,
+                    m.model.resolved is! MapModel,
               )) {
         final variantName = variantNames[m]!;
 

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -195,21 +195,16 @@ void main() {
     final combinedClass = generator.generateClass(model);
     final generated = format(combinedClass.accept(emitter).toString());
 
-    const expectedToFormMethod = r'''
+    const expectedToFormMethod = '''
         String toForm({ required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
             );
           }
-          final _$map = <String, String>{};
-          _$map.addAll($base.parameterProperties(allowEmpty: allowEmpty));
-          _$map.addAll(choice.parameterProperties(allowEmpty: allowEmpty));
-          return _$map.toForm(
-            explode: explode,
+          return parameterProperties(
             allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
+          ).toForm(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1627,6 +1627,92 @@ void main() {
         );
       },
     );
+
+    test(
+      'generates parameterProperties that throws when contains maps',
+      () {
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'AllOfWithMap',
+          models: {
+            MapModel(
+              valueModel: StringModel(context: context),
+              context: context,
+            ),
+          },
+          context: context,
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedParameterProperties = '''
+          Map<String, String> parameterProperties({
+            bool allowEmpty = true,
+            bool allowLists = true,
+          }) =>
+            throw EncodingException(
+              r'parameterProperties not supported for AllOfWithMap: contains map types',
+            );
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedParameterProperties)),
+        );
+      },
+    );
+
+    test(
+      'generates parameterProperties that throws for allOf mixing map and class',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'TestClass',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'AllOfMixedMapClass',
+          models: {
+            MapModel(
+              valueModel: IntegerModel(context: context),
+              context: context,
+            ),
+            classModel,
+          },
+          context: context,
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedParameterProperties = '''
+          Map<String, String> parameterProperties({
+            bool allowEmpty = true,
+            bool allowLists = true,
+          }) =>
+            throw EncodingException(
+              r'parameterProperties not supported for AllOfMixedMapClass: contains map types',
+            );
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedParameterProperties)),
+        );
+      },
+    );
   });
 
   group('nullable allOf', () {

--- a/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
@@ -105,20 +105,13 @@ void main() {
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
 
-      const expectedMethod = r'''
+      const expectedMethod = '''
         String toMatrix(
           String paramName, {
           required bool explode,
           required bool allowEmpty,
         }) {
-          final _$mergedProperties = <String, String>{};
-          _$mergedProperties.addAll(
-            class1.parameterProperties(allowEmpty: allowEmpty),
-          );
-          _$mergedProperties.addAll(
-            class2.parameterProperties(allowEmpty: allowEmpty),
-          );
-          return _$mergedProperties.toMatrix(
+          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
@@ -234,7 +227,7 @@ void main() {
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
 
-      const expectedMethod = r'''
+      const expectedMethod = '''
         String toMatrix(
           String paramName, {
           required bool explode,
@@ -245,10 +238,7 @@ void main() {
               'Simple encoding not supported: contains complex types',
             );
           }
-          final _$mergedProperties = <String, String>{};
-          _$mergedProperties.addAll(anyOfModel.parameterProperties(allowEmpty: allowEmpty));
-          _$mergedProperties.addAll(classModel.parameterProperties(allowEmpty: allowEmpty));
-          return _$mergedProperties.toMatrix(
+          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
@@ -442,15 +432,13 @@ void main() {
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
 
-      const expectedMethod = r'''
+      const expectedMethod = '''
         String toMatrix(
           String paramName, {
           required bool explode,
           required bool allowEmpty,
         }) {
-          final _$mergedProperties = <String, String>{};
-          _$mergedProperties.addAll(classModel.parameterProperties(allowEmpty: allowEmpty));
-          return _$mergedProperties.toMatrix(
+          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
@@ -555,6 +543,98 @@ void main() {
           contains(collapseWhitespace(expectedMethod)),
         );
       });
+
+      test(
+        'generates toMatrix delegating to parameterProperties for '
+        'ListModel with complex content',
+        () {
+          final complexListModel = ListModel(
+            content: ClassModel(
+              isDeprecated: false,
+              name: 'ComplexItem',
+              properties: [
+                Property(
+                  name: 'id',
+                  model: IntegerModel(context: context),
+                  isRequired: true,
+                  isNullable: false,
+                  isDeprecated: false,
+                ),
+              ],
+              context: context,
+            ),
+            context: context,
+          );
+
+          final model = AllOfModel(
+            isDeprecated: false,
+            name: 'AllOfComplexList',
+            models: {complexListModel},
+            context: context,
+          );
+
+          final generatedClass = generator.generateClass(model);
+          final classCode = format(generatedClass.accept(emitter).toString());
+
+          const expectedMethod = '''
+            String toMatrix(
+              String paramName, {
+              required bool explode,
+              required bool allowEmpty,
+            }) {
+              return parameterProperties(allowEmpty: allowEmpty).toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+            }
+          ''';
+          expect(
+            collapseWhitespace(classCode),
+            contains(collapseWhitespace(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates toMatrix delegating to parameterProperties for MapModel',
+        () {
+          final mapModel = MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+          );
+
+          final model = AllOfModel(
+            isDeprecated: false,
+            name: 'AllOfMap',
+            models: {mapModel},
+            context: context,
+          );
+
+          final generatedClass = generator.generateClass(model);
+          final classCode = format(generatedClass.accept(emitter).toString());
+
+          const expectedMethod = '''
+            String toMatrix(
+              String paramName, {
+              required bool explode,
+              required bool allowEmpty,
+            }) {
+              return parameterProperties(allowEmpty: allowEmpty).toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+            }
+          ''';
+          expect(
+            collapseWhitespace(classCode),
+            contains(collapseWhitespace(expectedMethod)),
+          );
+        },
+      );
 
       test('generates toMatrix for AllOf with multiple list models', () {
         final listStringModel = ListModel(


### PR DESCRIPTION
## Summary

- Add `MapModel` guard to `_buildParameterPropertiesMethod` (previously only `ListModel` was guarded)
- Use `.resolved` on model checks for alias safety
- Simplify `toMatrix` and `toForm` encoding methods to delegate to `this.parameterProperties()` instead of calling `.parameterProperties()` on individual composed-type fields — consistent with how `toSimple`, `toLabel`, and `toDeepObject` already work
- Fixes 15 compile errors in Cloudflare integration tests where `.parameterProperties()` was called on `List<T>` and `Map<String, T>` types

## Test plan

- [x] 4 new tests: MapModel guard in `parameterProperties`, `toMatrix` delegation for complex-content List and Map
- [x] 4 existing tests updated to match new delegation pattern
- [x] Full test suite passes (2041 tests)
- [x] Cloudflare integration test regenerated and analyzed — 0 errors