### PR TITLE
fix: forward useQueryComponent in allOf/anyOf toForm and add UriEncodable to ClassModel

### DIFF
--- a/docs/composite_data_types.md
+++ b/docs/composite_data_types.md
@@ -129,13 +129,15 @@ final fallback = PetChoice.fromJson({'petType': 'unknown', 'name': 'X', 'meow': 
 > ⚠️ **Important:** When constructing a variant, you must set the discriminator property value to match the variant type. For example, when creating a `PetChoiceCat`, always use `petType: 'cat'`. Setting an incorrect value (e.g., `petType: 'dog'` inside a `PetChoiceCat`) will produce JSON that won't roundtrip correctly - decoding will dispatch to the wrong variant based on the discriminator value.
 
 **How it works:**
-- Tonik detects when `oneOf`/`anyOf` variants inherit from a parent with a discriminator via `allOf`
+- Tonik detects when `oneOf` variants inherit from a parent with a discriminator via `allOf`
 - The discriminator property and mappings are inherited automatically
 - If a variant's schema name matches a mapping value, that mapping is used
 - On encode, the discriminator value from the inner type is preserved in the JSON output
-- On decode, the discriminator enables fast O(1) dispatch to the correct variant
+- On decode, the discriminator enables fast O(1) dispatch to the correct variant (oneOf only)
 - If the discriminator value is unknown, all variants are tried as fallback
 - Missing discriminator property will cause a `DecodingException` (since it's required)
+
+> **Note:** For `anyOf`, discriminator properties are inherited and preserved during encoding, but decoding always uses a try-all-variants strategy. This is by design — `anyOf` allows multiple variants to match simultaneously, so discriminator-based single-variant dispatch would change the semantics.
 
 ---
 

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1759,6 +1759,7 @@ for (final _\$e in $apFieldName.entries) {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
               'alreadyEncoded': literalBool(true),
+              'useQueryComponent': refer('useQueryComponent'),
             })
             .returned
             .statement,
@@ -1822,6 +1823,7 @@ for (final _\$e in $apFieldName.entries) {
             .call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
+              'useQueryComponent': refer('useQueryComponent'),
             })
             .returned
             .statement,
@@ -1964,6 +1966,7 @@ for (final _\$e in $apFieldName.entries) {
                   'explode': refer('explode'),
                   'allowEmpty': refer('allowEmpty'),
                   'alreadyEncoded': literalBool(true),
+                  'useQueryComponent': refer('useQueryComponent'),
                 })
                 .returned
                 .statement,
@@ -2001,6 +2004,7 @@ for (final _\$e in $apFieldName.entries) {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
               'alreadyEncoded': literalBool(true),
+              'useQueryComponent': refer('useQueryComponent'),
             })
             .returned
             .statement,
@@ -2051,6 +2055,7 @@ for (final _\$e in $apFieldName.entries) {
               .call([], {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
+                'useQueryComponent': refer('useQueryComponent'),
               })
               .returned
               .statement,

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -1306,7 +1306,8 @@ class AnyOfGenerator {
       ..addAll([
         const Code('explode: explode, '),
         const Code('allowEmpty: allowEmpty, '),
-        const Code('alreadyEncoded: true'),
+        const Code('alreadyEncoded: true, '),
+        const Code('useQueryComponent: useQueryComponent'),
         const Code(');'),
       ]);
 

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -172,6 +172,9 @@ class ClassGenerator {
           ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
           ..implements.add(
             refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),
+          )
+          ..implements.add(
+            refer('UriEncodable', 'package:tonik_util/tonik_util.dart'),
           );
 
         if (model.isDeprecated) {
@@ -244,6 +247,7 @@ class ClassGenerator {
           _buildToLabelMethod(),
           _buildToMatrixMethod(),
           _buildToDeepObjectMethod(),
+          _buildUriEncodeMethod(className),
         ]);
 
         b.fields.addAll(
@@ -1858,6 +1862,34 @@ if ($name != null) {
             .returned
             .statement,
       ]),
+  );
+
+  Method _buildUriEncodeMethod(String className) => Method(
+    (b) => b
+      ..annotations.add(refer('override', 'dart:core'))
+      ..name = 'uriEncode'
+      ..returns = refer('String', 'dart:core')
+      ..optionalParameters.addAll([
+        Parameter(
+          (b) => b
+            ..name = 'allowEmpty'
+            ..type = refer('bool', 'dart:core')
+            ..named = true
+            ..required = true,
+        ),
+        Parameter(
+          (b) => b
+            ..name = 'useQueryComponent'
+            ..type = refer('bool', 'dart:core')
+            ..named = true
+            ..defaultTo = literalBool(false).code,
+        ),
+      ])
+      ..lambda = false
+      ..body = generateEncodingExceptionExpression(
+        'Cannot uriEncode $className: complex types cannot be URI-encoded',
+        raw: true,
+      ).statement,
   );
 
   bool _hasStringCapturableAP(ClassModel model) {

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -127,9 +127,12 @@ void main() {
 
       const expectedToFormMethod = '''
         String toForm({ required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-          return parameterProperties(
+          return parameterProperties(allowEmpty: allowEmpty).toForm(
+            explode: explode,
             allowEmpty: allowEmpty,
-          ).toForm(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+          );
         }
       ''';
 
@@ -202,9 +205,12 @@ void main() {
               r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
             );
           }
-          return parameterProperties(
+          return parameterProperties(allowEmpty: allowEmpty).toForm(
+            explode: explode,
             allowEmpty: allowEmpty,
-          ).toForm(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+          );
         }
       ''';
 
@@ -230,7 +236,11 @@ void main() {
 
       const expectedToFormMethod = '''
         String toForm({ required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-          return bigDecimal.toForm(explode: explode, allowEmpty: allowEmpty);
+          return bigDecimal.toForm(
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+          );
         }
       ''';
 
@@ -299,7 +309,11 @@ void main() {
 
         const expectedToFormMethod = '''
         String toForm({ required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-          return status.toForm(explode: explode, allowEmpty: allowEmpty);
+          return status.toForm(
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+          );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -618,6 +618,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
           );
         }
       ''';
@@ -699,6 +700,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
           );
         }
       ''';
@@ -780,6 +782,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               alreadyEncoded: true,
+              useQueryComponent: useQueryComponent,
             );
           }
         }
@@ -952,6 +955,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 alreadyEncoded: true,
+                useQueryComponent: useQueryComponent,
               );
             }
           }
@@ -1114,6 +1118,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 alreadyEncoded: true,
+                useQueryComponent: useQueryComponent,
               );
             }
           }

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -773,6 +773,7 @@ String toForm({
     explode: explode,
     allowEmpty: allowEmpty,
     alreadyEncoded: true,
+    useQueryComponent: useQueryComponent,
   );
 }
       ''';

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -59,7 +59,8 @@ void main() {
       expect(annotation.accept(emitter).toString(), 'immutable');
     });
 
-    test('generates class implementing ParameterEncodable', () {
+    test('generates class implementing ParameterEncodable and UriEncodable',
+        () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'User',
@@ -69,11 +70,131 @@ void main() {
 
       final result = generator.generateClass(model);
 
-      expect(result.implements.length, 1);
-      expect(
-        result.implements.first.accept(emitter).toString(),
-        'ParameterEncodable',
-      );
+      expect(result.implements.length, 2);
+      final implementsNames =
+          result.implements.map((i) => i.accept(emitter).toString()).toList();
+      expect(implementsNames, contains('ParameterEncodable'));
+      expect(implementsNames, contains('UriEncodable'));
+    });
+
+    group('uriEncode', () {
+      test('generates uriEncode that throws for class with properties', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+            Property(
+              name: 'age',
+              model: IntegerModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final result = generator.generateClass(model);
+        final generated = format(result.accept(emitter).toString());
+
+        const expectedUriEncode = '''
+          @override
+          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+            throw EncodingException(
+              r'Cannot uriEncode User: complex types cannot be URI-encoded',
+            );
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedUriEncode)),
+        );
+      });
+
+      test('generates uriEncode that throws for empty class', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Empty',
+          properties: const [],
+          context: context,
+        );
+
+        final result = generator.generateClass(model);
+        final generated = format(result.accept(emitter).toString());
+
+        const expectedUriEncode = '''
+          @override
+          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+            throw EncodingException(
+              r'Cannot uriEncode Empty: complex types cannot be URI-encoded',
+            );
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedUriEncode)),
+        );
+      });
+
+      test('generates uriEncode with correct signature', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Item',
+          properties: [
+            Property(
+              name: 'id',
+              model: IntegerModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final result = generator.generateClass(model);
+        final uriEncodeMethod = result.methods.firstWhere(
+          (m) => m.name == 'uriEncode',
+        );
+
+        expect(uriEncodeMethod.returns?.accept(emitter).toString(), 'String');
+        expect(
+          uriEncodeMethod.annotations.first.accept(emitter).toString(),
+          'override',
+        );
+
+        final allowEmptyParam =
+            uriEncodeMethod.optionalParameters.firstWhere(
+          (p) => p.name == 'allowEmpty',
+        );
+        expect(allowEmptyParam.type?.accept(emitter).toString(), 'bool');
+        expect(allowEmptyParam.named, isTrue);
+        expect(allowEmptyParam.required, isTrue);
+
+        final useQueryComponentParam =
+            uriEncodeMethod.optionalParameters.firstWhere(
+          (p) => p.name == 'useQueryComponent',
+        );
+        expect(
+          useQueryComponentParam.type?.accept(emitter).toString(),
+          'bool',
+        );
+        expect(useQueryComponentParam.named, isTrue);
+        expect(useQueryComponentParam.required, isFalse);
+        expect(
+          useQueryComponentParam.defaultTo?.accept(emitter).toString(),
+          'false',
+        );
+      });
     });
 
     group('doc comments', () {


### PR DESCRIPTION
## Summary

- **Forward `useQueryComponent`** in 5 allOf `toForm` code paths and 1 anyOf `toForm` code path that silently dropped the parameter, causing incorrect percent-encoding instead of query-component encoding for `+` characters
- **Add `UriEncodable` interface** to `ClassModel` for consistency with composite types (oneOf, anyOf, allOf) which all implement both `ParameterEncodable` and `UriEncodable`
- **Clarify docs**: discriminator-based O(1) dispatch applies to `oneOf` only; `anyOf` uses try-all-variants decoding by design per OpenAPI spec semantics

## Test plan

- [x] Updated existing allOf form tests to expect `useQueryComponent` forwarding (4 tests)
- [x] Updated existing anyOf form tests to expect `useQueryComponent` forwarding (6 tests)
- [x] Added ClassModel `uriEncode` body tests (2 full-body, 1 signature)
- [x] Updated ClassModel interface test to expect both `ParameterEncodable` and `UriEncodable`
- [x] All 2138 unit tests pass
- [x] Integration tests regenerated and pass