### PR TITLE
fix: add useQueryComponent parameter to Date.toForm

### DIFF
--- a/packages/tonik_util/lib/src/date.dart
+++ b/packages/tonik_util/lib/src/date.dart
@@ -89,8 +89,12 @@ class Date {
   /// Converts this [Date] to a form-encoded string.
   ///
   /// Returns the date in ISO 8601 format (YYYY-MM-DD) with proper URL encoding.
-  String toForm({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty, useQueryComponent: true);
+  String toForm({
+    required bool explode,
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+  }) =>
+      uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
 
   /// Converts this [Date] to a label-encoded string.
   ///

--- a/packages/tonik_util/test/src/date_test.dart
+++ b/packages/tonik_util/test/src/date_test.dart
@@ -312,6 +312,33 @@ void main() {
           expect(decoded.day, testDate.day);
         }
       });
+
+      test(
+        'toForm uses encodeComponent by default '
+        'when useQueryComponent is false',
+        () {
+          final date = Date(2024, 3, 15);
+          final encoded = date.toForm(
+            explode: false,
+            allowEmpty: true,
+          );
+          expect(encoded, Uri.encodeComponent('2024-03-15'));
+        },
+      );
+
+      test(
+        'toForm uses encodeQueryComponent '
+        'when useQueryComponent is true',
+        () {
+          final date = Date(2024, 3, 15);
+          final encoded = date.toForm(
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          );
+          expect(encoded, Uri.encodeQueryComponent('2024-03-15'));
+        },
+      );
     });
   });
 


### PR DESCRIPTION
## Summary
- `Date.toForm` was missing the `useQueryComponent` parameter that the `FormEncodable` interface and all other primitive type extensions include
- This caused compile errors when a oneOf variant wraps a `DateModel` and the generated `toForm` passes `useQueryComponent` through
- Added `bool useQueryComponent = false` and pass it to `uriEncode()` instead of hardcoding `true`

## Test plan
- [x] New tests verify both default (`false`) and explicit `true` paths
- [x] All 3903 existing tests pass
- [x] Analysis clean
- [x] Patch coverage 100%