### PR TITLE
fix: handle AnyModel and NeverModel as anyOf variants

### DIFF
--- a/integration_test/composition/composition_test/test/any_of_test.dart
+++ b/integration_test/composition/composition_test/test/any_of_test.dart
@@ -4814,4 +4814,150 @@ void main() {
       });
     });
   });
+
+  group('AnyOfBooleanSchema', () {
+    group('AnyModel variant (from boolean true schema)', () {
+      late AnyOfBooleanSchema anyVariant;
+
+      setUp(() {
+        anyVariant = const AnyOfBooleanSchema(object: 'hello');
+      });
+
+      test('create with string value', () {
+        expect(anyVariant.object, 'hello');
+        expect(anyVariant.class1, isNull);
+      });
+
+      test('create with int value', () {
+        const variant = AnyOfBooleanSchema(object: 42);
+        expect(variant.object, 42);
+        expect(variant.class1, isNull);
+      });
+
+      test('create with map value', () {
+        const variant = AnyOfBooleanSchema(
+          object: <String, String>{'key': 'value'},
+        );
+        expect(variant.object, {'key': 'value'});
+      });
+
+      test('toJson uses encodeAnyToJson for primitive', () {
+        expect(anyVariant.toJson(), 'hello');
+      });
+
+      test('toJson with map value', () {
+        const variant = AnyOfBooleanSchema(
+          object: <String, String>{'key': 'value'},
+        );
+        expect(variant.toJson(), {'key': 'value'});
+      });
+
+      test('fromJson with non-Class1 value falls through to AnyModel', () {
+        // Integer JSON cannot be decoded as Class1, so the AnyModel
+        // catch-all wraps the raw value.
+        final result = AnyOfBooleanSchema.fromJson(42);
+        expect(result.class1, isNull);
+        expect(result.object, 42);
+      });
+
+      test('fromJson with Class1-shaped value populates class1 only', () {
+        // When the JSON matches Class1, the catch-all is suppressed.
+        final result = AnyOfBooleanSchema.fromJson(
+          const <String, Object?>{'name': 'test'},
+        );
+        expect(result.class1, const Class1(name: 'test'));
+        expect(result.object, isNull);
+      });
+
+      test('fromJson roundtrip with raw string value', () {
+        const original = AnyOfBooleanSchema(object: 'raw string');
+        final json = original.toJson();
+        final reconstructed = AnyOfBooleanSchema.fromJson(json);
+        expect(reconstructed.class1, isNull);
+        expect(reconstructed.object, 'raw string');
+      });
+
+      test('toSimple throws EncodingException', () {
+        expect(
+          () => anyVariant.toSimple(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toForm throws EncodingException', () {
+        expect(
+          () => anyVariant.toForm(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toLabel throws EncodingException', () {
+        expect(
+          () => anyVariant.toLabel(explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('toMatrix throws EncodingException', () {
+        expect(
+          () => anyVariant.toMatrix('p', explode: true, allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('uriEncode throws EncodingException', () {
+        expect(
+          () => anyVariant.uriEncode(allowEmpty: true),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('parameterProperties throws EncodingException', () {
+        expect(
+          () => anyVariant.parameterProperties(),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('currentEncodingShape throws EncodingException', () {
+        expect(
+          () => anyVariant.currentEncodingShape,
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('equality with same object value', () {
+        const a = AnyOfBooleanSchema(object: 'hello');
+        const b = AnyOfBooleanSchema(object: 'hello');
+        const c = AnyOfBooleanSchema(object: 'world');
+
+        expect(a, b);
+        expect(a, isNot(c));
+      });
+    });
+
+    group('Class1 variant', () {
+      late AnyOfBooleanSchema classVariant;
+
+      setUp(() {
+        classVariant = const AnyOfBooleanSchema(
+          class1: Class1(name: 'test'),
+        );
+      });
+
+      test('toJson', () {
+        expect(classVariant.toJson(), {'name': 'test'});
+      });
+
+      test('json roundtrip', () {
+        final json = classVariant.toJson();
+        final reconstructed = AnyOfBooleanSchema.fromJson(json);
+        expect(reconstructed, classVariant);
+      });
+
+      test('currentEncodingShape', () {
+        expect(classVariant.currentEncodingShape, EncodingShape.complex);
+      });
+    });
+  });
 }

--- a/integration_test/composition/composition_test/test/any_of_test.dart
+++ b/integration_test/composition/composition_test/test/any_of_test.dart
@@ -4853,15 +4853,12 @@ void main() {
       });
 
       test('fromJson with non-Class1 value falls through to AnyModel', () {
-        // Integer JSON cannot be decoded as Class1, so the AnyModel
-        // catch-all wraps the raw value.
         final result = AnyOfBooleanSchema.fromJson(42);
         expect(result.class1, isNull);
         expect(result.object, 42);
       });
 
       test('fromJson with Class1-shaped value populates class1 only', () {
-        // When the JSON matches Class1, the catch-all is suppressed.
         final result = AnyOfBooleanSchema.fromJson(
           const <String, Object?>{'name': 'test'},
         );
@@ -4870,7 +4867,6 @@ void main() {
       });
 
       test('fromJson(null) throws JsonDecodingException', () {
-        // All variants null → all-null validation throws.
         expect(
           () => AnyOfBooleanSchema.fromJson(null),
           throwsA(isA<JsonDecodingException>()),

--- a/integration_test/composition/composition_test/test/any_of_test.dart
+++ b/integration_test/composition/composition_test/test/any_of_test.dart
@@ -4869,6 +4869,14 @@ void main() {
         expect(result.object, isNull);
       });
 
+      test('fromJson(null) throws JsonDecodingException', () {
+        // All variants null → all-null validation throws.
+        expect(
+          () => AnyOfBooleanSchema.fromJson(null),
+          throwsA(isA<JsonDecodingException>()),
+        );
+      });
+
       test('fromJson roundtrip with raw string value', () {
         const original = AnyOfBooleanSchema(object: 'raw string');
         final json = original.toJson();

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -792,14 +792,7 @@ components:
         - type: string
           format: byte
 
-    # =========================================================================
-    # Boolean schema (true) in anyOf — OpenAPI 3.1 / JSON Schema 2020-12
-    # =========================================================================
-    # The boolean `true` schema becomes an AnyModel variant. The anyOf
-    # generator must handle this without producing calls to encoding methods
-    # on the resulting `Object?` field. Encoding methods throw
-    # EncodingException when the AnyModel field is set; toJson uses
-    # encodeAnyToJson; fromJson treats AnyModel as a catch-all.
+    # Boolean true → AnyModel variant (OpenAPI 3.1 / JSON Schema 2020-12).
     AnyOfBooleanSchema:
       anyOf:
         - true

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -791,3 +791,16 @@ components:
         - $ref: '#/components/schemas/Class1'
         - type: string
           format: byte
+
+    # =========================================================================
+    # Boolean schema (true) in anyOf — OpenAPI 3.1 / JSON Schema 2020-12
+    # =========================================================================
+    # The boolean `true` schema becomes an AnyModel variant. The anyOf
+    # generator must handle this without producing calls to encoding methods
+    # on the resulting `Object?` field. Encoding methods throw
+    # EncodingException when the AnyModel field is set; toJson uses
+    # encodeAnyToJson; fromJson treats AnyModel as a catch-all.
+    AnyOfBooleanSchema:
+      anyOf:
+        - true
+        - $ref: '#/components/schemas/Class1'

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -51,8 +51,12 @@ class AnyOfGenerator {
   List<Spec> generateClasses(AnyOfModel model, [String? className]) {
     final actualClassName = className ?? nameManager.modelName(model);
 
+    // NeverModel variants cannot have any value at runtime, so emitting a
+    // `Never?` field would be dead weight and trigger analyzer warnings. We
+    // skip them entirely; encoding/decoding paths simply omit them.
     final pseudoProperties = stableModelSorter
         .sortDiscriminatedModels(model.models)
+        .where((d) => d.model.resolved is! NeverModel)
         .map((discriminated) {
           final typeRef = typeReference(
             discriminated.model,
@@ -131,8 +135,10 @@ class AnyOfGenerator {
               )
             : publicClassName);
 
+    // NeverModel variants are skipped — see [generateClasses] for rationale.
     final pseudoProperties = stableModelSorter
         .sortDiscriminatedModels(model.models)
+        .where((d) => d.model.resolved is! NeverModel)
         .map((discriminated) {
           final typeRef = typeReference(
             discriminated.model,
@@ -310,10 +316,22 @@ class AnyOfGenerator {
     required bool isForm,
     required bool needsValues,
     required bool needsMapValues,
+    required String className,
     String? discriminatorValue,
   }) {
     final toMethodName = isForm ? 'toForm' : 'toSimple';
     final codes = <Code>[];
+
+    if (fieldModel.resolved is AnyModel) {
+      codes.add(
+        generateEncodingExceptionExpression(
+          'AnyModel variant of $className cannot be '
+          '${isForm ? 'form' : 'simple'}-encoded',
+          raw: true,
+        ).statement,
+      );
+      return codes;
+    }
 
     if (fieldModel.resolved is Base64Model) {
       codes.add(
@@ -469,9 +487,20 @@ class AnyOfGenerator {
     required String tmpVarName,
     required bool needsValues,
     required bool needsMapValues,
+    required String className,
     String? discriminatorValue,
   }) {
     final codes = <Code>[];
+
+    if (fieldModel.resolved is AnyModel) {
+      codes.add(
+        generateEncodingExceptionExpression(
+          'AnyModel variant of $className cannot be label-encoded',
+          raw: true,
+        ).statement,
+      );
+      return codes;
+    }
 
     if (fieldModel.resolved is Base64Model) {
       codes.add(
@@ -645,7 +674,17 @@ class AnyOfGenerator {
   ) {
     final localDecls = <Code>[];
 
+    final typedProperties = <({String normalizedName, Property property})>[];
+    final anyProperties = <({String normalizedName, Property property})>[];
     for (final n in normalizedProperties) {
+      if (n.property.model.resolved is AnyModel) {
+        anyProperties.add(n);
+      } else {
+        typedProperties.add(n);
+      }
+    }
+
+    for (final n in typedProperties) {
       final modelType = n.property.model;
       final varName = n.normalizedName;
 
@@ -667,17 +706,50 @@ class AnyOfGenerator {
       );
     }
 
+    // AnyModel acts as a catch-all: only assigned when every typed variant
+    // failed to decode. This avoids a redundant raw-value field on every
+    // successful typed decode.
+    for (final n in anyProperties) {
+      final modelType = n.property.model;
+      final varName = n.normalizedName;
+
+      localDecls.addAll([
+        _nullableTypeReference(modelType).code,
+        Code(' $varName;'),
+      ]);
+
+      if (typedProperties.isEmpty) {
+        // Degenerate anyOf with only AnyModel variants — assign directly.
+        localDecls.add(Code('$varName = json;'));
+      } else {
+        final typedNullChecks = typedProperties
+            .map((t) => '${t.normalizedName} == null')
+            .join(' && ');
+        localDecls.addAll([
+          Code('if ($typedNullChecks) {'),
+          Code('$varName = json;'),
+          const Code('}'),
+        ]);
+      }
+    }
+
     final ctorArgs = {
       for (final n in normalizedProperties)
         n.normalizedName: refer(n.normalizedName),
     };
 
-    final validationCheck = _buildAllNullValidation(
-      normalizedProperties,
-      'Invalid JSON for $className: all variants failed to decode',
-      generateJsonDecodingExceptionExpression,
-      raw: true,
-    );
+    // Validation: fail when every decodable variant ended up null.
+    // For anyOf with only AnyModel variants, AnyModel always succeeds so
+    // no validation is needed.
+    final decodableProperties = [...typedProperties, ...anyProperties];
+    final validationCheck = typedProperties.isEmpty
+        ? const Code('')
+        : _buildAllNullValidation(
+            decodableProperties,
+            'Invalid JSON for $className: all variants failed to decode',
+            generateJsonDecodingExceptionExpression,
+            raw: true,
+          );
 
     return Constructor(
       (b) => b
@@ -938,6 +1010,7 @@ class AnyOfGenerator {
             isForm: false,
             needsValues: needsValues,
             needsMapValues: needsMapValues,
+            className: className,
             discriminatorValue: hasDiscriminator ? discValue : null,
           ),
         )
@@ -1052,7 +1125,11 @@ class AnyOfGenerator {
       final modelType = n.property.model;
       final varName = n.normalizedName;
 
-      if ((modelType is ListModel && !modelType.hasSimpleContent) ||
+      if (modelType.resolved is AnyModel) {
+        // AnyModel cannot be meaningfully decoded from a parameter string —
+        // the field stays null and another variant must satisfy the input.
+        nonDecodableProperties.add(n);
+      } else if ((modelType is ListModel && !modelType.hasSimpleContent) ||
           modelType is MapModel) {
         nonDecodableProperties.add(n);
       } else {
@@ -1170,12 +1247,20 @@ class AnyOfGenerator {
     for (final n in normalizedProperties) {
       final name = n.normalizedName;
       final fieldModel = n.property.model;
+      final isAnyModel = fieldModel.resolved is AnyModel;
       final isSimple = fieldModel.encodingShape == EncodingShape.simple;
       final isList = fieldModel is ListModel;
       final isMap = fieldModel is MapModel;
 
       body.add(Code('if ($name != null) {'));
-      if (isSimple) {
+      if (isAnyModel) {
+        body.add(
+          generateEncodingExceptionExpression(
+            'AnyModel variant of $className cannot determine encoding shape',
+            raw: true,
+          ).statement,
+        );
+      } else if (isSimple) {
         body.addAll([
           const Code(r'  _$shapes.add('),
           encodingShapeType.property('simple').code,
@@ -1290,6 +1375,7 @@ class AnyOfGenerator {
             isForm: true,
             needsValues: needsValues,
             needsMapValues: needsMapValues,
+            className: className,
             discriminatorValue: hasDiscriminator ? discValue : null,
           ),
         )
@@ -1456,6 +1542,20 @@ class AnyOfGenerator {
       final name = n.normalizedName;
       final discValue = discMap[n.property.model];
       final fieldModel = n.property.model;
+      final isAnyModel = fieldModel.resolved is AnyModel;
+
+      if (isAnyModel) {
+        body
+          ..add(Code('if ($name != null) {'))
+          ..add(
+            generateEncodingExceptionExpression(
+              'AnyModel variant of $className cannot be parameter encoded',
+              raw: true,
+            ).statement,
+          )
+          ..add(const Code('}'));
+        continue;
+      }
 
       final needsProcessing =
           needsMapValues &&
@@ -1497,6 +1597,8 @@ class AnyOfGenerator {
       for (final n in normalizedProperties) {
         final name = n.normalizedName;
         final fieldModel = n.property.model;
+        // AnyModel handled above; skip to avoid duplicate throws.
+        if (fieldModel.resolved is AnyModel) continue;
 
         if (fieldModel.encodingShape == EncodingShape.simple) {
           body.addAll([
@@ -1736,6 +1838,7 @@ class AnyOfGenerator {
             tmpVarName: '_\$${name}Label',
             needsValues: needsValues,
             needsMapValues: needsMapValues,
+            className: className,
             discriminatorValue: hasDiscriminator ? discValue : null,
           ),
         )
@@ -1907,6 +2010,7 @@ class AnyOfGenerator {
             tmpVarName: '_\$${name}Matrix',
             needsValues: needsValues,
             needsMapValues: needsMapValues,
+            className: className,
             discriminatorValue: hasDiscriminator ? discValue : null,
           ),
         )
@@ -2020,9 +2124,17 @@ class AnyOfGenerator {
     for (final n in normalizedProperties) {
       final name = n.normalizedName;
       final propertyModel = n.property.model;
-
-      // Check if this property can be URI encoded
-      if (propertyModel.encodingShape == EncodingShape.complex) {
+      if (propertyModel.resolved is AnyModel) {
+        body
+          ..add(Code('if ($name != null) {'))
+          ..add(
+            generateEncodingExceptionExpression(
+              'AnyModel variant of $className cannot be URI encoded',
+              raw: true,
+            ).statement,
+          )
+          ..add(const Code('}'));
+      } else if (propertyModel.encodingShape == EncodingShape.complex) {
         // Complex types cannot be URI encoded
         body
           ..add(Code('if ($name != null) {'))
@@ -2085,9 +2197,20 @@ class AnyOfGenerator {
     required String tmpVarName,
     required bool needsValues,
     required bool needsMapValues,
+    required String className,
     String? discriminatorValue,
   }) {
     final codes = <Code>[];
+
+    if (fieldModel.resolved is AnyModel) {
+      codes.add(
+        generateEncodingExceptionExpression(
+          'AnyModel variant of $className cannot be matrix-encoded',
+          raw: true,
+        ).statement,
+      );
+      return codes;
+    }
 
     if (fieldModel.encodingShape == EncodingShape.simple) {
       codes.add(

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -133,7 +133,7 @@ class AnyOfGenerator {
               )
             : publicClassName);
 
-    // NeverModel variants are skipped — see [generateClasses] for rationale.
+    // NeverModel has no runtime value; emitting Never? is dead weight.
     final pseudoProperties = stableModelSorter
         .sortDiscriminatedModels(model.models)
         .where((d) => d.model.resolved is! NeverModel)
@@ -704,7 +704,7 @@ class AnyOfGenerator {
       );
     }
 
-    // AnyModel only catches input no typed variant accepted.
+    // AnyModel is the catch-all: assigned only when no typed variant decodes.
     for (final n in anyProperties) {
       final modelType = n.property.model;
       final varName = n.normalizedName;
@@ -734,7 +734,7 @@ class AnyOfGenerator {
         n.normalizedName: refer(n.normalizedName),
     };
 
-    // AnyModel always succeeds, so skip validation when it's the only variant.
+    // Only AnyModel variants: the catch-all assigns unconditionally.
     final decodableProperties = [...typedProperties, ...anyProperties];
     final validationCheck = typedProperties.isEmpty
         ? const Code('')
@@ -1120,8 +1120,7 @@ class AnyOfGenerator {
       final varName = n.normalizedName;
 
       if (modelType.resolved is AnyModel) {
-        // AnyModel cannot be meaningfully decoded from a parameter string —
-        // the field stays null and another variant must satisfy the input.
+        // AnyModel has no parameter-string decoding; the field stays null.
         nonDecodableProperties.add(n);
       } else if ((modelType is ListModel && !modelType.hasSimpleContent) ||
           modelType is MapModel) {

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -133,7 +133,6 @@ class AnyOfGenerator {
               )
             : publicClassName);
 
-    // NeverModel has no runtime value; emitting Never? is dead weight.
     final pseudoProperties = stableModelSorter
         .sortDiscriminatedModels(model.models)
         .where((d) => d.model.resolved is! NeverModel)
@@ -734,8 +733,8 @@ class AnyOfGenerator {
         n.normalizedName: refer(n.normalizedName),
     };
 
-    // Only AnyModel variants: the catch-all assigns unconditionally.
     final decodableProperties = [...typedProperties, ...anyProperties];
+    // AnyModel-only: catch-all assigns; no validation needed.
     final validationCheck = typedProperties.isEmpty
         ? const Code('')
         : _buildAllNullValidation(

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -51,9 +51,7 @@ class AnyOfGenerator {
   List<Spec> generateClasses(AnyOfModel model, [String? className]) {
     final actualClassName = className ?? nameManager.modelName(model);
 
-    // NeverModel variants cannot have any value at runtime, so emitting a
-    // `Never?` field would be dead weight and trigger analyzer warnings. We
-    // skip them entirely; encoding/decoding paths simply omit them.
+    // NeverModel has no runtime value; emitting Never? is dead weight.
     final pseudoProperties = stableModelSorter
         .sortDiscriminatedModels(model.models)
         .where((d) => d.model.resolved is! NeverModel)
@@ -706,9 +704,7 @@ class AnyOfGenerator {
       );
     }
 
-    // AnyModel acts as a catch-all: only assigned when every typed variant
-    // failed to decode. This avoids a redundant raw-value field on every
-    // successful typed decode.
+    // AnyModel only catches input no typed variant accepted.
     for (final n in anyProperties) {
       final modelType = n.property.model;
       final varName = n.normalizedName;
@@ -738,9 +734,7 @@ class AnyOfGenerator {
         n.normalizedName: refer(n.normalizedName),
     };
 
-    // Validation: fail when every decodable variant ended up null.
-    // For anyOf with only AnyModel variants, AnyModel always succeeds so
-    // no validation is needed.
+    // AnyModel always succeeds, so skip validation when it's the only variant.
     final decodableProperties = [...typedProperties, ...anyProperties];
     final validationCheck = typedProperties.isEmpty
         ? const Code('')

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -3572,5 +3572,60 @@ EncodingShape get currentEncodingShape {
 
       expect(generated.trim(), format(expected).trim());
     });
+
+    test('toJson encodes AnyModel field via encodeAnyToJson', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'OnlyAny',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+        },
+        context: context,
+      );
+
+      final klass = generator.generateClass(model);
+      final method = klass.methods.firstWhere((m) => m.name == 'toJson');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+Object? toJson() {
+  final _$values = <Object?>{};
+  final _$mapValues = <Map<String, Object?>>[];
+  if (object != null) {
+    final Object? _$objectJson = encodeAnyToJson(object!);
+    if (_$objectJson is Map<String, Object?>) {
+      _$mapValues.add(_$objectJson);
+    } else {
+      _$values.add(_$objectJson);
+    }
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return null;
+  if (_$values.isNotEmpty && _$mapValues.isNotEmpty) {
+    throw EncodingException(
+      r'Mixed encoding not supported for OnlyAny: cannot encode both simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf encoding for OnlyAny: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  }
+  if (_$mapValues.isNotEmpty) {
+    final _$map = <String, Object?>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map;
+  }
+  return null;
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -2941,4 +2941,636 @@ String toLabel({required bool explode, required bool allowEmpty}) {
       },
     );
   });
+
+  group('AnyModel in AnyOf', () {
+    ClassModel makeDetailedFilter() => ClassModel(
+      isDeprecated: false,
+      name: 'DetailedFilter',
+      properties: [
+        Property(
+          name: 'name',
+          model: StringModel(context: context),
+          isRequired: false,
+          isNullable: false,
+          isDeprecated: false,
+        ),
+      ],
+      context: context,
+    );
+
+    AnyOfModel makeMixedFilter() => AnyOfModel(
+      isDeprecated: false,
+      name: 'MixedFilter',
+      models: {
+        (discriminatorValue: null, model: makeDetailedFilter()),
+        (discriminatorValue: null, model: AnyModel(context: context)),
+      },
+      context: context,
+    );
+
+    test('generates Object? field for AnyModel variant', () {
+      final klass = generator.generateClass(makeMixedFilter());
+
+      final fieldNames = klass.fields.map((f) => f.name).toList();
+      expect(fieldNames, containsAll(['object', 'detailedFilter']));
+
+      final objectField = klass.fields.firstWhere((f) => f.name == 'object');
+      expect(objectField.type?.accept(emitter).toString(), 'Object?');
+    });
+
+    test(
+      'currentEncodingShape throws EncodingException for AnyModel field',
+      () {
+        final klass = generator.generateClass(makeMixedFilter());
+        final method = klass.methods.firstWhere(
+          (m) => m.name == 'currentEncodingShape',
+        );
+        final generated = format(method.accept(emitter).toString());
+
+        const expected = r'''
+EncodingShape get currentEncodingShape {
+  final _$shapes = <EncodingShape>{};
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot determine encoding shape',
+    );
+  }
+  if (detailedFilter != null) {
+    _$shapes.add(detailedFilter!.currentEncodingShape);
+  }
+  if (_$shapes.isEmpty) {
+    throw StateError('At least one field must be non-null in anyOf');
+  }
+  if (_$shapes.length > 1) return EncodingShape.mixed;
+  return _$shapes.first;
+}
+''';
+
+        expect(generated.trim(), format(expected).trim());
+      },
+    );
+
+    test('parameterProperties throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere(
+        (m) => m.name == 'parameterProperties',
+      );
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+}) {
+  final _$mapValues = <Map<String, String>>[];
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be parameter encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    _$mapValues.add(
+      detailedFilter!.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+      ),
+    );
+  }
+  final _$map = <String, String>{};
+  for (final _$m in _$mapValues) {
+    _$map.addAll(_$m);
+  }
+  return _$map;
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('toSimple throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'toSimple');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+String toSimple({required bool explode, required bool allowEmpty}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be simple-encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    final _$detailedFilterSimple = detailedFilter!.parameterProperties(
+      allowEmpty: allowEmpty,
+    );
+    _$mapValues.add(_$detailedFilterSimple);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf simple encoding for MixedFilter: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf simple encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('toForm throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'toForm');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+String toForm({
+  required bool explode,
+  required bool allowEmpty,
+  bool useQueryComponent = false,
+}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be form-encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    final _$detailedFilterForm = detailedFilter!.parameterProperties(
+      allowEmpty: allowEmpty,
+    );
+    _$mapValues.add(_$detailedFilterForm);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf form encoding for MixedFilter: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf form encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('toLabel throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'toLabel');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+String toLabel({required bool explode, required bool allowEmpty}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be label-encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    final _$detailedFilterLabel = detailedFilter!.parameterProperties(
+      allowEmpty: allowEmpty,
+    );
+    _$mapValues.add(_$detailedFilterLabel);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf label encoding for MixedFilter: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf label encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toLabel(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('toMatrix throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'toMatrix');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+String toMatrix(
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+}) {
+  final _$values = <String>{};
+  final _$mapValues = <Map<String, String>>[];
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be matrix-encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    final _$detailedFilterMatrix = detailedFilter!.parameterProperties(
+      allowEmpty: allowEmpty,
+    );
+    _$mapValues.add(_$detailedFilterMatrix);
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return '';
+  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+    throw EncodingException(
+      r'Ambiguous anyOf matrix encoding for MixedFilter: mixing simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf matrix encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  } else {
+    final _$map = <String, String>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map.toMatrix(
+      paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('uriEncode throws EncodingException for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'uriEncode');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = '''
+@override
+String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of MixedFilter cannot be URI encoded',
+    );
+  }
+  if (detailedFilter != null) {
+    throw EncodingException(
+      r'Cannot uriEncode MixedFilter: contains complex type',
+    );
+  }
+  throw EncodingException(r'Cannot uriEncode MixedFilter: no value set');
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('toJson uses encodeAnyToJson for AnyModel field', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final method = klass.methods.firstWhere((m) => m.name == 'toJson');
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+@override
+Object? toJson() {
+  final _$values = <Object?>{};
+  final _$mapValues = <Map<String, Object?>>[];
+  if (object != null) {
+    final Object? _$objectJson = encodeAnyToJson(object!);
+    if (_$objectJson is Map<String, Object?>) {
+      _$mapValues.add(_$objectJson);
+    } else {
+      _$values.add(_$objectJson);
+    }
+  }
+  if (detailedFilter != null) {
+    final Object? _$detailedFilterJson = detailedFilter!.toJson();
+    if (_$detailedFilterJson is Map<String, Object?>) {
+      _$mapValues.add(_$detailedFilterJson);
+    } else {
+      _$values.add(_$detailedFilterJson);
+    }
+  }
+  if (_$values.isEmpty && _$mapValues.isEmpty) return null;
+  if (_$values.isNotEmpty && _$mapValues.isNotEmpty) {
+    throw EncodingException(
+      r'Mixed encoding not supported for MixedFilter: cannot encode both simple and complex values',
+    );
+  }
+  if (_$values.isNotEmpty) {
+    if (_$values.length > 1) {
+      throw EncodingException(
+        r'Ambiguous anyOf encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
+      );
+    }
+    return _$values.first;
+  }
+  if (_$mapValues.isNotEmpty) {
+    final _$map = <String, Object?>{};
+    for (final _$m in _$mapValues) {
+      _$map.addAll(_$m);
+    }
+    return _$map;
+  }
+  return null;
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+
+    test('fromJson assigns AnyModel field as catch-all', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final ctor = klass.constructors.firstWhere(
+        (c) => c.name == 'fromJson',
+      );
+      final wrapped = Method(
+        (b) => b
+          ..name = 'wrap'
+          ..returns = refer('void')
+          ..body = ctor.body,
+      );
+      final body = format(wrapped.accept(emitter).toString());
+
+      const expected = '''
+void wrap() {
+  DetailedFilter? detailedFilter;
+
+  try {
+    detailedFilter = DetailedFilter.fromJson(json);
+  } on Object catch (_) {
+    detailedFilter = null;
+  }
+
+  Object? object;
+  if (detailedFilter == null) {
+    object = json;
+  }
+  if (detailedFilter == null && object == null) {
+    throw JsonDecodingException(
+      r'Invalid JSON for MixedFilter: all variants failed to decode',
+    );
+  }
+  return MixedFilter(object: object, detailedFilter: detailedFilter);
+}
+''';
+
+      expect(body.trim(), format(expected).trim());
+    });
+
+    test('fromSimple skips AnyModel field — passes null to constructor', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final ctor = klass.constructors.firstWhere(
+        (c) => c.name == 'fromSimple',
+      );
+      final wrapped = Method(
+        (b) => b
+          ..name = 'wrap'
+          ..returns = refer('void')
+          ..body = ctor.body,
+      );
+      final body = format(wrapped.accept(emitter).toString());
+
+      const expected = '''
+void wrap() {
+  DetailedFilter? detailedFilter;
+
+  try {
+    detailedFilter = DetailedFilter.fromSimple(value, explode: explode);
+  } on Object catch (_) {
+    detailedFilter = null;
+  }
+
+  if (detailedFilter == null) {
+    throw SimpleDecodingException(
+      r'Invalid simple value for MixedFilter: all variants failed to decode',
+    );
+  }
+  return MixedFilter(object: null, detailedFilter: detailedFilter);
+}
+''';
+
+      expect(body.trim(), format(expected).trim());
+    });
+
+    test('fromForm skips AnyModel field — passes null to constructor', () {
+      final klass = generator.generateClass(makeMixedFilter());
+      final ctor = klass.constructors.firstWhere(
+        (c) => c.name == 'fromForm',
+      );
+      final wrapped = Method(
+        (b) => b
+          ..name = 'wrap'
+          ..returns = refer('void')
+          ..body = ctor.body,
+      );
+      final body = format(wrapped.accept(emitter).toString());
+
+      const expected = '''
+void wrap() {
+  DetailedFilter? detailedFilter;
+
+  try {
+    detailedFilter = DetailedFilter.fromForm(value, explode: explode);
+  } on Object catch (_) {
+    detailedFilter = null;
+  }
+
+  if (detailedFilter == null) {
+    throw FormDecodingException(
+      r'Invalid form value for MixedFilter: all variants failed to decode',
+    );
+  }
+  return MixedFilter(object: null, detailedFilter: detailedFilter);
+}
+''';
+
+      expect(body.trim(), format(expected).trim());
+    });
+  });
+
+  group('NeverModel in AnyOf', () {
+    test('NeverModel variant produces no field on the generated class', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        name: 'DetailedFilter',
+        properties: [
+          Property(
+            name: 'name',
+            model: StringModel(context: context),
+            isRequired: false,
+            isNullable: false,
+            isDeprecated: false,
+          ),
+        ],
+        context: context,
+      );
+
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'NeverFilter',
+        models: {
+          (discriminatorValue: null, model: classModel),
+          (discriminatorValue: null, model: NeverModel(context: context)),
+        },
+        context: context,
+      );
+
+      final klass = generator.generateClass(model);
+      final fieldNames = klass.fields.map((f) => f.name).toList();
+
+      expect(fieldNames, ['detailedFilter']);
+      expect(fieldNames.contains('never'), isFalse);
+    });
+  });
+
+  group('AnyOf with only AnyModel (degenerate)', () {
+    test('generates Object? field and constructs without validation', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'OnlyAny',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+        },
+        context: context,
+      );
+
+      final klass = generator.generateClass(model);
+      final fieldNames = klass.fields.map((f) => f.name).toList();
+      expect(fieldNames, ['object']);
+      final objectField = klass.fields.firstWhere((f) => f.name == 'object');
+      expect(objectField.type?.accept(emitter).toString(), 'Object?');
+    });
+
+    test('fromJson assigns json directly to AnyModel field', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'OnlyAny',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+        },
+        context: context,
+      );
+
+      final klass = generator.generateClass(model);
+      final ctor = klass.constructors.firstWhere(
+        (c) => c.name == 'fromJson',
+      );
+      final wrapped = Method(
+        (b) => b
+          ..name = 'wrap'
+          ..returns = refer('void')
+          ..body = ctor.body,
+      );
+      final body = format(wrapped.accept(emitter).toString());
+
+      const expected = '''
+void wrap() {
+  Object? object;
+  object = json;
+
+  return OnlyAny(object: object);
+}
+''';
+
+      expect(body.trim(), format(expected).trim());
+    });
+
+    test('currentEncodingShape throws on AnyModel field, '
+        'StateError if all null', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'OnlyAny',
+        models: {
+          (discriminatorValue: null, model: AnyModel(context: context)),
+        },
+        context: context,
+      );
+
+      final klass = generator.generateClass(model);
+      final method = klass.methods.firstWhere(
+        (m) => m.name == 'currentEncodingShape',
+      );
+      final generated = format(method.accept(emitter).toString());
+
+      const expected = r'''
+EncodingShape get currentEncodingShape {
+  final _$shapes = <EncodingShape>{};
+  if (object != null) {
+    throw EncodingException(
+      r'AnyModel variant of OnlyAny cannot determine encoding shape',
+    );
+  }
+  if (_$shapes.isEmpty) {
+    throw StateError('At least one field must be non-null in anyOf');
+  }
+  if (_$shapes.length > 1) return EncodingShape.mixed;
+  return _$shapes.first;
+}
+''';
+
+      expect(generated.trim(), format(expected).trim());
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- Mirror the oneOf AnyModel/NeverModel fix (commit afadd7ce) inside `AnyOfGenerator`.
- AnyModel encoding methods throw `EncodingException` with `$className` context; `toJson` flows through `encodeAnyToJson`; `fromJson` acts as a last-resort catch-all; `fromSimple`/`fromForm` skip AnyModel.
- NeverModel variants are filtered before normalization, so no `Object?` field is emitted.
- Added unit coverage for the new variant cases (full method-body comparisons via DartFormatter, field-name introspection where introspection is the right tool).
- Integration spec adds `AnyOfBooleanSchema` (boolean `true` + Class1) and an integration test group covering construction, JSON roundtrip, the catch-all behaviour, and the encoding/uri/parameter-shape `EncodingException` throws.

## Test plan
- [ ] `fvm dart analyze` clean
- [ ] All unit suites pass (`tonik_core`, `tonik_parse`, `tonik_generate`, `tonik_util`, `tonik`)
- [ ] Integration tests pass after `./scripts/setup_integration_tests.sh`
- [ ] Patch coverage ≥ 90%