### PR TITLE
feat: add MapModel and Base64Model parameter encoding support

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1159,6 +1159,148 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  # =============================================================================
+  # LABEL STYLE - MAP PARAMETERS
+  # =============================================================================
+
+  /label/map/string/{values}:
+    get:
+      operationId: testLabelMapString
+      tags: [label]
+      summary: Label-style map with string values path parameter
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: label
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /label/map/integer/{values}:
+    get:
+      operationId: testLabelMapInteger
+      tags: [label]
+      summary: Label-style map with integer values path parameter
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: label
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  # =============================================================================
+  # MATRIX STYLE - MAP PARAMETERS
+  # =============================================================================
+
+  /matrix/map/string/{values}:
+    get:
+      operationId: testMatrixMapString
+      tags: [matrix]
+      summary: Matrix-style map with string values path parameter
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: matrix
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/map/integer/{values}:
+    get:
+      operationId: testMatrixMapInteger
+      tags: [matrix]
+      summary: Matrix-style map with integer values path parameter
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: matrix
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  # =============================================================================
+  # BASE64 PARAMETERS - LABEL AND MATRIX STYLES
+  # =============================================================================
+
+  /label/base64/{fileData}:
+    get:
+      operationId: testLabelBase64
+      tags: [label]
+      summary: Label-style base64 encoded binary data path parameter
+      parameters:
+        - name: fileData
+          in: path
+          required: true
+          style: label
+          schema:
+            type: string
+            format: byte
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/base64/{fileData}:
+    get:
+      operationId: testMatrixBase64
+      tags: [matrix]
+      summary: Matrix-style base64 encoded binary data path parameter
+      parameters:
+        - name: fileData
+          in: path
+          required: true
+          style: matrix
+          schema:
+            type: string
+            format: byte
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
 components:
   schemas:
     StatusEnum:

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -1432,6 +1432,130 @@ paths:
         '204':
           description: OK
 
+  # =============================================================================
+  # FORM STYLE - MAP PARAMETERS
+  # =============================================================================
+
+  /form-map:
+    get:
+      operationId: testFormMap
+      tags:
+        - query
+      summary: Test form-style map query parameters (explode=false)
+      description: Demonstrates form-style map query parameter encoding
+      parameters:
+        - name: mapString
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: mapInteger
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+        - name: mapDateTime
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+              format: date-time
+      responses:
+        '204':
+          description: OK
+
+  /form-map-explode:
+    get:
+      operationId: testFormMapExplode
+      tags:
+        - query
+      summary: Test form-style map query parameters (explode=true)
+      description: Demonstrates form-style map query parameter encoding with explode
+      parameters:
+        - name: mapString
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: mapInteger
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '204':
+          description: OK
+
+  # =============================================================================
+  # DEEP OBJECT STYLE - MAP PARAMETERS
+  # =============================================================================
+
+  /deepObject-map:
+    get:
+      operationId: testDeepObjectMap
+      tags:
+        - query
+      summary: Test deepObject-style map query parameters
+      description: Demonstrates deepObject-style map query parameter encoding
+      parameters:
+        - name: mapString
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: mapInteger
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '204':
+          description: OK
+
+  # =============================================================================
+  # BASE64 QUERY PARAMETERS
+  # =============================================================================
+
+  /form-base64:
+    get:
+      operationId: testFormBase64
+      tags:
+        - query
+      summary: Test form-style base64 query parameter
+      description: Demonstrates form-style base64 encoded binary data in query
+      parameters:
+        - name: fileData
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+            format: byte
+      responses:
+        '204':
+          description: OK
+
 components:
   schemas:
     Class:

--- a/integration_test/simple_encoding/openapi.yaml
+++ b/integration_test/simple_encoding/openapi.yaml
@@ -1009,6 +1009,163 @@ paths:
               schema:
                 $ref: '#/components/schemas/PriorityEnum'
 
+  # =============================================================================
+  # MAP PARAMETERS - SIMPLE STYLE
+  # =============================================================================
+
+  /map/string/{values}:
+    get:
+      operationId: testMapStringInPath
+      tags:
+        - simple-encoding
+      summary: Test map with string values in path parameter
+      parameters:
+        - name: values
+          in: path
+          style: simple
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+
+  /map/integer/{values}:
+    get:
+      operationId: testMapIntegerInPath
+      tags:
+        - simple-encoding
+      summary: Test map with integer values in path parameter
+      parameters:
+        - name: values
+          in: path
+          style: simple
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: OK
+
+  /map/datetime/{values}:
+    get:
+      operationId: testMapDateTimeInPath
+      tags:
+        - simple-encoding
+      summary: Test map with datetime values in path parameter
+      parameters:
+        - name: values
+          in: path
+          style: simple
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+              format: date-time
+      responses:
+        '200':
+          description: OK
+
+  /headers/roundtrip/maps:
+    get:
+      operationId: testHeaderRoundtripMaps
+      tags:
+        - simple-encoding
+      summary: Roundtrip test for map types in headers
+      description: Tests encoding and decoding of map parameters with various value types
+      parameters:
+        - name: X-Map-String
+          in: header
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: X-Map-Integer
+          in: header
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+        - name: X-Map-DateTime
+          in: header
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+              format: date-time
+      responses:
+        '200':
+          description: Echoed map headers
+          headers:
+            X-Map-String:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+            X-Map-Integer:
+              schema:
+                type: object
+                additionalProperties:
+                  type: integer
+            X-Map-DateTime:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+                  format: date-time
+
+  # =============================================================================
+  # BASE64 PARAMETERS - SIMPLE STYLE
+  # =============================================================================
+
+  /base64/{fileData}:
+    get:
+      operationId: testBase64InPath
+      tags:
+        - simple-encoding
+      summary: Test base64 encoded binary data in path parameter
+      parameters:
+        - name: fileData
+          in: path
+          style: simple
+          required: true
+          schema:
+            type: string
+            format: byte
+      responses:
+        '200':
+          description: OK
+
+  /headers/roundtrip/base64:
+    get:
+      operationId: testHeaderRoundtripBase64
+      tags:
+        - simple-encoding
+      summary: Roundtrip test for base64 encoded binary data in headers
+      parameters:
+        - name: X-File-Data
+          in: header
+          style: simple
+          schema:
+            type: string
+            format: byte
+      responses:
+        '200':
+          description: Echoed base64 header
+          headers:
+            X-File-Data:
+              schema:
+                type: string
+                format: byte
+
 components:
   schemas:
     StatusEnum:

--- a/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
@@ -1,0 +1,147 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+
+/// Builds an expression that converts a `Map<String, V>` to
+/// `Map<String, String>` based on the [MapModel]'s value type.
+///
+/// For StringModel values, returns the [receiver] unchanged (already
+/// `Map<String, String>`). For primitive values, emits a `.map()` call
+/// with the correct type-specific conversion. For unsupported values
+/// (ClassModel, ListModel, nested MapModel, BinaryModel, NeverModel),
+/// returns `null` -- the caller is responsible for throwing an
+/// `EncodingException`.
+///
+/// The [isNullable] parameter tracks whether the map itself is nullable
+/// (i.e. `Map<String, V>?`). Value-level nullability comes from
+/// `model.valueModel` and is checked separately inside this function.
+Expression? buildMapToStringMapExpression(
+  Expression receiver,
+  MapModel model, {
+  required bool isNullable,
+}) {
+  final valueModel = model.valueModel;
+  final valueIsNullable = valueModel.isEffectivelyNullable;
+  return _buildConversion(
+    receiver,
+    valueModel,
+    isNullable: isNullable,
+    valueIsNullable: valueIsNullable,
+  );
+}
+
+Expression? _buildConversion(
+  Expression receiver,
+  Model valueModel, {
+  required bool isNullable,
+  required bool valueIsNullable,
+}) {
+  return switch (valueModel) {
+    StringModel() => receiver,
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    DateModel() =>
+      _buildMapCall(
+        receiver,
+        _wrapNullable(
+          refer('v').property('toString').call([]),
+          valueIsNullable,
+        ),
+        isNullable: isNullable,
+      ),
+    DateTimeModel() => _buildMapCall(
+      receiver,
+      _wrapNullable(
+        refer('v').property('toTimeZonedIso8601String').call([]),
+        valueIsNullable,
+      ),
+      isNullable: isNullable,
+    ),
+    EnumModel<String>() => _buildMapCall(
+      receiver,
+      _wrapNullable(
+        refer('v').property('toJson').call([]),
+        valueIsNullable,
+      ),
+      isNullable: isNullable,
+    ),
+    EnumModel() => _buildMapCall(
+      receiver,
+      _wrapNullable(
+        refer('v').property('toJson').call([]).property('toString').call([]),
+        valueIsNullable,
+      ),
+      isNullable: isNullable,
+    ),
+    Base64Model() => _buildMapCall(
+      receiver,
+      _wrapNullable(
+        refer('v').property('toBase64String').call([]),
+        valueIsNullable,
+      ),
+      isNullable: isNullable,
+    ),
+    AnyModel() => _buildMapCall(
+      receiver,
+      refer(
+        'encodeAnyValueToString',
+        'package:tonik_util/tonik_util.dart',
+      ).call(
+        [refer('v')],
+        {'allowEmpty': literalBool(false)},
+      ),
+      isNullable: isNullable,
+    ),
+    AliasModel(:final model) => _buildConversion(
+      receiver,
+      model,
+      isNullable: isNullable,
+      valueIsNullable: valueIsNullable,
+    ),
+    ClassModel() ||
+    ListModel() ||
+    MapModel() ||
+    BinaryModel() ||
+    NeverModel() =>
+      null,
+    _ => null,
+  };
+}
+
+/// Wraps a conversion expression with a null check when the value
+/// is nullable: `v == null ? '' : <conversion>`.
+Expression _wrapNullable(Expression conversion, bool valueIsNullable) {
+  if (!valueIsNullable) return conversion;
+  return refer('v')
+      .equalTo(literalNull)
+      .conditional(literalString(''), conversion);
+}
+
+/// Builds a `.map((k, v) => MapEntry(k, <valueExpr>))` call on the
+/// [receiver].
+Expression _buildMapCall(
+  Expression receiver,
+  Expression valueExpression, {
+  required bool isNullable,
+}) {
+  final mapAccess = isNullable
+      ? receiver.nullSafeProperty('map')
+      : receiver.property('map');
+
+  final mapEntryClosure = Method(
+    (b) => b
+      ..requiredParameters.addAll([
+        Parameter((p) => p..name = 'k'),
+        Parameter((p) => p..name = 'v'),
+      ])
+      ..body = refer(
+        'MapEntry',
+        'dart:core',
+      ).newInstance([refer('k'), valueExpression]).code,
+  ).closure;
+
+  return mapAccess.call([mapEntryClosure]);
+}

--- a/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 Expression buildFormParameterExpression(
   Expression valueExpression,
@@ -34,8 +35,24 @@ Expression buildFormParameterExpression(
         'allowEmpty': allowEmpty,
       },
     ),
-    MapModel() => generateEncodingExceptionExpression(
-      'Form encoding not supported for map types.',
+    Base64Model() => (isNullable
+            ? valueExpression.nullSafeProperty('toBase64String')
+            : valueExpression.property('toBase64String'))
+        .call([])
+        .property('toForm')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
+    MapModel() => _buildMapFormExpression(
+      valueExpression,
+      model,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
     ),
     ListModel(:final content) => _buildListFormExpression(
       valueExpression,
@@ -136,6 +153,37 @@ Expression _buildListFormExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
+    Base64Model() => listMapAccess
+        .call([
+          Method(
+            (b) => b
+              ..requiredParameters.add(
+                Parameter((b) => b..name = 'e'),
+              )
+              ..body = refer('e')
+                  .property('toBase64String')
+                  .call([])
+                  .code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([])
+        .property('toForm')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+            'alreadyEncoded': literalBool(true),
+          },
+        ),
+    MapModel() => _buildListMapContentFormExpression(
+      valueExpression,
+      contentModel,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
+    ),
     ClassModel() || ListModel() => listPropertyAccess.call(
       [],
       {
@@ -150,4 +198,91 @@ Expression _buildListFormExpression(
       'Unsupported list content type for form encoding.',
     ),
   };
+}
+
+Expression _buildMapFormExpression(
+  Expression valueExpression,
+  MapModel model, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    valueExpression,
+    model,
+    isNullable: isNullable,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be form-encoded.',
+    );
+  }
+
+  final toFormAccess = (isNullable && converted == valueExpression)
+      ? converted.nullSafeProperty('toForm')
+      : converted.property('toForm');
+
+  return toFormAccess.call(
+    [],
+    {
+      'explode': explode,
+      'allowEmpty': allowEmpty,
+    },
+  );
+}
+
+Expression _buildListMapContentFormExpression(
+  Expression valueExpression,
+  MapModel contentModel, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be form-encoded.',
+    );
+  }
+
+  final listMapAccess = isNullable
+      ? valueExpression.nullSafeProperty('map')
+      : valueExpression.property('map');
+
+  return listMapAccess
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(
+              Parameter((b) => b..name = 'e'),
+            )
+            ..body = converted
+                .property('toForm')
+                .call(
+                  [],
+                  {
+                    'explode': explode,
+                    'allowEmpty': allowEmpty,
+                  },
+                )
+                .code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([])
+      .property('toForm')
+      .call(
+        [],
+        {
+          'explode': explode,
+          'allowEmpty': allowEmpty,
+          'alreadyEncoded': literalBool(true),
+        },
+      );
 }

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_util/tonik_util.dart';
 
@@ -22,7 +23,22 @@ List<Code> buildToFormQueryParameterCode(
     ];
   }
 
-  if (model is BinaryModel || model is Base64Model) {
+  if (model is Base64Model) {
+    final valueExpression =
+        '$parameterName.toBase64String().toForm(explode: $explode, '
+        'allowEmpty: $allowEmpty)';
+    return [
+      Code(
+        r'_$entries'
+        '.add(('
+        'name: ${specLiteralStringCode(parameter.rawName)}, '
+        'value: $valueExpression, '
+        '),);',
+      ),
+    ];
+  }
+
+  if (model is BinaryModel) {
     return [
       generateEncodingExceptionExpression(
         'Binary data cannot be form-encoded.',
@@ -31,10 +47,53 @@ List<Code> buildToFormQueryParameterCode(
   }
 
   if (model is MapModel) {
+    final converted = buildMapToStringMapExpression(
+      refer(parameterName),
+      model,
+      isNullable: false,
+    );
+
+    if (converted == null) {
+      return [
+        generateEncodingExceptionExpression(
+          'Map with complex value types cannot be form query encoded.',
+        ).statement,
+      ];
+    }
+
+    // For StringModel values, converted == refer(parameterName) (identity).
+    final convertedSuffix = '.toForm(explode: $explode, '
+        'allowEmpty: $allowEmpty)';
+
+    if (converted == refer(parameterName)) {
+      return [
+        Code(
+          r'_$entries'
+          '.add(('
+          'name: ${specLiteralStringCode(parameter.rawName)}, '
+          'value: $parameterName$convertedSuffix, '
+          '),);',
+        ),
+      ];
+    }
+
+    // For non-string value types, we need to use code_builder for the
+    // converted expression.
     return [
-      generateEncodingExceptionExpression(
-        'Map types cannot be form query encoded.',
-      ).statement,
+      const Code(r'_$entries.add(('),
+      Code('name: ${specLiteralStringCode(parameter.rawName)}, '),
+      const Code('value: '),
+      converted
+          .property('toForm')
+          .call(
+            [],
+            {
+              'explode': literalBool(explode),
+              'allowEmpty': literalBool(allowEmpty),
+            },
+          )
+          .code,
+      const Code(',),);'),
     ];
   }
 
@@ -62,8 +121,25 @@ List<Code> buildToFormQueryParameterCode(
     final contentModel = model.content.resolved;
     final contentShape = contentModel.encodingShape;
 
-    // Binary/Base64 content cannot be form-encoded.
-    if (contentModel is BinaryModel || contentModel is Base64Model) {
+    // Base64 content can be form-encoded via toBase64String.
+    if (contentModel is Base64Model) {
+      final toForm = 'toForm(explode: $explode, allowEmpty: $allowEmpty)';
+      final suffix = '.map((e) => e.toBase64String()).toList().$toForm';
+      final valueExpression = '$parameterName$suffix';
+
+      return [
+        Code(
+          r'_$entries'
+          '.add(('
+          'name: ${specLiteralStringCode(parameter.rawName)}, '
+          'value: $valueExpression, '
+          '),);',
+        ),
+      ];
+    }
+
+    // Binary content cannot be form-encoded.
+    if (contentModel is BinaryModel) {
       return [
         generateEncodingExceptionExpression(
           'Binary data cannot be form-encoded.',
@@ -235,6 +311,8 @@ String? _getFormSerializationSuffix(
       allowEmpty: allowEmpty,
     ),
 
+    Base64Model() => '.toBase64String().toForm($paramString)',
+
     AnyModel() => '?.toString() ?? ""',
     NeverModel() => null,
     BinaryModel() => null,
@@ -292,6 +370,10 @@ String? _handleListExpression(
       allowEmpty: allowEmpty,
       isContentNullable: isContentNullable || contentModel.isNullable,
     ),
+
+    Base64Model() => () {
+      return '.map((e) => e.toBase64String()).toList().toForm($paramString)';
+    }(),
 
     BinaryModel() => null,
 

--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 Expression buildLabelParameterExpression(
   Expression valueExpression,
@@ -53,11 +54,27 @@ Expression buildLabelParameterExpression(
       explode: explode,
       allowEmpty: allowEmpty,
     ),
+    Base64Model() => (isNullable
+            ? valueExpression.nullSafeProperty('toBase64String')
+            : valueExpression.property('toBase64String'))
+        .call([])
+        .property('toLabel')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be label-encoded',
     ),
-    MapModel() => generateEncodingExceptionExpression(
-      'Map types cannot be label-encoded.',
+    MapModel() => _buildMapLabelExpression(
+      valueExpression,
+      model,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
     ),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for label encoding.',
@@ -152,6 +169,37 @@ Expression _buildListLabelExpression(
               'alreadyEncoded': literalTrue,
             },
           ),
+    Base64Model() => listMapAccess
+        .call([
+          Method(
+            (b) => b
+              ..requiredParameters.add(
+                Parameter((b) => b..name = 'e'),
+              )
+              ..body = refer('e')
+                  .property('toBase64String')
+                  .call([])
+                  .code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([])
+        .property('toLabel')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+            'alreadyEncoded': literalTrue,
+          },
+        ),
+    MapModel() => _buildListMapContentLabelExpression(
+      valueExpression,
+      contentModel,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
+    ),
     ClassModel() || ListModel() => listPropertyAccess.call(
       [],
       {
@@ -166,6 +214,93 @@ Expression _buildListLabelExpression(
       'Unsupported list content type for label encoding.',
     ),
   };
+}
+
+Expression _buildMapLabelExpression(
+  Expression valueExpression,
+  MapModel model, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    valueExpression,
+    model,
+    isNullable: isNullable,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be label-encoded.',
+    );
+  }
+
+  final toLabelAccess = (isNullable && converted == valueExpression)
+      ? converted.nullSafeProperty('toLabel')
+      : converted.property('toLabel');
+
+  return toLabelAccess.call(
+    [],
+    {
+      'explode': explode,
+      'allowEmpty': allowEmpty,
+    },
+  );
+}
+
+Expression _buildListMapContentLabelExpression(
+  Expression valueExpression,
+  MapModel contentModel, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be label-encoded.',
+    );
+  }
+
+  final listMapAccess = isNullable
+      ? valueExpression.nullSafeProperty('map')
+      : valueExpression.property('map');
+
+  return listMapAccess
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(
+              Parameter((b) => b..name = 'e'),
+            )
+            ..body = converted
+                .property('toLabel')
+                .call(
+                  [],
+                  {
+                    'explode': explode,
+                    'allowEmpty': allowEmpty,
+                  },
+                )
+                .code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([])
+      .property('toLabel')
+      .call(
+        [],
+        {
+          'explode': explode,
+          'allowEmpty': allowEmpty,
+          'alreadyEncoded': literalTrue,
+        },
+      );
 }
 
 Expression _buildAnyModelLabelExpression(

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 /// Generates an expression for encoding a path parameter using label style.
 ///
@@ -45,13 +46,84 @@ Expression buildToLabelPathParameterExpression(
       });
     }
 
-    if (contentModel is BinaryModel || contentModel is Base64Model) {
+    if (contentModel is Base64Model) {
+      return valueRef
+          .property('map')
+          .call([
+            Method(
+              (b) => b
+                ..requiredParameters.add(
+                  Parameter((b) => b..name = 'e'),
+                )
+                ..body = refer('e')
+                    .property('toBase64String')
+                    .call([])
+                    .code,
+          ).closure,
+          ])
+          .property('toList')
+          .call([])
+          .property('toLabel')
+          .call(
+            [],
+            {
+              'explode': explode,
+              'allowEmpty': allowEmpty,
+              'alreadyEncoded': literalTrue,
+            },
+          );
+    }
+
+    if (contentModel is BinaryModel) {
       return generateEncodingExceptionExpression(
         'Binary data cannot be label-encoded',
       );
     }
 
-    if (contentModel is ClassModel || contentModel is MapModel) {
+    if (contentModel is MapModel) {
+      final converted = buildMapToStringMapExpression(
+        refer('e'),
+        contentModel,
+        isNullable: false,
+      );
+
+      if (converted == null) {
+        return generateEncodingExceptionExpression(
+          'Label encoding does not support arrays of maps with complex values',
+        );
+      }
+
+      return valueRef
+          .property('map')
+          .call([
+            Method(
+              (b) => b
+                ..requiredParameters.add(
+                  Parameter((b) => b..name = 'e'),
+                )
+                ..body = converted
+                    .property('toLabel')
+                    .call(
+                      [],
+                      {'explode': explode, 'allowEmpty': allowEmpty},
+                    )
+                    .code,
+            ).closure,
+          ])
+          .property('toList')
+          .call([])
+          .property('toLabel')
+          .call(
+            [],
+            {
+              'explode': explode,
+              'allowEmpty': allowEmpty,
+              'alreadyEncoded': literalTrue,
+            },
+          );
+    }
+
+    if (contentModel is ClassModel) {
       return generateEncodingExceptionExpression(
         'Label encoding does not support arrays of complex types',
       );
@@ -116,10 +188,40 @@ Expression buildToLabelPathParameterExpression(
         );
   }
 
+  if (model is Base64Model) {
+    return valueRef
+        .property('toBase64String')
+        .call([])
+        .property('toLabel')
+        .call([], {
+          'explode': explode,
+          'allowEmpty': allowEmpty,
+        });
+  }
+
   if (model is BinaryModel) {
     return generateEncodingExceptionExpression(
       'Binary data cannot be label-encoded',
     );
+  }
+
+  if (model is MapModel) {
+    final converted = buildMapToStringMapExpression(
+      valueRef,
+      model,
+      isNullable: false,
+    );
+
+    if (converted == null) {
+      return generateEncodingExceptionExpression(
+        'Map with complex value types cannot be label-encoded.',
+      );
+    }
+
+    return converted.property('toLabel').call([], {
+      'explode': explode,
+      'allowEmpty': allowEmpty,
+    });
   }
 
   return valueRef.property('toLabel').call([], {

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 Expression buildMatrixParameterExpression(
   Expression valueExpression,
@@ -57,11 +58,28 @@ Expression buildMatrixParameterExpression(
       explode: explode,
       allowEmpty: allowEmpty,
     ),
+    Base64Model() => (isNullable
+            ? valueExpression.nullSafeProperty('toBase64String')
+            : valueExpression.property('toBase64String'))
+        .call([])
+        .property('toMatrix')
+        .call(
+          [paramName],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be matrix-encoded',
     ),
-    MapModel() => generateEncodingExceptionExpression(
-      'Map types cannot be matrix-encoded.',
+    MapModel() => _buildMapMatrixExpression(
+      valueExpression,
+      model,
+      paramName: paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
     ),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for matrix encoding.',
@@ -75,10 +93,20 @@ Expression buildMatrixParameterExpression(
 /// Used by OneOf/AnyOf generators to decide whether to destructure the variant.
 bool matrixParameterExpressionUsesValue(Model model) {
   return switch (model) {
-    BinaryModel() || MapModel() => false,
+    BinaryModel() => false,
+    MapModel() => _mapMatrixUsesValue(model),
     ListModel(:final content) => _listMatrixContentUsesValue(content),
     _ => true,
   };
+}
+
+bool _mapMatrixUsesValue(MapModel model) {
+  final converted = buildMapToStringMapExpression(
+    refer('_'),
+    model,
+    isNullable: false,
+  );
+  return converted != null;
 }
 
 bool _listMatrixContentUsesValue(Model content) {
@@ -208,6 +236,42 @@ Expression _buildListMatrixExpression(
               'alreadyEncoded': literalTrue,
             },
           ),
+    Base64Model() => listMapAccess
+        .call(
+          [
+            Method(
+              (b) => b
+                ..requiredParameters.add(
+                  Parameter((b) => b..name = 'e'),
+                )
+                ..body = refer('e')
+                    .property('toBase64String')
+                    .call([])
+                    .code,
+            ).closure,
+          ],
+          {},
+          [refer('String', 'dart:core')],
+        )
+        .property('toList')
+        .call([])
+        .property('toMatrix')
+        .call(
+          [paramName],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+            'alreadyEncoded': literalTrue,
+          },
+        ),
+    MapModel() => _buildListMapContentMatrixExpression(
+      valueExpression,
+      contentModel,
+      paramName: paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
+    ),
     ClassModel() || ListModel() => generateEncodingExceptionExpression(
       'Lists with complex content cannot be matrix-encoded',
     ),
@@ -218,4 +282,97 @@ Expression _buildListMatrixExpression(
       'Unsupported list content type for matrix encoding.',
     ),
   };
+}
+
+Expression _buildMapMatrixExpression(
+  Expression valueExpression,
+  MapModel model, {
+  required Expression paramName,
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    valueExpression,
+    model,
+    isNullable: isNullable,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be matrix-encoded.',
+    );
+  }
+
+  final toMatrixAccess = (isNullable && converted == valueExpression)
+      ? converted.nullSafeProperty('toMatrix')
+      : converted.property('toMatrix');
+
+  return toMatrixAccess.call(
+    [paramName],
+    {
+      'explode': explode,
+      'allowEmpty': allowEmpty,
+    },
+  );
+}
+
+Expression _buildListMapContentMatrixExpression(
+  Expression valueExpression,
+  MapModel contentModel, {
+  required Expression paramName,
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be matrix-encoded.',
+    );
+  }
+
+  final listMapAccess = isNullable
+      ? valueExpression.nullSafeProperty('map')
+      : valueExpression.property('map');
+
+  return listMapAccess
+      .call(
+        [
+          Method(
+            (b) => b
+              ..requiredParameters.add(
+                Parameter((b) => b..name = 'e'),
+              )
+              ..body = converted
+                  .property('toMatrix')
+                  .call(
+                    [paramName],
+                    {
+                      'explode': explode,
+                      'allowEmpty': allowEmpty,
+                    },
+                  )
+                  .code,
+          ).closure,
+        ],
+        {},
+        [refer('String', 'dart:core')],
+      )
+      .property('toList')
+      .call([])
+      .property('toMatrix')
+      .call(
+        [paramName],
+        {
+          'explode': explode,
+          'allowEmpty': allowEmpty,
+          'alreadyEncoded': literalTrue,
+        },
+      );
 }

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 Expression buildSimpleParameterExpression(
   Expression valueExpression,
@@ -56,11 +57,27 @@ Expression buildSimpleParameterExpression(
           'allowEmpty': allowEmpty,
         },
       ),
+    Base64Model() => (isNullable
+            ? valueExpression.nullSafeProperty('toBase64String')
+            : valueExpression.property('toBase64String'))
+        .call([])
+        .property('toSimple')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be simple-encoded',
     ),
-    MapModel() => generateEncodingExceptionExpression(
-      'Map types cannot be simple-encoded.',
+    MapModel() => _buildMapSimpleExpression(
+      valueExpression,
+      model,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
     ),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for simple encoding.',
@@ -158,6 +175,37 @@ Expression _buildListSimpleExpression(
               'alreadyEncoded': literalBool(true),
             },
           ),
+    Base64Model() => listMapAccess
+        .call([
+          Method(
+            (b) => b
+              ..requiredParameters.add(
+                Parameter((b) => b..name = 'e'),
+              )
+              ..body = refer('e')
+                  .property('toBase64String')
+                  .call([])
+                  .code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([])
+        .property('toSimple')
+        .call(
+          [],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+            'alreadyEncoded': literalBool(true),
+          },
+        ),
+    MapModel() => _buildListMapContentSimpleExpression(
+      valueExpression,
+      contentModel,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      isNullable: isNullable,
+    ),
     ClassModel() || ListModel() => listPropertyAccess.call(
       [],
       {
@@ -172,4 +220,94 @@ Expression _buildListSimpleExpression(
       'Unsupported list content type for simple encoding.',
     ),
   };
+}
+
+Expression _buildMapSimpleExpression(
+  Expression valueExpression,
+  MapModel model, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    valueExpression,
+    model,
+    isNullable: isNullable,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be simple-encoded.',
+    );
+  }
+
+  // For StringModel values, converted == valueExpression (identity).
+  // For other types, converted is the .map() call result.
+  final toSimpleAccess = (isNullable && converted == valueExpression)
+      ? converted.nullSafeProperty('toSimple')
+      : converted.property('toSimple');
+
+  return toSimpleAccess.call(
+    [],
+    {
+      'explode': explode,
+      'allowEmpty': allowEmpty,
+    },
+  );
+}
+
+Expression _buildListMapContentSimpleExpression(
+  Expression valueExpression,
+  MapModel contentModel, {
+  required Expression explode,
+  required Expression allowEmpty,
+  bool isNullable = false,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be simple-encoded.',
+    );
+  }
+
+  final listMapAccess = isNullable
+      ? valueExpression.nullSafeProperty('map')
+      : valueExpression.property('map');
+
+  // Each element is converted to Map<String, String>, then simple-encoded.
+  return listMapAccess
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(
+              Parameter((b) => b..name = 'e'),
+            )
+            ..body = converted
+                .property('toSimple')
+                .call(
+                  [],
+                  {
+                    'explode': explode,
+                    'allowEmpty': allowEmpty,
+                  },
+                )
+                .code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([])
+      .property('toSimple')
+      .call(
+        [],
+        {
+          'explode': explode,
+          'allowEmpty': allowEmpty,
+          'alreadyEncoded': literalBool(true),
+        },
+      );
 }

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 /// Creates a Dart expression that correctly serializes a path parameter
 /// to its simple parameter encoding representation.
@@ -116,10 +117,26 @@ Expression _buildSimpleSerializationExpression(
     OneOfModel() ||
     AnyOfModel() => callToSimple(receiver),
 
-    // MapModel cannot be simple-encoded
-    MapModel() => generateEncodingExceptionExpression(
-      'Map types cannot be simple-encoded.',
+    // MapModel: convert values to strings, then call toSimple
+    MapModel() => _buildMapSimpleExpression(
+      receiver,
+      model,
+      isNullable: isNullable,
+      explode: explode,
+      allowEmpty: allowEmpty,
     ),
+
+    // Base64Model: convert to base64 string, then call toSimple
+    Base64Model() => () {
+      final base64Expr = useNullAware
+          ? receiver.nullSafeProperty('toBase64String').call([])
+          : receiver.property('toBase64String').call([]);
+      final args = <String, Expression>{
+        'explode': literalBool(explode),
+        'allowEmpty': literalBool(allowEmpty),
+      };
+      return base64Expr.property('toSimple').call([], args);
+    }(),
 
     // Lists need special handling
     ListModel() => _handleListExpression(
@@ -258,8 +275,133 @@ Expression _handleListExpression(
 
     AnyModel() => callToSimpleOnList(receiver), // Pass through list as-is
 
+    // Base64Model: each element → toBase64String(), then list toSimple
+    Base64Model() => () {
+      final mapClosure = Method(
+        (b) => b
+          ..requiredParameters.add(Parameter((p) => p..name = 'e'))
+          ..body = refer('e').property('toBase64String').call([]).code,
+      ).closure;
+
+      final mappedList = isNullable
+          ? receiver
+                .nullSafeProperty('map')
+                .call([mapClosure])
+                .property('toList')
+                .call([])
+          : receiver
+                .property('map')
+                .call([mapClosure])
+                .property('toList')
+                .call([]);
+
+      return mappedList.property('toSimple').call([], {
+        ...toSimpleArgs,
+        'alreadyEncoded': literalBool(true),
+      });
+    }(),
+
+    // MapModel: each element → convert to string map, then simple-encode
+    MapModel() => _buildListMapContentSimpleExpression(
+      receiver,
+      contentModel,
+      isNullable: isNullable,
+      explode: explode,
+      allowEmpty: allowEmpty,
+    ),
+
     _ => generateEncodingExceptionExpression(
       'Unsupported content model for simple encoding.',
     ),
   };
+}
+
+Expression _buildMapSimpleExpression(
+  Expression receiver,
+  MapModel model, {
+  required bool isNullable,
+  required bool explode,
+  required bool allowEmpty,
+}) {
+  final converted = buildMapToStringMapExpression(
+    receiver,
+    model,
+    isNullable: isNullable,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be simple-encoded.',
+    );
+  }
+
+  // For StringModel values, converted == receiver (identity).
+  // For other types, converted is the .map() call result.
+  final toSimpleAccess = (isNullable && converted == receiver)
+      ? converted.nullSafeProperty('toSimple')
+      : converted.property('toSimple');
+
+  return toSimpleAccess.call(
+    [],
+    {
+      'explode': literalBool(explode),
+      'allowEmpty': literalBool(allowEmpty),
+    },
+  );
+}
+
+Expression _buildListMapContentSimpleExpression(
+  Expression receiver,
+  MapModel contentModel, {
+  required bool isNullable,
+  required bool explode,
+  required bool allowEmpty,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be simple-encoded.',
+    );
+  }
+
+  final listMapAccess = isNullable
+      ? receiver.nullSafeProperty('map')
+      : receiver.property('map');
+
+  // Each element is converted to Map<String, String>, then simple-encoded.
+  return listMapAccess
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(
+              Parameter((b) => b..name = 'e'),
+            )
+            ..body = converted
+                .property('toSimple')
+                .call(
+                  [],
+                  {
+                    'explode': literalBool(explode),
+                    'allowEmpty': literalBool(allowEmpty),
+                  },
+                )
+                .code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([])
+      .property('toSimple')
+      .call(
+        [],
+        {
+          'explode': literalBool(explode),
+          'allowEmpty': literalBool(allowEmpty),
+          'alreadyEncoded': literalBool(true),
+        },
+      );
 }

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 Expression buildUriEncodeExpression(
   Expression valueExpression,
@@ -39,8 +40,11 @@ Expression buildUriEncodeExpression(
           'useQueryComponent': ?useQueryComponent,
         },
       ),
-    MapModel() => generateEncodingExceptionExpression(
-      'Map types cannot be URI-encoded.',
+    MapModel() => _buildMapUriEncodeExpression(
+      valueExpression,
+      model,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
     ),
     ListModel(:final content) => _buildListUriEncodeExpression(
       valueExpression,
@@ -155,6 +159,12 @@ Expression _buildListUriEncodeExpression(
               'useQueryComponent': ?useQueryComponent,
             },
           ),
+    MapModel() => _buildListMapContentUriEncodeExpression(
+      listExpr,
+      contentModel,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    ),
     AliasModel() => _buildListUriEncodeExpression(
       valueExpression,
       contentModel.model,
@@ -166,4 +176,81 @@ Expression _buildListUriEncodeExpression(
       'Unsupported list content type for URI encoding.',
     ),
   };
+}
+
+Expression _buildMapUriEncodeExpression(
+  Expression valueExpression,
+  MapModel model, {
+  required Expression allowEmpty,
+  Expression? useQueryComponent,
+}) {
+  final converted = buildMapToStringMapExpression(
+    valueExpression,
+    model,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'Map with complex value types cannot be URI-encoded.',
+    );
+  }
+
+  return converted.property('uriEncode').call(
+    [],
+    {
+      'allowEmpty': allowEmpty,
+      'useQueryComponent': ?useQueryComponent,
+    },
+  );
+}
+
+Expression _buildListMapContentUriEncodeExpression(
+  Expression listExpression,
+  MapModel contentModel, {
+  required Expression allowEmpty,
+  Expression? useQueryComponent,
+}) {
+  final converted = buildMapToStringMapExpression(
+    refer('e'),
+    contentModel,
+    isNullable: false,
+  );
+
+  if (converted == null) {
+    return generateEncodingExceptionExpression(
+      'List of maps with complex value types cannot be URI-encoded.',
+    );
+  }
+
+  return listExpression
+      .property('map')
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(
+              Parameter((b) => b..name = 'e'),
+            )
+            ..body = converted
+                .property('uriEncode')
+                .call(
+                  [],
+                  {
+                    'allowEmpty': allowEmpty,
+                    'useQueryComponent': ?useQueryComponent,
+                  },
+                )
+                .code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([])
+      .property('uriEncode')
+      .call(
+        [],
+        {
+          'allowEmpty': allowEmpty,
+          'useQueryComponent': ?useQueryComponent,
+        },
+      );
 }

--- a/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
@@ -1372,7 +1372,7 @@ void main() {
           package: 'my_package',
           useImmutableCollections: true,
         ).accept(emitter).toString(),
-        'value == null ? null : IMap(value.decodeJsonMap((v) => v.decodeJsonString()))',
+        '''value == null ? null : IMap(value.decodeJsonMap((v) => v.decodeJsonString()))''',
       );
     });
 
@@ -1394,7 +1394,7 @@ void main() {
           useImmutableCollections: true,
         ).accept(emitter).toString(),
         equals(
-          'IList(value.decodeJsonList<Object?>().map((e) => IList(e.decodeJsonList<String>())).toList())',
+          '''IList(value.decodeJsonList<Object?>().map((e) => IList(e.decodeJsonList<String>())).toList())''',
         ),
       );
     });

--- a/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
@@ -1,0 +1,588 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
+
+void main() {
+  late Context context;
+  late DartEmitter emitter;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  setUp(() {
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  /// Helper: wraps an expression in a method for formatting.
+  String formatExpression(Expression expr) {
+    final method = Method(
+      (b) => b
+        ..name = 'test'
+        ..body = declareFinal('result').assign(expr).statement,
+    );
+    return format(method.accept(emitter).toString());
+  }
+
+  group('buildMapToStringMapExpression', () {
+    group('StringModel values', () {
+      test('returns receiver unchanged', () {
+        final model = MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.accept(emitter).toString(), 'myMap');
+      });
+    });
+
+    group('IntegerModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('DoubleModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: DoubleModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('NumberModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: NumberModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('BooleanModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: BooleanModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('DateTimeModel values', () {
+      test('emits .map with v.toTimeZonedIso8601String()', () {
+        final model = MapModel(
+          valueModel: DateTimeModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(k, v.toTimeZonedIso8601String()),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('DateModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: DateModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('DecimalModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: DecimalModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('UriModel values', () {
+      test('emits .map with v.toString()', () {
+        final model = MapModel(
+          valueModel: UriModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('EnumModel<String> values', () {
+      test('emits .map with v.toJson()', () {
+        final model = MapModel(
+          valueModel: EnumModel<String>(
+            isDeprecated: false,
+            name: 'Status',
+            values: {
+              const EnumEntry(value: 'active'),
+              const EnumEntry(value: 'inactive'),
+            },
+            isNullable: false,
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toJson()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('EnumModel<int> values (non-string)', () {
+      test('emits .map with v.toJson().toString()', () {
+        final model = MapModel(
+          valueModel: EnumModel<int>(
+            isDeprecated: false,
+            name: 'Priority',
+            values: {
+              const EnumEntry(value: 1),
+              const EnumEntry(value: 2),
+            },
+            isNullable: false,
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(k, v.toJson().toString()),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('Base64Model values', () {
+      test('emits .map with v.toBase64String()', () {
+        final model = MapModel(
+          valueModel: Base64Model(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(k, v.toBase64String()),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('AnyModel values', () {
+      test('emits .map with encodeAnyValueToString(v)', () {
+        final model = MapModel(
+          valueModel: AnyModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(
+                k, encodeAnyValueToString(v, allowEmpty: false),
+              ),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('AliasModel values', () {
+      test('unwraps alias to StringModel and returns identity', () {
+        final model = MapModel(
+          valueModel: AliasModel(
+            name: 'MyString',
+            model: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.accept(emitter).toString(), 'myMap');
+      });
+
+      test('unwraps alias to IntegerModel and emits .map', () {
+        final model = MapModel(
+          valueModel: AliasModel(
+            name: 'MyInt',
+            model: IntegerModel(context: context),
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('unsupported types return null', () {
+      test('ClassModel returns null', () {
+        final model = MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNull);
+      });
+
+      test('ListModel returns null', () {
+        final model = MapModel(
+          valueModel: ListModel(
+            content: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNull);
+      });
+
+      test('nested MapModel returns null', () {
+        final model = MapModel(
+          valueModel: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNull);
+      });
+
+      test('BinaryModel returns null', () {
+        final model = MapModel(
+          valueModel: BinaryModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNull);
+      });
+
+      test('NeverModel returns null', () {
+        final model = MapModel(
+          valueModel: NeverModel(context: context),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNull);
+      });
+    });
+
+    group('nullable map (isNullable=true)', () {
+      test('emits null-safe .map for IntegerModel values', () {
+        final model = MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+          isNullable: true,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: true,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap?.map((k, v) => MapEntry(k, v.toString()));
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+
+    group('nullable value type', () {
+      test('emits null check for nullable IntegerModel values', () {
+        final model = MapModel(
+          valueModel: AliasModel(
+            name: 'NullableInt',
+            model: IntegerModel(context: context),
+            context: context,
+            isNullable: true,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(k, v == null ? '' : v.toString()),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+
+      test('emits null check for nullable DateTimeModel values', () {
+        final model = MapModel(
+          valueModel: AliasModel(
+            name: 'NullableDateTime',
+            model: DateTimeModel(context: context),
+            context: context,
+            isNullable: true,
+          ),
+          context: context,
+        );
+
+        final result = buildMapToStringMapExpression(
+          refer('myMap'),
+          model,
+          isNullable: false,
+        );
+
+        expect(result, isNotNull);
+        final generated = formatExpression(result!);
+        final expected = format('''
+          test() {
+            final result = myMap.map(
+              (k, v) => MapEntry(
+                k, v == null ? '' : v.toTimeZonedIso8601String(),
+              ),
+            );
+          }
+        ''');
+        expect(collapseWhitespace(generated), collapseWhitespace(expected));
+      });
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/util/to_form_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_parameter_expression_generator_test.dart
@@ -445,6 +445,256 @@ void main() {
         '''throw  _i1.EncodingException('Unsupported list content type for form encoding.')''',
       );
     });
+
+    test('generates toForm for MapModel with StringModel values', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.toForm(explode: explode, allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('generates map and toForm for MapModel with IntegerModel values', () {
+      final model = MapModel(
+        valueModel: IntegerModel(context: context),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toString()))
+              .toForm(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates runtime throw for MapModel with ClassModel values', () {
+      final model = MapModel(
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [],
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'Map with complex value types cannot be form-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String and toForm for Base64Model', () {
+      final model = Base64Model(context: context);
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .toBase64String()
+              .toForm(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String list content for List<Base64Model>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((e) => e.toBase64String())
+              .toList()
+              .toForm(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates list-of-map encoding for List<Map<String, int>>', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toForm(explode: explode, allowEmpty: allowEmpty),
+              )
+              .toList()
+              .toForm(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test(
+        'generates runtime throw for List<Map<String, ClassModel>> '
+        '(unsupported)', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildFormParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'List of maps with complex value types cannot be form-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
   });
 
   group('nullable receiver support', () {

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -107,7 +107,7 @@ void main() {
     });
 
     group('MapModel', () {
-      test('generates encoding exception for MapModel', () {
+      test('generates form encoding for MapModel with StringModel values', () {
         final parameter = createParameter(
           name: 'mapParam',
           rawName: 'mapParam',
@@ -125,20 +125,97 @@ void main() {
         );
 
         final generated = emitCodes(codes);
+        final expected = format(r'''
+          test() {
+            _$entries.add((
+              name: r'mapParam',
+              value: mapParam.toForm(explode: false, allowEmpty: true),
+            ));
+          }
+        ''');
 
         expect(
           collapseWhitespace(generated),
-          contains(
-            collapseWhitespace(
-              '''throw _i1.EncodingException('Map types cannot be form query encoded.')''',
-            ),
+          collapseWhitespace(expected),
+        );
+      });
+
+      test('generates form encoding for MapModel with IntegerModel values', () {
+        final parameter = createParameter(
+          name: 'mapParam',
+          rawName: 'mapParam',
+          model: MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
           ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToFormQueryParameterCode(
+          'mapParam',
+          parameter,
+        );
+
+        final generated = emitCodes(codes);
+        final expected = format(r'''
+          test() {
+            _$entries.add((
+              name: r'mapParam',
+              value: mapParam
+                  .map((k, v) => _i1.MapEntry(k, v.toString()))
+                  .toForm(explode: false, allowEmpty: true),
+            ));
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
+        );
+      });
+
+      test('generates encoding exception for MapModel with ClassModel values',
+          () {
+        final parameter = createParameter(
+          name: 'mapParam',
+          rawName: 'mapParam',
+          model: MapModel(
+            valueModel: ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: [],
+              context: context,
+            ),
+            context: context,
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToFormQueryParameterCode(
+          'mapParam',
+          parameter,
+        );
+
+        final generated = emitCodes(codes);
+        final expected = format('''
+          test() {
+            throw _i1.EncodingException(
+              'Map with complex value types cannot be form query encoded.',
+            );
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
         );
       });
     });
 
     group('unsupported model types generate runtime throws', () {
-      test('Base64Model generates encoding exception', () {
+      test('Base64Model generates toBase64String form encoding', () {
         final parameter = createParameter(
           name: 'base64Param',
           rawName: 'base64Param',
@@ -153,14 +230,21 @@ void main() {
         );
 
         final generated = emitCodes(codes);
+        final expected = format(r'''
+          test() {
+            _$entries.add((
+              name: r'base64Param',
+              value: base64Param.toBase64String().toForm(
+                    explode: false,
+                    allowEmpty: true,
+                  ),
+            ));
+          }
+        ''');
 
         expect(
           collapseWhitespace(generated),
-          contains(
-            collapseWhitespace(
-              '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
-            ),
-          ),
+          collapseWhitespace(expected),
         );
       });
 
@@ -249,7 +333,7 @@ void main() {
       );
 
       test(
-        'List with Base64Model content generates encoding exception',
+        'List with Base64Model content generates toBase64String encoding',
         () {
           final parameter = createParameter(
             name: 'base64ListParam',
@@ -268,14 +352,21 @@ void main() {
           );
 
           final generated = emitCodes(codes);
+          final expected = format(r'''
+            test() {
+              _$entries.add((
+                name: r'base64ListParam',
+                value: base64ListParam
+                    .map((e) => e.toBase64String())
+                    .toList()
+                    .toForm(explode: false, allowEmpty: true),
+              ));
+            }
+          ''');
 
           expect(
             collapseWhitespace(generated),
-            contains(
-              collapseWhitespace(
-                '''throw _i1.EncodingException('Binary data cannot be form-encoded.')''',
-              ),
-            ),
+            collapseWhitespace(expected),
           );
         },
       );

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -445,6 +445,257 @@ void main() {
         '''throw  _i1.EncodingException('Unsupported list content type for label encoding.')''',
       );
     });
+
+    test('generates toLabel for MapModel with StringModel values', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.toLabel(explode: explode, allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('generates map and toLabel for MapModel with IntegerModel values',
+        () {
+      final model = MapModel(
+        valueModel: IntegerModel(context: context),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toString()))
+              .toLabel(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates runtime throw for MapModel with ClassModel values', () {
+      final model = MapModel(
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [],
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'Map with complex value types cannot be label-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String and toLabel for Base64Model', () {
+      final model = Base64Model(context: context);
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .toBase64String()
+              .toLabel(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String list content for List<Base64Model>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((e) => e.toBase64String())
+              .toList()
+              .toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates list-of-map encoding for List<Map<String, int>>', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toLabel(explode: explode, allowEmpty: allowEmpty),
+              )
+              .toList()
+              .toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test(
+        'generates runtime throw for List<Map<String, ClassModel>> '
+        '(unsupported)', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'List of maps with complex value types cannot be label-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
   });
 
   group('nullable receiver support', () {

--- a/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
@@ -586,6 +586,121 @@ void main() {
     );
   });
 
+  group('MapModel direct support', () {
+    test('generates label encoding for MapModel with StringModel values', () {
+      final parameter = PathParameterObject(
+        name: 'tags',
+        rawName: 'tags',
+        description: 'Tags parameter',
+        model: MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+      );
+      expect(
+        emit(buildToLabelPathParameterExpression('tags', parameter)),
+        'tags.toLabel(explode: false, allowEmpty: false, )',
+      );
+    });
+
+    test(
+      'generates label encoding for MapModel with IntegerModel values',
+      () {
+        final parameter = PathParameterObject(
+          name: 'counts',
+          rawName: 'counts',
+          description: 'Counts parameter',
+          model: MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
+          ),
+          encoding: PathParameterEncoding.label,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        final result =
+            emit(buildToLabelPathParameterExpression('counts', parameter));
+        expect(
+          collapseWhitespace(result),
+          collapseWhitespace([
+            'counts.map((k, v, ) => MapEntry(k, v.toString(), ))',
+            '.toLabel(explode: false, allowEmpty: false, )',
+          ].join()),
+        );
+      },
+    );
+
+    test(
+      'throws for MapModel with ClassModel values',
+      () {
+        final parameter = PathParameterObject(
+          name: 'data',
+          rawName: 'data',
+          description: 'Data parameter',
+          model: MapModel(
+            valueModel: ClassModel(
+              isDeprecated: false,
+              context: context,
+              name: 'Obj',
+              properties: [],
+            ),
+            context: context,
+          ),
+          encoding: PathParameterEncoding.label,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          collapseWhitespace(
+            emit(buildToLabelPathParameterExpression('data', parameter)),
+          ),
+          collapseWhitespace([
+            'throw EncodingException(',
+            "'Map with complex value types cannot be label-encoded.')",
+          ].join()),
+        );
+      },
+    );
+  });
+
+  group('Base64Model direct support', () {
+    test('generates toBase64String then toLabel for Base64Model', () {
+      final parameter = PathParameterObject(
+        name: 'fileData',
+        rawName: 'fileData',
+        description: 'Base64 file parameter',
+        model: Base64Model(context: context),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+      );
+      final result =
+          emit(buildToLabelPathParameterExpression('fileData', parameter));
+      expect(
+        collapseWhitespace(result),
+        collapseWhitespace([
+          'fileData.toBase64String()',
+          '.toLabel(explode: false, allowEmpty: false, )',
+        ].join()),
+      );
+    });
+  });
+
   group('unsupported types generate throw', () {
     test('List of ClassModel throws EncodingException', () {
       final parameter = PathParameterObject(
@@ -617,45 +732,95 @@ void main() {
         context: context,
       );
       expect(
-        emit(buildToLabelPathParameterExpression('itemList', parameter)),
-        contains('throw'),
-      );
-      expect(
-        emit(buildToLabelPathParameterExpression('itemList', parameter)),
-        contains('EncodingException'),
-      );
-    });
-
-    test('List of MapModel throws EncodingException', () {
-      final parameter = PathParameterObject(
-        name: 'items',
-        rawName: 'items',
-        description: 'List of maps parameter',
-        model: ListModel(
-          context: context,
-          content: MapModel(
-            valueModel: IntegerModel(context: context),
-            context: context,
-          ),
+        collapseWhitespace(
+          emit(buildToLabelPathParameterExpression('itemList', parameter)),
         ),
-        encoding: PathParameterEncoding.label,
-        explode: false,
-        allowEmptyValue: false,
-        isRequired: true,
-        isDeprecated: false,
-        context: context,
-      );
-      expect(
-        emit(buildToLabelPathParameterExpression('items', parameter)),
-        contains('throw'),
-      );
-      expect(
-        emit(buildToLabelPathParameterExpression('items', parameter)),
-        contains('EncodingException'),
+        collapseWhitespace([
+          'throw EncodingException(',
+          "'Label encoding does not support ",
+          "arrays of complex types')",
+        ].join()),
       );
     });
 
-    test('List of Base64Model throws EncodingException', () {
+    test(
+      'List of MapModel with IntegerModel values generates '
+      'label encoding',
+      () {
+        final parameter = PathParameterObject(
+          name: 'items',
+          rawName: 'items',
+          description: 'List of maps parameter',
+          model: ListModel(
+            context: context,
+            content: MapModel(
+              valueModel: IntegerModel(context: context),
+              context: context,
+            ),
+          ),
+          encoding: PathParameterEncoding.label,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        final result =
+            emit(buildToLabelPathParameterExpression('items', parameter));
+        expect(
+          collapseWhitespace(result),
+          collapseWhitespace([
+            'items.map((e) => e.map((k, v, ) ',
+            '=> MapEntry(k, v.toString(), ))',
+            '.toLabel(explode: false, allowEmpty: false, ))',
+            '.toList()',
+            '.toLabel(explode: false, ',
+            'allowEmpty: false, alreadyEncoded: true, )',
+          ].join()),
+        );
+      },
+    );
+
+    test(
+      'List of MapModel with ClassModel values throws EncodingException',
+      () {
+        final parameter = PathParameterObject(
+          name: 'items',
+          rawName: 'items',
+          description: 'List of maps parameter',
+          model: ListModel(
+            context: context,
+            content: MapModel(
+              valueModel: ClassModel(
+                isDeprecated: false,
+                context: context,
+                name: 'Obj',
+                properties: [],
+              ),
+              context: context,
+            ),
+          ),
+          encoding: PathParameterEncoding.label,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          collapseWhitespace(
+            emit(buildToLabelPathParameterExpression('items', parameter)),
+          ),
+          collapseWhitespace([
+            'throw EncodingException(',
+            "'Label encoding does not support ",
+            "arrays of maps with complex values')",
+          ].join()),
+        );
+      },
+    );
+
+    test('List of Base64Model generates label encoding', () {
       final parameter = PathParameterObject(
         name: 'files',
         rawName: 'files',
@@ -671,13 +836,15 @@ void main() {
         isDeprecated: false,
         context: context,
       );
+      final result =
+          emit(buildToLabelPathParameterExpression('files', parameter));
       expect(
-        emit(buildToLabelPathParameterExpression('files', parameter)),
-        contains('throw'),
-      );
-      expect(
-        emit(buildToLabelPathParameterExpression('files', parameter)),
-        contains('EncodingException'),
+        collapseWhitespace(result),
+        collapseWhitespace([
+          'files.map((e) => e.toBase64String()).toList()',
+          '.toLabel(explode: false, ',
+          'allowEmpty: false, alreadyEncoded: true, )',
+        ].join()),
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -462,6 +462,272 @@ void main() {
         '''throw  _i1.EncodingException('Unsupported list content type for matrix encoding.')''',
       );
     });
+
+    test('generates toMatrix for MapModel with StringModel values', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('generates map and toMatrix for MapModel with IntegerModel values',
+        () {
+      final model = MapModel(
+        valueModel: IntegerModel(context: context),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toString()))
+              .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates runtime throw for MapModel with ClassModel values', () {
+      final model = MapModel(
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [],
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'Map with complex value types cannot be matrix-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String and toMatrix for Base64Model', () {
+      final model = Base64Model(context: context);
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value.toBase64String().toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String list content for List<Base64Model>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map<String>((e) => e.toBase64String())
+              .toList()
+              .toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates list-of-map encoding for List<Map<String, int>>', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map<String>(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toMatrix(
+                      paramName,
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                    ),
+              )
+              .toList()
+              .toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test(
+        'generates runtime throw for List<Map<String, ClassModel>> '
+        '(unsupported)', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'List of maps with complex value types cannot be matrix-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
   });
 
   group('nullable receiver support', () {

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -413,6 +413,332 @@ void main() {
       );
     });
 
+    test('generates toSimple for MapModel with StringModel values', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.toSimple(explode: explode, allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('generates map and toSimple for MapModel with IntegerModel values',
+        () {
+      final model = MapModel(
+        valueModel: IntegerModel(context: context),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toString()))
+              .toSimple(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates map and toSimple for MapModel with DateTimeModel values',
+        () {
+      final model = MapModel(
+        valueModel: DateTimeModel(context: context),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toTimeZonedIso8601String()))
+              .toSimple(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates map and toSimple for MapModel with EnumModel values', () {
+      final model = MapModel(
+        valueModel: EnumModel<String>(
+          isDeprecated: false,
+          name: 'Status',
+          values: {
+            const EnumEntry(value: 'active'),
+          },
+          isNullable: false,
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toJson()))
+              .toSimple(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates runtime throw for MapModel with ClassModel values', () {
+      final model = MapModel(
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [],
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'Map with complex value types cannot be simple-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String and toSimple for Base64Model', () {
+      final model = Base64Model(context: context);
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .toBase64String()
+              .toSimple(explode: explode, allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates toBase64String list content for List<Base64Model>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((e) => e.toBase64String())
+              .toList()
+              .toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates list-of-map encoding for List<Map<String, int>>', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toSimple(explode: explode, allowEmpty: allowEmpty),
+              )
+              .toList()
+              .toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test(
+        'generates runtime throw for List<Map<String, ClassModel>> '
+        '(unsupported)', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'List of maps with complex value types cannot be simple-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
     test('generates runtime throw for NeverModel', () {
       final model = NeverModel(context: context);
       final expression = buildSimpleParameterExpression(

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
@@ -8,6 +9,10 @@ void main() {
   late Context context;
   late DartEmitter emitter;
   late DartEmitter scopedEmitter;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
 
   setUp(() {
     context = Context.initial();
@@ -360,26 +365,511 @@ void main() {
           '''throw  _i1.EncodingException('Unsupported model type for simple encoding.')''',
         );
       });
+    });
 
-      test('generates runtime throw for List with MapModel content', () {
-        final model = ListModel(
-          content: MapModel(
-            valueModel: StringModel(context: context),
-            context: context,
-          ),
+    group('MapModel', () {
+      test('generates toSimple for MapModel with StringModel values', () {
+        final model = MapModel(
+          valueModel: StringModel(context: context),
           context: context,
         );
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final generated = format(
+          'final result = ${expression.accept(emitter)};',
+        );
+        const expected = '''
+          final result = value.toSimple(explode: false, allowEmpty: true);
+        ''';
 
         expect(
-          buildSimpleValueExpression(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expected)),
+        );
+      });
+
+      test(
+        'generates map and toSimple for MapModel with IntegerModel values',
+        () {
+          final model = MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
             refer('value'),
             model,
             explode: false,
             allowEmpty: true,
-          ).accept(scopedEmitter).toString(),
-          '''throw  _i1.EncodingException('Unsupported content model for simple encoding.')''',
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map((k, v) => MapEntry(k, v.toString()))
+                  .toSimple(explode: false, allowEmpty: true);
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates map and toSimple for MapModel with DateTimeModel values',
+        () {
+          final model = MapModel(
+            valueModel: DateTimeModel(context: context),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map((k, v) => MapEntry(k, v.toTimeZonedIso8601String()))
+                  .toSimple(explode: false, allowEmpty: true);
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates map and toSimple for MapModel with EnumModel values',
+        () {
+          final model = MapModel(
+            valueModel: EnumModel<String>(
+              isDeprecated: false,
+              name: 'Status',
+              values: {
+                const EnumEntry(value: 'active'),
+              },
+              isNullable: false,
+              context: context,
+            ),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map((k, v) => MapEntry(k, v.toJson()))
+                  .toSimple(explode: false, allowEmpty: true);
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates runtime throw for MapModel with ClassModel values',
+        () {
+          final model = MapModel(
+            valueModel: ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: [],
+              context: context,
+            ),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(scopedEmitter).toString());
+          final expected = format('''
+            test() {
+              final result = throw _i1.EncodingException(
+                'Map with complex value types cannot be simple-encoded.',
+              );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates null-safe toSimple for nullable MapModel '
+        'with StringModel values',
+        () {
+          final model = MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+            isNullable: true,
+          );
+
+          final generated = format(
+            'final result = ${expression.accept(emitter)};',
+          );
+          const expected = '''
+            final result = value?.toSimple(explode: false, allowEmpty: true);
+          ''';
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(format(expected)),
+          );
+        },
+      );
+    });
+
+    group('Base64Model', () {
+      test('generates toBase64String and toSimple for Base64Model', () {
+        final model = Base64Model(context: context);
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final method = Method(
+          (b) => b
+            ..name = 'test'
+            ..body = declareFinal('result').assign(expression).statement,
+        );
+
+        final generated = format(method.accept(emitter).toString());
+        final expected = format('''
+          test() {
+            final result = value
+                .toBase64String()
+                .toSimple(explode: false, allowEmpty: true);
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
         );
       });
+
+      test(
+        'generates null-safe toBase64String for nullable Base64Model',
+        () {
+          final model = Base64Model(context: context);
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+            isNullable: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  ?.toBase64String()
+                  .toSimple(explode: false, allowEmpty: true);
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+    });
+
+    group('List<Base64Model>', () {
+      test(
+        'generates toBase64String list content for List<Base64Model>',
+        () {
+          final model = ListModel(
+            content: Base64Model(context: context),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map((e) => e.toBase64String())
+                  .toList()
+                  .toSimple(
+                    explode: false,
+                    allowEmpty: true,
+                    alreadyEncoded: true,
+                  );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates null-safe map for nullable List<Base64Model>',
+        () {
+          final model = ListModel(
+            content: Base64Model(context: context),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+            isNullable: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  ?.map((e) => e.toBase64String())
+                  .toList()
+                  .toSimple(
+                    explode: false,
+                    allowEmpty: true,
+                    alreadyEncoded: true,
+                  );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+    });
+
+    group('List<MapModel>', () {
+      test(
+        'generates list-of-map encoding for List<Map<String, String>>',
+        () {
+          final model = ListModel(
+            content: MapModel(
+              valueModel: StringModel(context: context),
+              context: context,
+            ),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map(
+                    (e) => e.toSimple(explode: false, allowEmpty: true),
+                  )
+                  .toList()
+                  .toSimple(
+                    explode: false,
+                    allowEmpty: true,
+                    alreadyEncoded: true,
+                  );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates list-of-map encoding for List<Map<String, int>>',
+        () {
+          final model = ListModel(
+            content: MapModel(
+              valueModel: IntegerModel(context: context),
+              context: context,
+            ),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(emitter).toString());
+          final expected = format('''
+            test() {
+              final result = value
+                  .map(
+                    (e) => e
+                        .map((k, v) => MapEntry(k, v.toString()))
+                        .toSimple(explode: false, allowEmpty: true),
+                  )
+                  .toList()
+                  .toSimple(
+                    explode: false,
+                    allowEmpty: true,
+                    alreadyEncoded: true,
+                  );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates runtime throw for List<Map<String, ClassModel>>',
+        () {
+          final model = ListModel(
+            content: MapModel(
+              valueModel: ClassModel(
+                isDeprecated: false,
+                name: 'User',
+                properties: [],
+                context: context,
+              ),
+              context: context,
+            ),
+            context: context,
+          );
+          final expression = buildSimpleValueExpression(
+            refer('value'),
+            model,
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final method = Method(
+            (b) => b
+              ..name = 'test'
+              ..body = declareFinal('result').assign(expression).statement,
+          );
+
+          final generated = format(method.accept(scopedEmitter).toString());
+          final expected = format('''
+            test() {
+              final result = throw _i1.EncodingException(
+                'List of maps with complex value types cannot be simple-encoded.',
+              );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
     });
   });
 

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -599,4 +599,182 @@ void main() {
       );
     });
   });
+
+  group('buildUriEncodeExpression for MapModel', () {
+    test('generates uriEncode for MapModel with StringModel values', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('generates map and uriEncode for MapModel with IntegerModel values',
+        () {
+      final model = MapModel(
+        valueModel: IntegerModel(context: context),
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((k, v) => MapEntry(k, v.toString()))
+              .uriEncode(allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('generates runtime throw for MapModel with ClassModel values', () {
+      final model = MapModel(
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'TestClass',
+          properties: [],
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'Map with complex value types cannot be URI-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('buildUriEncodeExpression for list-of-map content', () {
+    test('generates list-of-map encoding for List<Map<String, int>>', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .uriEncode(allowEmpty: allowEmpty),
+              )
+              .toList()
+              .uriEncode(allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test(
+        'generates runtime throw for List<Map<String, ClassModel>> '
+        '(unsupported)', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'TestClass',
+            properties: [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal('result').assign(expression).statement,
+      );
+
+      final generated = format(method.accept(scopedEmitter).toString());
+      final expected = format('''
+        test() {
+          final result = throw _i1.EncodingException(
+            'List of maps with complex value types cannot be URI-encoded.',
+          );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+  });
 }

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -1,4 +1,5 @@
 import 'package:big_decimal/big_decimal.dart';
+import 'package:tonik_util/src/date.dart';
 import 'package:tonik_util/src/encoding/datetime_extension.dart';
 import 'package:tonik_util/src/encoding/deep_object_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/encodable.dart';
@@ -290,6 +291,37 @@ String encodeAnyToUri(
   }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to URI',
+  );
+}
+
+/// Converts any value to its string representation for map parameter encoding.
+///
+/// Used when a map has AnyModel values (`Map<String, dynamic>`).
+/// Handles runtime type detection -- primitives produce their standard string
+/// form; unsupported types throw EncodingException.
+///
+/// When [allowEmpty] is false, null throws [EmptyValueException];
+/// when true, null produces an empty string.
+String encodeAnyValueToString(
+  Object? value, {
+  required bool allowEmpty,
+}) {
+  if (value == null) {
+    if (!allowEmpty) {
+      throw const EmptyValueException();
+    }
+    return '';
+  }
+  if (value is String) return value;
+  if (value is int) return value.toString();
+  if (value is double) return value.toString();
+  if (value is bool) return value.toString();
+  if (value is DateTime) return value.toTimeZonedIso8601String();
+  if (value is Date) return value.toString();
+  if (value is Uri) return value.toString();
+  if (value is BigDecimal) return value.toString();
+  throw EncodingException(
+    'Cannot encode ${value.runtimeType} to string for map parameter encoding',
   );
 }
 

--- a/packages/tonik_util/lib/src/tonik_file/tonik_file.dart
+++ b/packages/tonik_util/lib/src/tonik_file/tonik_file.dart
@@ -28,6 +28,9 @@ sealed class TonikFile {
   /// native platforms. Throws [UnsupportedError] on web.
   List<int> toBytes();
 
+  /// Returns the binary content as a base64-encoded string.
+  String toBase64String() => base64Encode(toBytes());
+
   /// URI-encodes this file's binary content.
   ///
   /// Converts the binary data to a UTF-8 string, then URI-encodes it.

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1,5 +1,6 @@
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
+import 'package:tonik_util/src/date.dart';
 import 'package:tonik_util/src/encoding/any_encoding.dart';
 import 'package:tonik_util/src/encoding/encodable.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
@@ -1320,6 +1321,144 @@ void main() {
       test('throws for List (not directly supported)', () {
         expect(
           () => encodeAnyToUri(['a', 'b'], allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+  });
+
+  group('encodeAnyValueToString', () {
+    group('String', () {
+      test('returns string as-is', () {
+        expect(
+          encodeAnyValueToString('hello', allowEmpty: true),
+          'hello',
+        );
+      });
+
+      test('returns empty string', () {
+        expect(
+          encodeAnyValueToString('', allowEmpty: true),
+          '',
+        );
+      });
+    });
+
+    group('int', () {
+      test('converts int to string', () {
+        expect(
+          encodeAnyValueToString(42, allowEmpty: true),
+          '42',
+        );
+      });
+
+      test('converts negative int', () {
+        expect(
+          encodeAnyValueToString(-7, allowEmpty: true),
+          '-7',
+        );
+      });
+    });
+
+    group('double', () {
+      test('converts double to string', () {
+        expect(
+          encodeAnyValueToString(3.14, allowEmpty: true),
+          '3.14',
+        );
+      });
+    });
+
+    group('bool', () {
+      test('converts true', () {
+        expect(
+          encodeAnyValueToString(true, allowEmpty: true),
+          'true',
+        );
+      });
+
+      test('converts false', () {
+        expect(
+          encodeAnyValueToString(false, allowEmpty: true),
+          'false',
+        );
+      });
+    });
+
+    group('DateTime', () {
+      test('converts DateTime to ISO8601 with timezone', () {
+        final dt = DateTime.utc(2024, 1, 15, 10, 30);
+        expect(
+          encodeAnyValueToString(dt, allowEmpty: true),
+          '2024-01-15T10:30:00.000Z',
+        );
+      });
+    });
+
+    group('Date', () {
+      test('converts Date to string', () {
+        final date = Date(2024, 1, 15);
+        expect(
+          encodeAnyValueToString(date, allowEmpty: true),
+          '2024-01-15',
+        );
+      });
+    });
+
+    group('Uri', () {
+      test('converts Uri to string', () {
+        final uri = Uri.parse('https://example.com');
+        expect(
+          encodeAnyValueToString(uri, allowEmpty: true),
+          'https://example.com',
+        );
+      });
+    });
+
+    group('BigDecimal', () {
+      test('converts BigDecimal to string', () {
+        final bd = BigDecimal.parse('123.456');
+        expect(
+          encodeAnyValueToString(bd, allowEmpty: true),
+          '123.456',
+        );
+      });
+    });
+
+    group('null handling', () {
+      test('returns empty string for null with allowEmpty=true', () {
+        expect(
+          encodeAnyValueToString(null, allowEmpty: true),
+          '',
+        );
+      });
+
+      test('throws EmptyValueException for null with allowEmpty=false', () {
+        expect(
+          () => encodeAnyValueToString(null, allowEmpty: false),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+    });
+
+    group('unsupported types', () {
+      test('throws for unsupported type', () {
+        expect(
+          () => encodeAnyValueToString(Object(), allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for List', () {
+        expect(
+          () => encodeAnyValueToString([1, 2, 3], allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for Map', () {
+        expect(
+          () => encodeAnyValueToString({'a': 'b'}, allowEmpty: true),
           throwsA(isA<EncodingException>()),
         );
       });

--- a/packages/tonik_util/test/src/tonik_file/tonik_file_test.dart
+++ b/packages/tonik_util/test/src/tonik_file/tonik_file_test.dart
@@ -1,3 +1,4 @@
+import 'dart:convert';
 import 'dart:io';
 
 import 'package:test/test.dart';
@@ -157,6 +158,33 @@ void main() {
 
       expect(file.toString(), contains('TonikFilePath'));
       expect(file.toString(), contains('/tmp/photo.jpg'));
+    });
+  });
+
+  group('toBase64String', () {
+    test('returns base64-encoded string for TonikFileBytes', () {
+      // "Hello" in UTF-8
+      const file = TonikFileBytes([72, 101, 108, 108, 111]);
+      expect(file.toBase64String(), base64Encode([72, 101, 108, 108, 111]));
+    });
+
+    test('returns base64-encoded string for TonikFilePath', () {
+      final tempFile =
+          File('${Directory.systemTemp.path}/tonik_base64_test.txt')
+            ..writeAsBytesSync([72, 101, 108, 108, 111]);
+      addTearDown(() {
+        if (tempFile.existsSync()) {
+          tempFile.deleteSync();
+        }
+      });
+
+      final file = TonikFilePath(tempFile.path);
+      expect(file.toBase64String(), base64Encode([72, 101, 108, 108, 111]));
+    });
+
+    test('returns empty base64 string for empty bytes', () {
+      const file = TonikFileBytes([]);
+      expect(file.toBase64String(), base64Encode([]));
     });
   });
 


### PR DESCRIPTION
## Summary

- Add type-specific map value conversion at codegen time instead of generic runtime `toString()`. The generator examines `MapModel.valueModel` and emits correct conversion per type (identity for String, `.toString()` for int, `.toTimeZonedIso8601String()` for DateTime, `.toJson()` for enums), rejecting unsupported complex types with `EncodingException`.
- Add `TonikFile.toBase64String()` for base64 encoding of binary data in parameter encoding.
- Add `encodeAnyValueToString()` runtime function for `AnyModel` map value dispatch.
- Update all 8 parameter encoding generators (simple, form, matrix, label, label-path, form-query, uri-encode, simple-value) with MapModel and Base64Model support. Deep object and delimited generators intentionally unchanged.
- Add integration test schemas exercising map parameters (string, int, datetime values) and base64 parameters across simple, label, matrix, form, and deepObject encoding styles.

## Test plan

- [x] Unit tests for `buildMapToStringMapExpression` covering all value types
- [x] Unit tests for `encodeAnyValueToString` covering all runtime types and null handling
- [x] Unit tests for `TonikFile.toBase64String()` on both subtypes
- [x] MapModel/Base64Model tests added to all 8 generator test files
- [x] Integration test schemas for map + base64 params across all encoding styles
- [x] All 34 integration test suites pass
- [x] `fvm dart analyze` clean (zero errors)