### PR TITLE
fix: handle AliasModel in cookie parameter encoding

### DIFF
--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -676,4 +676,85 @@ void main() {
       expect(getCookieHeader(response), 'items=a,1,true');
     });
   });
+
+  group('alias-wrapped cookies', () {
+    test('nested alias to list of booleans', () async {
+      // FlagList -> BoolArray -> array of boolean. Without alias resolution,
+      // the cookie generator produced code that did not compile.
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasBoolListCookie(
+        flags: [true, false, true],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'flags=true,false,true');
+    });
+
+    test('nested alias to list of integers encodes as form list', () async {
+      // NumberList -> IntArray -> array of integer. Regression: without
+      // alias resolution, this fell through to the FormBinaryEncoder path
+      // and produced incorrect encoding.
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasIntListCookie(numbers: [1, 2, 3]);
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'numbers=1,2,3');
+    });
+
+    test('alias to list of strings', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasStringListCookie(
+        names: ['alice', 'bob', 'carol'],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'names=alice,bob,carol');
+    });
+
+    test('optional alias to list of integers when provided', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testOptionalAliasIntListCookie(
+        numbers: [10, 20],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'numbers=10,20');
+    });
+
+    test('optional alias to list of integers when not provided', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testOptionalAliasIntListCookie();
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), isNull);
+    });
+
+    test('alias to map of integers', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasMapCookie(
+        prefs: {'volume': 80, 'brightness': 50},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'prefs=volume=80&brightness=50');
+    });
+
+    test('alias to AnyModel scalar', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasAnyCookie(data: 'hello');
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'data=hello');
+    });
+
+    test('alias to list of AnyModel', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.testAliasArrayAnyCookie(
+        items: ['a', 1, true],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(getCookieHeader(response), 'items=a,1,true');
+    });
+  });
 }

--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -679,8 +679,6 @@ void main() {
 
   group('alias-wrapped cookies', () {
     test('nested alias to list of booleans', () async {
-      // FlagList -> BoolArray -> array of boolean. Without alias resolution,
-      // the cookie generator produced code that did not compile.
       final api = buildCookiesApi(responseStatus: '204');
       final response = await api.testAliasBoolListCookie(
         flags: [true, false, true],
@@ -691,9 +689,6 @@ void main() {
     });
 
     test('nested alias to list of integers encodes as form list', () async {
-      // NumberList -> IntArray -> array of integer. Regression: without
-      // alias resolution, this fell through to the FormBinaryEncoder path
-      // and produced incorrect encoding.
       final api = buildCookiesApi(responseStatus: '204');
       final response = await api.testAliasIntListCookie(numbers: [1, 2, 3]);
 

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -693,8 +693,6 @@ paths:
           description: No content
 
   # Cookie schema is $ref -> $ref -> array of boolean.
-  # Reproduces the bug where the cookie generator skipped the list path
-  # because the model was AliasModel rather than ListModel.
   /alias-bool-list-cookie:
     get:
       operationId: testAliasBoolListCookie
@@ -715,8 +713,6 @@ paths:
           description: No content
 
   # Cookie schema is $ref -> $ref -> array of integer.
-  # Regression: List<int> has a FormBinaryEncoder extension that lets the
-  # default branch silently compile but produces wrong (binary) encoding.
   /alias-int-list-cookie:
     get:
       operationId: testAliasIntListCookie

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -692,6 +692,150 @@ paths:
         '204':
           description: No content
 
+  # Cookie schema is $ref -> $ref -> array of boolean.
+  # Reproduces the bug where the cookie generator skipped the list path
+  # because the model was AliasModel rather than ListModel.
+  /alias-bool-list-cookie:
+    get:
+      operationId: testAliasBoolListCookie
+      tags:
+        - cookies
+      summary: Test cookie with nested alias to list of booleans
+      description: Demonstrates a cookie parameter using $ref to $ref to array of booleans
+      parameters:
+        - name: flags
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/FlagList'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Cookie schema is $ref -> $ref -> array of integer.
+  # Regression: List<int> has a FormBinaryEncoder extension that lets the
+  # default branch silently compile but produces wrong (binary) encoding.
+  /alias-int-list-cookie:
+    get:
+      operationId: testAliasIntListCookie
+      tags:
+        - cookies
+      summary: Test cookie with nested alias to list of integers
+      description: Demonstrates a cookie parameter using $ref to $ref to array of integers
+      parameters:
+        - name: numbers
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/NumberList'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Cookie schema is $ref -> array of string (sanity case).
+  /alias-string-list-cookie:
+    get:
+      operationId: testAliasStringListCookie
+      tags:
+        - cookies
+      summary: Test cookie with alias to list of strings
+      description: Demonstrates a cookie parameter using $ref to array of strings
+      parameters:
+        - name: names
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/StringArray'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Optional alias to list of integers (covers nullable path).
+  /optional-alias-int-list-cookie:
+    get:
+      operationId: testOptionalAliasIntListCookie
+      tags:
+        - cookies
+      summary: Test optional cookie with alias to list of integers
+      description: Demonstrates an optional cookie parameter using $ref to array of integers
+      parameters:
+        - name: numbers
+          in: cookie
+          required: false
+          schema:
+            $ref: '#/components/schemas/IntArray'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Cookie schema is $ref -> object with additionalProperties: integer.
+  /alias-map-cookie:
+    get:
+      operationId: testAliasMapCookie
+      tags:
+        - cookies
+      summary: Test cookie with alias to map of integers
+      description: Demonstrates a cookie parameter using $ref to a map schema
+      parameters:
+        - name: prefs
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/IntPrefsMap'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Cookie schema is $ref -> boolean schema true (alias to AnyModel scalar).
+  /alias-any-cookie:
+    get:
+      operationId: testAliasAnyCookie
+      tags:
+        - cookies
+      summary: Test cookie with alias to AnyModel
+      description: Demonstrates a cookie parameter using $ref to a true boolean schema
+      parameters:
+        - name: data
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/AnyData'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Cookie schema is $ref -> array of items: true (alias to list of AnyModel).
+  /alias-array-any-cookie:
+    get:
+      operationId: testAliasArrayAnyCookie
+      tags:
+        - cookies
+      summary: Test cookie with alias to list of AnyModel
+      description: Demonstrates a cookie parameter using $ref to an array of any items
+      parameters:
+        - name: items
+          in: cookie
+          required: true
+          schema:
+            $ref: '#/components/schemas/AnyList'
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
 components:
   schemas:
     ThemeEnum:
@@ -743,6 +887,42 @@ components:
           properties:
             theme:
               type: string
+
+    # Nested alias chain: FlagList -> BoolArray -> array of boolean.
+    FlagList:
+      $ref: '#/components/schemas/BoolArray'
+    BoolArray:
+      type: array
+      items:
+        type: boolean
+
+    # Nested alias chain: NumberList -> IntArray -> array of integer.
+    NumberList:
+      $ref: '#/components/schemas/IntArray'
+    IntArray:
+      type: array
+      items:
+        type: integer
+
+    # Single alias to array of string.
+    StringArray:
+      type: array
+      items:
+        type: string
+
+    # Alias to map (object with additionalProperties: integer).
+    IntPrefsMap:
+      type: object
+      additionalProperties:
+        type: integer
+
+    # Alias to AnyModel (boolean schema true).
+    AnyData: true
+
+    # Alias to list of AnyModel.
+    AnyList:
+      type: array
+      items: true
 
   parameters:
     SessionCookie:

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -413,8 +413,13 @@ class OptionsGenerator {
     final paramName = cookie.normalizedName;
     final explode = cookie.parameter.explode;
 
-    if (model is ListModel) {
-      final contentModel = model.content.resolved;
+    // Resolve aliases so a cookie schema declared via $ref to a list/map/any
+    // schema is routed to the correct encoding branch. .resolved follows
+    // nested alias chains automatically.
+    final resolvedModel = model.resolved;
+
+    if (resolvedModel is ListModel) {
+      final contentModel = resolvedModel.content.resolved;
 
       if (contentModel is StringModel) {
         final encodedValue = refer(paramName).property('toForm').call([], {
@@ -503,10 +508,10 @@ class OptionsGenerator {
     }
 
     // MapModel: convert values to Map<String, String> before calling toForm.
-    if (model is MapModel) {
+    if (resolvedModel is MapModel) {
       final converted = buildMapToStringMapExpression(
         refer(paramName),
-        model,
+        resolvedModel,
         isNullable: false,
       );
 
@@ -538,7 +543,7 @@ class OptionsGenerator {
     }
 
     // AnyModel: use encodeAnyToForm for runtime type dispatch.
-    if (model is AnyModel) {
+    if (resolvedModel is AnyModel) {
       final encodedValue = refer(
         'encodeAnyToForm',
         'package:tonik_util/tonik_util.dart',

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1884,6 +1884,606 @@ void main() {
       },
     );
 
+    group('alias-wrapped cookie parameters', () {
+      test(
+        'alias to list of strings routes through list path',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'tags',
+            rawName: 'tags',
+            description: 'Alias to list of strings',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'TagList',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasStringListCookie',
+            context: context,
+            summary: 'With alias string list cookie',
+            description: 'Operation with alias-to-list-of-string cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-string-list-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'tags', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'tags',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'TagList');
+
+          const expectedMethod = r'''
+            Options _options({required TagList tags}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [r'tags=', tags.toForm(explode: false, allowEmpty: true)].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'alias to list of integers uses list-form encoding (not binary)',
+        () {
+          // Regression: List<int> has a FormBinaryEncoder extension that
+          // accidentally compiles when the alias branch was missed, but it
+          // produces wrong output. The fix must route this through the
+          // generic list branch so each element calls .toForm individually.
+          final cookieParam = CookieParameterObject(
+            name: 'numbers',
+            rawName: 'numbers',
+            description: 'Alias to list of integers',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'IntList',
+              model: ListModel(
+                content: IntegerModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasIntListCookie',
+            context: context,
+            summary: 'With alias int list cookie',
+            description: 'Operation with alias-to-list-of-int cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-int-list-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'numbers', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'numbers',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'IntList');
+
+          const expectedMethod = r'''
+            Options _options({required IntList numbers}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [
+                  r'numbers=',
+                  numbers
+                      .map((e) => e.toForm(explode: false, allowEmpty: true))
+                      .toList()
+                      .toForm(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                      ),
+                ].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'nested alias chain to list of booleans routes through list path',
+        () {
+          // Reproduces the bug: FlagList -> BoolArray -> array of boolean.
+          // Without the .resolved unwrap, model is AliasModel and falls
+          // through to the .toForm() default path which has no extension on
+          // List<bool>, producing a compile error.
+          final boolArray = AliasModel(
+            name: 'BoolArray',
+            model: ListModel(
+              content: BooleanModel(context: context),
+              context: context,
+            ),
+            context: context,
+          );
+          final flagList = AliasModel(
+            name: 'FlagList',
+            model: boolArray,
+            context: context,
+          );
+
+          final cookieParam = CookieParameterObject(
+            name: 'flags',
+            rawName: 'flags',
+            description: 'Nested alias chain to list of booleans',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: flagList,
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withNestedAliasBoolListCookie',
+            context: context,
+            summary: 'With nested alias bool list cookie',
+            description: 'Operation with nested-alias-to-list-of-bool cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/nested-alias-bool-list-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'flags', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'flags',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'FlagList');
+
+          const expectedMethod = r'''
+            Options _options({required FlagList flags}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [
+                  r'flags=',
+                  flags
+                      .map((e) => e.toForm(explode: false, allowEmpty: true))
+                      .toList()
+                      .toForm(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                      ),
+                ].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'optional alias to list of integers routes through list path',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'numbers',
+            rawName: 'numbers',
+            description: 'Optional alias to list of integers',
+            isRequired: false,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'IntList',
+              model: ListModel(
+                content: IntegerModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withOptionalAliasIntListCookie',
+            context: context,
+            summary: 'With optional alias int list cookie',
+            description: 'Operation with optional alias-to-list-of-int cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-alias-int-list-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'numbers', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'numbers',
+          );
+          expect(param.required, isFalse);
+          expect(param.type?.accept(emitter).toString(), 'IntList?');
+
+          const expectedMethod = r'''
+            Options _options({IntList? numbers}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              if (numbers != null) {
+                _$cookieParts.add(
+                  [
+                    r'numbers=',
+                    numbers
+                        .map((e) => e.toForm(explode: false, allowEmpty: true))
+                        .toList()
+                        .toForm(
+                          explode: false,
+                          allowEmpty: true,
+                          alreadyEncoded: true,
+                        ),
+                  ].join(),
+                );
+              }
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test('alias to map routes through map path', () {
+        final cookieParam = CookieParameterObject(
+          name: 'prefs',
+          rawName: 'prefs',
+          description: 'Alias to map of integers',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: AliasModel(
+            name: 'PrefsMap',
+            model: MapModel(
+              valueModel: IntegerModel(context: context),
+              context: context,
+            ),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withAliasMapCookie',
+          context: context,
+          summary: 'With alias map cookie',
+          description: 'Operation with alias-to-map cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/alias-map-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'prefs', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'prefs',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.symbol, 'PrefsMap');
+
+        const expectedMethod = r'''
+          Options _options({required PrefsMap prefs}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'prefs=',
+                prefs
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .toForm(explode: false, allowEmpty: true),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('alias to AnyModel scalar routes through any path', () {
+        final cookieParam = CookieParameterObject(
+          name: 'data',
+          rawName: 'data',
+          description: 'Alias to AnyModel scalar',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: AliasModel(
+            name: 'AnyData',
+            model: AnyModel(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withAliasAnyCookie',
+          context: context,
+          summary: 'With alias any cookie',
+          description: 'Operation with alias-to-AnyModel cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/alias-any-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'data', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'data',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.symbol, 'AnyData');
+
+        const expectedMethod = r'''
+          Options _options({required AnyData data}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'data=',
+                encodeAnyToForm(data, explode: false, allowEmpty: true),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test(
+        'alias to list of AnyModel routes through list-of-any path',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'items',
+            rawName: 'items',
+            description: 'Alias to list of AnyModel',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'AnyList',
+              model: ListModel(
+                content: AnyModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasAnyListCookie',
+            context: context,
+            summary: 'With alias any list cookie',
+            description: 'Operation with alias-to-list-of-AnyModel cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-any-list-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'items', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'items',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'AnyList');
+
+          const expectedMethod = r'''
+            Options _options({required AnyList items}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [
+                  r'items=',
+                  items
+                      .map(
+                        (e) =>
+                            encodeAnyToForm(e, explode: false, allowEmpty: true),
+                      )
+                      .toList()
+                      .toForm(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                      ),
+                ].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+    });
+
     group('multipart content type', () {
       test('sets contentType to null for single multipart content type', () {
         final requestBody = RequestBodyObject(

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -2482,6 +2482,332 @@ void main() {
           );
         },
       );
+
+      test(
+        'alias to list of strings with explode true threads explode through',
+        () {
+          // Cookies default to explode: true for form style. Ensure the
+          // generated body wires the explode flag literal through to the
+          // toForm call so a regression that swaps the literal for
+          // literalBool(false) would be caught.
+          final cookieParam = CookieParameterObject(
+            name: 'names',
+            rawName: 'names',
+            description: 'Alias to list of strings, explode true',
+            isRequired: true,
+            isDeprecated: false,
+            explode: true,
+            model: AliasModel(
+              name: 'NameList',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasStringListCookieExplodeTrue',
+            context: context,
+            summary: 'With alias string list cookie explode true',
+            description: 'Operation with alias-to-list-of-string cookie '
+                'using explode true',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-string-list-cookie-explode-true',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'names', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'names',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'NameList');
+
+          const expectedMethod = r'''
+            Options _options({required NameList names}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [r'names=', names.toForm(explode: true, allowEmpty: true)].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'alias to map with unsupported value type throws EncodingException',
+        () {
+          // Covers the converted == null path inside the MapModel branch when
+          // reached via an alias. A future refactor of
+          // buildMapToStringMapExpression that quietly accepts complex value
+          // types would silently regress this.
+          final cookieParam = CookieParameterObject(
+            name: 'data',
+            rawName: 'data',
+            description: 'Alias to map of complex values',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'NestedMap',
+              model: MapModel(
+                valueModel: ClassModel(
+                  name: 'Nested',
+                  properties: const [],
+                  context: context,
+                  isDeprecated: false,
+                ),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasUnsupportedMapCookie',
+            context: context,
+            summary: 'With alias unsupported map cookie',
+            description: 'Operation with alias-to-map cookie of complex '
+                'values',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-unsupported-map-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'data', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'data',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'NestedMap');
+
+          const expectedMethod = r'''
+            Options _options({required NestedMap data}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              throw EncodingException(
+                'Map with complex value types cannot be form-encoded for cookie data',
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test('optional alias to map', () {
+        final cookieParam = CookieParameterObject(
+          name: 'prefs',
+          rawName: 'prefs',
+          description: 'Optional alias to map of integers',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: AliasModel(
+            name: 'PrefsMap',
+            model: MapModel(
+              valueModel: IntegerModel(context: context),
+              context: context,
+            ),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalAliasMapCookie',
+          context: context,
+          summary: 'With optional alias map cookie',
+          description: 'Operation with optional alias-to-map cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-alias-map-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'prefs', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'prefs',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'PrefsMap?');
+
+        const expectedMethod = r'''
+          Options _options({PrefsMap? prefs}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (prefs != null) {
+              _$cookieParts.add(
+                [
+                  r'prefs=',
+                  prefs
+                      .map((k, v) => MapEntry(k, v.toString()))
+                      .toForm(explode: false, allowEmpty: true),
+                ].join(),
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('optional alias to AnyModel scalar', () {
+        final cookieParam = CookieParameterObject(
+          name: 'data',
+          rawName: 'data',
+          description: 'Optional alias to AnyModel scalar',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: AliasModel(
+            name: 'AnyData',
+            model: AnyModel(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalAliasAnyCookie',
+          context: context,
+          summary: 'With optional alias any cookie',
+          description: 'Operation with optional alias-to-AnyModel cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-alias-any-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'data', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'data',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'AnyData?');
+
+        const expectedMethod = r'''
+          Options _options({AnyData? data}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (data != null) {
+              _$cookieParts.add(
+                [
+                  r'data=',
+                  encodeAnyToForm(data, explode: false, allowEmpty: true),
+                ].join(),
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
     });
 
     group('multipart content type', () {

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1965,10 +1965,6 @@ void main() {
       test(
         'alias to list of integers uses list-form encoding (not binary)',
         () {
-          // Regression: List<int> has a FormBinaryEncoder extension that
-          // accidentally compiles when the alias branch was missed, but it
-          // produces wrong output. The fix must route this through the
-          // generic list branch so each element calls .toForm individually.
           final cookieParam = CookieParameterObject(
             name: 'numbers',
             rawName: 'numbers',
@@ -2056,10 +2052,6 @@ void main() {
       test(
         'nested alias chain to list of booleans routes through list path',
         () {
-          // Reproduces the bug: FlagList -> BoolArray -> array of boolean.
-          // Without the .resolved unwrap, model is AliasModel and falls
-          // through to the .toForm() default path which has no extension on
-          // List<bool>, producing a compile error.
           final boolArray = AliasModel(
             name: 'BoolArray',
             model: ListModel(
@@ -2486,10 +2478,6 @@ void main() {
       test(
         'alias to list of strings with explode true threads explode through',
         () {
-          // Cookies default to explode: true for form style. Ensure the
-          // generated body wires the explode flag literal through to the
-          // toForm call so a regression that swaps the literal for
-          // literalBool(false) would be caught.
           final cookieParam = CookieParameterObject(
             name: 'names',
             rawName: 'names',
@@ -2568,10 +2556,6 @@ void main() {
       test(
         'alias to map with unsupported value type throws EncodingException',
         () {
-          // Covers the converted == null path inside the MapModel branch when
-          // reached via an alias. A future refactor of
-          // buildMapToStringMapExpression that quietly accepts complex value
-          // types would silently regress this.
           final cookieParam = CookieParameterObject(
             name: 'data',
             rawName: 'data',


### PR DESCRIPTION
## Summary

Cookie parameters whose schema is a `$ref` to a list/map/any schema were routed through the bare `.toForm()` default path because `_addCookieEncodingStatement` checked `model is ListModel/MapModel/AnyModel` directly. For named schemas the model is `AliasModel`, so those checks failed silently:

- `List<bool>` (and most non-`String`/non-`int` element types): generated code did not compile (`The method 'toForm' isn't defined for the type 'List'`).
- `List<int>`: compiled via an unrelated `FormBinaryEncoder` extension on `List<int>` and silently produced binary-shaped output instead of the form-style list encoding the spec demands.
- `Map<String, NonString>` and `AnyModel` via alias: same class of failure.

## Fix

Resolve the alias chain via `model.resolved` before the type checks. `.resolved` follows nested aliases automatically, matching the canonical pattern in `all_of_generator.dart` and `one_of_generator.dart`. The 12-line generator change is purely a routing fix — the inner encoding logic is unchanged.

## Test plan

- [x] Unit tests in `options_generator_test.dart` covering: alias→list-of-string, alias→list-of-int (binary-encoding regression), nested alias chain `FlagList`→`BoolArray`→list-of-bool (the bug spec scenario), optional alias→list-of-int, alias→map, alias→AnyModel scalar, alias→list-of-AnyModel. Full method body comparisons via `DartFormatter` + `collapseWhitespace`.
- [x] Integration fixture (`openapi.yaml`) extended with seven new operations covering each alias case, including the exact nested-alias chain from the bug.
- [x] Integration tests asserting the produced `Cookie` header (e.g. `flags=true,false,true`, `numbers=1,2,3`, `prefs=volume=80&brightness=50`).
- [x] `fvm dart analyze` clean.
- [x] `melos run test` passes (4233 unit tests + integration suites).
- [x] Patch coverage 100%.