### PR TITLE
fix: allOf generator calls .toJson() on Map<String, T> types

### DIFF
--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -776,28 +776,47 @@ class AllOfGenerator {
         if (isNullable) {
           bodyCode.add(Code('if ($fieldName != null) {'));
         }
-        bodyCode.addAll([
-          Code('final $fieldNameJson = '),
-          if (isNullable)
-            Code('$fieldName!.toJson();')
-          else ...[
-            refer(fieldName).code,
-            const Code('.toJson();'),
-          ],
-          const Code('if ('),
-          refer(fieldNameJson).code,
-          const Code(' is! '),
-          mapType.code,
-          const Code(') {'),
-          generateEncodingExceptionExpression(
-            'Expected ${fieldName.replaceAll(r'$', r'\$')}.toJson() to '
-            'return Map<String, Object?>, got \${$fieldNameJson.runtimeType}',
-          ).statement,
-          const Code('}'),
-          const Code(r'_$map.addAll('),
-          refer(fieldNameJson).code,
-          const Code(');'),
-        ]);
+
+        final toJsonExpr = buildToJsonPropertyExpression(
+          fieldName,
+          normalized.property,
+          forceNonNullReceiver: isNullable,
+          useImmutableCollections: useImmutableCollections,
+        );
+
+        final isMapModel = normalized.property.model.resolved is MapModel;
+
+        if (isMapModel) {
+          // MapModel properties are already compile-time typed as Map,
+          // so no runtime type check is needed.
+          bodyCode.addAll([
+            Code('final $fieldNameJson = '),
+            toJsonExpr.code,
+            const Code(';'),
+            const Code(r'_$map.addAll('),
+            refer(fieldNameJson).code,
+            const Code(');'),
+          ]);
+        } else {
+          bodyCode.addAll([
+            Code('final $fieldNameJson = '),
+            toJsonExpr.code,
+            const Code(';'),
+            const Code('if ('),
+            refer(fieldNameJson).code,
+            const Code(' is! '),
+            mapType.code,
+            const Code(') {'),
+            generateEncodingExceptionExpression(
+              'Expected ${fieldName.replaceAll(r'$', r'\$')}.toJson() to '
+              'return Map<String, Object?>, got \${$fieldNameJson.runtimeType}',
+            ).statement,
+            const Code('}'),
+            const Code(r'_$map.addAll('),
+            refer(fieldNameJson).code,
+            const Code(');'),
+          ]);
+        }
         if (isNullable) {
           bodyCode.add(const Code('}'));
         }
@@ -897,28 +916,49 @@ class AllOfGenerator {
           if (isNullable) {
             mapParts.add(Code('if ($fieldName != null) {'));
           }
-          mapParts.addAll([
-            Code('final $fieldNameJson = '),
-            if (isNullable)
-              Code('$fieldName!.toJson();')
-            else ...[
-              refer(fieldName).code,
-              const Code('.toJson();'),
-            ],
-            const Code('if ('),
-            refer(fieldNameJson).code,
-            const Code(' is! '),
-            mapType.code,
-            const Code(') {'),
-            generateEncodingExceptionExpression(
-              'Expected ${fieldName.replaceAll(r'$', r'\$')}.toJson() to '
-              'return Map<String, Object?>, got \${$fieldNameJson.runtimeType}',
-            ).statement,
-            const Code('}'),
-            const Code(r'_$map.addAll('),
-            refer(fieldNameJson).code,
-            const Code(');'),
-          ]);
+
+          final toJsonExpr = buildToJsonPropertyExpression(
+            fieldName,
+            normalized.property,
+            forceNonNullReceiver: isNullable,
+            useImmutableCollections: useImmutableCollections,
+          );
+
+          final isMapModel = normalized.property.model.resolved is MapModel;
+
+          if (isMapModel) {
+            // MapModel properties are already compile-time typed as Map,
+            // so no runtime type check is needed.
+            mapParts.addAll([
+              Code('final $fieldNameJson = '),
+              toJsonExpr.code,
+              const Code(';'),
+              const Code(r'_$map.addAll('),
+              refer(fieldNameJson).code,
+              const Code(');'),
+            ]);
+          } else {
+            mapParts.addAll([
+              Code('final $fieldNameJson = '),
+              toJsonExpr.code,
+              const Code(';'),
+              const Code('if ('),
+              refer(fieldNameJson).code,
+              const Code(' is! '),
+              mapType.code,
+              const Code(') {'),
+              generateEncodingExceptionExpression(
+                'Expected '
+                '${fieldName.replaceAll(r'$', r'\$')}.toJson() to '
+                'return Map<String, Object?>, '
+                'got \${$fieldNameJson.runtimeType}',
+              ).statement,
+              const Code('}'),
+              const Code(r'_$map.addAll('),
+              refer(fieldNameJson).code,
+              const Code(');'),
+            ]);
+          }
           if (isNullable) {
             mapParts.add(const Code('}'));
           }

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -3507,4 +3507,199 @@ Object? toJson() {
       },
     );
   });
+
+  group('allOf with MapModel components', () {
+    test(
+      'generates toJson without calling .toJson() on MapModel '
+      'in complex encoding shape',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Base',
+          properties: [
+            Property(
+              name: 'id',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final mapModel = MapModel(
+          valueModel: NumberModel(context: context),
+          context: context,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'CombinedWithMap',
+          models: {classModel, mapModel},
+          context: context,
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedToJson = r'''
+          Object? toJson() {
+            final _$map = <String, Object?>{};
+            final _$$baseJson = $base.toJson();
+            if (_$$baseJson is! Map<String, Object?>) {
+              throw EncodingException(
+                'Expected \$base.toJson() to return Map<String, Object?>, got ${_$$baseJson.runtimeType}',
+              );
+            }
+            _$map.addAll(_$$baseJson);
+            final _$mapJson = map;
+            _$map.addAll(_$mapJson);
+            return _$map;
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedToJson)),
+        );
+      },
+    );
+
+    test(
+      'generates toJson with null guard for nullable MapModel '
+      'in complex encoding shape',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Base',
+          properties: [
+            Property(
+              name: 'id',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final mapModel = MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+          isNullable: true,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'CombinedWithNullableMap',
+          models: {classModel, mapModel},
+          context: context,
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedToJson = r'''
+          Object? toJson() {
+            final _$map = <String, Object?>{};
+            final _$$baseJson = $base.toJson();
+            if (_$$baseJson is! Map<String, Object?>) {
+              throw EncodingException(
+                'Expected \$base.toJson() to return Map<String, Object?>, got ${_$$baseJson.runtimeType}',
+              );
+            }
+            _$map.addAll(_$$baseJson);
+            if (map != null) {
+              final _$mapJson = map!;
+              _$map.addAll(_$mapJson);
+            }
+            return _$map;
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedToJson)),
+        );
+      },
+    );
+
+    test(
+      'generates toJson without calling .toJson() on MapModel '
+      'in dynamic encoding shape path',
+      () {
+        // A OneOfModel with mixed encoding shapes (simple + complex)
+        // triggers the dynamic path in _buildToJsonMethod.
+        final statusOneOf = OneOfModel(
+          isDeprecated: false,
+          name: 'Status',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (
+              discriminatorValue: null,
+              model: ClassModel(
+                isDeprecated: false,
+                name: 'State',
+                properties: const [],
+                context: context,
+              ),
+            ),
+          },
+          context: context,
+        );
+
+        final mapModel = MapModel(
+          valueModel: NumberModel(context: context),
+          context: context,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'DynamicWithMap',
+          models: {statusOneOf, mapModel},
+          context: context,
+        );
+
+        nameManager.prime(
+          models: {model, statusOneOf},
+          requestBodies: const <RequestBody>[],
+          responses: const <Response>[],
+          operations: const <Operation>[],
+          tags: const <Tag>[],
+          servers: const <Server>[],
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedToJson = r'''
+          Object? toJson() {
+            if (currentEncodingShape == EncodingShape.mixed) {
+              throw EncodingException(
+                r'Cannot encode DynamicWithMap: mixing simple values (primitives/enums) and complex types is not supported',
+              );
+            }
+            final _$map = <String, Object?>{};
+            final _$mapJson = map;
+            _$map.addAll(_$mapJson);
+            final _$statusJson = status.toJson();
+            if (_$statusJson is! Map<String, Object?>) {
+              throw EncodingException(
+                'Expected status.toJson() to return Map<String, Object?>, got ${_$statusJson.runtimeType}',
+              );
+            }
+            _$map.addAll(_$statusJson);
+            return _$map;
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedToJson)),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- The allOf generator was calling `.toJson()` on `Map<String, T>` types (from `additionalProperties`-based schemas), but Dart's `Map` doesn't have a `.toJson()` method
- Replaced hardcoded `.toJson()` calls in both the dynamic and complex encoding shape paths with `buildToJsonPropertyExpression`, which correctly handles MapModel
- Skips the redundant `is! Map<String, Object?>` type check for MapModel properties since their compile-time type already guarantees they're a Map

## Test plan

- [x] Unit test: allOf composing ClassModel + MapModel (complex encoding shape)
- [x] Unit test: allOf composing with nullable MapModel (complex encoding shape)
- [x] Unit test: allOf with dynamic encoding shape path where one component is a MapModel
- [x] `fvm dart analyze` passes with zero issues
- [x] Integration test analysis produces zero new warnings
- [x] Patch coverage: 100% (32/32 lines)