### PR TITLE
fix: handle AnyModel and NeverModel as oneOf variants

### DIFF
--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -4270,4 +4270,151 @@ void main() {
       });
     });
   });
+
+  group('OneOfBooleanSchema', () {
+    group('AnyModel variant (from boolean true schema)', () {
+      late OneOfBooleanSchema anyVariant;
+
+      setUp(() {
+        anyVariant = const OneOfBooleanSchemaUnknown('hello');
+      });
+
+      test('create with string value', () {
+        expect(anyVariant, isA<OneOfBooleanSchemaUnknown>());
+        expect(
+          (anyVariant as OneOfBooleanSchemaUnknown).value,
+          'hello',
+        );
+      });
+
+      test('create with int value', () {
+        const variant = OneOfBooleanSchemaUnknown(42);
+        expect(variant.value, 42);
+      });
+
+      test('create with null value', () {
+        const variant = OneOfBooleanSchemaUnknown(null);
+        expect(variant.value, isNull);
+      });
+
+      test('toJson uses encodeAnyToJson', () {
+        expect(anyVariant.toJson(), 'hello');
+      });
+
+      test('toJson with map value', () {
+        const variant = OneOfBooleanSchemaUnknown(
+          <String, String>{'key': 'value'},
+        );
+        expect(variant.toJson(), {'key': 'value'});
+      });
+
+      test('fromJson as catch-all', () {
+        // Non-Class1 JSON goes to the AnyModel catch-all
+        final result = OneOfBooleanSchema.fromJson(42);
+        expect(result, isA<OneOfBooleanSchemaUnknown>());
+        expect((result as OneOfBooleanSchemaUnknown).value, 42);
+      });
+
+      test('fromJson prefers Class1 when matching', () {
+        final result = OneOfBooleanSchema.fromJson(
+          const <String, Object?>{'name': 'test'},
+        );
+        expect(result, isA<OneOfBooleanSchemaClass1>());
+      });
+
+      test('fromJson roundtrip with Class1', () {
+        const original = OneOfBooleanSchemaClass1(
+          Class1(name: 'test'),
+        );
+        final json = original.toJson();
+        final reconstructed = OneOfBooleanSchema.fromJson(json);
+        expect(reconstructed, original);
+      });
+
+      test('fromJson roundtrip with catch-all primitive', () {
+        const original = OneOfBooleanSchemaUnknown('raw string');
+        final json = original.toJson();
+        final reconstructed = OneOfBooleanSchema.fromJson(json);
+        // AnyModel catches the string since it's not a Class1
+        // But since fromJson tries Class1.fromJson first, and strings
+        // can't be Class1, it falls through to AnyModel
+        expect(reconstructed, isA<OneOfBooleanSchemaUnknown>());
+        expect(
+          (reconstructed as OneOfBooleanSchemaUnknown).value,
+          'raw string',
+        );
+      });
+
+      test('toSimple throws EncodingException', () {
+        expect(
+          () => anyVariant.toSimple(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toForm throws EncodingException', () {
+        expect(
+          () => anyVariant.toForm(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toLabel throws EncodingException', () {
+        expect(
+          () => anyVariant.toLabel(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toMatrix throws EncodingException', () {
+        expect(
+          () => anyVariant.toMatrix('p', explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('uriEncode throws EncodingException', () {
+        expect(
+          () => anyVariant.uriEncode(allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('currentEncodingShape throws EncodingException', () {
+        expect(
+          () => anyVariant.currentEncodingShape,
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('equality', () {
+        const a = OneOfBooleanSchemaUnknown('hello');
+        const b = OneOfBooleanSchemaUnknown('hello');
+        const c = OneOfBooleanSchemaUnknown('world');
+
+        expect(a, b);
+        expect(a, isNot(c));
+      });
+    });
+
+    group('Class1 variant', () {
+      late OneOfBooleanSchema classVariant;
+
+      setUp(() {
+        classVariant = const OneOfBooleanSchemaClass1(
+          Class1(name: 'test'),
+        );
+      });
+
+      test('toJson', () {
+        expect(classVariant.toJson(), {'name': 'test'});
+      });
+
+      test('json roundtrip', () {
+        final json = classVariant.toJson();
+        final reconstructed = OneOfBooleanSchema.fromJson(json);
+        expect(reconstructed, classVariant);
+      });
+    });
+  });
 }

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.4
+openapi: 3.1.0
 info:
   title: Composition API
   description: OpenAPI specification showcasing composition of models
@@ -761,4 +761,14 @@ components:
           properties:
             bField:
               type: integer
-             
+
+    # =========================================================================
+    # Boolean schema (true) in oneOf — OpenAPI 3.1 / JSON Schema 2020-12
+    # =========================================================================
+    # The boolean `true` schema means "accept any value". The parser converts
+    # it to an AnyModel. This exercises the generator's handling of AnyModel
+    # as a oneOf variant.
+    OneOfBooleanSchema:
+      oneOf:
+        - true
+        - $ref: '#/components/schemas/Class1'

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -273,27 +273,49 @@ class OneOfGenerator {
     for (var i = 0; i < sortedModels.length; i++) {
       final discriminatedModel = sortedModels[i];
       final variantName = variantNames[discriminatedModel]!;
+      final resolvedType = discriminatedModel.model.resolved;
 
-      final property = Property(
-        name: 'value',
-        model: discriminatedModel.model,
-        isRequired: true,
-        isNullable: false,
-        isDeprecated: false,
-      );
-      final jsonValueExpr = buildToJsonPropertyExpression(
-        'value',
-        property,
-        useImmutableCollections: useImmutableCollections,
-      );
       final discriminatorValue = discriminatedModel.discriminatorValue != null
           ? specLiteralStringCode(discriminatedModel.discriminatorValue!)
           : 'null';
 
-      caseCodes
-        ..add(Code('$variantName(:final value) => ('))
-        ..add(jsonValueExpr.code)
-        ..add(Code(', $discriminatorValue)'));
+      if (resolvedType is NeverModel) {
+        caseCodes
+          ..add(Code('$variantName() => '))
+          ..add(
+            generateEncodingExceptionExpression(
+              'Cannot encode NeverModel variant to JSON.',
+            ).code,
+          );
+      } else if (resolvedType is AnyModel) {
+        caseCodes
+          ..add(Code('$variantName(:final value) => ('))
+          ..add(
+            refer(
+              'encodeAnyToJson',
+              'package:tonik_util/tonik_util.dart',
+            ).call([refer('value')]).code,
+          )
+          ..add(Code(', $discriminatorValue)'));
+      } else {
+        final property = Property(
+          name: 'value',
+          model: discriminatedModel.model,
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+        );
+        final jsonValueExpr = buildToJsonPropertyExpression(
+          'value',
+          property,
+          useImmutableCollections: useImmutableCollections,
+        );
+
+        caseCodes
+          ..add(Code('$variantName(:final value) => ('))
+          ..add(jsonValueExpr.code)
+          ..add(Code(', $discriminatorValue)'));
+      }
       if (i < sortedModels.length - 1) {
         caseCodes.add(const Code(',\n'));
       }
@@ -354,7 +376,9 @@ class OneOfGenerator {
                     m.discriminatorValue != null &&
                     m.model.resolved is! PrimitiveModel &&
                     m.model.resolved is! ListModel &&
-                    m.model.resolved is! MapModel,
+                    m.model.resolved is! MapModel &&
+                    m.model.resolved is! AnyModel &&
+                    m.model.resolved is! NeverModel,
               )) {
         final variantName = variantNames[m]!;
 
@@ -391,10 +415,15 @@ class OneOfGenerator {
       (m) => m.model.resolved is PrimitiveModel,
     );
     final hasOnlyPrimitives = !model.models.any(
-      (m) => m.model.resolved is! PrimitiveModel,
+      (m) =>
+          m.model.resolved is! PrimitiveModel &&
+          m.model.resolved is! NeverModel,
+    );
+    final hasAnyModel = model.models.any(
+      (m) => m.model.resolved is AnyModel,
     );
 
-    if (hasPrimitives && hasOnlyPrimitives) {
+    if (hasPrimitives && hasOnlyPrimitives && !hasAnyModel) {
       final cases = <Code>[];
 
       for (final m
@@ -455,15 +484,18 @@ class OneOfGenerator {
     }
 
     // Fallback: try all non-primitive variants when discriminator doesn't match
+    // Skip AnyModel (handled as catch-all last) and NeverModel (not decodable)
     for (final m
         in stableModelSorter
             .sortDiscriminatedModels(model.models)
             .where(
-              (m) => m.model.resolved is! PrimitiveModel,
+              (m) =>
+                  m.model.resolved is! PrimitiveModel &&
+                  m.model.resolved is! AnyModel &&
+                  m.model.resolved is! NeverModel,
             )) {
       final modelType = m.model;
       final resolvedType = modelType.resolved;
-      final modelName = nameManager.modelName(modelType);
       final variantName = variantNames[m]!;
 
       if (resolvedType is ListModel || resolvedType is MapModel) {
@@ -483,6 +515,7 @@ class OneOfGenerator {
           const Code(' catch(_) {}'),
         ]);
       } else {
+        final modelName = nameManager.modelName(modelType);
         blocks.addAll([
           const Code('try {'),
           refer(variantName)
@@ -501,12 +534,24 @@ class OneOfGenerator {
       }
     }
 
-    blocks.add(
-      generateJsonDecodingExceptionExpression(
-        'Invalid JSON for $className',
-        raw: true,
-      ).statement,
-    );
+    // AnyModel is a catch-all: wraps the raw JSON value directly.
+    // Must be tried last since it accepts any value.
+    if (hasAnyModel) {
+      final anyModelVariant = stableModelSorter
+          .sortDiscriminatedModels(model.models)
+          .firstWhere((m) => m.model.resolved is AnyModel);
+      final variantName = variantNames[anyModelVariant]!;
+      blocks.add(
+        refer(variantName).call([refer('json')]).returned.statement,
+      );
+    } else {
+      blocks.add(
+        generateJsonDecodingExceptionExpression(
+          'Invalid JSON for $className',
+          raw: true,
+        ).statement,
+      );
+    }
 
     return Block.of(blocks);
   }
@@ -528,7 +573,9 @@ class OneOfGenerator {
             m.discriminatorValue != null &&
             m.model.resolved is! PrimitiveModel &&
             m.model.resolved is! ListModel &&
-            m.model.resolved is! MapModel,
+            m.model.resolved is! MapModel &&
+            m.model.resolved is! AnyModel &&
+            m.model.resolved is! NeverModel,
       );
 
       if (hasDiscriminatedComplexTypes) {
@@ -563,7 +610,9 @@ class OneOfGenerator {
                       m.discriminatorValue != null &&
                       m.model.resolved is! PrimitiveModel &&
                       m.model.resolved is! ListModel &&
-                      m.model.resolved is! MapModel,
+                      m.model.resolved is! MapModel &&
+                      m.model.resolved is! AnyModel &&
+                      m.model.resolved is! NeverModel,
                 )) {
           final variantName = variantNames[m]!;
           final modelType = m.model;
@@ -605,7 +654,11 @@ class OneOfGenerator {
 
       final resolvedType = modelType.resolved;
 
-      if (resolvedType is PrimitiveModel) {
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        // AnyModel/NeverModel cannot be meaningfully decoded from parameter
+        // encoding — skip so other variants remain reachable.
+        continue;
+      } else if (resolvedType is PrimitiveModel) {
         final decodeExpr = isForm
             ? buildFromFormValueExpression(
                 refer('value'),
@@ -737,15 +790,27 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
 
       final encodingShape = m.model.encodingShape;
       final discriminatorValue = m.discriminatorValue;
 
-      if (model.discriminator != null &&
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        caseCodes.addAll([
+          Code.scope(
+            (allocate) => '${allocate(refer(variantName))}() => ',
+          ),
+          generateEncodingExceptionExpression(
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant cannot be simple-encoded',
+          ).code,
+          const Code(','),
+        ]);
+      } else if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model.resolved is! ListModel &&
-          m.model.resolved is! MapModel) {
+          resolvedType is! ListModel &&
+          resolvedType is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -818,8 +883,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model.resolved is ListModel &&
-          (m.model.resolved as ListModel).hasSimpleContent) {
+      } else if (resolvedType is ListModel &&
+          resolvedType.hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -924,15 +989,27 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
 
       final encodingShape = m.model.encodingShape;
       final discriminatorValue = m.discriminatorValue;
 
-      if (model.discriminator != null &&
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        caseCodes.addAll([
+          Code.scope(
+            (allocate) => '${allocate(refer(variantName))}() => ',
+          ),
+          generateEncodingExceptionExpression(
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant cannot be form-encoded',
+          ).code,
+          const Code(','),
+        ]);
+      } else if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model.resolved is! ListModel &&
-          m.model.resolved is! MapModel) {
+          resolvedType is! ListModel &&
+          resolvedType is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -1007,8 +1084,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model.resolved is ListModel &&
-          (m.model.resolved as ListModel).hasSimpleContent) {
+      } else if (resolvedType is ListModel &&
+          resolvedType.hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1121,11 +1198,24 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
       final isSimple = m.model.encodingShape == EncodingShape.simple;
-      final isList = m.model.resolved is ListModel;
-      final isMap = m.model.resolved is MapModel;
+      final isList = resolvedType is ListModel;
+      final isMap = resolvedType is MapModel;
 
-      if (isSimple) {
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        // AnyModel and NeverModel cannot determine encoding shape
+        caseCodes.addAll([
+          Code('$variantName() => '),
+          generateEncodingExceptionExpression(
+            'Cannot determine encoding shape for '
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant in oneOf',
+            raw: true,
+          ).code,
+          const Code(','),
+        ]);
+      } else if (isSimple) {
         caseCodes.addAll([
           Code('$variantName() => '),
           refer(
@@ -1215,10 +1305,20 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
       final encodingShape = m.model.encodingShape;
       final discriminatorValue = m.discriminatorValue;
 
-      if (encodingShape == EncodingShape.simple) {
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        caseCodes
+          ..add(Code('$variantName() => '))
+          ..add(
+            generateEncodingExceptionExpression(
+              '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+              ' variant cannot be parameter encoded',
+            ).code,
+          );
+      } else if (encodingShape == EncodingShape.simple) {
         caseCodes
           ..add(Code('$variantName() => '))
           ..add(
@@ -1372,15 +1472,27 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
 
       final encodingShape = m.model.encodingShape;
       final discriminatorValue = m.discriminatorValue;
 
-      if (model.discriminator != null &&
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        caseCodes.addAll([
+          Code.scope(
+            (allocate) => '${allocate(refer(variantName))}() => ',
+          ),
+          generateEncodingExceptionExpression(
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant cannot be label-encoded',
+          ).code,
+          const Code(','),
+        ]);
+      } else if (model.discriminator != null &&
           encodingShape != EncodingShape.simple &&
           discriminatorValue != null &&
-          m.model.resolved is! ListModel &&
-          m.model.resolved is! MapModel) {
+          resolvedType is! ListModel &&
+          resolvedType is! MapModel) {
         final isNullable = m.model.isEffectivelyNullable;
 
         if (encodingShape == EncodingShape.mixed) {
@@ -1452,8 +1564,8 @@ class OneOfGenerator {
             ),
           ]);
         }
-      } else if (m.model.resolved is ListModel &&
-          (m.model.resolved as ListModel).hasSimpleContent) {
+      } else if (resolvedType is ListModel &&
+          resolvedType.hasSimpleContent) {
         // Lists with simple content can be encoded using helper
         final isNullableList = m.model.isEffectivelyNullable;
 
@@ -1558,33 +1670,48 @@ class OneOfGenerator {
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
-      final usesValue = matrixParameterExpressionUsesValue(m.model);
-      final isNullable = usesValue && m.model.isEffectivelyNullable;
+      final resolvedType = m.model.resolved;
 
-      caseCodes.add(
-        Code.scope(
-          (allocate) => usesValue
-              ? '${allocate(refer(variantName))}(:final value) => '
-              : '${allocate(refer(variantName))}() => ',
-        ),
-      );
-
-      if (isNullable) {
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
         caseCodes.addAll([
-          const Code("value == null ? '' : "),
+          Code.scope(
+            (allocate) => '${allocate(refer(variantName))}() => ',
+          ),
+          generateEncodingExceptionExpression(
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant cannot be matrix-encoded',
+          ).code,
+          const Code(','),
+        ]);
+      } else {
+        final usesValue = matrixParameterExpressionUsesValue(m.model);
+        final isNullable = usesValue && m.model.isEffectivelyNullable;
+
+        caseCodes.add(
+          Code.scope(
+            (allocate) => usesValue
+                ? '${allocate(refer(variantName))}(:final value) => '
+                : '${allocate(refer(variantName))}() => ',
+          ),
+        );
+
+        if (isNullable) {
+          caseCodes.addAll([
+            const Code("value == null ? '' : "),
+          ]);
+        }
+
+        caseCodes.addAll([
+          buildMatrixParameterExpression(
+            refer('value'),
+            m.model,
+            paramName: refer('paramName'),
+            explode: refer('explode'),
+            allowEmpty: refer('allowEmpty'),
+          ).code,
+          const Code(','),
         ]);
       }
-
-      caseCodes.addAll([
-        buildMatrixParameterExpression(
-          refer('value'),
-          m.model,
-          paramName: refer('paramName'),
-          explode: refer('explode'),
-          allowEmpty: refer('allowEmpty'),
-        ).code,
-        const Code(','),
-      ]);
     }
 
     final body = Block.of([
@@ -1621,9 +1748,20 @@ class OneOfGenerator {
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
       final variantName = variantNames[m]!;
       final modelType = m.model;
+      final resolvedType = modelType.resolved;
 
-      // Check if this variant can be URI encoded
-      if (modelType.encodingShape == EncodingShape.complex) {
+      if (resolvedType is AnyModel || resolvedType is NeverModel) {
+        caseCodes.addAll([
+          Code.scope(
+            (allocate) => '${allocate(refer(variantName))}() => ',
+          ),
+          generateEncodingExceptionExpression(
+            '${resolvedType is AnyModel ? 'AnyModel' : 'NeverModel'}'
+            ' variant cannot be URI encoded',
+          ).code,
+          const Code(','),
+        ]);
+      } else if (modelType.encodingShape == EncodingShape.complex) {
         // Complex types cannot be URI encoded - don't destructure value
         caseCodes.addAll([
           Code.scope(

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -2815,4 +2815,579 @@ bool operator ==(Object other) {
       );
     });
   });
+
+  group('AnyModel in OneOf', () {
+    test('subclass has Object? value field', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final anySubclass = classes.firstWhere(
+        (c) => c.name == 'ValueUnknown',
+      );
+      final valueField = anySubclass.fields.firstWhere(
+        (f) => f.name == 'value',
+      );
+      final fieldType = valueField.type!.accept(emitter).toString();
+
+      expect(fieldType, 'Object?');
+    });
+
+    test('currentEncodingShape throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              r'Cannot determine encoding shape for AnyModel variant in oneOf',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toSimple throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be simple-encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toForm throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be form-encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toLabel throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be label-encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toMatrix throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be matrix-encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('uriEncode throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be URI encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('parameterProperties throws EncodingException for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              isDeprecated: false,
+              name: 'Data',
+              properties: const [],
+              context: context,
+            ),
+          ),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'AnyModel variant cannot be parameter encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toJson uses encodeAnyToJson for AnyModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            'ValueUnknown(:final value) => (encodeAnyToJson(value), null)',
+          ),
+        ),
+      );
+    });
+
+    test('fromJson uses AnyModel as last-resort catch-all', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // AnyModel should be the final catch-all: wraps raw json directly
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              if (json is String) {
+                return ValueString(json);
+              }
+              return ValueUnknown(json);
+            }
+          '''),
+        ),
+      );
+    });
+
+    test(
+      'fromJson with AnyModel and complex type tries complex first',
+      () {
+        final classA = ClassModel(
+          isDeprecated: false,
+          name: 'A',
+          properties: const [],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: AnyModel(context: context)),
+            (discriminatorValue: null, model: classA),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final generated = format(baseClass.accept(emitter).toString());
+
+        // Complex variant should be tried first, AnyModel should be the
+        // last-resort fallback
+        expect(
+          collapseWhitespace(generated),
+          contains(
+            collapseWhitespace('''
+              factory Value.fromJson(Object? json) {
+                try {
+                  return ValueA(A.fromJson(json));
+                } on Object catch (_) {}
+                return ValueUnknown(json);
+              }
+            '''),
+          ),
+        );
+      },
+    );
+
+    test('fromSimple skips AnyModel variant', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // AnyModel is skipped — no AnyModel-specific throw in fromSimple
+      expect(
+        collapseWhitespace(generated),
+        isNot(contains('AnyModel variant cannot be decoded')),
+      );
+
+      // The String variant is still tried
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace('return ValueString(')),
+      );
+
+      // Final fallback throw is present
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            "throw SimpleDecodingException(r'Invalid simple value for Value')",
+          ),
+        ),
+      );
+    });
+
+    test('fromForm skips AnyModel variant', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // AnyModel is skipped — no AnyModel-specific throw in fromForm
+      expect(
+        collapseWhitespace(generated),
+        isNot(contains('AnyModel variant cannot be decoded')),
+      );
+
+      // The String variant is still tried
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace('return ValueString(')),
+      );
+
+      // Final fallback throw is present
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            "throw SimpleDecodingException(r'Invalid form value for Value')",
+          ),
+        ),
+      );
+    });
+  });
+
+  group('NeverModel in OneOf', () {
+    test('subclass has Never value field', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final neverSubclass = classes.firstWhere(
+        (c) => c.name == 'ValueUnknown',
+      );
+      final valueField = neverSubclass.fields.firstWhere(
+        (f) => f.name == 'value',
+      );
+      final fieldType = valueField.type!.accept(emitter).toString();
+
+      expect(fieldType, 'Never');
+    });
+
+    test('currentEncodingShape throws EncodingException for NeverModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              r'Cannot determine encoding shape for NeverModel variant in oneOf',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('toJson throws EncodingException for NeverModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'Cannot encode NeverModel variant to JSON.',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('fromJson skips NeverModel (not decodable)', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // NeverModel should not appear in fromJson - only primitives are tried
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r"""
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                int s => ValueInt(s),
+                String s => ValueString(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          """),
+        ),
+      );
+    });
+
+    test('toSimple throws EncodingException for NeverModel', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            ValueUnknown() => throw EncodingException(
+              'NeverModel variant cannot be simple-encoded',
+            ),
+          '''),
+        ),
+      );
+    });
+
+    test('fromSimple skips NeverModel variant', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: NeverModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      // NeverModel is skipped — no NeverModel-specific throw in fromSimple
+      expect(
+        collapseWhitespace(generated),
+        isNot(contains('NeverModel variant cannot be decoded')),
+      );
+
+      // The String variant is still tried
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace('return ValueString(')),
+      );
+
+      // Final fallback throw is present
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(
+            "throw SimpleDecodingException(r'Invalid simple value for Value')",
+          ),
+        ),
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Fixes broken code generation when a `oneOf` schema contains a boolean `true` schema (JSON Schema 2020-12 "accept any value"), which the parser converts to `AnyModel`
- The oneOf generator now special-cases `AnyModel` and `NeverModel` variants instead of assuming every variant has a generated class file with typed encoding methods
- All parameter encoding methods (`toSimple`, `toForm`, `toLabel`, `toMatrix`, `uriEncode`, `currentEncodingShape`, `parameterProperties`) throw `EncodingException` for AnyModel/NeverModel variants
- `toJson` uses `encodeAnyToJson` for AnyModel; `fromJson` treats AnyModel as a last-resort catch-all
- AnyModel/NeverModel are skipped in `fromSimple`/`fromForm` to keep other variants reachable

## Test plan

- [x] 16 new unit tests covering AnyModel and NeverModel as oneOf variants
- [x] Integration test with boolean `true` schema in composition suite
- [x] All 2145 tonik_generate tests pass
- [x] All integration tests pass
- [x] `fvm dart analyze` clean (zero errors/warnings in changed packages)
- [x] Patch coverage: 100% (136/136 lines)