### PR TITLE
fix: immutable collections code generation fixes

### DIFF
--- a/integration_test/additional_properties/additional_properties_test/pubspec.lock
+++ b/integration_test/additional_properties/additional_properties_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
+++ b/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/composition/composition_test/pubspec.lock
+++ b/integration_test/composition/composition_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/defs/defs_test/pubspec.lock
+++ b/integration_test/defs/defs_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/fastify_type_provider_zod/fastify_type_provider_zod_test/pubspec.lock
+++ b/integration_test/fastify_type_provider_zod/fastify_type_provider_zod_test/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/immutable_collections/immutable_collections_test/pubspec.lock
+++ b/integration_test/immutable_collections/immutable_collections_test/pubspec.lock
@@ -365,7 +365,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/immutable_collections/immutable_collections_test/test/model_test.dart
+++ b/integration_test/immutable_collections/immutable_collections_test/test/model_test.dart
@@ -226,6 +226,68 @@ void main() {
   });
 
   // -------------------------------------------------------------------
+  // 3b. TaggedItem — class with properties + typed AP (list values)
+  // -------------------------------------------------------------------
+
+  group('TaggedItem (class with typed AP list values)', () {
+    test('additionalProperties field is IMap<String, IList<String>>', () {
+      final item = TaggedItem(
+        name: 'item1',
+        additionalProperties: IMap(<String, IList<String>>{
+          'colors': <String>['red', 'blue'].lock,
+        }),
+      );
+      expect(item.additionalProperties, isA<IMap<String, IList<String>>>());
+      expect(item.additionalProperties['colors'], isA<IList<String>>());
+    });
+
+    test('fromJson round-trip preserves IMap<String, IList<String>>', () {
+      final original = TaggedItem(
+        name: 'item1',
+        additionalProperties: IMap(<String, IList<String>>{
+          'colors': <String>['red', 'blue'].lock,
+          'sizes': <String>['small', 'large'].lock,
+        }),
+      );
+
+      final json = original.toJson();
+      final restored = TaggedItem.fromJson(json);
+
+      expect(restored.name, 'item1');
+      expect(
+        restored.additionalProperties,
+        isA<IMap<String, IList<String>>>(),
+      );
+      expect(restored.additionalProperties['colors'], isA<IList<String>>());
+      expect(
+        restored.additionalProperties['colors'],
+        <String>['red', 'blue'].lock,
+      );
+      expect(
+        restored.additionalProperties['sizes'],
+        <String>['small', 'large'].lock,
+      );
+    });
+
+    test('equality works with IMap<String, IList<String>> AP', () {
+      final a = TaggedItem(
+        name: 'x',
+        additionalProperties: IMap(<String, IList<String>>{
+          'tags': <String>['a'].lock,
+        }),
+      );
+      final b = TaggedItem(
+        name: 'x',
+        additionalProperties: IMap(<String, IList<String>>{
+          'tags': <String>['a'].lock,
+        }),
+      );
+      expect(a, b);
+      expect(a.hashCode, b.hashCode);
+    });
+  });
+
+  // -------------------------------------------------------------------
   // 4. copyWith — verify it works with IList/IMap fields
   // -------------------------------------------------------------------
 

--- a/integration_test/immutable_collections/immutable_collections_test/test/model_test.dart
+++ b/integration_test/immutable_collections/immutable_collections_test/test/model_test.dart
@@ -79,6 +79,21 @@ void main() {
   });
 
   // -------------------------------------------------------------------
+  // 1b. allOf with MapModel component — field types
+  // -------------------------------------------------------------------
+
+  group('Combined (allOf with MapModel) type checks', () {
+    test('extraData field is ExtraData (IMap<String, String>)', () {
+      final combined = Combined(
+        extraData: IMap(const {'key': 'value'}),
+        combinedModel: const CombinedModel(name: 'test'),
+      );
+      expect(combined.extraData, isA<IMap<String, String>>());
+      expect(combined.extraData['key'], 'value');
+    });
+  });
+
+  // -------------------------------------------------------------------
   // 2. Serialization round-trips — toJson → fromJson preserves types
   // -------------------------------------------------------------------
 
@@ -132,6 +147,24 @@ void main() {
       expect(restored.matrix[0][0], 'a');
       expect(restored.matrix[1][1], 'd');
       expect(restored.matrix, original.matrix);
+    });
+  });
+
+  group('Combined (allOf with MapModel) serialization', () {
+    test('round-trip preserves IMap in allOf with MapModel component', () {
+      final original = Combined(
+        extraData: IMap(const {'extra1': 'value1', 'extra2': 'value2'}),
+        combinedModel: const CombinedModel(name: 'test'),
+      );
+
+      final json = original.toJson();
+      expect(json, isA<Map<String, dynamic>>());
+
+      final restored = Combined.fromJson(json);
+      expect(restored.extraData, isA<IMap<String, String>>());
+      expect(restored.extraData['extra1'], 'value1');
+      expect(restored.extraData['extra2'], 'value2');
+      expect(restored.combinedModel.name, 'test');
     });
   });
 

--- a/integration_test/immutable_collections/openapi.yaml
+++ b/integration_test/immutable_collections/openapi.yaml
@@ -361,7 +361,7 @@ components:
           type: string
 
     # allOf combining a MapModel component with a ClassModel — tests
-    # that fast_immutable_collections import is emitted for .lock usage
+    # that fast_immutable_collections import is emitted for IMap constructor usage
     Combined:
       allOf:
         - $ref: '#/components/schemas/ExtraData'

--- a/integration_test/immutable_collections/openapi.yaml
+++ b/integration_test/immutable_collections/openapi.yaml
@@ -84,6 +84,45 @@ paths:
                   color: red
                   size: large
 
+  /string-list:
+    get:
+      operationId: listStrings
+      tags:
+        - items
+      summary: Get a list of strings directly
+      responses:
+        '200':
+          description: A list of strings
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  type: string
+              example:
+                - alpha
+                - bravo
+                - charlie
+
+  /counts:
+    get:
+      operationId: getCounts
+      tags:
+        - items
+      summary: Get a map of string to int directly
+      responses:
+        '200':
+          description: A map of counts
+          content:
+            application/json:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+              example:
+                apples: 3
+                bananas: 5
+
   /nested:
     post:
       operationId: createNested

--- a/integration_test/immutable_collections/openapi.yaml
+++ b/integration_test/immutable_collections/openapi.yaml
@@ -149,6 +149,24 @@ paths:
                   - - c
                     - d
 
+  /combined:
+    get:
+      operationId: getCombined
+      tags:
+        - items
+      summary: Get a combined allOf with MapModel component
+      responses:
+        '200':
+          description: A combined object
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Combined'
+              example:
+                name: test
+                extra1: value1
+                extra2: value2
+
 components:
   schemas:
     # Simple list property + map property + list of objects
@@ -267,5 +285,21 @@ components:
           items:
             type: array
             items:
+              type: string
+
+    # Pure map typedef (additionalProperties-only) for allOf composition test
+    ExtraData:
+      type: object
+      additionalProperties:
+        type: string
+
+    # allOf combining a MapModel component with a ClassModel — tests
+    # that fast_immutable_collections import is emitted for .lock usage
+    Combined:
+      allOf:
+        - $ref: '#/components/schemas/ExtraData'
+        - type: object
+          properties:
+            name:
               type: string
 

--- a/integration_test/immutable_collections/openapi.yaml
+++ b/integration_test/immutable_collections/openapi.yaml
@@ -149,6 +149,20 @@ paths:
                   - - c
                     - d
 
+  /tagged-item:
+    get:
+      operationId: getTaggedItem
+      tags:
+        - items
+      summary: Get a tagged item (class with properties + typed AP with list values)
+      responses:
+        '200':
+          description: A tagged item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/TaggedItem'
+
   /combined:
     get:
       operationId: getCombined
@@ -286,6 +300,18 @@ components:
             type: array
             items:
               type: string
+
+    # Class with properties + typed additionalProperties (list values)
+    # Tests that fromJson scratch map uses IList<String> as value type
+    TaggedItem:
+      type: object
+      properties:
+        name:
+          type: string
+      additionalProperties:
+        type: array
+        items:
+          type: string
 
     # Pure map typedef (additionalProperties-only) for allOf composition test
     ExtraData:

--- a/integration_test/immutable_collections/openapi.yaml
+++ b/integration_test/immutable_collections/openapi.yaml
@@ -163,6 +163,26 @@ paths:
               schema:
                 $ref: '#/components/schemas/TaggedItem'
 
+  /extended-item:
+    get:
+      operationId: getExtendedItem
+      tags:
+        - items
+      summary: Get an extended item (allOf with typed additionalProperties list values)
+      responses:
+        '200':
+          description: An extended item
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExtendedItem'
+              example:
+                id: abc-123
+                name: Widget
+                customTags:
+                  - cool
+                  - useful
+
   /combined:
     get:
       operationId: getCombined
@@ -318,6 +338,27 @@ components:
       type: object
       additionalProperties:
         type: string
+
+    # Base schema for allOf composition test with typed additionalProperties
+    BaseItem:
+      type: object
+      properties:
+        id:
+          type: string
+
+    # allOf with typed additionalProperties (list values) at the allOf level
+    # Tests that fromJson scratch map in allOf generator uses IList<String>
+    ExtendedItem:
+      allOf:
+        - $ref: '#/components/schemas/BaseItem'
+        - type: object
+          properties:
+            name:
+              type: string
+      additionalProperties:
+        type: array
+        items:
+          type: string
 
     # allOf combining a MapModel component with a ClassModel — tests
     # that fast_immutable_collections import is emitted for .lock usage

--- a/integration_test/multipart/multipart_test/pubspec.lock
+++ b/integration_test/multipart/multipart_test/pubspec.lock
@@ -364,7 +364,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/music_streaming/music_streaming_test/pubspec.lock
+++ b/integration_test/music_streaming/music_streaming_test/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/naming/naming_test/pubspec.lock
+++ b/integration_test/naming/naming_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/path_encoding/path_encoding_test/pubspec.lock
+++ b/integration_test/path_encoding/path_encoding_test/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/read_write_only/read_write_only_test/pubspec.lock
+++ b/integration_test/read_write_only/read_write_only_test/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/server_variables/server_variables_test/pubspec.lock
+++ b/integration_test/server_variables/server_variables_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/simple_encoding/simple_encoding_test/pubspec.lock
+++ b/integration_test/simple_encoding/simple_encoding_test/pubspec.lock
@@ -357,7 +357,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   typed_data:
     dependency: transitive
     description:

--- a/integration_test/type_arrays/type_arrays_test/pubspec.lock
+++ b/integration_test/type_arrays/type_arrays_test/pubspec.lock
@@ -350,7 +350,7 @@ packages:
       path: "../../../packages/tonik_util"
       relative: true
     source: path
-    version: "0.6.0"
+    version: "0.7.0"
   type_arrays_api:
     dependency: "direct main"
     description:

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -14,10 +14,15 @@ import 'package:tonik_generate/src/util/source_file_url.dart';
 
 /// Generator for creating API client classes from Operation definitions.
 class ApiClientGenerator {
-  ApiClientGenerator({required this.nameManager, required this.package});
+  ApiClientGenerator({
+    required this.nameManager,
+    required this.package,
+    this.useImmutableCollections = false,
+  });
 
   final NameManager nameManager;
   final String package;
+  final bool useImmutableCollections;
 
   ({String code, String filename}) generate(
     Set<Operation> operations,
@@ -118,7 +123,12 @@ class ApiClientGenerator {
       package: package,
     );
 
-    final resultType = resultTypeForOperation(operation, nameManager, package);
+    final resultType = resultTypeForOperation(
+      operation,
+      nameManager,
+      package,
+      useImmutableCollections: useImmutableCollections,
+    );
     final operationFieldName =
         '_${nameManager.operationName(operation).toCamelCase()}';
 

--- a/packages/tonik_generate/lib/src/generator.dart
+++ b/packages/tonik_generate/lib/src/generator.dart
@@ -124,6 +124,7 @@ class Generator {
     final apiClientGenerator = ApiClientGenerator(
       nameManager: nameManager,
       package: package,
+      useImmutableCollections: useImmutableCollections,
     );
 
     final apiClientFileGenerator = ApiClientFileGenerator(

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -484,6 +484,7 @@ class AllOfGenerator {
       model.additionalProperties,
       nameManager,
       package,
+      useImmutableCollections: useImmutableCollections,
     );
 
     codes.add(

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -534,7 +534,11 @@ class AllOfGenerator {
       ),
     );
     constructorArgs[apFieldName] = useImmutableCollections
-        ? refer(r'_$additional').property('lock')
+        ? refer(
+            'IMap',
+            'package:fast_immutable_collections/'
+                'fast_immutable_collections.dart',
+          ).call([refer(r'_$additional')])
         : refer(r'_$additional');
 
     codes.add(
@@ -1134,7 +1138,11 @@ class AllOfGenerator {
     ];
 
     constructorArgs[apFieldName] = useImmutableCollections
-        ? refer(r'_$additional').property('lock')
+        ? refer(
+            'IMap',
+            'package:fast_immutable_collections/'
+                'fast_immutable_collections.dart',
+          ).call([refer(r'_$additional')])
         : refer(r'_$additional');
 
     codes.add(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -541,7 +541,11 @@ class ClassGenerator {
         const Code('}'),
       ]);
       constructorArgs[apFieldName] = useImmutableCollections
-          ? refer(r'_$additional').property('lock')
+          ? refer(
+              'IMap',
+              'package:fast_immutable_collections/'
+                  'fast_immutable_collections.dart',
+            ).call([refer(r'_$additional')])
           : refer(r'_$additional');
     }
 
@@ -720,7 +724,14 @@ class ClassGenerator {
       if (useImmutableCollections) {
         propertyAssignments
           ..add(Code('$apFieldName: '))
-          ..add(const Code(r'_$additional.lock,'));
+          ..add(
+            refer(
+              'IMap',
+              'package:fast_immutable_collections/'
+                  'fast_immutable_collections.dart',
+            ).call([refer(r'_$additional')]).code,
+          )
+          ..add(const Code(','));
       } else {
         propertyAssignments
           ..add(Code('$apFieldName: '))
@@ -1736,7 +1747,11 @@ if ($name != null) {
         const Code('}'),
       ]);
       constructorArgs[apFieldName] = useImmutableCollections
-          ? refer(r'_$additional').property('lock')
+          ? refer(
+              'IMap',
+              'package:fast_immutable_collections/'
+                  'fast_immutable_collections.dart',
+            ).call([refer(r'_$additional')])
           : refer(r'_$additional');
     }
 

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -490,7 +490,12 @@ class ClassGenerator {
     if (captureAP && ap != null) {
       final apFieldName = pickAdditionalPropertiesFieldName(allProperties);
       final knownKeySet = expectedKeys.map(specLiteralStringCode).join(', ');
-      final mapType = additionalPropertiesType(ap, nameManager, package);
+      final mapType = additionalPropertiesType(
+        ap,
+        nameManager,
+        package,
+        useImmutableCollections: useImmutableCollections,
+      );
       codes.addAll([
         Code('const _\$knownKeys = {$knownKeySet};'),
         declareFinal(r'_$additional')
@@ -678,6 +683,7 @@ class ClassGenerator {
         model.additionalProperties,
         nameManager,
         package,
+        useImmutableCollections: useImmutableCollections,
       );
 
       codes.addAll([
@@ -1694,7 +1700,12 @@ if ($name != null) {
     if (captureAP && ap != null) {
       final apFieldName = pickAdditionalPropertiesFieldName(allProperties);
       final knownKeySet = expectedKeys.map(specLiteralStringCode).join(', ');
-      final mapType = additionalPropertiesType(ap, nameManager, package);
+      final mapType = additionalPropertiesType(
+        ap,
+        nameManager,
+        package,
+        useImmutableCollections: useImmutableCollections,
+      );
       codes.addAll([
         Code('const _\$knownKeys = {$knownKeySet};'),
         declareFinal(r'_$additional')

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -216,7 +216,12 @@ class OperationGenerator {
 
     final queryExpr = refer('_queryParameters').call([], queryArgs);
 
-    final resultType = resultTypeForOperation(operation, nameManager, package);
+    final resultType = resultTypeForOperation(
+      operation,
+      nameManager,
+      package,
+      useImmutableCollections: useImmutableCollections,
+    );
     final isVoidReturn =
         resultType.types.isNotEmpty && resultType.types.first.symbol == 'void';
     const responseVar = r'_$response';

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -422,9 +422,10 @@ class OptionsGenerator {
         });
         bodyStatements.add(
           refer(r'_$cookieParts').property('add').call([
-            literalList([specLiteralString('$rawName='), encodedValue])
-                .property('join')
-                .call([]),
+            literalList([
+              specLiteralString('$rawName='),
+              encodedValue,
+            ]).property('join').call([]),
           ]).statement,
         );
         return;
@@ -470,9 +471,10 @@ class OptionsGenerator {
     });
     bodyStatements.add(
       refer(r'_$cookieParts').property('add').call([
-        literalList([specLiteralString('$rawName='), encodedValue])
-            .property('join')
-            .call([]),
+        literalList([
+          specLiteralString('$rawName='),
+          encodedValue,
+        ]).property('join').call([]),
       ]).statement,
     );
   }

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -28,6 +28,7 @@ class ParseGenerator {
       operation,
       nameManager,
       package,
+      useImmutableCollections: useImmutableCollections,
     ).types.first;
     final cases = <Code>[];
 

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -186,7 +186,13 @@ Expression _buildListFromJsonExpression(
 
   // isNullable already accounts for model.isEffectivelyNullable via the
   // caller (buildFromJsonValueExpression), so no need to recompute here.
-  final listDecoder = isNullable ? 'decodeJsonNullableList' : 'decodeJsonList';
+  //
+  // When using immutable collections, always use the non-nullable decoder
+  // internally. We handle null ourselves via a ternary wrapping IList(), so
+  // that refer('IList', ficUrl) properly tracks the import.
+  final effectiveNullable = !useImmutableCollections && isNullable;
+  final listDecoder =
+      effectiveNullable ? 'decodeJsonNullableList' : 'decodeJsonList';
 
   // Unwrap alias to get the underlying model
   final unwrappedContent = content is AliasModel ? content.model : content;
@@ -213,7 +219,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer('Object?', 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? listExpr
                 .nullSafeProperty('map')
                 .call([mapFunction])
@@ -241,7 +247,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer('Object?', 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? listExpr
                 .nullSafeProperty('map')
                 .call([mapFunction])
@@ -272,7 +278,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer('Object?', 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? mapListExpr
                 .nullSafeProperty('map')
                 .call([mapDecoderClosure])
@@ -299,7 +305,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer(jsonType, 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? listExpr
                 .nullSafeProperty('map')
                 .call([mapFunction])
@@ -328,7 +334,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer('String', 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? listExpr
                 .nullSafeProperty('map')
                 .call([mapFunction])
@@ -357,7 +363,7 @@ Expression _buildListFromJsonExpression(
         contextParam,
         [refer('String', 'dart:core')],
       );
-      result = isNullable
+      result = effectiveNullable
           ? listExpr
                 .nullSafeProperty('map')
                 .call([mapFunction])
@@ -381,11 +387,15 @@ Expression _buildListFromJsonExpression(
       ).property(listDecoder).call([], contextParam, [typeArg]);
   }
 
-  // When using immutable collections, wrap with .lock to convert to IList.
+  // When using immutable collections, wrap with IList() constructor to convert.
+  // Using refer() ensures the fast_immutable_collections import is tracked.
   if (useImmutableCollections) {
-    result = isNullable
-        ? result.nullSafeProperty('lock')
-        : result.property('lock');
+    result = _wrapImmutable(
+      'IList',
+      result,
+      isNullable: isNullable,
+      value: value,
+    );
   }
 
   return result;
@@ -419,21 +429,56 @@ Expression _buildMapFromJsonExpression(
       ).code,
   ).closure;
 
-  final mapDecoder = isNullable ? 'decodeJsonNullableMap' : 'decodeJsonMap';
+  // When using immutable collections, always use non-nullable decoder and
+  // handle null ourselves so that refer('IMap', ficUrl) tracks the import.
+  final effectiveNullable = !useImmutableCollections && isNullable;
+  final mapDecoder =
+      effectiveNullable ? 'decodeJsonNullableMap' : 'decodeJsonMap';
 
   var result = refer(value).property(mapDecoder).call(
     [decoderClosure],
     contextParam,
   );
 
-  // When using immutable collections, wrap with .lock to convert to IMap.
+  // When using immutable collections, wrap with IMap() constructor to convert.
+  // Using refer() ensures the fast_immutable_collections import is tracked.
   if (useImmutableCollections) {
-    result = isNullable
-        ? result.nullSafeProperty('lock')
-        : result.property('lock');
+    result = _wrapImmutable(
+      'IMap',
+      result,
+      isNullable: isNullable,
+      value: value,
+    );
   }
 
   return result;
+}
+
+const _ficUrl =
+    'package:fast_immutable_collections/fast_immutable_collections.dart';
+
+/// Wraps [result] in an immutable collection constructor (`IList` or `IMap`).
+///
+/// For non-nullable results, generates `IList(result)` / `IMap(result)`.
+/// For nullable results, generates `value == null ? null : IList(result)`.
+/// The [result] expression must use a non-nullable decoder (guaranteed by
+/// the caller setting `effectiveNullable = false`), and [value] is the
+/// original JSON variable name for the null guard.
+///
+/// Using `refer(symbol, ficUrl)` ensures the `fast_immutable_collections`
+/// import is automatically tracked by code_builder.
+Expression _wrapImmutable(
+  String symbol,
+  Expression result, {
+  required bool isNullable,
+  required String value,
+}) {
+  final immutableRef = refer(symbol, _ficUrl);
+  final wrapped = immutableRef.call([result]);
+  if (!isNullable) {
+    return wrapped;
+  }
+  return refer(value).equalTo(literalNull).conditional(literalNull, wrapped);
 }
 
 String? _decodeMethodForPrimitive(Model model) {

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -10,8 +10,8 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 /// to its Dart representation.
 ///
 /// When [useImmutableCollections] is `true`, decoded lists and maps are
-/// wrapped with `.lock` at every nesting level so the result is
-/// `IList` / `IMap` throughout.
+/// wrapped in `IList()` / `IMap()` constructors at every nesting level so
+/// the result is `IList` / `IMap` throughout.
 Expression buildFromJsonValueExpression(
   String value, {
   required Model model,

--- a/packages/tonik_generate/lib/src/util/response_type_generator.dart
+++ b/packages/tonik_generate/lib/src/util/response_type_generator.dart
@@ -10,8 +10,9 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 TypeReference resultTypeForOperation(
   Operation operation,
   NameManager nameManager,
-  String package,
-) {
+  String package, {
+  bool useImmutableCollections = false,
+}) {
   final responses = operation.responses;
   final response = responses.values.firstOrNull;
   final hasHeaders = response?.hasHeaders ?? false;
@@ -51,6 +52,7 @@ TypeReference resultTypeForOperation(
             response!.resolved.bodies.first.model,
             nameManager,
             package,
+            useImmutableCollections: useImmutableCollections,
           ),
         ),
     ),

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -3506,6 +3506,71 @@ Object? toJson() {
         );
       },
     );
+
+    test(
+      'allOf with typed additionalProperties (list values) and '
+      'useImmutableCollections',
+      () {
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'ExtendedItem',
+          models: {
+            ClassModel(
+              isDeprecated: false,
+              name: 'Base',
+              context: context,
+              properties: [
+                Property(
+                  name: 'id',
+                  model: StringModel(context: context),
+                  isRequired: true,
+                  isNullable: false,
+                  isDeprecated: false,
+                ),
+              ],
+            ),
+          },
+          context: context,
+          additionalProperties: TypedAdditionalProperties(
+            valueModel: ListModel(
+              content: StringModel(context: context),
+              context: context,
+            ),
+          ),
+        );
+
+        final combinedClass = immutableGenerator.generateClass(model);
+        final generated = format(
+          combinedClass.accept(emitter).toString(),
+        );
+
+        // fromJson scratch map should use IList<String> as value type
+        const expectedFromJson = r'''
+factory ExtendedItem.fromJson(Object? json) {
+  final _$map = json.decodeMap(context: r'ExtendedItem');
+  const _$knownKeys = {r'id'};
+  final _$additional = <String, IList<String>>{};
+  for (final _$entry in _$map.entries) {
+    if (!_$knownKeys.contains(_$entry.key)) {
+      _$additional[_$entry.key] = IList(
+        _$entry.value.decodeJsonList<String>(
+          context: r'ExtendedItem.additionalProperties',
+        ),
+      );
+    }
+  }
+  return ExtendedItem(
+    $base: Base.fromJson(json),
+    additionalProperties: IMap(_$additional),
+  );
+}
+''';
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedFromJson)),
+        );
+      },
+    );
   });
 
   group('allOf with MapModel components', () {

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -3463,7 +3463,7 @@ bool operator ==(Object other) {
           'const IMapConst({})',
         );
 
-        // fromJson should use .lock on _$additional
+        // fromJson should wrap _$additional in IMap constructor
         const expectedFromJson = r'''
 factory ExtendedImmutable.fromJson(Object? json) {
   final _$map = json.decodeMap(context: r'ExtendedImmutable');
@@ -3476,7 +3476,7 @@ factory ExtendedImmutable.fromJson(Object? json) {
   }
   return ExtendedImmutable(
     $base: Base.fromJson(json),
-    additionalProperties: _$additional.lock,
+    additionalProperties: IMap(_$additional),
   );
 }
 ''';
@@ -3698,6 +3698,75 @@ Object? toJson() {
         expect(
           collapseWhitespace(generated),
           contains(collapseWhitespace(expectedToJson)),
+        );
+      },
+    );
+  });
+
+  group('allOf with MapModel component and useImmutableCollections', () {
+    late AllOfGenerator immutableGenerator;
+
+    setUp(() {
+      immutableGenerator = AllOfGenerator(
+        nameManager: nameManager,
+        package: 'example',
+        stableModelSorter: StableModelSorter(),
+        useImmutableCollections: true,
+      );
+    });
+
+    test(
+      'fromJson wraps MapModel component in IMap constructor',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Details',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final mapModel = MapModel(
+          name: 'ExtraData',
+          valueModel: StringModel(context: context),
+          context: context,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'Combined',
+          models: {classModel, mapModel},
+          context: context,
+        );
+
+        final combinedClass = immutableGenerator.generateClass(model);
+        final generated = format(
+          combinedClass.accept(emitter).toString(),
+        );
+
+        const expectedFromJson = '''
+factory Combined.fromJson(Object? json) {
+  return Combined(
+    details: Details.fromJson(json),
+    extraData: IMap(
+      json.decodeJsonMap(
+        (v) => v.decodeJsonString(context: r'Combined'),
+        context: r'Combined',
+      ),
+    ),
+  );
+}
+''';
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedFromJson)),
         );
       },
     );

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -2819,5 +2819,78 @@ Map<String, String> parameterProperties({
         },
       );
     });
+
+    group(
+      'immutable collections — typed AP with list values in fromJson',
+      () {
+        late ClassGenerator immutableGenerator;
+
+        setUp(() {
+          immutableGenerator = ClassGenerator(
+            nameManager: nameManager,
+            package: 'example',
+            useImmutableCollections: true,
+          );
+        });
+
+        test(
+          'fromJson scratch map uses IList value type for typed AP with '
+          'list values',
+          () {
+            final model = ClassModel(
+              isDeprecated: false,
+              name: 'TaggedItem',
+              properties: [
+                Property(
+                  name: 'name',
+                  model: StringModel(context: context),
+                  isRequired: false,
+                  isNullable: true,
+                  isDeprecated: false,
+                ),
+              ],
+              context: context,
+              additionalProperties: TypedAdditionalProperties(
+                valueModel: ListModel(
+                  content: StringModel(context: context),
+                  context: context,
+                ),
+              ),
+            );
+
+            final result = immutableGenerator.generateClass(model);
+            final generatedCode = format(result.accept(emitter).toString());
+
+            const expectedFromJson = r'''
+factory TaggedItem.fromJson(Object? json) {
+  final _$map = json.decodeMap(context: r'TaggedItem');
+  const _$knownKeys = {r'name'};
+  final _$additional = <String, IList<String>>{};
+  for (final _$entry in _$map.entries) {
+    if (!_$knownKeys.contains(_$entry.key)) {
+      _$additional[_$entry.key] = IList(
+        _$entry.value.decodeJsonList<String>(
+          context: r'TaggedItem.additionalProperties',
+        ),
+      );
+    }
+  }
+  return TaggedItem(
+    name: _$map[r'name'].decodeJsonNullableString(
+      context: r'TaggedItem.name',
+    ),
+    additionalProperties: IMap(_$additional),
+  );
+}
+            ''';
+
+            expect(
+              collapseWhitespace(generatedCode),
+              contains(collapseWhitespace(expectedFromJson)),
+            );
+          },
+        );
+      },
+    );
   });
 }

--- a/packages/tonik_generate/test/src/model/class_immutable_collections_test.dart
+++ b/packages/tonik_generate/test/src/model/class_immutable_collections_test.dart
@@ -80,14 +80,14 @@ void main() {
         expect((typeRef.types.first as TypeReference).symbol, 'String');
       });
 
-      test('fromJson uses .lock to convert decoded list', () {
+      test('fromJson wraps decoded list in IList constructor', () {
         final generatedClass = generator.generateClass(model);
         final code = _formatClass(generatedClass);
         const expectedBody = r'''
 factory User.fromJson(Object? json) {
   final _$map = json.decodeMap(context: r'User');
   return User(
-    tags: _$map[r'tags'].decodeJsonList<String>(context: r'User.tags').lock,
+    tags: IList(_$map[r'tags'].decodeJsonList<String>(context: r'User.tags')),
   );
 }
 ''';
@@ -188,19 +188,19 @@ int get hashCode => tags.hashCode;
         expect((typeRef.types.last as TypeReference).symbol, 'String');
       });
 
-      test('fromJson uses .lock to convert decoded map', () {
+      test('fromJson wraps decoded map in IMap constructor', () {
         final generatedClass = generator.generateClass(model);
         final code = _formatClass(generatedClass);
         const expectedBody = r'''
 factory Config.fromJson(Object? json) {
   final _$map = json.decodeMap(context: r'Config');
   return Config(
-    settings: _$map[r'settings']
-        .decodeJsonMap(
-          (v) => v.decodeJsonString(context: r'Config.settings'),
-          context: r'Config.settings',
-        )
-        .lock,
+    settings: IMap(
+      _$map[r'settings'].decodeJsonMap(
+        (v) => v.decodeJsonString(context: r'Config.settings'),
+        context: r'Config.settings',
+      ),
+    ),
   );
 }
 ''';
@@ -258,18 +258,21 @@ Object? toJson() => {r'settings': settings.unlock};
         );
       });
 
-      test('fromJson locks at every nesting level', () {
+      test('fromJson wraps in IList at every nesting level', () {
         final generatedClass = generator.generateClass(model);
         final code = _formatClass(generatedClass);
         const expectedBody = r'''
 factory Matrix.fromJson(Object? json) {
   final _$map = json.decodeMap(context: r'Matrix');
   return Matrix(
-    rows: _$map[r'rows']
-        .decodeJsonList<Object?>(context: r'Matrix.rows')
-        .map((e) => e.decodeJsonList<String>(context: r'Matrix.rows').lock)
-        .toList()
-        .lock,
+    rows: IList(
+      _$map[r'rows']
+          .decodeJsonList<Object?>(context: r'Matrix.rows')
+          .map(
+            (e) => IList(e.decodeJsonList<String>(context: r'Matrix.rows')),
+          )
+          .toList(),
+    ),
   );
 }
 ''';
@@ -343,20 +346,20 @@ Object? toJson() => {r'rows': rows.unlock.map((e) => e.unlock).toList()};
         );
       });
 
-      test('fromJson locks at every nesting level', () {
+      test('fromJson wraps in IMap and IList at every nesting level', () {
         final generatedClass = generator.generateClass(model);
         final code = _formatClass(generatedClass);
         const expectedBody = r'''
 factory Lookup.fromJson(Object? json) {
   final _$map = json.decodeMap(context: r'Lookup');
   return Lookup(
-    data: _$map[r'data']
-        .decodeJsonMap(
-          (v) =>
-              v.decodeJsonList<String>(context: r'Lookup.data').lock,
-          context: r'Lookup.data',
-        )
-        .lock,
+    data: IMap(
+      _$map[r'data'].decodeJsonMap(
+        (v) =>
+            IList(v.decodeJsonList<String>(context: r'Lookup.data')),
+        context: r'Lookup.data',
+      ),
+    ),
   );
 }
 ''';
@@ -577,7 +580,7 @@ Object? toJson() => {r'tags': tags};
         );
       });
 
-      test('fromJson uses .lock on additional properties', () {
+      test('fromJson wraps additional properties in IMap constructor', () {
         final generatedClass = generator.generateClass(model);
         final code = _formatClass(generatedClass);
         const expectedBody = r'''
@@ -592,7 +595,7 @@ factory Flexible.fromJson(Object? json) {
   }
   return Flexible(
     name: _$map[r'name'].decodeJsonString(context: r'Flexible.name'),
-    additionalProperties: _$additional.lock,
+    additionalProperties: IMap(_$additional),
   );
 }
 ''';

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2316,8 +2316,9 @@ String _parseResponse(Response<List<int>> response) {
           },
           securitySchemes: const {},
         );
-        final method =
-            immutableGenerator.generateParseResponseMethod(operation);
+        final method = immutableGenerator.generateParseResponseMethod(
+          operation,
+        );
         const expectedMethod = r'''
 IList<String> _parseResponse(Response<List<int>> response) {
   switch ((response.statusCode, response.headers.value('content-type'))) {
@@ -2372,8 +2373,9 @@ IList<String> _parseResponse(Response<List<int>> response) {
           },
           securitySchemes: const {},
         );
-        final method =
-            immutableGenerator.generateParseResponseMethod(operation);
+        final method = immutableGenerator.generateParseResponseMethod(
+          operation,
+        );
         const expectedMethod = r'''
 IMap<String, int> _parseResponse(Response<List<int>> response) {
   switch ((response.statusCode, response.headers.value('content-type'))) {

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2270,5 +2270,129 @@ String _parseResponse(Response<List<int>> response) {
         );
       },
     );
+
+    group('immutable collections', () {
+      late ParseGenerator immutableGenerator;
+
+      setUp(() {
+        immutableGenerator = ParseGenerator(
+          nameManager: nameManager,
+          package: package,
+          useImmutableCollections: true,
+        );
+      });
+
+      test('generates IList return type for direct list response body', () {
+        final operation = Operation(
+          operationId: 'listStringsOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/strings',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: ListModel(
+                    content: StringModel(context: context),
+                    context: context,
+                  ),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method =
+            immutableGenerator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+IList<String> _parseResponse(Response<List<int>> response) {
+  switch ((response.statusCode, response.headers.value('content-type'))) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonList<String>().lock;
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('generates IMap return type for direct map response body', () {
+        final operation = Operation(
+          operationId: 'getCountsOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/counts',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: MapModel(
+                    valueModel: IntegerModel(context: context),
+                    context: context,
+                  ),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method =
+            immutableGenerator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+IMap<String, int> _parseResponse(Response<List<int>> response) {
+  switch ((response.statusCode, response.headers.value('content-type'))) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonMap((v) => v.decodeJsonInt()).lock;
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2324,7 +2324,7 @@ IList<String> _parseResponse(Response<List<int>> response) {
   switch ((response.statusCode, response.headers.value('content-type'))) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
-      final _$body = _$json.decodeJsonList<String>().lock;
+      final _$body = IList(_$json.decodeJsonList<String>());
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
@@ -2381,7 +2381,7 @@ IMap<String, int> _parseResponse(Response<List<int>> response) {
   switch ((response.statusCode, response.headers.value('content-type'))) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
-      final _$body = _$json.decodeJsonMap((v) => v.decodeJsonInt()).lock;
+      final _$body = IMap(_$json.decodeJsonMap((v) => v.decodeJsonInt()));
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';

--- a/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
@@ -1306,7 +1306,7 @@ void main() {
   });
 
   group('with useImmutableCollections', () {
-    test('simple list produces .lock', () {
+    test('simple list wraps in IList constructor', () {
       final listModel = ListModel(
         content: StringModel(context: context),
         context: context,
@@ -1319,11 +1319,11 @@ void main() {
           package: 'my_package',
           useImmutableCollections: true,
         ).accept(emitter).toString(),
-        'value.decodeJsonList<String>().lock',
+        'IList(value.decodeJsonList<String>())',
       );
     });
 
-    test('nullable list produces ?.lock', () {
+    test('nullable list wraps in IList with null guard', () {
       final listModel = ListModel(
         content: StringModel(context: context),
         context: context,
@@ -1337,11 +1337,11 @@ void main() {
           isNullable: true,
           useImmutableCollections: true,
         ).accept(emitter).toString(),
-        'value.decodeJsonNullableList<String>()?.lock',
+        'value == null ? null : IList(value.decodeJsonList<String>())',
       );
     });
 
-    test('simple map produces .lock', () {
+    test('simple map wraps in IMap constructor', () {
       final mapModel = MapModel(
         valueModel: StringModel(context: context),
         context: context,
@@ -1354,11 +1354,11 @@ void main() {
           package: 'my_package',
           useImmutableCollections: true,
         ).accept(emitter).toString(),
-        'value.decodeJsonMap((v) => v.decodeJsonString()).lock',
+        'IMap(value.decodeJsonMap((v) => v.decodeJsonString()))',
       );
     });
 
-    test('nullable map produces ?.lock', () {
+    test('nullable map wraps in IMap with null guard', () {
       final mapModel = MapModel(
         valueModel: StringModel(context: context),
         context: context,
@@ -1372,11 +1372,11 @@ void main() {
           package: 'my_package',
           useImmutableCollections: true,
         ).accept(emitter).toString(),
-        'value.decodeJsonNullableMap((v) => v.decodeJsonString())?.lock',
+        'value == null ? null : IMap(value.decodeJsonMap((v) => v.decodeJsonString()))',
       );
     });
 
-    test('nested list produces .lock at both levels', () {
+    test('nested list wraps in IList at both levels', () {
       final innerList = ListModel(
         content: StringModel(context: context),
         context: context,
@@ -1394,12 +1394,12 @@ void main() {
           useImmutableCollections: true,
         ).accept(emitter).toString(),
         equals(
-          '''value.decodeJsonList<Object?>().map((e) => e.decodeJsonList<String>().lock).toList().lock''',
+          'IList(value.decodeJsonList<Object?>().map((e) => IList(e.decodeJsonList<String>())).toList())',
         ),
       );
     });
 
-    test('map with list values produces .lock at both levels', () {
+    test('map with list values wraps in IMap and IList at both levels', () {
       final listModel = ListModel(
         content: StringModel(context: context),
         context: context,
@@ -1417,7 +1417,7 @@ void main() {
           useImmutableCollections: true,
         ).accept(emitter).toString(),
         equals(
-          'value.decodeJsonMap((v) => v.decodeJsonList<String>().lock).lock',
+          'IMap(value.decodeJsonMap((v) => IList(v.decodeJsonList<String>())))',
         ),
       );
     });


### PR DESCRIPTION
## Summary

- Fix direct collection response bodies (list/map) to use `IList`/`IMap` return types when `--immutable-collections` is enabled
- Use `IList`/`IMap` constructors via `refer()` instead of `.lock` extension to ensure proper imports in generated code
- Pass `useImmutableCollections` to `additionalPropertiesType()` in class and allOf `fromJson`/`fromSimple`/`fromForm` so scratch map value types match the immutable types produced by decode expressions

## Test plan

- [x] Unit tests for direct collection response type generation
- [x] Unit tests for class generator `fromJson` with typed additionalProperties + immutable collections
- [x] Unit tests for allOf generator `fromJson` with typed additionalProperties (list values) + immutable collections
- [x] Integration test spec extended with additional schemas (typed AP, allOf + AP, allOf + MapModel, direct list/map responses)
- [x] Integration tests verify round-trip serialization with `IList`/`IMap` types
- [x] `dart analyze` clean on all generated code