### PR TITLE
fix: register named ListModels early to prevent orphan duplicates

### DIFF
--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -676,17 +676,31 @@ class ModelImporter {
     final items = schema.items;
 
     final modelContext = context.push('array');
-    final content = items == null
-        ? AnyModel(context: modelContext)
-        : _resolveSchemaRef(null, items, modelContext);
-    return ListModel(
-      content: content,
+
+    // Register the model early (with an AnyModel placeholder content) so
+    // that circular references to a named array schema resolve to this
+    // same ListModel instead of triggering a duplicate parse via
+    // _resolveWithCycleCheck.
+    final listModel = ListModel(
+      content: AnyModel(context: modelContext),
       context: context,
       name: name,
       isNullable: schema.isNullable ?? false,
       isReadOnly: schema.isReadOnly ?? false,
       isWriteOnly: schema.isWriteOnly ?? false,
     );
+
+    if (name != null &&
+        models.none((m) => m is NamedModel && m.name == name)) {
+      _logModelAdded(listModel);
+      models.add(listModel);
+    }
+
+    listModel.content = items == null
+        ? AnyModel(context: modelContext)
+        : _resolveSchemaRef(null, items, modelContext);
+
+    return listModel;
   }
 
   AllOfModel _parseAllOf(String? name, Schema schema, Context context) {

--- a/packages/tonik_parse/test/model/circular_reference_test.dart
+++ b/packages/tonik_parse/test/model/circular_reference_test.dart
@@ -660,6 +660,59 @@ void main() {
       },
     );
 
+    test(
+      r'top-level array whose items $ref back to the array via a property '
+      'produces exactly one ListModel (no duplicate)',
+      () {
+        // Reproduces the Cloudflare `request-tracer_trace` bug: a top-level
+        // array schema with inline items that self-reference via a property.
+        const spec = {
+          'openapi': '3.0.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': <String, dynamic>{},
+          'components': {
+            'schemas': {
+              'TracerTrace': {
+                'type': 'array',
+                'items': {
+                  'type': 'object',
+                  'properties': {
+                    'trace': {r'$ref': '#/components/schemas/TracerTrace'},
+                  },
+                },
+              },
+            },
+          },
+        };
+
+        final api = Importer().import(spec);
+
+        // Exactly ONE ListModel named 'TracerTrace' exists.
+        final tracerTraceModels = api.models
+            .whereType<ListModel>()
+            .where((m) => m.name == 'TracerTrace')
+            .toList();
+        expect(tracerTraceModels.length, 1);
+
+        final tracerTrace = tracerTraceModels.single;
+
+        // The items ClassModel is present in api.models.
+        final itemsModels = api.models.whereType<ClassModel>().toList();
+        expect(itemsModels.length, 1);
+        final itemsModel = itemsModels.single;
+
+        // ListModel.content points to the items ClassModel.
+        expect(identical(tracerTrace.content, itemsModel), isTrue);
+
+        // The items ClassModel has a property 'trace' whose model is
+        // identical to the registered TracerTrace ListModel.
+        final traceProp = itemsModel.properties.firstWhere(
+          (p) => p.name == 'trace',
+        );
+        expect(identical(traceProp.model, tracerTrace), isTrue);
+      },
+    );
+
     test('bare ref cycle produces valid AliasModels', () {
       const spec = {
         'openapi': '3.0.0',

--- a/packages/tonik_parse/test/model/model_list_test.dart
+++ b/packages/tonik_parse/test/model/model_list_test.dart
@@ -120,4 +120,26 @@ void main() {
 
     expect(api.models, contains(oneOf.models.last.model));
   });
+
+  test('imports array schema without items as ListModel of AnyModel', () {
+    const spec = {
+      'openapi': '3.0.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'OpenList': {'type': 'array'},
+        },
+      },
+    };
+
+    final api = Importer().import(spec);
+
+    final model = api.models.whereType<ListModel>().firstWhere(
+      (m) => m.name == 'OpenList',
+    );
+
+    expect(model, isA<ListModel>());
+    expect(model.content, isA<AnyModel>());
+  });
 }

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -241,6 +241,14 @@ if [ -d "twilio/twilio_api" ]; then
     add_dependency_overrides_recursive "twilio/twilio_api"
 fi
 
+if [ -f "cloudflare/tonik.yaml" ]; then
+    rm -rf cloudflare/cloudflare_api
+    $TONIK_BINARY --config cloudflare/tonik.yaml || echo "WARNING: Cloudflare generation failed."
+    if [ -d "cloudflare/cloudflare_api" ]; then
+        add_dependency_overrides_recursive "cloudflare/cloudflare_api"
+    fi
+fi
+
 $TONIK_BINARY --config immutable_collections/tonik.yaml
 add_dependency_overrides_recursive "immutable_collections/immutable_collections_api"
 
@@ -280,6 +288,7 @@ echo "Running dart pub get for all generated packages in parallel..."
   ([ -d "openai/openai_full_api" ] && cd openai/openai_full_api && dart pub get) &
   ([ -d "asana/asana_api" ] && cd asana/asana_api && dart pub get) &
   ([ -d "twilio/twilio_api" ] && cd twilio/twilio_api && dart pub get) &
+  ([ -d "cloudflare/cloudflare_api" ] && cd cloudflare/cloudflare_api && dart pub get) &
   cd immutable_collections/immutable_collections_api && dart pub get &
   wait
 )


### PR DESCRIPTION
## Summary

- Fixes a bug where `_parseArray` in the parser created duplicate `ListModel` instances for self-referencing top-level array schemas (e.g. Cloudflare's `request-tracer_trace`), causing generated code to reference a file that was never written (`request_tracer_trace_model.dart`)
- Applies the same early-registration pattern already used by `_parseAllOf`: construct the `ListModel` with placeholder content, register it to `models`, then resolve items
- Adds Cloudflare spec generation to the integration test setup script

## Test plan

- [x] New unit test reproducing the exact bug: top-level array whose items `$ref` back to the array via a property — asserts exactly one ListModel (no duplicate) with correct identity links
- [x] New test for array schema without items (covers the `items == null` branch of the updated code)
- [x] All 3897 existing tests pass (zero regressions)
- [x] Static analysis clean (zero errors, zero warnings)
- [x] Patch coverage 100% (8/8 lines)
- [x] After regeneration: `request_tracer_trace_model.dart` / `RequestTracerTraceModel` no longer appear in generated Cloudflare output