### PR TITLE
fix: handle Base64Model variant in oneOf and anyOf encoding methods

### DIFF
--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -772,3 +772,22 @@ components:
       oneOf:
         - true
         - $ref: '#/components/schemas/Class1'
+
+    # =========================================================================
+    # Base64 (format: byte) variant in oneOf and anyOf
+    # =========================================================================
+    # `type: string, format: byte` is parsed as Base64Model and represented as
+    # TonikFile at the API surface. Encoding to simple/form/label parameter
+    # styles must convert the file via toBase64String() before delegating to
+    # the String encoders, mirroring the precedent in plain Base64 encoders.
+    OneOfBase64Variant:
+      oneOf:
+        - $ref: '#/components/schemas/Class1'
+        - type: string
+          format: byte
+
+    AnyOfBase64Variant:
+      anyOf:
+        - $ref: '#/components/schemas/Class1'
+        - type: string
+          format: byte

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -316,8 +316,6 @@ class AnyOfGenerator {
     final codes = <Code>[];
 
     if (fieldModel.resolved is Base64Model) {
-      // Base64Model is represented as TonikFile at the API surface; convert
-      // via toBase64String() before delegating to the String encoder.
       codes.add(
         Code(
           'final $tmpVarName = $fieldName!.toBase64String().$toMethodName( '
@@ -476,8 +474,6 @@ class AnyOfGenerator {
     final codes = <Code>[];
 
     if (fieldModel.resolved is Base64Model) {
-      // Base64Model is represented as TonikFile at the API surface; convert
-      // via toBase64String() before delegating to the String encoder.
       codes.add(
         Code(
           'final $tmpVarName = $fieldName!.toBase64String().toLabel( '

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -315,7 +315,20 @@ class AnyOfGenerator {
     final toMethodName = isForm ? 'toForm' : 'toSimple';
     final codes = <Code>[];
 
-    if (fieldModel is BinaryModel) {
+    if (fieldModel.resolved is Base64Model) {
+      // Base64Model is represented as TonikFile at the API surface; convert
+      // via toBase64String() before delegating to the String encoder.
+      codes.add(
+        Code(
+          'final $tmpVarName = $fieldName!.toBase64String().$toMethodName( '
+          'explode: explode, allowEmpty: allowEmpty'
+          '${isForm ? ', useQueryComponent: useQueryComponent' : ''});',
+        ),
+      );
+      if (needsValues) {
+        codes.add(Code('_\$values.add($tmpVarName);'));
+      }
+    } else if (fieldModel is BinaryModel) {
       codes.add(
         generateEncodingExceptionExpression(
           'Binary data cannot be ${isForm ? 'form' : 'simple'}-encoded',
@@ -462,7 +475,19 @@ class AnyOfGenerator {
   }) {
     final codes = <Code>[];
 
-    if (fieldModel is BinaryModel) {
+    if (fieldModel.resolved is Base64Model) {
+      // Base64Model is represented as TonikFile at the API surface; convert
+      // via toBase64String() before delegating to the String encoder.
+      codes.add(
+        Code(
+          'final $tmpVarName = $fieldName!.toBase64String().toLabel( '
+          'explode: explode, allowEmpty: allowEmpty);',
+        ),
+      );
+      if (needsValues) {
+        codes.add(Code('_\$values.add($tmpVarName);'));
+      }
+    } else if (fieldModel is BinaryModel) {
       codes.add(
         generateEncodingExceptionExpression(
           'Binary data cannot be label-encoded',

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -917,8 +917,6 @@ class OneOfGenerator {
           const Code(','),
         ]);
       } else if (m.model.resolved is Base64Model) {
-        // Base64Model is represented as TonikFile at the API surface; convert
-        // via toBase64String() before delegating to the String encoder.
         final isNullable = m.model.isEffectivelyNullable;
 
         caseCodes.add(Code('$variantName(:final value) => '));
@@ -1142,8 +1140,6 @@ class OneOfGenerator {
           const Code(','),
         ]);
       } else if (m.model.resolved is Base64Model) {
-        // Base64Model is represented as TonikFile at the API surface; convert
-        // via toBase64String() before delegating to the String encoder.
         final isNullable = m.model.isEffectivelyNullable;
 
         caseCodes.add(Code('$variantName(:final value) => '));
@@ -1647,8 +1643,6 @@ class OneOfGenerator {
           const Code(','),
         ]);
       } else if (m.model.resolved is Base64Model) {
-        // Base64Model is represented as TonikFile at the API surface; convert
-        // via toBase64String() before delegating to the String encoder.
         final isNullable = m.model.isEffectivelyNullable;
 
         caseCodes.add(Code('$variantName(:final value) => '));

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -916,6 +916,31 @@ class OneOfGenerator {
               .code,
           const Code(','),
         ]);
+      } else if (m.model.resolved is Base64Model) {
+        // Base64Model is represented as TonikFile at the API surface; convert
+        // via toBase64String() before delegating to the String encoder.
+        final isNullable = m.model.isEffectivelyNullable;
+
+        caseCodes.add(Code('$variantName(:final value) => '));
+
+        if (isNullable) {
+          caseCodes.addAll([
+            const Code("value == null ? '' : "),
+          ]);
+        }
+
+        caseCodes.addAll([
+          refer('value')
+              .property('toBase64String')
+              .call([])
+              .property('toSimple')
+              .call([], {
+                'explode': refer('explode'),
+                'allowEmpty': refer('allowEmpty'),
+              })
+              .code,
+          const Code(','),
+        ]);
       } else if (m.model.resolved is BinaryModel) {
         caseCodes.addAll([
           Code.scope(
@@ -1113,6 +1138,32 @@ class OneOfGenerator {
                 ),
               ])
               .thrown
+              .code,
+          const Code(','),
+        ]);
+      } else if (m.model.resolved is Base64Model) {
+        // Base64Model is represented as TonikFile at the API surface; convert
+        // via toBase64String() before delegating to the String encoder.
+        final isNullable = m.model.isEffectivelyNullable;
+
+        caseCodes.add(Code('$variantName(:final value) => '));
+
+        if (isNullable) {
+          caseCodes.addAll([
+            const Code("value == null ? '' : "),
+          ]);
+        }
+
+        caseCodes.addAll([
+          refer('value')
+              .property('toBase64String')
+              .call([])
+              .property('toForm')
+              .call([], {
+                'explode': refer('explode'),
+                'allowEmpty': refer('allowEmpty'),
+                'useQueryComponent': refer('useQueryComponent'),
+              })
               .code,
           const Code(','),
         ]);
@@ -1592,6 +1643,31 @@ class OneOfGenerator {
                 ),
               ])
               .thrown
+              .code,
+          const Code(','),
+        ]);
+      } else if (m.model.resolved is Base64Model) {
+        // Base64Model is represented as TonikFile at the API surface; convert
+        // via toBase64String() before delegating to the String encoder.
+        final isNullable = m.model.isEffectivelyNullable;
+
+        caseCodes.add(Code('$variantName(:final value) => '));
+
+        if (isNullable) {
+          caseCodes.addAll([
+            const Code("value == null ? '' : "),
+          ]);
+        }
+
+        caseCodes.addAll([
+          refer('value')
+              .property('toBase64String')
+              .call([])
+              .property('toLabel')
+              .call([], {
+                'explode': refer('explode'),
+                'allowEmpty': refer('allowEmpty'),
+              })
               .code,
           const Code(','),
         ]);

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -2690,4 +2690,255 @@ bool operator ==(Object other) {
       );
     });
   });
+
+  group('Base64Model in AnyOf', () {
+    test(
+      'toSimple converts Base64Model field via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfBase64',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final klass = generator.generateClass(model);
+        final toSimpleMethod = klass.methods.firstWhere(
+          (m) => m.name == 'toSimple',
+        );
+        final generated = format(toSimpleMethod.accept(emitter).toString());
+
+        const expectedMethod = r'''
+@override
+String toSimple({required bool explode, required bool allowEmpty}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (tonikFile != null) {
+    final _$tonikFileSimple = tonikFile!.toBase64String().toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+    );
+    _$values.add(_$tonikFileSimple);
+  }
+  if (text != null) {
+    final _$textSimple = text!.parameterProperties(allowEmpty: allowEmpty);
+    _$mapValues.add(_$textSimple);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf simple encoding for AnyOfBase64: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf simple encoding for AnyOfBase64: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+}
+''';
+
+        expect(generated.trim(), format(expectedMethod).trim());
+      },
+    );
+
+    test(
+      'toForm converts Base64Model field via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfBase64',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final klass = generator.generateClass(model);
+        final toFormMethod = klass.methods.firstWhere(
+          (m) => m.name == 'toForm',
+        );
+        final generated = format(toFormMethod.accept(emitter).toString());
+
+        const expectedMethod = r'''
+@override
+String toForm({
+  required bool explode,
+  required bool allowEmpty,
+  bool useQueryComponent = false,
+}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (tonikFile != null) {
+    final _$tonikFileForm = tonikFile!.toBase64String().toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+    _$values.add(_$tonikFileForm);
+  }
+  if (text != null) {
+    final _$textForm = text!.parameterProperties(allowEmpty: allowEmpty);
+    _$mapValues.add(_$textForm);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf form encoding for AnyOfBase64: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf form encoding for AnyOfBase64: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+}
+''';
+
+        expect(generated.trim(), format(expectedMethod).trim());
+      },
+    );
+
+    test(
+      'toLabel converts Base64Model field via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfBase64',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final klass = generator.generateClass(model);
+        final toLabelMethod = klass.methods.firstWhere(
+          (m) => m.name == 'toLabel',
+        );
+        final generated = format(toLabelMethod.accept(emitter).toString());
+
+        const expectedMethod = r'''
+@override
+String toLabel({required bool explode, required bool allowEmpty}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (tonikFile != null) {
+    final _$tonikFileLabel = tonikFile!.toBase64String().toLabel(
+      explode: explode,
+      allowEmpty: allowEmpty,
+    );
+    _$values.add(_$tonikFileLabel);
+  }
+  if (text != null) {
+    final _$textLabel = text!.parameterProperties(allowEmpty: allowEmpty);
+    _$mapValues.add(_$textLabel);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf label encoding for AnyOfBase64: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf label encoding for AnyOfBase64: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toLabel(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+}
+''';
+
+        expect(generated.trim(), format(expectedMethod).trim());
+      },
+    );
+  });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -3390,4 +3390,396 @@ bool operator ==(Object other) {
       );
     });
   });
+
+  group('Base64Model in OneOf', () {
+    test(
+      'toSimple converts Base64Model variant via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toSimpleMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toSimple',
+        );
+        final generated = format(toSimpleMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toSimple({required bool explode, required bool allowEmpty}) {
+            return switch (this) {
+              ValueBase64(:final value) => value.toBase64String().toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+              ValueText(:final value) => value.toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'toSimple wraps nullable Base64Model variant in null check',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (
+              discriminatorValue: null,
+              model: AliasModel(
+                name: 'NullableData',
+                model: Base64Model(context: context),
+                isNullable: true,
+                context: context,
+              ),
+            ),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toSimpleMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toSimple',
+        );
+        final generated = format(toSimpleMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toSimple({required bool explode, required bool allowEmpty}) {
+            return switch (this) {
+              ValueNullableData(:final value) => value == null
+                  ? ''
+                  : value.toBase64String().toSimple(
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                    ),
+              ValueText(:final value) => value.toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'toForm converts Base64Model variant via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toFormMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toForm',
+        );
+        final generated = format(toFormMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toForm({
+            required bool explode,
+            required bool allowEmpty,
+            bool useQueryComponent = false,
+          }) {
+            return switch (this) {
+              ValueBase64(:final value) => value.toBase64String().toForm(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+              ),
+              ValueText(:final value) => value.toForm(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'toForm wraps nullable Base64Model variant in null check',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (
+              discriminatorValue: null,
+              model: AliasModel(
+                name: 'NullableData',
+                model: Base64Model(context: context),
+                isNullable: true,
+                context: context,
+              ),
+            ),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toFormMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toForm',
+        );
+        final generated = format(toFormMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toForm({
+            required bool explode,
+            required bool allowEmpty,
+            bool useQueryComponent = false,
+          }) {
+            return switch (this) {
+              ValueNullableData(:final value) => value == null
+                  ? ''
+                  : value.toBase64String().toForm(
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                      useQueryComponent: useQueryComponent,
+                    ),
+              ValueText(:final value) => value.toForm(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'toLabel converts Base64Model variant via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toLabelMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toLabel',
+        );
+        final generated = format(toLabelMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toLabel({required bool explode, required bool allowEmpty}) {
+            return switch (this) {
+              ValueBase64(:final value) => value.toBase64String().toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+              ValueText(:final value) => value.toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'toLabel wraps nullable Base64Model variant in null check',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+            ),
+          ],
+          context: context,
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (
+              discriminatorValue: null,
+              model: AliasModel(
+                name: 'NullableData',
+                model: Base64Model(context: context),
+                isNullable: true,
+                context: context,
+              ),
+            ),
+          },
+          context: context,
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final toLabelMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'toLabel',
+        );
+        final generated = format(toLabelMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String toLabel({required bool explode, required bool allowEmpty}) {
+            return switch (this) {
+              ValueNullableData(:final value) => value == null
+                  ? ''
+                  : value.toBase64String().toLabel(
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                    ),
+              ValueText(:final value) => value.toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary
- `_generateToSimpleMethod`/`_generateToFormMethod`/`_generateToLabelMethod` in `one_of_generator.dart` and `_generateFieldEncoding`/`_generateFieldEncodingLabel` in `any_of_generator.dart` had explicit `BinaryModel` branches but no `Base64Model` branch. A `oneOf`/`anyOf` containing a `format: byte` variant therefore fell through to the default branch and emitted `value.toSimple/toForm/toLabel(...)` against `TonikFile`, producing `undefined_method` errors.
- Added explicit `Base64Model` branches that convert via `value.toBase64String().toX(...)`, mirroring the existing precedent in `to_simple_value_expression_generator.dart`, `to_form_query_parameter_expression_generator.dart`, `to_label_parameter_expression_generator.dart`, and `to_matrix_parameter_expression_generator.dart`.
- The first commit adds an integration-test schema reproducing the bug; the second commit applies the fix and adds unit tests.

## Test plan
- [x] `fvm dart analyze` from project root: clean (no new warnings)
- [x] `tonik_core`, `tonik_parse`, `tonik_generate`, `tonik_util`, `tonik` unit tests: all pass
- [x] Integration tests: all pass (regenerated `composition_api/lib/src/model/one_of_base64_variant.dart` and `any_of_base64_variant.dart` compile and behave correctly)
- [x] New unit tests cover toSimple/toForm/toLabel for both nullable and non-nullable Base64 variants in oneOf, and the corresponding methods in anyOf
- [x] Patch coverage: 100%