### PR TITLE
fix: correct JSON decoding for List<Uri>, List<Map<String, T>>, and multipart enum arrays

### DIFF
--- a/integration_test/additional_properties/additional_properties_test/test/additional_properties_test.dart
+++ b/integration_test/additional_properties/additional_properties_test/test/additional_properties_test.dart
@@ -450,7 +450,117 @@ void main() {
   });
 
   // -------------------------------------------------------------------
-  // 9. Runtime errors: invalid encodings
+  // 9. Bug: List<Uri> fromJson
+  //    Generated code uses decodeJsonList<Uri>() which calls
+  //    whereType<Uri>() on String elements. Since JSON arrays contain
+  //    strings (not Uri objects), this always fails.
+  // -------------------------------------------------------------------
+
+  group('UriListHolder (List<Uri> JSON roundtrip)', () {
+    test('toJson encodes Uri list as string list', () {
+      final obj = UriListHolder(
+        links: [
+          Uri.parse('https://example.com'),
+          Uri.parse('https://dart.dev/guides'),
+        ],
+      );
+      expect(obj.toJson(), {
+        'links': ['https://example.com', 'https://dart.dev/guides'],
+      });
+    });
+
+    test('fromJson decodes string list back to Uri list', () {
+      final obj = UriListHolder.fromJson({
+        'links': ['https://example.com', 'https://dart.dev/guides'],
+      });
+      expect(obj.links, [
+        Uri.parse('https://example.com'),
+        Uri.parse('https://dart.dev/guides'),
+      ]);
+    });
+
+    test('json roundtrip', () {
+      final obj = UriListHolder(
+        links: [
+          Uri.parse('https://example.com'),
+          Uri.parse('https://dart.dev/guides'),
+        ],
+      );
+      final json = obj.toJson();
+      final decoded = UriListHolder.fromJson(json);
+      expect(decoded, obj);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 10. Bug: List<Map<String, Address>> fromJson
+  //     Generated code uses decodeJsonList<Map<String, Address>>()
+  //     which fails because JSON maps are Map<String, dynamic>, not
+  //     Map<String, Address>. Inner values are never decoded.
+  // -------------------------------------------------------------------
+
+  group('AddressMapListHolder (List<Map<String, Address>> JSON roundtrip)', () {
+    test('toJson encodes list of address maps', () {
+      const obj = AddressMapListHolder(
+        departments: [
+          {
+            'main': Address(street: '1 Main', city: 'NYC'),
+          },
+          {
+            'branch': Address(street: '2 Oak', city: 'LA'),
+          },
+        ],
+      );
+      expect(obj.toJson(), {
+        'departments': [
+          {
+            'main': {'street': '1 Main', 'city': 'NYC'},
+          },
+          {
+            'branch': {'street': '2 Oak', 'city': 'LA'},
+          },
+        ],
+      });
+    });
+
+    test('fromJson decodes list of address maps', () {
+      final obj = AddressMapListHolder.fromJson({
+        'departments': [
+          {
+            'main': {'street': '1 Main', 'city': 'NYC'},
+          },
+          {
+            'branch': {'street': '2 Oak', 'city': 'LA'},
+          },
+        ],
+      });
+      expect(obj.departments, hasLength(2));
+      expect(
+        obj.departments[0]['main'],
+        const Address(street: '1 Main', city: 'NYC'),
+      );
+      expect(
+        obj.departments[1]['branch'],
+        const Address(street: '2 Oak', city: 'LA'),
+      );
+    });
+
+    test('json roundtrip', () {
+      const obj = AddressMapListHolder(
+        departments: [
+          {
+            'main': Address(street: '1 Main', city: 'NYC'),
+          },
+        ],
+      );
+      final json = obj.toJson();
+      final decoded = AddressMapListHolder.fromJson(json);
+      expect(decoded, obj);
+    });
+  });
+
+  // -------------------------------------------------------------------
+  // 11. Runtime errors: invalid encodings
   // -------------------------------------------------------------------
 
   group('MixedComplexAp - runtime encoding errors', () {

--- a/integration_test/additional_properties/openapi.yaml
+++ b/integration_test/additional_properties/openapi.yaml
@@ -259,6 +259,38 @@ components:
         $ref: '#/components/schemas/Address'
 
     # ---------------------------------------------------------------
+    # 9. Schemas that expose fromJson bugs for list types
+    # ---------------------------------------------------------------
+
+    # Bug: List<Uri> fromJson generates decodeJsonList<Uri>() which
+    # uses whereType<Uri>() on String elements → always throws.
+    UriListHolder:
+      type: object
+      required:
+        - links
+      properties:
+        links:
+          type: array
+          items:
+            type: string
+            format: uri
+
+    # Bug: List<Map<String, Address>> fromJson generates
+    # decodeJsonList<Map<String, Address>>() which fails because
+    # JSON-decoded maps are Map<String, dynamic>, not Map<String, Address>.
+    AddressMapListHolder:
+      type: object
+      required:
+        - departments
+      properties:
+        departments:
+          type: array
+          items:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/Address'
+
+    # ---------------------------------------------------------------
     # Helper schemas (used by the above)
     # ---------------------------------------------------------------
 

--- a/integration_test/multipart/multipart_test/test/multipart_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_test.dart
@@ -188,6 +188,71 @@ void main() {
     );
   });
 
+  group('Enum array with content-based JSON encoding', () {
+    test(
+      'enum values with special characters are JSON-encoded, not URI-encoded',
+      () async {
+        // The Category enum has values like "science & tech" that contain
+        // special characters. When encoded as application/json in a multipart
+        // part, they should appear as raw strings in the JSON array, not
+        // percent-encoded (e.g., "science & tech", NOT "science%20%26%20tech").
+
+        // Capture the request body before Dio sends it by using an interceptor.
+        String? capturedBody;
+        final capturingApi = MultipartApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              interceptors: [
+                InterceptorsWrapper(
+                  onRequest: (options, handler) {
+                    final data = options.data;
+                    if (data is FormData) {
+                      // Clone the file to read its content without consuming it.
+                      final file = data.files
+                          .firstWhere((e) => e.key == 'categories')
+                          .value;
+                      capturedBody = file.filename;
+                      // Also capture via clone for content inspection.
+                      final clone = file.clone();
+                      clone.finalize().listen(
+                        (chunk) {
+                          capturedBody = String.fromCharCodes(chunk);
+                        },
+                      );
+                    }
+                    handler.next(options);
+                  },
+                ),
+              ],
+            ),
+          ),
+        );
+
+        const form = CategoryArrayForm(
+          categories: [
+            Category.scienceAmpersandTech,
+            Category.artsAmpersandCrafts,
+          ],
+        );
+
+        await capturingApi.postCategoryArrayFields(body: form);
+
+        // Wait for the async stream listener to complete.
+        await Future<void>.delayed(const Duration(milliseconds: 100));
+
+        // The JSON content should contain raw enum values, not URI-encoded.
+        // Correct:   ["science & tech","arts & crafts"]
+        // Bug gives: ["science%20%26%20tech","arts%20%26%20crafts"]
+        expect(capturedBody, isNotNull);
+        expect(capturedBody, contains('science & tech'));
+        expect(capturedBody, contains('arts & crafts'));
+        expect(capturedBody, isNot(contains('%26')));
+        expect(capturedBody, isNot(contains('%20')));
+      },
+    );
+  });
+
   group('Mixed required/optional fields', () {
     test('sends only required fields when optional are null', () async {
       const form = MixedRequiredForm(requiredField: 'hello');

--- a/integration_test/multipart/openapi.yaml
+++ b/integration_test/multipart/openapi.yaml
@@ -129,6 +129,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArrayResponse'
 
+  /multipart/category-arrays:
+    post:
+      operationId: postCategoryArrayFields
+      tags:
+        - multipart
+      summary: Post enum array with content-based encoding
+      description: >-
+        Tests that enum arrays are JSON-encoded correctly when using
+        content-based encoding. The Category enum has values with special
+        characters (spaces, ampersands) that expose the difference between
+        uriEncode (wrong — percent-encodes) and toJson (correct — preserves).
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/CategoryArrayForm'
+            encoding:
+              categories:
+                contentType: application/json
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericResponse'
+
   /multipart/mixed-required:
     post:
       operationId: postMixedRequired
@@ -523,6 +551,27 @@ components:
         - low
         - medium
         - high
+
+    # Bug: Multipart enum list encoding uses uriEncode instead of
+    # toJson for JSON-encoded arrays. The special characters in these
+    # values make the difference visible: uriEncode percent-encodes
+    # spaces/ampersands, toJson preserves them in the JSON string.
+    Category:
+      type: string
+      enum:
+        - science & tech
+        - arts & crafts
+        - health and wellness
+
+    CategoryArrayForm:
+      type: object
+      required:
+        - categories
+      properties:
+        categories:
+          type: array
+          items:
+            $ref: '#/components/schemas/Category'
 
     ArrayForm:
       type: object

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -253,7 +253,38 @@ Expression _buildListFromJsonExpression(
                 .property('toList')
                 .call([]);
 
-    case DateTimeModel() || DateModel() || DecimalModel():
+    case final MapModel mapModel:
+      final mapDecoderClosure = Method(
+        (b) => b
+          ..requiredParameters.add(Parameter((b) => b..name = 'e'))
+          ..body = _buildMapFromJsonExpression(
+            'e',
+            mapModel,
+            nameManager,
+            package: package,
+            contextClass: contextClass,
+            contextProperty: contextProperty,
+            useImmutableCollections: useImmutableCollections,
+          ).code,
+      ).closure;
+      final mapListExpr = refer(value).property(listDecoder).call(
+        [],
+        contextParam,
+        [refer('Object?', 'dart:core')],
+      );
+      result = isNullable
+          ? mapListExpr
+                .nullSafeProperty('map')
+                .call([mapDecoderClosure])
+                .property('toList')
+                .call([])
+          : mapListExpr
+                .property('map')
+                .call([mapDecoderClosure])
+                .property('toList')
+                .call([]);
+
+    case DateTimeModel() || DateModel() || DecimalModel() || UriModel():
       final jsonType = _jsonTypeForPrimitive(unwrappedContent);
       final decodeMethod = _decodeMethodForPrimitive(unwrappedContent)!;
       final mapFunction = Method(
@@ -414,13 +445,16 @@ String? _decodeMethodForPrimitive(Model model) {
   if (model is BooleanModel) return 'decodeJsonBool';
   if (model is DateTimeModel) return 'decodeJsonDateTime';
   if (model is DateModel) return 'decodeJsonDate';
+  if (model is UriModel) return 'decodeJsonUri';
   if (model is BinaryModel) return 'decodeJsonBinary';
   if (model is Base64Model) return 'decodeJsonBase64';
   return null;
 }
 
 String _jsonTypeForPrimitive(Model model) {
-  if (model is DateTimeModel || model is DateModel) return 'String';
+  if (model is DateTimeModel || model is DateModel || model is UriModel) {
+    return 'String';
+  }
   if (model is IntegerModel) return 'int';
   if (model is NumberModel || model is DoubleModel) return 'num';
   if (model is DecimalModel) return 'String';

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -787,7 +787,7 @@ Code _buildContentBasedListAddition(
         .property('toList')
         .call([]);
   } else if (contentModel is EnumModel) {
-    // Enums: map each item to its URI-encoded string representation.
+    // Enums: map each item to its JSON representation for JSON-encoded arrays.
     jsonArg = refer(accessor)
         .property('map')
         .call([
@@ -795,9 +795,7 @@ Code _buildContentBasedListAddition(
             (b) => b
               ..lambda = true
               ..requiredParameters.add(Parameter((p) => p..name = 'e'))
-              ..body = refer('e').property('uriEncode').call([], {
-                'allowEmpty': literalTrue,
-              }).code,
+              ..body = refer('e').property('toJson').call([]).code,
           ).closure,
         ])
         .property('toList')

--- a/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
@@ -444,6 +444,51 @@ void main() {
       );
     });
 
+    test('generates for list of URIs', () {
+      final uriListModel = ListModel(
+        content: UriModel(context: context),
+        context: context,
+      );
+      expect(
+        buildFromJsonValueExpression(
+          'value',
+          model: uriListModel,
+          nameManager: nameManager,
+          package: 'my_package',
+        ).accept(emitter).toString(),
+        equals(
+          'value.decodeJsonList<String>()'
+          '.map((e) => e.decodeJsonUri()).toList()',
+        ),
+      );
+    });
+
+    test('generates for list of maps with typed values', () {
+      final addressModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        name: 'Address',
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        valueModel: addressModel,
+        context: context,
+      );
+      final listModel = ListModel(content: mapModel, context: context);
+      expect(
+        buildFromJsonValueExpression(
+          'value',
+          model: listModel,
+          nameManager: nameManager,
+          package: 'my_package',
+        ).accept(emitter).toString(),
+        equals(
+          'value.decodeJsonList<Object?>()'
+          '.map((e) => e.decodeJsonMap((v) => Address.fromJson(v))).toList()',
+        ),
+      );
+    });
+
     test('generates for list of classes', () {
       final classModel = ClassModel(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -6151,7 +6151,7 @@ void main() {
             format(r'''
             void test() {
               final _$formData = FormData();
-              _$formData.files.add(MapEntry(r'priorities', MultipartFile.fromString(jsonEncode(body.priorities.map((e) => e.uriEncode(allowEmpty: true)).toList()), contentType: DioMediaType.parse(r'application/json'))));
+              _$formData.files.add(MapEntry(r'priorities', MultipartFile.fromString(jsonEncode(body.priorities.map((e) => e.toJson()).toList()), contentType: DioMediaType.parse(r'application/json'))));
               return _$formData;
             }
           '''),


### PR DESCRIPTION
## Summary

- **`List<Uri>` fromJson** — generated `decodeJsonList<Uri>()` which used `whereType<Uri>()` on String elements, always throwing `InvalidTypeException`. Now generates `decodeJsonList<String>().map((e) => e.decodeJsonUri()).toList()`.
- **`List<Map<String, T>>` fromJson** — generated `decodeJsonList<Map<String, T>>()` which failed because JSON maps are `Map<String, dynamic>`, not `Map<String, T>`. Now decodes via `decodeJsonList<Object?>().map(...)` with a recursive map decoder closure.
- **Multipart enum list encoding** — used `uriEncode()` instead of `toJson()` for JSON-encoded arrays, producing percent-encoded values inside JSON strings (e.g. `"science%20%26%20tech"` instead of `"science & tech"`).

## Test plan

- [x] Unit test: `from_json_value_expression_generator_test.dart` — "generates for list of URIs"
- [x] Unit test: `from_json_value_expression_generator_test.dart` — "generates for list of maps with typed values"
- [x] Unit test: `to_multipart_expression_generator_test.dart` — "list of string enums, content-based mode"
- [x] Integration test: `additional_properties_test.dart` — `UriListHolder` JSON roundtrip (3 tests)
- [x] Integration test: `additional_properties_test.dart` — `AddressMapListHolder` JSON roundtrip (3 tests)
- [x] Integration test: `multipart_test.dart` — enum array with special characters not percent-encoded in JSON
- [x] Full regression: all 54 fromJson generator tests pass, all 126 multipart generator tests pass
- [x] Full regression: all 57 additional_properties integration tests pass, all 39 multipart integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)