### PR TITLE
fix: reject complex list element types in label path parameter encoding

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -386,6 +386,56 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  # =============================================================================
+  # LABEL STYLE - EDGE CASES (bug coverage)
+  # =============================================================================
+
+  /label/array/objects/{itemList}:
+    get:
+      operationId: testLabelArrayObjects
+      tags: [label]
+      summary: Label-style array of objects path parameter (bug 005)
+      parameters:
+        - name: itemList
+          in: path
+          required: true
+          style: label
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/Item'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /label/array/maps/{items}:
+    get:
+      operationId: testLabelArrayMaps
+      tags: [label]
+      summary: Label-style array of maps path parameter (bug 010)
+      parameters:
+        - name: items
+          in: path
+          required: true
+          style: label
+          schema:
+            type: array
+            items:
+              type: object
+              additionalProperties:
+                type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
   /matrix/primitive/string/{value}:
     get:
       operationId: testMatrixPrimitiveString
@@ -1208,6 +1258,17 @@ components:
           type: string
         'a=b':
           type: integer
+
+    Item:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
 
     EchoResponse:
       type: object

--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -394,7 +394,7 @@ paths:
     get:
       operationId: testLabelArrayObjects
       tags: [label]
-      summary: Label-style array of objects path parameter (bug 005)
+      summary: Label-style array of objects path parameter
       parameters:
         - name: itemList
           in: path
@@ -416,7 +416,7 @@ paths:
     get:
       operationId: testLabelArrayMaps
       tags: [label]
-      summary: Label-style array of maps path parameter (bug 010)
+      summary: Label-style array of maps path parameter
       parameters:
         - name: items
           in: path

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -45,9 +45,15 @@ Expression buildToLabelPathParameterExpression(
       });
     }
 
-    if (contentModel is BinaryModel) {
+    if (contentModel is BinaryModel || contentModel is Base64Model) {
       return generateEncodingExceptionExpression(
         'Binary data cannot be label-encoded',
+      );
+    }
+
+    if (contentModel is ClassModel || contentModel is MapModel) {
+      return generateEncodingExceptionExpression(
+        'Label encoding does not support arrays of complex types',
       );
     }
 

--- a/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
@@ -586,6 +586,102 @@ void main() {
     );
   });
 
+  group('unsupported types generate throw', () {
+    test('List of ClassModel throws EncodingException', () {
+      final parameter = PathParameterObject(
+        name: 'itemList',
+        rawName: 'itemList',
+        description: 'List of objects parameter',
+        model: ListModel(
+          context: context,
+          content: ClassModel(
+            isDeprecated: false,
+            context: context,
+            name: 'Item',
+            properties: [
+              Property(
+                name: 'id',
+                model: IntegerModel(context: context),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+              ),
+            ],
+          ),
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('itemList', parameter)),
+        contains('throw'),
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('itemList', parameter)),
+        contains('EncodingException'),
+      );
+    });
+
+    test('List of MapModel throws EncodingException', () {
+      final parameter = PathParameterObject(
+        name: 'items',
+        rawName: 'items',
+        description: 'List of maps parameter',
+        model: ListModel(
+          context: context,
+          content: MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
+          ),
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('items', parameter)),
+        contains('throw'),
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('items', parameter)),
+        contains('EncodingException'),
+      );
+    });
+
+    test('List of Base64Model throws EncodingException', () {
+      final parameter = PathParameterObject(
+        name: 'files',
+        rawName: 'files',
+        description: 'List of base64 files',
+        model: ListModel(
+          context: context,
+          content: Base64Model(context: context),
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('files', parameter)),
+        contains('throw'),
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('files', parameter)),
+        contains('EncodingException'),
+      );
+    });
+  });
+
   group('nullable model support', () {
     test(
       'uses null assertion for nullable AliasModel '


### PR DESCRIPTION
## Summary
- The label path parameter generator fell through to a `.uriEncode()` catch-all for list content types like `ClassModel`, `MapModel`, and `Base64Model`, which don't have that method — producing compile errors in generated code.
- Add explicit checks that generate `throw EncodingException` for these unsupported types, matching the behavior of the simple and matrix generators.

## Test plan
- [x] 3 new unit tests for `List<ClassModel>`, `List<MapModel>`, `List<Base64Model>`
- [x] 2 new integration test operations (`/label/array/objects/`, `/label/array/maps/`)
- [x] All 27 label path parameter tests pass
- [x] All 45 path_encoding integration tests pass
- [x] `dart analyze` clean on generated code