### PR TITLE
fix: handle MapModel in cookie parameter encoding

### DIFF
--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -578,6 +578,62 @@ void main() {
     });
   });
 
+  group('map cookies', () {
+    test('map with string values', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testMapStringCookie(
+        labels: {'color': 'blue', 'size': 'large'},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'labels=color=blue&size=large');
+    });
+
+    test('map with integer values', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testMapIntegerCookie(
+        prefs: {'volume': 80, 'brightness': 50},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'prefs=volume=80&brightness=50');
+    });
+
+    test('map with single entry', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testMapIntegerCookie(prefs: {'volume': 80});
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'prefs=volume=80');
+    });
+
+    test('empty map', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testMapIntegerCookie(prefs: {});
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'prefs=');
+    });
+
+    test('optional map when provided', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testOptionalMapCookie(
+        settings: {'timeout': 30},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'settings=timeout=30');
+    });
+
+    test('optional map when not provided', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testOptionalMapCookie();
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), isNull);
+    });
+  });
+
   group('nested object cookies', () {
     test('nested object cookie returns encoding error', () async {
       final api = buildCookiesApi(responseStatus: '204');

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -565,6 +565,72 @@ paths:
         '204':
           description: No content
 
+  # Map cookie with integer values (additionalProperties)
+  /map-integer-cookie:
+    get:
+      operationId: testMapIntegerCookie
+      tags:
+        - cookies
+      summary: Test map cookie with integer values
+      description: Demonstrates a map cookie with additionalProperties integer values
+      parameters:
+        - name: prefs
+          in: cookie
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Map cookie with string values (additionalProperties)
+  /map-string-cookie:
+    get:
+      operationId: testMapStringCookie
+      tags:
+        - cookies
+      summary: Test map cookie with string values
+      description: Demonstrates a map cookie with additionalProperties string values
+      parameters:
+        - name: labels
+          in: cookie
+          required: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Optional map cookie with integer values
+  /optional-map-cookie:
+    get:
+      operationId: testOptionalMapCookie
+      tags:
+        - cookies
+      summary: Test optional map cookie
+      description: Demonstrates an optional map cookie parameter
+      parameters:
+        - name: settings
+          in: cookie
+          required: false
+          schema:
+            type: object
+            additionalProperties:
+              type: integer
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
   # Nested object cookie
   /nested-object-cookie:
     get:

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -478,7 +478,8 @@ class OptionsGenerator {
         // BinaryModel, NeverModel) cannot be form-encoded.
         bodyStatements.add(
           generateEncodingExceptionExpression(
-            'Map with complex value types cannot be form-encoded as a cookie.',
+            'Map with complex value types cannot be form-encoded '
+            'for cookie $rawName',
           ).statement,
         );
         return;

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -2,6 +2,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
@@ -464,7 +465,41 @@ class OptionsGenerator {
       return;
     }
 
-    // For non-list types, use toForm directly.
+    // MapModel: convert values to Map<String, String> before calling toForm.
+    if (model is MapModel) {
+      final converted = buildMapToStringMapExpression(
+        refer(paramName),
+        model,
+        isNullable: false,
+      );
+
+      if (converted == null) {
+        // Unsupported map value types (ClassModel, ListModel, nested MapModel,
+        // BinaryModel, NeverModel) cannot be form-encoded.
+        bodyStatements.add(
+          generateEncodingExceptionExpression(
+            'Map with complex value types cannot be form-encoded as a cookie.',
+          ).statement,
+        );
+        return;
+      }
+
+      final encodedValue = converted.property('toForm').call([], {
+        'explode': literalBool(explode),
+        'allowEmpty': literalBool(true),
+      });
+      bodyStatements.add(
+        refer(r'_$cookieParts').property('add').call([
+          literalList([
+            specLiteralString('$rawName='),
+            encodedValue,
+          ]).property('join').call([]),
+        ]).statement,
+      );
+      return;
+    }
+
+    // For non-list, non-map types, use toForm directly.
     final encodedValue = refer(paramName).property('toForm').call([], {
       'explode': literalBool(explode),
       'allowEmpty': literalBool(true),

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1385,6 +1385,268 @@ void main() {
       );
     });
 
+    test('generates Cookie header for map cookie with string values', () {
+      final cookieParam = CookieParameterObject(
+        name: 'labels',
+        rawName: 'labels',
+        description: 'Labels map',
+        isRequired: true,
+        isDeprecated: false,
+        explode: false,
+        model: MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+        ),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withMapStringCookie',
+        context: context,
+        summary: 'With map string cookie',
+        description: 'Operation with map string cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/map-string-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'labels', parameter: cookieParam),
+      ]);
+
+      // Check method has required Map<String, String> parameter.
+      final param = method.optionalParameters.firstWhere(
+        (p) => p.name == 'labels',
+      );
+      expect(param.required, isTrue);
+      expect(
+        param.type?.accept(emitter).toString(),
+        'Map<String,String>',
+      );
+
+      // For string values, the map is passed directly to toForm.
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        contains(
+          collapseWhitespace(r'''
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [r'labels=', labels.toForm(explode: false, allowEmpty: true)].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('generates Cookie header for map cookie with integer values', () {
+      final cookieParam = CookieParameterObject(
+        name: 'prefs',
+        rawName: 'prefs',
+        description: 'Preferences map',
+        isRequired: true,
+        isDeprecated: false,
+        explode: true,
+        model: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withMapIntCookie',
+        context: context,
+        summary: 'With map int cookie',
+        description: 'Operation with map int cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/map-int-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'prefs', parameter: cookieParam),
+      ]);
+
+      // Check method has required Map<String, int> parameter.
+      final param = method.optionalParameters.firstWhere(
+        (p) => p.name == 'prefs',
+      );
+      expect(param.required, isTrue);
+      expect(
+        param.type?.accept(emitter).toString(),
+        'Map<String,int>',
+      );
+
+      // For integer values, the map is converted to Map<String, String> first.
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        contains(
+          collapseWhitespace(r'''
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'prefs=',
+                prefs
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toForm(explode: true, allowEmpty: true),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('generates Cookie header for optional map cookie', () {
+      final cookieParam = CookieParameterObject(
+        name: 'settings',
+        rawName: 'settings',
+        description: 'Settings map',
+        isRequired: false,
+        isDeprecated: false,
+        explode: false,
+        model: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withOptionalMapCookie',
+        context: context,
+        summary: 'With optional map cookie',
+        description: 'Operation with optional map cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/optional-map-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'settings', parameter: cookieParam),
+      ]);
+
+      // Check method has optional nullable Map<String, int>? parameter.
+      final param = method.optionalParameters.firstWhere(
+        (p) => p.name == 'settings',
+      );
+      expect(param.required, isFalse);
+      expect(
+        param.type?.accept(emitter).toString(),
+        'Map<String,int>?',
+      );
+
+      // Optional map cookie wraps in null check.
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        contains(
+          collapseWhitespace(r'''
+            final _$cookieParts = <String>[];
+            if (settings != null) {
+              _$cookieParts.add(
+                [
+                  r'settings=',
+                  settings
+                      .map((k, v) => MapEntry(k, v.toString()))
+                      .toForm(explode: false, allowEmpty: true),
+                ].join(),
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('generates throw for map cookie with unsupported value type', () {
+      final cookieParam = CookieParameterObject(
+        name: 'data',
+        rawName: 'data',
+        description: 'Data map',
+        isRequired: true,
+        isDeprecated: false,
+        explode: false,
+        model: MapModel(
+          valueModel: ClassModel(
+            name: 'Nested',
+            properties: const [],
+            context: context,
+            isDeprecated: false,
+          ),
+          context: context,
+        ),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withUnsupportedMapCookie',
+        context: context,
+        summary: 'With unsupported map cookie',
+        description: 'Operation with unsupported map cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/unsupported-map-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'data', parameter: cookieParam),
+      ]);
+
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        contains(
+          collapseWhitespace('''
+            throw EncodingException(
+              'Map with complex value types cannot be form-encoded as a cookie.',
+            );
+          '''),
+        ),
+      );
+    });
+
     group('multipart content type', () {
       test('sets contentType to null for single multipart content type', () {
         final requestBody = RequestBodyObject(

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1640,7 +1640,7 @@ void main() {
         contains(
           collapseWhitespace('''
             throw EncodingException(
-              'Map with complex value types cannot be form-encoded as a cookie.',
+              'Map with complex value types cannot be form-encoded for cookie data',
             );
           '''),
         ),


### PR DESCRIPTION
## Summary

- Cookie parameters with non-string Map schemas (e.g. `additionalProperties: { type: integer }`) generated code calling `.toForm()` on `Map<String, int>`, which doesn't exist — the `FormStringMapEncoder` extension only applies to `Map<String, String>`
- Detect `MapModel` in `_addCookieEncodingStatement` and convert values to `Map<String, String>` via `buildMapToStringMapExpression` before calling `.toForm()`, matching the pattern used by the simple encoder
- For unsupported map value types (ClassModel, ListModel, nested MapModel), generate a throw with a clear error message

## Test plan

- [x] Unit tests: Map with string values (passthrough), integer values (conversion), optional map (null check), unsupported types (throw)
- [x] Integration tests: Added Map cookie endpoints to cookies spec (Map<String, int>, Map<String, String>, optional Map<String, int>)
- [x] All 4154 unit tests pass, all 39 integration test suites pass
- [x] `fvm dart analyze` clean
- [x] Patch coverage: 100%