### PR TITLE
fix: use non-null-aware access for nullable headers inside null-check blocks

### DIFF
--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -230,6 +230,7 @@ class OptionsGenerator {
                   acceptHeader!.parameter,
                   explode: acceptHeader.parameter.explode,
                   allowEmpty: acceptHeader.parameter.allowEmptyValue,
+                  isNullChecked: true,
                 ),
               )
               .statement,
@@ -301,12 +302,13 @@ class OptionsGenerator {
       }
 
       parameters.add(_generateHeaderParameter(paramName, resolvedParam));
-      final headerAssignment = _generateHeaderAssignment(
-        paramName,
-        resolvedParam,
-      );
 
       if (!resolvedParam.isRequired) {
+        final headerAssignment = _generateHeaderAssignment(
+          paramName,
+          resolvedParam,
+          isNullChecked: true,
+        );
         bodyStatements.add(
           Block.of([
             Code('if ($paramName != null) {'),
@@ -315,6 +317,10 @@ class OptionsGenerator {
           ]),
         );
       } else {
+        final headerAssignment = _generateHeaderAssignment(
+          paramName,
+          resolvedParam,
+        );
         bodyStatements.add(headerAssignment);
       }
     }
@@ -490,13 +496,15 @@ class OptionsGenerator {
 
   Code _generateHeaderAssignment(
     String paramName,
-    RequestHeaderObject resolvedParam,
-  ) {
+    RequestHeaderObject resolvedParam, {
+    bool isNullChecked = false,
+  }) {
     final valueExpression = buildToSimpleHeaderParameterExpression(
       paramName,
       resolvedParam,
       explode: resolvedParam.explode,
       allowEmpty: resolvedParam.allowEmptyValue,
+      isNullChecked: isNullChecked,
     );
 
     return refer(r'_$headers')

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -30,19 +30,21 @@ Expression buildToSimplePathParameterExpression(
 /// Creates a Dart expression that correctly serializes a
 /// header parameter to its simple parameter encoding representation.
 ///
-/// Header parameters use `?.` when the model is nullable, as they can be
-/// optional.
+/// When [isNullChecked] is true, the expression is already inside a
+/// null-check block (`if (param != null)`), so null-aware access is
+/// unnecessary even for nullable models.
 Expression buildToSimpleHeaderParameterExpression(
   String parameterName,
   RequestHeaderObject parameter, {
   bool explode = false,
   bool allowEmpty = true,
+  bool isNullChecked = false,
 }) {
   final model = parameter.model;
   return _buildSimpleSerializationExpression(
     refer(parameterName),
     model,
-    isNullable: model.isEffectivelyNullable,
+    isNullable: !isNullChecked && model.isEffectivelyNullable,
     explode: explode,
     allowEmpty: allowEmpty,
   );

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -421,6 +421,82 @@ void main() {
       );
     });
 
+    test(
+      'optional header with nullable model uses non-null access '
+      'inside null-check block',
+      () {
+        final optionalNullableHeader = RequestHeaderObject(
+          name: 'X-Nullable-Object',
+          rawName: 'X-Nullable-Object',
+          description: 'An optional header with a nullable model',
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          model: ClassModel(
+            name: 'NullableObj',
+            properties: const [],
+            context: context,
+            isNullable: true,
+            isDeprecated: false,
+          ),
+          encoding: HeaderParameterEncoding.simple,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'operationWithNullableHeader',
+          context: context,
+          summary: 'Operation with nullable header',
+          description: 'An operation with an optional nullable header',
+          tags: const {},
+          isDeprecated: false,
+          path: '/with-nullable-header',
+          method: HttpMethod.get,
+          headers: {optionalNullableHeader},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final headers =
+            <({String normalizedName, RequestHeaderObject parameter})>[
+              (
+                normalizedName: 'xNullableObject',
+                parameter: optionalNullableHeader,
+              ),
+            ];
+
+        const expectedMethod = r'''
+            Options _options({NullableObj? xNullableObject}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              if (xNullableObject != null) {
+                _$headers[r'X-Nullable-Object'] =
+                    xNullableObject.toSimple(explode: false, allowEmpty: false);
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+        final method =
+            generator.generateOptionsMethod(operation, headers, []);
+
+        expect(method, isA<Method>());
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
     test('encodes headers with allowEmpty and explode flags', () {
       final requestHeader = RequestHeaderObject(
         name: 'X-My-Header',

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -462,5 +462,107 @@ void main() {
         'xCustomHeader?.toSimple(explode: false, allowEmpty: true, )',
       );
     });
+
+    test(
+      'uses non-null call for effectively nullable AliasModel '
+      'when isNullChecked is true',
+      () {
+        final parameter = RequestHeaderObject(
+          name: 'x-custom-header',
+          rawName: 'x-custom-header',
+          description: 'Custom header',
+          model: AliasModel(
+            name: 'HeaderAlias',
+            model: StringModel(context: context),
+            context: context,
+            isNullable: true,
+          ),
+          encoding: HeaderParameterEncoding.simple,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: false,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          emit(
+            buildToSimpleHeaderParameterExpression(
+              'xCustomHeader',
+              parameter,
+              isNullChecked: true,
+            ),
+          ),
+          'xCustomHeader.toSimple(explode: false, allowEmpty: true, )',
+        );
+      },
+    );
+
+    test(
+      'uses non-null call for nullable ClassModel '
+      'when isNullChecked is true',
+      () {
+        final parameter = RequestHeaderObject(
+          name: 'x-nullable-object',
+          rawName: 'X-Nullable-Object',
+          description: 'Nullable object header',
+          model: ClassModel(
+            name: 'NullableObj',
+            properties: const [],
+            context: context,
+            isNullable: true,
+            isDeprecated: false,
+          ),
+          encoding: HeaderParameterEncoding.simple,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: false,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          emit(
+            buildToSimpleHeaderParameterExpression(
+              'xNullableObject',
+              parameter,
+              isNullChecked: true,
+            ),
+          ),
+          'xNullableObject.toSimple(explode: false, allowEmpty: true, )',
+        );
+      },
+    );
+
+    test(
+      'uses null-safe call for nullable model when isNullChecked is false',
+      () {
+        final parameter = RequestHeaderObject(
+          name: 'x-nullable-header',
+          rawName: 'X-Nullable-Header',
+          description: 'Nullable header',
+          model: ClassModel(
+            name: 'NullableObj',
+            properties: const [],
+            context: context,
+            isNullable: true,
+            isDeprecated: false,
+          ),
+          encoding: HeaderParameterEncoding.simple,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          emit(
+            buildToSimpleHeaderParameterExpression(
+              'xNullableHeader',
+              parameter,
+            ),
+          ),
+          'xNullableHeader?.toSimple(explode: false, allowEmpty: true, )',
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Fixed code generator producing `?.toSimple()` (null-aware) for optional nullable header parameters inside `if (param != null)` blocks, where the variable is already promoted to non-null
- The `?.` operator produces `String?` instead of `String`, triggering `invalid_null_aware_operator` analyzer warnings
- Added `isNullChecked` parameter to `buildToSimpleHeaderParameterExpression` that forces non-null-aware access when the call site already handles nullability

## Test plan
- [x] Unit tests for `buildToSimpleHeaderParameterExpression` with `isNullChecked: true` (AliasModel, ClassModel)
- [x] Regression test for `isNullChecked: false` preserving `?.` behavior
- [x] Full method body test in `options_generator_test` verifying `.toSimple` inside if-block
- [x] Integration tests pass (3528 tests, 33 suites) — `simple_encoding` `test_header_roundtrip_nullable.dart` no longer has warnings
- [x] Analysis clean, patch coverage 100%