### PR TITLE
fix: handle AnyModel in cookie parameter encoding

### DIFF
--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -650,4 +650,30 @@ void main() {
       expect(error.error, isA<EncodingException>());
     });
   });
+
+  group('AnyModel cookies', () {
+    test('required AnyModel cookie with string value', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAnyCookie(data: 'hello');
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'data=hello');
+    });
+
+    test('required AnyModel cookie with integer value', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAnyCookie(data: 42);
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'data=42');
+    });
+
+    test('array of AnyModel cookie', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testArrayAnyCookie(items: ['a', 1, true]);
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'items=a,1,true');
+    });
+  });
 }

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.4
+openapi: 3.1.0
 info:
   title: Cookie Parameters API
   description: OpenAPI specification showcasing cookie parameters
@@ -370,8 +370,9 @@ paths:
           in: cookie
           required: false
           schema:
-            type: string
-            nullable: true
+            type:
+              - string
+              - 'null'
       responses:
         '200':
           description: OK
@@ -645,6 +646,46 @@ paths:
           required: true
           schema:
             $ref: '#/components/schemas/NestedProfile'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # AnyModel cookie (schema: true — OAS 3.1 boolean schema)
+  /any-cookie:
+    get:
+      operationId: testAnyCookie
+      tags:
+        - cookies
+      summary: Test AnyModel cookie parameter
+      description: Demonstrates a cookie parameter with boolean schema true (any value)
+      parameters:
+        - name: data
+          in: cookie
+          required: true
+          schema: true
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Array of AnyModel cookie (items: true — OAS 3.1 boolean schema)
+  /array-any-cookie:
+    get:
+      operationId: testArrayAnyCookie
+      tags:
+        - cookies
+      summary: Test array of AnyModel cookie parameter
+      description: Demonstrates a cookie parameter with array of any values
+      parameters:
+        - name: items
+          in: cookie
+          required: true
+          schema:
+            type: array
+            items: true
       responses:
         '200':
           description: OK

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -432,6 +432,43 @@ class OptionsGenerator {
         return;
       }
 
+      if (contentModel is AnyModel) {
+        bodyStatements.add(
+          refer(r'_$cookieParts').property('add').call([
+            literalList([
+              specLiteralString('$rawName='),
+              refer(paramName)
+                  .property('map')
+                  .call([
+                    Method(
+                      (b) => b
+                        ..lambda = true
+                        ..requiredParameters.add(
+                          Parameter((b) => b..name = 'e'),
+                        )
+                        ..body = refer(
+                          'encodeAnyToForm',
+                          'package:tonik_util/tonik_util.dart',
+                        ).call([refer('e')], {
+                          'explode': literalBool(explode),
+                          'allowEmpty': literalBool(true),
+                        }).code,
+                    ).closure,
+                  ])
+                  .property('toList')
+                  .call([])
+                  .property('toForm')
+                  .call([], {
+                    'explode': literalBool(explode),
+                    'allowEmpty': literalBool(true),
+                    'alreadyEncoded': literalBool(true),
+                  }),
+            ]).property('join').call([]),
+          ]).statement,
+        );
+        return;
+      }
+
       bodyStatements.add(
         refer(r'_$cookieParts').property('add').call([
           literalList([
@@ -486,6 +523,26 @@ class OptionsGenerator {
       }
 
       final encodedValue = converted.property('toForm').call([], {
+        'explode': literalBool(explode),
+        'allowEmpty': literalBool(true),
+      });
+      bodyStatements.add(
+        refer(r'_$cookieParts').property('add').call([
+          literalList([
+            specLiteralString('$rawName='),
+            encodedValue,
+          ]).property('join').call([]),
+        ]).statement,
+      );
+      return;
+    }
+
+    // AnyModel: use encodeAnyToForm for runtime type dispatch.
+    if (model is AnyModel) {
+      final encodedValue = refer(
+        'encodeAnyToForm',
+        'package:tonik_util/tonik_util.dart',
+      ).call([refer(paramName)], {
         'explode': literalBool(explode),
         'allowEmpty': literalBool(true),
       });

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1647,6 +1647,243 @@ void main() {
       );
     });
 
+    test(
+      'generates Cookie header for required AnyModel cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'data',
+          rawName: 'data',
+          description: 'Any data',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: AnyModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withAnyCookie',
+          context: context,
+          summary: 'With any cookie',
+          description: 'Operation with AnyModel cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/any-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'data', parameter: cookieParam),
+        ]);
+
+        // Check method has required Object? parameter.
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'data',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.accept(emitter).toString(), 'Object?');
+
+        const expectedMethod = r'''
+          Options _options({required Object? data}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'data=',
+                encodeAnyToForm(data, explode: false, allowEmpty: true),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates Cookie header for list of AnyModel cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'items',
+          rawName: 'items',
+          description: 'List of any items',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: ListModel(
+            content: AnyModel(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withArrayAnyCookie',
+          context: context,
+          summary: 'With array any cookie',
+          description: 'Operation with list of AnyModel cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/array-any-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'items', parameter: cookieParam),
+        ]);
+
+        // Check method has required List<Object?> parameter.
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'items',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.accept(emitter).toString(), 'List<Object?>');
+
+        const expectedMethod = r'''
+          Options _options({required List<Object?> items}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'items=',
+                items
+                    .map(
+                      (e) =>
+                          encodeAnyToForm(e, explode: false, allowEmpty: true),
+                    )
+                    .toList()
+                    .toForm(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    ),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates Cookie header for optional AnyModel cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'metadata',
+          rawName: 'metadata',
+          description: 'Optional any data',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: AnyModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalAnyCookie',
+          context: context,
+          summary: 'With optional any cookie',
+          description: 'Operation with optional AnyModel cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-any-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'metadata', parameter: cookieParam),
+        ]);
+
+        // Check method has optional Object? parameter.
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'metadata',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'Object?');
+
+        const expectedMethod = r'''
+          Options _options({Object? metadata}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (metadata != null) {
+              _$cookieParts.add(
+                [
+                  r'metadata=',
+                  encodeAnyToForm(metadata, explode: false, allowEmpty: true),
+                ].join(),
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
     group('multipart content type', () {
       test('sets contentType to null for single multipart content type', () {
         final requestBody = RequestBodyObject(

--- a/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
@@ -511,5 +511,70 @@ void main() {
         },
       );
     });
+
+    group('AnyModel nullability', () {
+      late Context context;
+      late NameManager nameManager;
+      const package = 'package:test/test.dart';
+
+      setUp(() {
+        context = Context.initial();
+        nameManager = NameManager(
+          generator: NameGenerator(),
+          stableModelSorter: StableModelSorter(),
+        );
+      });
+
+      test('returns nullable Object for AnyModel by default', () {
+        final model = AnyModel(context: context);
+
+        final result = typeReference(model, nameManager, package);
+
+        expect(result.symbol, 'Object');
+        expect(result.url, 'dart:core');
+        expect(result.isNullable, isTrue);
+      });
+
+      test(
+        'returns nullable Object for AnyModel with isNullableOverride true',
+        () {
+          final model = AnyModel(context: context);
+
+          final result = typeReference(
+            model,
+            nameManager,
+            package,
+            isNullableOverride: true,
+          );
+
+          expect(result.symbol, 'Object');
+          expect(result.url, 'dart:core');
+          expect(result.isNullable, isTrue);
+        },
+      );
+
+      test(
+        'returns nullable Object for AnyModel in ListModel content',
+        () {
+          final anyModel = AnyModel(context: context);
+          final model = ListModel(
+            content: anyModel,
+            context: context,
+          );
+
+          final result = typeReference(model, nameManager, package);
+
+          expect(result.symbol, 'List');
+          expect(result.url, 'dart:core');
+          expect(result.isNullable, isFalse);
+          expect(result.types, hasLength(1));
+
+          final innerType = result.types[0] as TypeReference;
+          expect(innerType.symbol, 'Object');
+          expect(innerType.url, 'dart:core');
+          expect(innerType.isNullable, isTrue);
+        },
+      );
+    });
   });
 }


### PR DESCRIPTION
## Summary
- Cookie parameters with AnyModel (`schema: true` in OpenAPI 3.1) now use `encodeAnyToForm` for runtime type dispatch instead of calling `.toForm()` directly on `Object?`
- Handles both scalar AnyModel and `List<AnyModel>` cookie parameters
- Adds integration test cases for AnyModel cookies (scalar with string/int values, array with mixed values)

## Test plan
- [x] Unit tests for AnyModel cookie encoding (scalar required, scalar optional, list)
- [x] Unit tests for AnyModel type reference nullability behavior
- [x] Integration tests: 58 cookie tests pass including 3 new AnyModel cases
- [x] `fvm dart analyze` clean (zero errors)
- [x] 100% patch coverage (39/39 lines)