### PR TITLE
fix: use wildcard pattern in throw-only switch arms

### DIFF
--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -88,7 +88,7 @@ class DataGenerator {
                   NamedModel() ||
                   CompositeModel():
                 switchCases
-                  ..add(const Code(' value => '))
+                  ..add(const Code(' _ => '))
                   ..add(
                     generateEncodingExceptionExpression(
                       'Unsupported model for bytes content type.',
@@ -126,8 +126,9 @@ class DataGenerator {
               )
               ..add(const Code(','));
           case .multipart:
+            final isClassModel = c.model.resolved is ClassModel;
             switchCases
-              ..add(const Code(' value => '))
+              ..add(Code(isClassModel ? ' value => ' : ' _ => '))
               ..add(
                 buildMultipartBodyExpression(
                   c,

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1603,7 +1603,7 @@ void main() {
 
       test(
         'generates runtime throw for EnumModel with bytes in '
-        'multi-content request body',
+        'multi-content request body using wildcard pattern',
         () {
           final operation = Operation(
             operationId: 'testOp',
@@ -1649,14 +1649,100 @@ void main() {
             securitySchemes: const {},
           );
 
+          const expectedMethod = '''
+            Object? _data({required Test body}) {
+              return switch (body) {
+                final TestJson value => value.value.toJson(),
+                final TestOctetStream _ => throw EncodingException('Unsupported model for bytes content type.'),
+              };
+            }
+          ''';
+
           final method = generator.generateDataMethod(operation);
           final methodString = format(method.accept(emitter).toString());
           expect(
             collapseWhitespace(methodString),
-            contains('EncodingException'),
+            collapseWhitespace(format(expectedMethod)),
           );
         },
       );
     });
+
+    group(
+      'non-ClassModel multipart in multi-content uses wildcard pattern',
+      () {
+        test(
+          'generates throw with wildcard pattern for MapModel multipart in '
+          'multi-content request body',
+          () {
+            final jsonModel = ClassModel(
+              name: 'JsonPayload',
+              isDeprecated: false,
+              properties: const [],
+              context: testContext,
+            );
+
+            final mapModel = MapModel(
+              name: 'AssetMap',
+              valueModel: StringModel(context: testContext),
+              context: testContext,
+            );
+
+            final operation = Operation(
+              operationId: 'createItem',
+              path: '/items',
+              method: HttpMethod.post,
+              requestBody: RequestBodyObject(
+                name: 'createItem',
+                context: testContext,
+                description: null,
+                isRequired: true,
+                content: {
+                  RequestContent(
+                    model: jsonModel,
+                    contentType: ContentType.json,
+                    rawContentType: 'application/json',
+                  ),
+                  RequestContent(
+                    model: mapModel,
+                    contentType: ContentType.multipart,
+                    rawContentType: 'multipart/form-data',
+                  ),
+                },
+              ),
+              responses: const {},
+              pathParameters: const {},
+              cookieParameters: const {},
+              queryParameters: const {},
+              headers: const {},
+              context: testContext,
+              tags: const {},
+              isDeprecated: false,
+              securitySchemes: const {},
+            );
+
+            const expectedMethod = '''
+              Future<Object?> _data({required CreateItem body}) async {
+                return switch (body) {
+                  final CreateItemJson value => value.value.toJson(),
+                  final CreateItemFormData _ => await () async {
+                    throw UnsupportedError(
+                      'Multipart request bodies require an object schema (ClassModel). Got: MapModel.',
+                    );
+                  }(),
+                };
+              }
+            ''';
+
+            final method = generator.generateDataMethod(operation);
+            final methodString = format(method.accept(emitter).toString());
+            expect(
+              collapseWhitespace(methodString),
+              collapseWhitespace(format(expectedMethod)),
+            );
+          },
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Generated switch expression arms that only throw (bytes with unsupported models, multipart with non-ClassModel schemas) now bind `_` instead of `value`, eliminating `unused_local_variable` lint warnings in generated code
- Updated existing bytes throw test to use full method body comparison
- Added new test for multipart throw-only arm in multi-content switch expressions

## Test plan
- [x] Unit tests verify both bytes and multipart throw arms use `_` pattern
- [x] `fvm dart analyze` passes with zero issues
- [x] All 908 unit tests pass
- [x] All 35 integration test suites pass after regeneration
- [x] Patch coverage: 100%