### PR TITLE
fix: sanitize naming collisions for keywords, Object members, and body params

### DIFF
--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -1,0 +1,1680 @@
+openapi: 3.0.4
+info:
+  title: Naming Nightmare API
+  version: 1.0.0
+
+paths:
+  /keyword/switch:
+    get:
+      operationId: switch
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/class:
+    get:
+      operationId: class
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/return:
+    get:
+      operationId: return
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/void:
+    get:
+      operationId: void
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/null:
+    get:
+      operationId: "null"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/true:
+    get:
+      operationId: "true"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/false:
+    get:
+      operationId: "false"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/new:
+    get:
+      operationId: new
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/abstract:
+    get:
+      operationId: abstract
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/enum:
+    get:
+      operationId: enum
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/is:
+    get:
+      operationId: is
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/in:
+    get:
+      operationId: in
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/extends:
+    get:
+      operationId: extends
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/with:
+    get:
+      operationId: with
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/try:
+    get:
+      operationId: try
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/throw:
+    get:
+      operationId: throw
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/super:
+    get:
+      operationId: super
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/this:
+    get:
+      operationId: this
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/async:
+    get:
+      operationId: async
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/await:
+    get:
+      operationId: await
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/yield:
+    get:
+      operationId: yield
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/import:
+    get:
+      operationId: import
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/export:
+    get:
+      operationId: export
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/factory:
+    get:
+      operationId: factory
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/implements:
+    get:
+      operationId: implements
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/var:
+    get:
+      operationId: var
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/final:
+    get:
+      operationId: final
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/const:
+    get:
+      operationId: const
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/dynamic:
+    get:
+      operationId: dynamic
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/default:
+    get:
+      operationId: default
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/toString:
+    get:
+      operationId: toString
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/hashCode:
+    get:
+      operationId: hashCode
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/runtimeType:
+    get:
+      operationId: runtimeType
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/noSuchMethod:
+    get:
+      operationId: noSuchMethod
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/call:
+    get:
+      operationId: call
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /keyword/main:
+    get:
+      operationId: main
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /body-collision/query:
+    post:
+      operationId: createWithBodyQuery
+      parameters:
+        - name: body
+          in: query
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /body-collision/header:
+    post:
+      operationId: createWithBodyHeader
+      parameters:
+        - name: body
+          in: header
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /body-collision/cookie:
+    post:
+      operationId: createWithBodyCookie
+      parameters:
+        - name: body
+          in: cookie
+          required: false
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /body-collision/all:
+    post:
+      operationId: createWithBodyEverywhere
+      parameters:
+        - name: body
+          in: query
+          schema:
+            type: string
+        - name: body
+          in: header
+          schema:
+            type: string
+        - name: body
+          in: cookie
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+
+  /param-keyword-collision/{class}:
+    post:
+      operationId: createWithKeywordParams
+      parameters:
+        - name: class
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: return
+          in: query
+          schema:
+            type: string
+        - name: void
+          in: query
+          schema:
+            type: string
+        - name: switch
+          in: header
+          schema:
+            type: string
+        - name: async
+          in: cookie
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+
+  /param-duplicates/{id}:
+    get:
+      operationId: getWithDuplicateParams
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: string
+        - name: id
+          in: header
+          schema:
+            type: string
+        - name: id
+          in: cookie
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /object-methods:
+    get:
+      operationId: getObjectMethodCollider
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ObjectMethodCollider'
+
+  /functions:
+    get:
+      operationId: listFunctions
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Function'
+
+  /functions/{id}:
+    get:
+      operationId: getFunction
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Function'
+
+  /types:
+    get:
+      operationId: getTypeContainer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TypeContainer'
+
+  /generated-methods:
+    get:
+      operationId: getGeneratedMethodCollider
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneratedMethodCollider'
+
+  /camel-collision:
+    get:
+      operationId: getCamelCaseCollider
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CamelCaseCollider'
+
+  /keyword-enum:
+    get:
+      operationId: getByKeywordEnum
+      parameters:
+        - name: status
+          in: query
+          schema:
+            $ref: '#/components/schemas/KeywordEnum'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /numeric-enum:
+    get:
+      operationId: getByNumericEnum
+      parameters:
+        - name: code
+          in: query
+          schema:
+            $ref: '#/components/schemas/NumericEnum'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /weird-properties:
+    get:
+      operationId: getWeirdProperties
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/WeirdPropertyNames'
+
+  /keyword-properties:
+    get:
+      operationId: getKeywordProperties
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeywordPropertyNames'
+
+  /lowercase-function:
+    get:
+      operationId: getLowercaseFunction
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/function'
+
+  /dart-core-errors:
+    get:
+      operationId: getDartCoreErrors
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DartCoreContainer'
+
+  /self-referencing:
+    get:
+      operationId: getSelfReferencing
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SelfReferencer'
+
+  /discriminator-keywords:
+    get:
+      operationId: getDiscriminatorKeywords
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/KeywordDiscriminator'
+
+  /allof-property-clash:
+    get:
+      operationId: getAllOfPropertyClash
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AllOfPropertyClash'
+
+  /operationId-collision/camel:
+    get:
+      operationId: getItems
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /operationId-collision/snake:
+    get:
+      operationId: get_items
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /operationId-collision/kebab:
+    get:
+      operationId: get-items
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /operationId-starts-with-number:
+    get:
+      operationId: 2faVerify
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /operationId-underscore:
+    get:
+      operationId: _
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /operationId-double-underscore:
+    get:
+      operationId: __private
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /enum-reserved:
+    get:
+      operationId: getEnumReserved
+      parameters:
+        - name: pick
+          in: query
+          schema:
+            $ref: '#/components/schemas/EnumReservedNames'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /enum-case-collision:
+    get:
+      operationId: getEnumCaseCollision
+      parameters:
+        - name: toggle
+          in: query
+          schema:
+            $ref: '#/components/schemas/CaseCollisionEnum'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /enum-special:
+    get:
+      operationId: getEnumSpecial
+      parameters:
+        - name: value
+          in: query
+          schema:
+            $ref: '#/components/schemas/SpecialCharEnum'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
+  /naming-api:
+    get:
+      operationId: getNamingApi
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NamingApi'
+
+  /default-api:
+    get:
+      operationId: getDefaultApi
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultApi'
+
+  /self-named-property:
+    get:
+      operationId: getSelfNamedProperty
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SelfNamedProperty'
+
+components:
+  schemas:
+    SimpleResult:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: string
+        message:
+          type: string
+
+    ObjectMethodCollider:
+      type: object
+      required:
+        - runtimeType
+        - hashCode
+      properties:
+        runtimeType:
+          type: string
+        hashCode:
+          type: integer
+        noSuchMethod:
+          type: string
+        toString:
+          type: string
+
+    Function:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        arn:
+          type: string
+        runtime:
+          type: string
+
+    function:
+      type: object
+      properties:
+        handler:
+          type: string
+        timeout:
+          type: integer
+
+    Type:
+      type: object
+      properties:
+        name:
+          type: string
+        kind:
+          type: string
+
+    Object:
+      type: object
+      properties:
+        key:
+          type: string
+        value:
+          type: string
+
+    String:
+      type: object
+      properties:
+        content:
+          type: string
+        encoding:
+          type: string
+
+    List:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            type: string
+        count:
+          type: integer
+
+    Map:
+      type: object
+      properties:
+        entries:
+          type: object
+          additionalProperties:
+            type: string
+
+    "Null":
+      type: object
+      properties:
+        reason:
+          type: string
+
+    Set:
+      type: object
+      properties:
+        elements:
+          type: array
+          items:
+            type: string
+
+    Future:
+      type: object
+      properties:
+        status:
+          type: string
+        completedAt:
+          type: string
+          format: date-time
+
+    Stream:
+      type: object
+      properties:
+        url:
+          type: string
+        protocol:
+          type: string
+
+    Error:
+      type: object
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: integer
+        message:
+          type: string
+        stackTrace:
+          type: string
+
+    Exception:
+      type: object
+      properties:
+        type:
+          type: string
+        cause:
+          type: string
+
+    Iterator:
+      type: object
+      properties:
+        current:
+          type: string
+        hasNext:
+          type: boolean
+
+    Iterable:
+      type: object
+      properties:
+        length:
+          type: integer
+        isEmpty:
+          type: boolean
+
+    Duration:
+      type: object
+      properties:
+        milliseconds:
+          type: integer
+
+    DateTime:
+      type: object
+      properties:
+        iso:
+          type: string
+        epoch:
+          type: integer
+
+    Uri:
+      type: object
+      properties:
+        scheme:
+          type: string
+        host:
+          type: string
+        path:
+          type: string
+
+    RegExp:
+      type: object
+      properties:
+        pattern:
+          type: string
+        flags:
+          type: string
+
+    Enum:
+      type: object
+      properties:
+        index:
+          type: integer
+        name:
+          type: string
+
+    Record:
+      type: object
+      properties:
+        fields:
+          type: array
+          items:
+            type: string
+
+    Symbol:
+      type: object
+      properties:
+        name:
+          type: string
+
+    StackTrace:
+      type: object
+      properties:
+        frames:
+          type: array
+          items:
+            type: string
+
+    Comparable:
+      type: object
+      properties:
+        rank:
+          type: integer
+
+    Pattern:
+      type: object
+      properties:
+        regex:
+          type: string
+
+    int:
+      type: object
+      properties:
+        value:
+          type: integer
+
+    double:
+      type: object
+      properties:
+        value:
+          type: number
+
+    bool:
+      type: object
+      properties:
+        value:
+          type: boolean
+
+    num:
+      type: object
+      properties:
+        value:
+          type: number
+
+    dynamic:
+      type: object
+      properties:
+        value:
+          type: string
+
+    TypeContainer:
+      type: object
+      properties:
+        type:
+          $ref: '#/components/schemas/Type'
+        object:
+          $ref: '#/components/schemas/Object'
+        string:
+          $ref: '#/components/schemas/String'
+        list:
+          $ref: '#/components/schemas/List'
+        map:
+          $ref: '#/components/schemas/Map'
+        nullValue:
+          $ref: '#/components/schemas/Null'
+        set:
+          $ref: '#/components/schemas/Set'
+        future:
+          $ref: '#/components/schemas/Future'
+        stream:
+          $ref: '#/components/schemas/Stream'
+
+    DartCoreContainer:
+      type: object
+      properties:
+        error:
+          $ref: '#/components/schemas/Error'
+        exception:
+          $ref: '#/components/schemas/Exception'
+        iterator:
+          $ref: '#/components/schemas/Iterator'
+        iterable:
+          $ref: '#/components/schemas/Iterable'
+        duration:
+          $ref: '#/components/schemas/Duration'
+        dateTime:
+          $ref: '#/components/schemas/DateTime'
+        uri:
+          $ref: '#/components/schemas/Uri'
+        regExp:
+          $ref: '#/components/schemas/RegExp'
+        enum:
+          $ref: '#/components/schemas/Enum'
+        record:
+          $ref: '#/components/schemas/Record'
+        symbol:
+          $ref: '#/components/schemas/Symbol'
+        stackTrace:
+          $ref: '#/components/schemas/StackTrace'
+        comparable:
+          $ref: '#/components/schemas/Comparable'
+        pattern:
+          $ref: '#/components/schemas/Pattern'
+        intValue:
+          $ref: '#/components/schemas/int'
+        doubleValue:
+          $ref: '#/components/schemas/double'
+        boolValue:
+          $ref: '#/components/schemas/bool'
+        numValue:
+          $ref: '#/components/schemas/num'
+        dynamicValue:
+          $ref: '#/components/schemas/dynamic'
+
+    GeneratedMethodCollider:
+      type: object
+      properties:
+        fromJson:
+          type: string
+        toJson:
+          type: string
+        copyWith:
+          type: string
+        fromSimple:
+          type: string
+        toSimple:
+          type: string
+        fromForm:
+          type: string
+        toForm:
+          type: string
+        toLabel:
+          type: string
+        toMatrix:
+          type: string
+        toDeepObject:
+          type: string
+        currentEncodingShape:
+          type: string
+        parameterProperties:
+          type: string
+        uriEncode:
+          type: string
+
+    CamelCaseCollider:
+      type: object
+      properties:
+        my_field:
+          type: string
+        myField:
+          type: string
+        my-field:
+          type: string
+        MY_FIELD:
+          type: string
+        myfield:
+          type: string
+        My_Field:
+          type: string
+
+    TripleCamelCollider:
+      type: object
+      properties:
+        status_code:
+          type: integer
+        statusCode:
+          type: integer
+        status-code:
+          type: integer
+        STATUS_CODE:
+          type: integer
+        status_Code:
+          type: integer
+        Status_Code:
+          type: integer
+
+    KeywordEnum:
+      type: string
+      enum:
+        - switch
+        - class
+        - return
+        - void
+        - "null"
+        - "true"
+        - "false"
+        - abstract
+        - enum
+        - super
+        - new
+        - this
+        - is
+        - in
+        - if
+        - for
+        - while
+        - do
+        - try
+        - catch
+        - throw
+        - final
+        - const
+        - var
+        - dynamic
+        - async
+        - await
+        - yield
+        - factory
+        - operator
+        - typedef
+        - mixin
+        - extends
+        - implements
+        - with
+        - late
+        - required
+        - sealed
+        - base
+        - interface
+
+    NumericEnum:
+      type: string
+      enum:
+        - "200"
+        - "404"
+        - "500"
+        - "0"
+        - "-1"
+        - "007"
+        - "1.0"
+        - "2.1.0"
+        - "100_000"
+
+    EnumReservedNames:
+      type: string
+      enum:
+        - index
+        - values
+        - name
+        - normal
+        - hashCode
+        - toString
+        - runtimeType
+        - noSuchMethod
+
+    CaseCollisionEnum:
+      type: string
+      enum:
+        - "ON"
+        - "on"
+        - "On"
+        - "oN"
+        - "OFF"
+        - "off"
+        - "Off"
+        - active
+        - ACTIVE
+        - Active
+
+    SpecialCharEnum:
+      type: string
+      enum:
+        - ""
+        - " "
+        - "  "
+        - "hello world"
+        - "with-dashes"
+        - "with.dots"
+        - "with/slash"
+        - "with:colon"
+        - "$dollar"
+        - "@at"
+        - "#hash"
+        - "+plus"
+        - "*star"
+        - "~tilde"
+        - "a"
+        - "1"
+
+    WeirdPropertyNames:
+      type: object
+      properties:
+        "123start":
+          type: string
+        "9lives":
+          type: string
+        "0":
+          type: string
+        "1":
+          type: string
+        "_leading":
+          type: string
+        "__double":
+          type: string
+        "___triple":
+          type: string
+        "_":
+          type: string
+        "__":
+          type: string
+        "$dollar":
+          type: string
+        "$$doubleDollar":
+          type: string
+        "with spaces":
+          type: string
+        "with.dots":
+          type: string
+        "with/slashes":
+          type: string
+        "with:colons":
+          type: string
+        "with@at":
+          type: string
+        "with#hash":
+          type: string
+        "with+plus":
+          type: string
+        "with*star":
+          type: string
+        "with~tilde":
+          type: string
+        "with<angle>brackets":
+          type: string
+        "with(parens)":
+          type: string
+        "with[brackets]":
+          type: string
+        "with{braces}":
+          type: string
+        "SCREAMING_CASE":
+          type: string
+        "a":
+          type: string
+        "x-custom-header":
+          type: string
+        "":
+          type: string
+        " ":
+          type: string
+        "kebab-case-name":
+          type: string
+        "snake_case_name":
+          type: string
+        "camelCaseName":
+          type: string
+        "PascalCaseName":
+          type: string
+
+    KeywordPropertyNames:
+      type: object
+      properties:
+        class:
+          type: string
+        factory:
+          type: string
+        operator:
+          type: string
+        is:
+          type: boolean
+        as:
+          type: string
+        in:
+          type: string
+        late:
+          type: string
+        required:
+          type: boolean
+        default:
+          type: string
+        switch:
+          type: string
+        return:
+          type: string
+        void:
+          type: string
+        yield:
+          type: string
+        async:
+          type: string
+        await:
+          type: string
+        import:
+          type: string
+        export:
+          type: string
+        extends:
+          type: string
+        implements:
+          type: string
+        with:
+          type: string
+        dynamic:
+          type: string
+        covariant:
+          type: string
+        static:
+          type: string
+        external:
+          type: string
+        typedef:
+          type: string
+        mixin:
+          type: string
+        enum:
+          type: string
+        abstract:
+          type: string
+        new:
+          type: string
+        super:
+          type: string
+        this:
+          type: string
+        throw:
+          type: string
+        try:
+          type: string
+        catch:
+          type: string
+        finally:
+          type: string
+        for:
+          type: string
+        while:
+          type: string
+        do:
+          type: string
+        if:
+          type: string
+        else:
+          type: string
+        break:
+          type: string
+        continue:
+          type: string
+        assert:
+          type: string
+        final:
+          type: string
+        const:
+          type: string
+        var:
+          type: string
+        "null":
+          type: string
+        "true":
+          type: string
+        "false":
+          type: string
+        rethrow:
+          type: string
+        sealed:
+          type: string
+        base:
+          type: string
+        interface:
+          type: string
+        when:
+          type: string
+        show:
+          type: string
+        hide:
+          type: string
+        of:
+          type: string
+        on:
+          type: string
+        part:
+          type: string
+        deferred:
+          type: string
+        library:
+          type: string
+        get:
+          type: string
+        set:
+          type: string
+        sync:
+          type: string
+        extension:
+          type: string
+
+    SelfReferencer:
+      type: object
+      properties:
+        name:
+          type: string
+        parent:
+          $ref: '#/components/schemas/SelfReferencer'
+        children:
+          type: array
+          items:
+            $ref: '#/components/schemas/SelfReferencer'
+
+    KeywordDiscriminator:
+      oneOf:
+        - $ref: '#/components/schemas/DiscriminatorVariantA'
+        - $ref: '#/components/schemas/DiscriminatorVariantB'
+      discriminator:
+        propertyName: class
+        mapping:
+          switch: '#/components/schemas/DiscriminatorVariantA'
+          return: '#/components/schemas/DiscriminatorVariantB'
+
+    DiscriminatorVariantA:
+      type: object
+      required:
+        - class
+      properties:
+        class:
+          type: string
+        switch:
+          type: string
+
+    DiscriminatorVariantB:
+      type: object
+      required:
+        - class
+      properties:
+        class:
+          type: string
+        return:
+          type: string
+
+    AllOfPropertyClash:
+      allOf:
+        - $ref: '#/components/schemas/AllOfBase'
+        - $ref: '#/components/schemas/AllOfExtension'
+
+    AllOfBase:
+      type: object
+      required:
+        - type
+        - name
+      properties:
+        type:
+          type: string
+        name:
+          type: string
+        class:
+          type: string
+
+    AllOfExtension:
+      type: object
+      properties:
+        type:
+          type: integer
+        value:
+          type: string
+        class:
+          type: integer
+
+    NamingApi:
+      type: object
+      properties:
+        id:
+          type: string
+        endpoint:
+          type: string
+
+    DefaultApi:
+      type: object
+      properties:
+        id:
+          type: string
+        version:
+          type: string
+
+    SelfNamedProperty:
+      type: object
+      properties:
+        selfNamedProperty:
+          type: string
+        SelfNamedProperty:
+          type: string
+        self_named_property:
+          type: string

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -154,7 +154,7 @@ class ApiClientGenerator {
     return Method(
       (b) {
         b
-          ..name = nameManager.operationName(operation).toCamelCase()
+          ..name = nameManager.operationMethodName(operation)
           ..returns = TypeReference(
             (b) => b
               ..symbol = 'Future'

--- a/packages/tonik_generate/lib/src/naming/name_generator.dart
+++ b/packages/tonik_generate/lib/src/naming/name_generator.dart
@@ -1,5 +1,6 @@
 import 'package:change_case/change_case.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_utils.dart';
 
 /// A manager for handling unique names in generated Dart code.
 class NameGenerator {
@@ -31,6 +32,8 @@ class NameGenerator {
     String? discriminatorValue,
   ) {
     if (model is NamedModel && model.name != null && model.name!.isNotEmpty) {
+      // No keyword check needed: variant names are always combined with
+      // a parent prefix (e.g., 'ResultError'), making them safe.
       final sanitizedName = _sanitizeName(model.name!);
       final variantName = '$parentClassName$sanitizedName';
       return _makeUnique(variantName, '');
@@ -56,7 +59,9 @@ class NameGenerator {
         baseName = _generateBaseName(name: name, context: model.context);
       }
     } else {
-      baseName = _generateBaseName(name: name, context: model.context);
+      baseName = ensureValidClassName(
+        _generateBaseName(name: name, context: model.context),
+      );
     }
 
     if (name == null || name.isEmpty) {
@@ -137,10 +142,16 @@ class NameGenerator {
   /// 2. Combined context path components
   /// 3. 'Anonymous' as fallback
   String generateResponseName(Response response) {
-    final baseName = _generateBaseName(
+    final rawBaseName = _generateBaseName(
       name: response.name,
       context: response.context,
     );
+
+    // Only apply keyword check when the response has an explicit name
+    final baseName =
+        response.name != null && response.name!.isNotEmpty
+            ? ensureValidClassName(rawBaseName)
+            : rawBaseName;
 
     // Only add Response suffix for anonymous responses
     if (response.name == null || (response.name?.isEmpty ?? false)) {
@@ -159,9 +170,11 @@ class NameGenerator {
   /// 4. 'Anonymous' as fallback
   String generateOperationName(Operation operation) {
     final name = operation.nameOverride ?? operation.operationId;
-    final baseName = _generateBaseName(
-      name: name,
-      context: operation.context,
+    final baseName = ensureValidClassName(
+      _generateBaseName(
+        name: name,
+        context: operation.context,
+      ),
     );
     return _makeUniqueWithTypeSuffix(baseName, _operationSuffix);
   }
@@ -169,7 +182,7 @@ class NameGenerator {
   /// Generates a unique API class name for a tag.
   String generateTagName(Tag tag) {
     final name = tag.nameOverride ?? tag.name;
-    final baseName = _sanitizeName(name);
+    final baseName = ensureValidClassName(_sanitizeName(name));
     final nameWithSuffix = '$baseName$_apiSuffix';
 
     if (!_usedNames.contains(nameWithSuffix)) {

--- a/packages/tonik_generate/lib/src/naming/name_manager.dart
+++ b/packages/tonik_generate/lib/src/naming/name_manager.dart
@@ -1,7 +1,9 @@
+import 'package:change_case/change_case.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_utils.dart';
 
 /// Manages name generation and caches results for consistent naming.
 class NameManager {
@@ -165,11 +167,25 @@ class NameManager {
     });
   }
 
-  /// Gets a cached or generates a new unique operation name.
+  /// Gets a cached or generates a new unique operation name in PascalCase.
+  ///
+  /// Used for operation class names (e.g., `Switch`, `GetUser`).
+  /// For API client method names, use [operationMethodName] instead.
   String operationName(Operation operation) {
     return operationNames.putIfAbsent(operation, () {
       return generator.generateOperationName(operation);
     });
+  }
+
+  /// Gets a camelCase method name for an operation, suitable for use
+  /// in API client classes.
+  ///
+  /// Converts the PascalCase [operationName] to camelCase and applies
+  /// keyword escaping, since camelCase names like `switch` or `class`
+  /// collide with Dart reserved words.
+  String operationMethodName(Operation operation) {
+    final pascalName = operationName(operation);
+    return ensureNotKeyword(pascalName.toCamelCase());
   }
 
   /// Gets a cached or generates a new unique API class name for a tag.

--- a/packages/tonik_generate/lib/src/naming/name_utils.dart
+++ b/packages/tonik_generate/lib/src/naming/name_utils.dart
@@ -111,7 +111,20 @@ const generatedClassTokens = {
   'uriEncode',
 };
 
-const Set<String> allKeywords = {...dartKeywords, ...generatedClassTokens};
+/// Members inherited from [Object] that conflict with field declarations.
+/// Unlike [generatedClassTokens] which are methods the generator adds,
+/// these are members every Dart class inherits. A field named `runtimeType`
+/// would illegally override `Object.runtimeType` with an incompatible type.
+const reservedObjectMembers = {
+  'runtimeType',
+  'noSuchMethod',
+};
+
+const Set<String> allKeywords = {
+  ...dartKeywords,
+  ...generatedClassTokens,
+  ...reservedObjectMembers,
+};
 
 /// Names that conflict with members inherited by all Dart enums.
 /// These are only reserved for enum values, not class properties.
@@ -213,8 +226,27 @@ String _numberToWords(int number) {
 
 /// Ensures a name is not a Dart keyword by adding a $ prefix if necessary.
 String ensureNotKeyword(String name) {
-  if (allKeywords.contains(name.toCamelCase()) ||
+  if (allKeywords.contains(name) ||
+      allKeywords.contains(name.toCamelCase()) ||
       allKeywords.contains(name.toLowerCase())) {
+    return '\$$name';
+  }
+  return name;
+}
+
+/// Ensures a PascalCase class name is not a Dart built-in identifier.
+///
+/// Only checks exact match against [allKeywords]. PascalCase forms of
+/// lowercase keywords like `Switch`, `Return`, `Default` are valid Dart
+/// class names. The only keyword stored with an uppercase letter is
+/// `Function`, making it the only realistic collision for schema names.
+///
+/// Note: `dart:core` types like `String`, `List`, `Object`, `Enum` are
+/// NOT blocked because Tonik imports `dart:core` with a prefix
+/// (via `CorePrefixedAllocator`), so user-defined classes with those
+/// names never shadow built-in types.
+String ensureValidClassName(String name) {
+  if (allKeywords.contains(name)) {
     return '\$$name';
   }
   return name;

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -42,6 +42,7 @@ NormalizedRequestParameters normalizeRequestParameters({
   required Set<QueryParameterObject> queryParameters,
   required Set<RequestHeaderObject> headers,
   Set<CookieParameterObject> cookieParameters = const {},
+  Set<String> reservedNames = const {},
 }) {
   final normalizedPathParams = _normalizePathParameters(pathParameters);
   final normalizedQueryParams = _normalizeQueryParameters(queryParameters);
@@ -50,6 +51,15 @@ NormalizedRequestParameters normalizeRequestParameters({
 
   // Track which parameter types contain each name.
   final nameInTypes = <String, Set<String>>{};
+
+  // Seed with reserved names so parameters that collide with them
+  // get a type suffix (e.g., a query param named 'body' becomes
+  // 'bodyQuery' when 'body' is reserved by the request body).
+  for (final reserved in reservedNames) {
+    nameInTypes
+        .putIfAbsent(reserved.toLowerCase(), () => <String>{})
+        .add('reserved');
+  }
 
   // Count occurrences per type.
   for (final item in normalizedPathParams) {

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -97,11 +97,15 @@ class OperationGenerator {
         .map((p) => p.resolve())
         .toSet();
 
+    final hasRequestBody =
+        operation.requestBody?.resolvedContent.isNotEmpty ?? false;
+
     final normalizedParams = normalizeRequestParameters(
       pathParameters: pathParams,
       queryParameters: queryParams,
       headers: headerParams,
       cookieParameters: cookieParams,
+      reservedNames: hasRequestBody ? {'body'} : {},
     );
 
     return Class(
@@ -187,38 +191,23 @@ class OperationGenerator {
     }
 
     for (final pathParam in normalizedParams.pathParameters) {
-      // When the parameter name collides with the request body's hardcoded
-      // 'body' name, the external parameter gets a type suffix (e.g.,
-      // 'bodyPath'). The internal method still uses the original name.
-      final externalName = hasRequestBody &&
-              pathParam.normalizedName.toLowerCase() == 'body'
-          ? '${pathParam.normalizedName}Path'
-          : pathParam.normalizedName;
-      pathArgs[pathParam.normalizedName] = refer(externalName);
+      pathArgs[pathParam.normalizedName] = refer(pathParam.normalizedName);
     }
 
     for (final queryParam in normalizedParams.queryParameters) {
-      final externalName = hasRequestBody &&
-              queryParam.normalizedName.toLowerCase() == 'body'
-          ? '${queryParam.normalizedName}Query'
-          : queryParam.normalizedName;
-      queryArgs[queryParam.normalizedName] = refer(externalName);
+      queryArgs[queryParam.normalizedName] = refer(queryParam.normalizedName);
     }
 
     for (final headerParam in normalizedParams.headers) {
-      final externalName = hasRequestBody &&
-              headerParam.normalizedName.toLowerCase() == 'body'
-          ? '${headerParam.normalizedName}Header'
-          : headerParam.normalizedName;
-      headerArgs[headerParam.normalizedName] = refer(externalName);
+      headerArgs[headerParam.normalizedName] = refer(
+        headerParam.normalizedName,
+      );
     }
 
     for (final cookieParam in normalizedParams.cookieParameters) {
-      final externalName = hasRequestBody &&
-              cookieParam.normalizedName.toLowerCase() == 'body'
-          ? '${cookieParam.normalizedName}Cookie'
-          : cookieParam.normalizedName;
-      cookieArgs[cookieParam.normalizedName] = refer(externalName);
+      cookieArgs[cookieParam.normalizedName] = refer(
+        cookieParam.normalizedName,
+      );
     }
 
     final pathExpr = pathArgs.isEmpty

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -187,23 +187,38 @@ class OperationGenerator {
     }
 
     for (final pathParam in normalizedParams.pathParameters) {
-      pathArgs[pathParam.normalizedName] = refer(pathParam.normalizedName);
+      // When the parameter name collides with the request body's hardcoded
+      // 'body' name, the external parameter gets a type suffix (e.g.,
+      // 'bodyPath'). The internal method still uses the original name.
+      final externalName = hasRequestBody &&
+              pathParam.normalizedName.toLowerCase() == 'body'
+          ? '${pathParam.normalizedName}Path'
+          : pathParam.normalizedName;
+      pathArgs[pathParam.normalizedName] = refer(externalName);
     }
 
     for (final queryParam in normalizedParams.queryParameters) {
-      queryArgs[queryParam.normalizedName] = refer(queryParam.normalizedName);
+      final externalName = hasRequestBody &&
+              queryParam.normalizedName.toLowerCase() == 'body'
+          ? '${queryParam.normalizedName}Query'
+          : queryParam.normalizedName;
+      queryArgs[queryParam.normalizedName] = refer(externalName);
     }
 
     for (final headerParam in normalizedParams.headers) {
-      headerArgs[headerParam.normalizedName] = refer(
-        headerParam.normalizedName,
-      );
+      final externalName = hasRequestBody &&
+              headerParam.normalizedName.toLowerCase() == 'body'
+          ? '${headerParam.normalizedName}Header'
+          : headerParam.normalizedName;
+      headerArgs[headerParam.normalizedName] = refer(externalName);
     }
 
     for (final cookieParam in normalizedParams.cookieParameters) {
-      cookieArgs[cookieParam.normalizedName] = refer(
-        cookieParam.normalizedName,
-      );
+      final externalName = hasRequestBody &&
+              cookieParam.normalizedName.toLowerCase() == 'body'
+          ? '${cookieParam.normalizedName}Cookie'
+          : cookieParam.normalizedName;
+      cookieArgs[cookieParam.normalizedName] = refer(externalName);
     }
 
     final pathExpr = pathArgs.isEmpty

--- a/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
+++ b/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
@@ -242,9 +242,11 @@ Code _buildCallMethodBody(
     // we cast back to the original type to pass to the constructor.
     final originalType = prop.typeRef;
 
-    final isObjectNullable =
-        originalType.symbol == 'Object' && (originalType.isNullable ?? false);
-    final shouldSkipCast = prop.skipCast || isObjectNullable;
+    final isDartCoreObjectNullable =
+        originalType.symbol == 'Object' &&
+        originalType.url == 'dart:core' &&
+        (originalType.isNullable ?? false);
+    final shouldSkipCast = prop.skipCast || isDartCoreObjectNullable;
 
     final valueExpression = shouldSkipCast
         ? refer(name)

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -48,7 +48,8 @@ List<Parameter> generateParameters({
     );
   }
 
-  // Normalize all parameter names
+  // Normalize all parameter names, reserving 'body' when a request body
+  // exists so that any parameter named 'body' gets a type suffix.
   final normalizedParams = normalizeRequestParameters(
     pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
     queryParameters: operation.queryParameters.map((p) => p.resolve()).toSet(),
@@ -56,6 +57,7 @@ List<Parameter> generateParameters({
     cookieParameters: operation.cookieParameters
         .map((p) => p.resolve())
         .toSet(),
+    reservedNames: hasRequestBody ? {'body'} : {},
   );
 
   // Add path parameters
@@ -67,16 +69,11 @@ List<Parameter> generateParameters({
       isNullableOverride: !pathParam.parameter.isRequired,
     );
 
-    final paramName = hasRequestBody &&
-            pathParam.normalizedName.toLowerCase() == 'body'
-        ? '${pathParam.normalizedName}Path'
-        : pathParam.normalizedName;
-
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = paramName
+            ..name = pathParam.normalizedName
             ..type = parameterType
             ..named = true
             ..required = pathParam.parameter.isRequired;
@@ -102,16 +99,11 @@ List<Parameter> generateParameters({
       isNullableOverride: !queryParam.parameter.isRequired,
     );
 
-    final paramName = hasRequestBody &&
-            queryParam.normalizedName.toLowerCase() == 'body'
-        ? '${queryParam.normalizedName}Query'
-        : queryParam.normalizedName;
-
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = paramName
+            ..name = queryParam.normalizedName
             ..type = parameterType
             ..named = true
             ..required = queryParam.parameter.isRequired;
@@ -137,16 +129,11 @@ List<Parameter> generateParameters({
       isNullableOverride: !headerParam.parameter.isRequired,
     );
 
-    final paramName = hasRequestBody &&
-            headerParam.normalizedName.toLowerCase() == 'body'
-        ? '${headerParam.normalizedName}Header'
-        : headerParam.normalizedName;
-
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = paramName
+            ..name = headerParam.normalizedName
             ..type = parameterType
             ..named = true
             ..required = headerParam.parameter.isRequired;
@@ -172,16 +159,11 @@ List<Parameter> generateParameters({
       isNullableOverride: !cookieParam.parameter.isRequired,
     );
 
-    final paramName = hasRequestBody &&
-            cookieParam.normalizedName.toLowerCase() == 'body'
-        ? '${cookieParam.normalizedName}Cookie'
-        : cookieParam.normalizedName;
-
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = paramName
+            ..name = cookieParam.normalizedName
             ..type = parameterType
             ..named = true
             ..required = cookieParam.parameter.isRequired;

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -67,11 +67,16 @@ List<Parameter> generateParameters({
       isNullableOverride: !pathParam.parameter.isRequired,
     );
 
+    final paramName = hasRequestBody &&
+            pathParam.normalizedName.toLowerCase() == 'body'
+        ? '${pathParam.normalizedName}Path'
+        : pathParam.normalizedName;
+
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = pathParam.normalizedName
+            ..name = paramName
             ..type = parameterType
             ..named = true
             ..required = pathParam.parameter.isRequired;
@@ -97,11 +102,16 @@ List<Parameter> generateParameters({
       isNullableOverride: !queryParam.parameter.isRequired,
     );
 
+    final paramName = hasRequestBody &&
+            queryParam.normalizedName.toLowerCase() == 'body'
+        ? '${queryParam.normalizedName}Query'
+        : queryParam.normalizedName;
+
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = queryParam.normalizedName
+            ..name = paramName
             ..type = parameterType
             ..named = true
             ..required = queryParam.parameter.isRequired;
@@ -127,11 +137,16 @@ List<Parameter> generateParameters({
       isNullableOverride: !headerParam.parameter.isRequired,
     );
 
+    final paramName = hasRequestBody &&
+            headerParam.normalizedName.toLowerCase() == 'body'
+        ? '${headerParam.normalizedName}Header'
+        : headerParam.normalizedName;
+
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = headerParam.normalizedName
+            ..name = paramName
             ..type = parameterType
             ..named = true
             ..required = headerParam.parameter.isRequired;
@@ -157,11 +172,16 @@ List<Parameter> generateParameters({
       isNullableOverride: !cookieParam.parameter.isRequired,
     );
 
+    final paramName = hasRequestBody &&
+            cookieParam.normalizedName.toLowerCase() == 'body'
+        ? '${cookieParam.normalizedName}Cookie'
+        : cookieParam.normalizedName;
+
     parameters.add(
       Parameter(
         (b) {
           b
-            ..name = cookieParam.normalizedName
+            ..name = paramName
             ..type = parameterType
             ..named = true
             ..required = cookieParam.parameter.isRequired;

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1261,5 +1261,111 @@ void main() {
         contains('_i3.Future<_i4.TonikResult<void>> getUser()'),
       );
     });
+
+    group('keyword operationId method names', () {
+      test('escapes keyword operationId in method name with dollar prefix', () {
+        final operation = Operation(
+          operationId: 'switch',
+          context: testContext,
+          tags: {Tag(name: 'keywords')},
+          isDeprecated: false,
+          path: '/keyword/switch',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final generatedClass = generator.generateClass(
+          {operation},
+          Tag(name: 'keywords'),
+          testServers,
+        );
+
+        final method = generatedClass.methods.first;
+        expect(method.name, r'$switch');
+      });
+
+      test('escapes return operationId in method name with dollar prefix', () {
+        final operation = Operation(
+          operationId: 'return',
+          context: testContext,
+          tags: {Tag(name: 'keywords')},
+          isDeprecated: false,
+          path: '/keyword/return',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final generatedClass = generator.generateClass(
+          {operation},
+          Tag(name: 'keywords'),
+          testServers,
+        );
+
+        final method = generatedClass.methods.first;
+        expect(method.name, r'$return');
+      });
+
+      test('does not escape non-keyword operationId in method name', () {
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{id}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final generatedClass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+
+        final method = generatedClass.methods.first;
+        expect(method.name, 'getUser');
+      });
+
+      test('uses escaped field name matching escaped method name', () {
+        final operation = Operation(
+          operationId: 'class',
+          context: testContext,
+          tags: {Tag(name: 'keywords')},
+          isDeprecated: false,
+          path: '/keyword/class',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final generatedClass = generator.generateClass(
+          {operation},
+          Tag(name: 'keywords'),
+          testServers,
+        );
+
+        final method = generatedClass.methods.first;
+        expect(method.name, r'$class');
+      });
+    });
   });
 }

--- a/packages/tonik_generate/test/src/naming/name_generator_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_generator_test.dart
@@ -1291,5 +1291,177 @@ void main() {
         expect(result.baseName, 'Server');
       });
     });
+
+    group('keyword schema names', () {
+      test('escapes Function schema name with dollar prefix', () {
+        final model = ClassModel(
+          name: 'Function',
+          isDeprecated: false,
+          properties: const [],
+          context: Context.initial().pushAll([
+            'components',
+            'schemas',
+            'Function',
+          ]),
+        );
+        expect(nameGenerator.generateModelName(model), r'$Function');
+      });
+
+      test('escapes lowercase function schema name with dollar prefix', () {
+        final model = ClassModel(
+          name: 'function',
+          isDeprecated: false,
+          properties: const [],
+          context: Context.initial().pushAll([
+            'components',
+            'schemas',
+            'function',
+          ]),
+        );
+        // _sanitizeName('function') → 'Function' (PascalCase)
+        // ensureValidClassName('Function') matches exactly → '$Function'
+        expect(nameGenerator.generateModelName(model), r'$Function');
+      });
+
+      test('does not escape PascalCase keyword class names', () {
+        // PascalCase versions of keywords are valid Dart class names
+        final model = ClassModel(
+          name: 'dynamic',
+          isDeprecated: false,
+          properties: const [],
+          context: Context.initial().pushAll([
+            'components',
+            'schemas',
+            'dynamic',
+          ]),
+        );
+        // _sanitizeName('dynamic') → 'Dynamic' (PascalCase)
+        // 'Dynamic' is not in allKeywords (only 'dynamic' is)
+        expect(nameGenerator.generateModelName(model), 'Dynamic');
+      });
+
+      test('does not escape non-keyword schema names', () {
+        final model = ClassModel(
+          name: 'User',
+          isDeprecated: false,
+          properties: const [],
+          context: Context.initial().pushAll([
+            'components',
+            'schemas',
+            'User',
+          ]),
+        );
+        expect(nameGenerator.generateModelName(model), 'User');
+      });
+
+      test('does not escape dart:core type names (prefixed imports)', () {
+        for (final name in ['Enum', 'Error', 'Object', 'String', 'List']) {
+          final model = ClassModel(
+            name: name,
+            isDeprecated: false,
+            properties: const [],
+            context: Context.initial().pushAll([
+              'components',
+              'schemas',
+              name,
+            ]),
+          );
+          expect(
+            nameGenerator.generateModelName(model),
+            name,
+            reason: '$name is valid because dart:core is imported with prefix',
+          );
+          // Reset the generator for each iteration to avoid uniqueness suffixes
+          nameGenerator = NameGenerator();
+        }
+      });
+    });
+
+    group('keyword operation names', () {
+      test('does not escape PascalCase switch operation name', () {
+        final operation = Operation(
+          operationId: 'switch',
+          context: Context.initial(),
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+        // PascalCase 'Switch' is a valid Dart class name
+        expect(
+          nameGenerator.generateOperationName(operation),
+          'Switch',
+        );
+      });
+
+      test('does not escape PascalCase return operation name', () {
+        final operation = Operation(
+          operationId: 'return',
+          context: Context.initial(),
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+        // PascalCase 'Return' is a valid Dart class name
+        expect(
+          nameGenerator.generateOperationName(operation),
+          'Return',
+        );
+      });
+
+      test('escapes function operationId with dollar prefix', () {
+        final operation = Operation(
+          operationId: 'function',
+          context: Context.initial(),
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+        // 'Function' is a built-in identifier (stored with capital F)
+        expect(
+          nameGenerator.generateOperationName(operation),
+          r'$Function',
+        );
+      });
+    });
+
+    group('keyword tag names', () {
+      test('escapes Function tag name with dollar prefix', () {
+        final tag = Tag(name: 'Function');
+        expect(
+          nameGenerator.generateTagName(tag),
+          r'$FunctionApi',
+        );
+      });
+
+      test('does not escape PascalCase keyword tag names', () {
+        // 'Default' and 'Switch' are valid Dart class names
+        final defaultTag = Tag(name: 'default');
+        expect(
+          nameGenerator.generateTagName(defaultTag),
+          'DefaultApi',
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_generate/test/src/naming/name_utils_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_utils_test.dart
@@ -274,4 +274,86 @@ void main() {
       expect(result, isNot(startsWith(RegExp(r'\d').pattern)));
     });
   });
+
+  group('ensureNotKeyword', () {
+    test('prefixes exact keyword matches with dollar sign', () {
+      expect(ensureNotKeyword('class'), r'$class');
+      expect(ensureNotKeyword('void'), r'$void');
+      expect(ensureNotKeyword('switch'), r'$switch');
+      expect(ensureNotKeyword('return'), r'$return');
+    });
+
+    test('prefixes Function with dollar sign via exact match', () {
+      expect(ensureNotKeyword('Function'), r'$Function');
+    });
+
+    test('prefixes generatedClassTokens with dollar sign', () {
+      expect(ensureNotKeyword('fromJson'), r'$fromJson');
+      expect(ensureNotKeyword('toJson'), r'$toJson');
+      expect(ensureNotKeyword('copyWith'), r'$copyWith');
+      expect(ensureNotKeyword('toString'), r'$toString');
+      expect(ensureNotKeyword('hashCode'), r'$hashCode');
+    });
+
+    test('prefixes runtimeType and noSuchMethod with dollar sign', () {
+      expect(ensureNotKeyword('runtimeType'), r'$runtimeType');
+      expect(ensureNotKeyword('noSuchMethod'), r'$noSuchMethod');
+    });
+
+    test('does not prefix non-keywords', () {
+      expect(ensureNotKeyword('myField'), 'myField');
+      expect(ensureNotKeyword('User'), 'User');
+      expect(ensureNotKeyword('getData'), 'getData');
+    });
+  });
+
+  group('ensureValidClassName', () {
+    test('prefixes Function with dollar sign', () {
+      expect(ensureValidClassName('Function'), r'$Function');
+    });
+
+    test('does not prefix PascalCase versions of keywords', () {
+      expect(ensureValidClassName('Switch'), 'Switch');
+      expect(ensureValidClassName('Return'), 'Return');
+      expect(ensureValidClassName('Default'), 'Default');
+      expect(ensureValidClassName('Dynamic'), 'Dynamic');
+      expect(ensureValidClassName('Class'), 'Class');
+    });
+
+    test('does not prefix dart:core types (prefixed imports)', () {
+      expect(ensureValidClassName('Object'), 'Object');
+      expect(ensureValidClassName('String'), 'String');
+      expect(ensureValidClassName('List'), 'List');
+      expect(ensureValidClassName('Map'), 'Map');
+      expect(ensureValidClassName('Set'), 'Set');
+      expect(ensureValidClassName('Future'), 'Future');
+      expect(ensureValidClassName('Stream'), 'Stream');
+      expect(ensureValidClassName('Error'), 'Error');
+      expect(ensureValidClassName('Enum'), 'Enum');
+      expect(ensureValidClassName('DateTime'), 'DateTime');
+    });
+
+    test('does not prefix non-keywords', () {
+      expect(ensureValidClassName('User'), 'User');
+      expect(ensureValidClassName('MyModel'), 'MyModel');
+    });
+  });
+
+  group('normalizeSingle escapes Object method names', () {
+    test('escapes runtimeType as a property name', () {
+      expect(normalizeSingle('runtimeType'), r'$runtimeType');
+    });
+
+    test('escapes noSuchMethod as a property name', () {
+      expect(normalizeSingle('noSuchMethod'), r'$noSuchMethod');
+    });
+
+    test('escapes toString as a property name', () {
+      expect(normalizeSingle('toString'), r'$toString');
+    });
+
+    test('escapes hashCode as a property name', () {
+      expect(normalizeSingle('hashCode'), r'$hashCode');
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -345,6 +345,40 @@ void main() {
     );
   });
 
+  group('reservedNames', () {
+    test('adds type suffix when parameter collides with reserved name', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('body')},
+        headers: {createHeader('body')},
+        cookieParameters: {createCookieParameter('body')},
+        reservedNames: {'body'},
+      );
+
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'bodyQuery',
+      ]);
+      expect(result.headers.map((r) => r.normalizedName).toList(), [
+        'bodyHeader',
+      ]);
+      expect(result.cookieParameters.map((r) => r.normalizedName).toList(), [
+        'bodyCookie',
+      ]);
+    });
+
+    test('does not add suffix when no reserved names are set', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('body')},
+        headers: {},
+      );
+
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'body',
+      ]);
+    });
+  });
+
   group('normalizeMultipartHeaderName', () {
     test('combines property name and header name', () {
       expect(

--- a/packages/tonik_generate/test/src/naming/property_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/property_name_normalizer_test.dart
@@ -312,6 +312,36 @@ void main() {
     });
   });
 
+  group('Object method property names', () {
+    test('escapes runtimeType and noSuchMethod as property names', () {
+      final result = normalizeProperties([
+        createProperty('runtimeType'),
+        createProperty('noSuchMethod'),
+      ]);
+
+      expect(result.map((r) => r.normalizedName).toList(), [
+        r'$runtimeType',
+        r'$noSuchMethod',
+      ]);
+    });
+
+    test('escapes all Object method names as property names', () {
+      final result = normalizeProperties([
+        createProperty('runtimeType'),
+        createProperty('noSuchMethod'),
+        createProperty('toString'),
+        createProperty('hashCode'),
+      ]);
+
+      expect(result.map((r) => r.normalizedName).toList(), [
+        r'$runtimeType',
+        r'$noSuchMethod',
+        r'$toString',
+        r'$hashCode',
+      ]);
+    });
+  });
+
   group('special character property names', () {
     test('replaces special characters with word equivalents', () {
       final result = normalizeProperties([

--- a/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
@@ -399,7 +399,7 @@ void main() {
       });
 
       test(
-        'call method skips cast for Object? type regardless of skipCast',
+        'call method skips cast for dart:core Object? type',
         () {
           final result = generateCopyWith(
             className: 'TestClass',
@@ -409,6 +409,7 @@ void main() {
                 typeRef: TypeReference(
                   (b) => b
                     ..symbol = 'Object'
+                    ..url = 'dart:core'
                     ..isNullable = true,
                 ),
                 skipCast: false,
@@ -423,6 +424,41 @@ void main() {
           @override
           $Res call({Object? value = _sentinel}) {
             return (TestClass(value: identical(value, _sentinel, ) ? this.value : value) as $Res);
+          }
+        ''';
+          expect(
+            collapseWhitespace(callMethod.accept(emitter).toString()),
+            collapseWhitespace(expectedCallMethod),
+          );
+        },
+      );
+
+      test(
+        'call method casts user-defined Object? type (not dart:core)',
+        () {
+          final result = generateCopyWith(
+            className: 'TestClass',
+            properties: [
+              (
+                normalizedName: 'object',
+                typeRef: TypeReference(
+                  (b) => b
+                    ..symbol = 'Object'
+                    ..url = 'package:my_api/src/model/object.dart'
+                    ..isNullable = true,
+                ),
+                skipCast: false,
+              ),
+            ],
+          );
+
+          final callMethod = result!.implClass.methods.firstWhere(
+            (m) => m.name == 'call',
+          );
+          const expectedCallMethod = r'''
+          @override
+          $Res call({Object? object = _sentinel}) {
+            return (TestClass(object: identical(object, _sentinel, ) ? this.object : (object as Object?)) as $Res);
           }
         ''';
           expect(

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -1078,4 +1078,256 @@ void main() {
       expect(typeCode, contains('String'));
     });
   });
+
+  group('body parameter name collision', () {
+    test(
+      'adds Query suffix to query parameter named body when '
+      'request body is present',
+      () {
+        final queryParam = QueryParameterObject(
+          name: null,
+          rawName: 'body',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+        );
+
+        final requestBody = RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'Payload',
+                properties: const [],
+                context: context,
+                isDeprecated: false,
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'createWithBodyQuery',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: {queryParam},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final paramNames = parameters.map((p) => p.name).toList();
+        expect(paramNames, contains('body'));
+        expect(paramNames, contains('bodyQuery'));
+        expect(
+          paramNames.toSet().length,
+          paramNames.length,
+          reason: 'Parameter names must be unique: $paramNames',
+        );
+      },
+    );
+
+    test(
+      'adds Header suffix to header parameter named body when '
+      'request body is present',
+      () {
+        final headerParam = RequestHeaderObject(
+          name: null,
+          rawName: 'body',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: HeaderParameterEncoding.simple,
+          context: context,
+        );
+
+        final requestBody = RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'Payload',
+                properties: const [],
+                context: context,
+                isDeprecated: false,
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'createWithBodyHeader',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.post,
+          headers: {headerParam},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final paramNames = parameters.map((p) => p.name).toList();
+        expect(paramNames, contains('body'));
+        expect(paramNames, contains('bodyHeader'));
+        expect(
+          paramNames.toSet().length,
+          paramNames.length,
+          reason: 'Parameter names must be unique: $paramNames',
+        );
+      },
+    );
+
+    test(
+      'adds Cookie suffix to cookie parameter named body when '
+      'request body is present',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: null,
+          rawName: 'body',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final requestBody = RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'Payload',
+                properties: const [],
+                context: context,
+                isDeprecated: false,
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'createWithBodyCookie',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final paramNames = parameters.map((p) => p.name).toList();
+        expect(paramNames, contains('body'));
+        expect(paramNames, contains('bodyCookie'));
+        expect(
+          paramNames.toSet().length,
+          paramNames.length,
+          reason: 'Parameter names must be unique: $paramNames',
+        );
+      },
+    );
+
+    test(
+      'does not add suffix when parameter named body has no request body',
+      () {
+        final queryParam = QueryParameterObject(
+          name: null,
+          rawName: 'body',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'getWithBody',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: {queryParam},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        expect(parameters.length, 1);
+        expect(parameters.first.name, 'body');
+      },
+    );
+  });
 }

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -1008,11 +1008,18 @@ class ModelImporter {
       final description = propertySchema.description;
       final nameOverride = propertySchema.xDartName;
 
+      // Use a placeholder for empty or whitespace-only property names
+      // so the context path remains valid.
+      final contextPropertyName =
+          propertyName.trim().isEmpty ? 'property' : propertyName;
+
       final property = Property(
         name: propertyName,
         model: _resolveSchemaRefForProperty(
           propertySchema,
-          context.pushAll([name, propertyName].whereType<String>()),
+          context.pushAll(
+            [name, contextPropertyName].whereType<String>(),
+          ),
         ),
         isRequired: schema.required?.contains(propertyName) ?? false,
         isNullable: isNullable,

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -130,6 +130,7 @@ rm -rf kubernetes/kubernetes_api
 rm -rf cloudflare/cloudflare_api
 rm -rf totem/totem_api
 rm -rf immutable_collections/immutable_collections_api
+rm -rf naming/naming_api
 
 # Generate API code with automatic dependency overrides for local tonik_util
 # Using compiled binary for much faster generation
@@ -268,6 +269,11 @@ fi
 $TONIK_BINARY --config immutable_collections/tonik.yaml
 add_dependency_overrides_recursive "immutable_collections/immutable_collections_api"
 
+$TONIK_BINARY -p naming_api -s naming/openapi.yaml -o naming || echo "WARNING: Naming generation failed."
+if [ -d "naming/naming_api" ]; then
+    add_dependency_overrides_recursive "naming/naming_api"
+fi
+
 # Run dart pub get for all generated packages in parallel
 echo "Running dart pub get for all generated packages in parallel..."
 (
@@ -309,6 +315,7 @@ echo "Running dart pub get for all generated packages in parallel..."
   ([ -d "cloudflare/cloudflare_api" ] && cd cloudflare/cloudflare_api && dart pub get) &
   ([ -d "totem/totem_api" ] && cd totem/totem_api && dart pub get) &
   cd immutable_collections/immutable_collections_api && dart pub get &
+  ([ -d "naming/naming_api" ] && cd naming/naming_api && dart pub get) &
   wait
 )
 echo "All dart pub get operations completed"


### PR DESCRIPTION
## Summary

- **Bug 003**: Properties named `runtimeType`/`noSuchMethod` now get `$` prefix via new `reservedObjectMembers` set, preventing invalid overrides of `Object` members
- **Bug 004**: Schema named `Function` (built-in identifier) now generates as `$Function`. New `ensureValidClassName` checks exact match only — PascalCase keywords like `Switch`, `Return` are valid class names. dart:core types (`Enum`, `Error`, `String`, etc.) are NOT blocked since Tonik uses `CorePrefixedAllocator`
- **Bug 006**: When an operation has both a request body and a parameter named `body`, the parameter gets a type suffix (`bodyQuery`, `bodyHeader`, `bodyCookie`, `bodyPath`)
- **Bug 007**: New `operationMethodName` on `NameManager` provides clean camelCase method names with keyword escaping (e.g., `switch` → `$switch`). API client generator uses this instead of ad-hoc name manipulation

## Test plan

- [x] Unit tests for `ensureNotKeyword` exact-match fix (catches `Function`)
- [x] Unit tests for `ensureValidClassName` (Function prefixed, dart:core types NOT prefixed)
- [x] Unit tests for `reservedObjectMembers` (`runtimeType`, `noSuchMethod` get `$` prefix)
- [x] Unit tests for body parameter collision (query, header, cookie, no-collision cases)
- [x] Unit tests for keyword operationId method names (`$switch`, `$class`, `$return`)
- [x] Unit tests for dart:core schema names NOT being prefixed (`Enum`, `Error`, `Object`, `String`, `List`)
- [x] Naming integration test OAS spec (70 operations, 54 schemas) generates successfully
- [x] All 3983 tests pass, analysis clean, 91% patch coverage