### PR TITLE
Centralize AnyModel encoding policy and fix runtime List/Map gaps

### DIFF
--- a/packages/tonik_generate/lib/src/util/encoding_policy.dart
+++ b/packages/tonik_generate/lib/src/util/encoding_policy.dart
@@ -1,91 +1,52 @@
 import 'package:code_builder/code_builder.dart';
 
-/// Per-encoding-style policy for emitting `AnyModel` arms.
-///
-/// Centralizes the choice of runtime helper for each encoding style so that
-/// every value-level and parameter-level generator routes through one table.
-/// Adding a new style or fixing an edge case is a single edit point here.
-class EncodingPolicy {
-  const EncodingPolicy({required this.encodeAny});
+const _utilUri = 'package:tonik_util/tonik_util.dart';
 
-  final Expression Function(Expression receiver) encodeAny;
-}
+Expression encodeAnyToJsonExpression(Expression receiver) =>
+    refer('encodeAnyToJson', _utilUri).call([receiver]);
 
-EncodingPolicy jsonEncodingPolicy() {
-  return EncodingPolicy(
-    encodeAny: (receiver) => refer(
-      'encodeAnyToJson',
-      'package:tonik_util/tonik_util.dart',
-    ).call([receiver]),
-  );
-}
-
-EncodingPolicy simpleEncodingPolicy({
+Expression encodeAnyToSimpleExpression(
+  Expression receiver, {
   required Expression explode,
   required Expression allowEmpty,
-}) {
-  return EncodingPolicy(
-    encodeAny: (receiver) =>
-        refer('encodeAnyToSimple', 'package:tonik_util/tonik_util.dart').call(
-          [receiver],
-          {
-            'explode': explode,
-            'allowEmpty': allowEmpty,
-          },
-        ),
-  );
-}
+}) => refer('encodeAnyToSimple', _utilUri).call(
+  [receiver],
+  {'explode': explode, 'allowEmpty': allowEmpty},
+);
 
 /// When [useQueryComponent] is non-null, it is forwarded to the runtime helper
 /// so primitives use `Uri.encodeQueryComponent` (spaces → `+`) instead of
-/// `Uri.encodeComponent` (spaces → `%20`).
-EncodingPolicy formEncodingPolicy({
+/// `Uri.encodeComponent` (spaces → `%20`). The choice threads through
+/// recursive list/map element encoding.
+Expression encodeAnyToFormExpression(
+  Expression receiver, {
   required Expression explode,
   required Expression allowEmpty,
   Expression? useQueryComponent,
-}) {
-  return EncodingPolicy(
-    encodeAny: (receiver) =>
-        refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart').call(
-          [receiver],
-          {
-            'explode': explode,
-            'allowEmpty': allowEmpty,
-            'useQueryComponent': ?useQueryComponent,
-          },
-        ),
-  );
-}
+}) => refer('encodeAnyToForm', _utilUri).call(
+  [receiver],
+  {
+    'explode': explode,
+    'allowEmpty': allowEmpty,
+    'useQueryComponent': ?useQueryComponent,
+  },
+);
 
-EncodingPolicy matrixEncodingPolicy({
+Expression encodeAnyToMatrixExpression(
+  Expression receiver, {
   required Expression paramName,
   required Expression explode,
   required Expression allowEmpty,
-}) {
-  return EncodingPolicy(
-    encodeAny: (receiver) =>
-        refer('encodeAnyToMatrix', 'package:tonik_util/tonik_util.dart').call(
-          [receiver, paramName],
-          {
-            'explode': explode,
-            'allowEmpty': allowEmpty,
-          },
-        ),
-  );
-}
+}) => refer('encodeAnyToMatrix', _utilUri).call(
+  [receiver, paramName],
+  {'explode': explode, 'allowEmpty': allowEmpty},
+);
 
-EncodingPolicy labelEncodingPolicy({
+Expression encodeAnyToLabelExpression(
+  Expression receiver, {
   required Expression explode,
   required Expression allowEmpty,
-}) {
-  return EncodingPolicy(
-    encodeAny: (receiver) =>
-        refer('encodeAnyToLabel', 'package:tonik_util/tonik_util.dart').call(
-          [receiver],
-          {
-            'explode': explode,
-            'allowEmpty': allowEmpty,
-          },
-        ),
-  );
-}
+}) => refer('encodeAnyToLabel', _utilUri).call(
+  [receiver],
+  {'explode': explode, 'allowEmpty': allowEmpty},
+);

--- a/packages/tonik_generate/lib/src/util/encoding_policy.dart
+++ b/packages/tonik_generate/lib/src/util/encoding_policy.dart
@@ -1,3 +1,8 @@
+/// Builders for code_builder Expressions that call into the encodeAnyTo*
+/// runtime helpers in tonik_util. Centralizes the runtime-helper URI and
+/// call shape so generators don't refer('encodeAnyTo*') directly.
+library;
+
 import 'package:code_builder/code_builder.dart';
 
 const _utilUri = 'package:tonik_util/tonik_util.dart';
@@ -48,5 +53,30 @@ Expression encodeAnyToLabelExpression(
   required Expression allowEmpty,
 }) => refer('encodeAnyToLabel', _utilUri).call(
   [receiver],
+  {'explode': explode, 'allowEmpty': allowEmpty},
+);
+
+/// When [useQueryComponent] is non-null, it is forwarded to the runtime helper
+/// so primitives use `Uri.encodeQueryComponent` (spaces → `+`) instead of
+/// `Uri.encodeComponent` (spaces → `%20`).
+Expression encodeAnyToUriExpression(
+  Expression receiver, {
+  required Expression allowEmpty,
+  Expression? useQueryComponent,
+}) => refer('encodeAnyToUri', _utilUri).call(
+  [receiver],
+  {
+    'allowEmpty': allowEmpty,
+    'useQueryComponent': ?useQueryComponent,
+  },
+);
+
+Expression encodeAnyToDeepObjectExpression(
+  Expression receiver, {
+  required Expression paramName,
+  required Expression explode,
+  required Expression allowEmpty,
+}) => refer('encodeAnyToDeepObject', _utilUri).call(
+  [receiver, paramName],
   {'explode': explode, 'allowEmpty': allowEmpty},
 );

--- a/packages/tonik_generate/lib/src/util/encoding_policy.dart
+++ b/packages/tonik_generate/lib/src/util/encoding_policy.dart
@@ -1,0 +1,136 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
+
+/// Per-encoding-style policy for emitting `AnyModel` and `NeverModel` arms.
+///
+/// Centralizes the choice of runtime helper for each encoding style so that
+/// every value-level and parameter-level generator routes through one table.
+/// Adding a new style or fixing an edge case is a single edit point here.
+///
+/// The closure-based shape lets each style express its own runtime-helper
+/// signature (matrix's `paramName`, simple/form/label/matrix's
+/// `explode`/`allowEmpty`) without leaking per-style arms back into call
+/// sites.
+class EncodingPolicy {
+  const EncodingPolicy({required this.encodeAny, required this.neverThrow});
+
+  /// Builds the expression that encodes an `AnyModel` value via the
+  /// runtime helper configured for the chosen encoding style.
+  final Expression Function(Expression receiver) encodeAny;
+
+  /// Builds a throw expression for `NeverModel` values that carry no
+  /// per-site context.
+  ///
+  /// Reserved for an upcoming consolidation that will route every
+  /// `NeverModel` arm through this policy as well; not yet wired into call
+  /// sites, which continue to inline the literal throw at each `NeverModel`
+  /// arm.
+  final Expression Function() neverThrow;
+}
+
+/// Standard message used by every catch-all NeverModel encoding throw.
+const String _neverModelMessage =
+    'Cannot encode NeverModel - this type does not permit any value.';
+
+Expression _neverThrow() =>
+    generateEncodingExceptionExpression(_neverModelMessage);
+
+/// Policy that routes `AnyModel` JSON encoding through `encodeAnyToJson`.
+EncodingPolicy jsonEncodingPolicy() {
+  return EncodingPolicy(
+    encodeAny: (receiver) => refer(
+      'encodeAnyToJson',
+      'package:tonik_util/tonik_util.dart',
+    ).call([receiver]),
+    neverThrow: _neverThrow,
+  );
+}
+
+/// Policy that routes `AnyModel` simple-style encoding through
+/// `encodeAnyToSimple` with the supplied [explode] and [allowEmpty]
+/// arguments.
+EncodingPolicy simpleEncodingPolicy({
+  required Expression explode,
+  required Expression allowEmpty,
+}) {
+  return EncodingPolicy(
+    encodeAny: (receiver) =>
+        refer('encodeAnyToSimple', 'package:tonik_util/tonik_util.dart').call(
+          [receiver],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
+    neverThrow: _neverThrow,
+  );
+}
+
+/// Policy that routes `AnyModel` form-style encoding through
+/// `encodeAnyToForm` with the supplied [explode] and [allowEmpty]
+/// arguments.
+///
+/// When [useQueryComponent] is non-null, it is forwarded to the runtime
+/// helper so that primitives use `Uri.encodeQueryComponent` (spaces → `+`)
+/// instead of `Uri.encodeComponent` (spaces → `%20`). Generators that emit
+/// form-urlencoded request bodies pass `literalBool(true)`; generators that
+/// emit form-style query parameters omit the argument.
+EncodingPolicy formEncodingPolicy({
+  required Expression explode,
+  required Expression allowEmpty,
+  Expression? useQueryComponent,
+}) {
+  return EncodingPolicy(
+    encodeAny: (receiver) =>
+        refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart').call(
+          [receiver],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+            'useQueryComponent': ?useQueryComponent,
+          },
+        ),
+    neverThrow: _neverThrow,
+  );
+}
+
+/// Policy that routes `AnyModel` matrix-style encoding through
+/// `encodeAnyToMatrix` with the supplied [paramName], [explode], and
+/// [allowEmpty] arguments.
+EncodingPolicy matrixEncodingPolicy({
+  required Expression paramName,
+  required Expression explode,
+  required Expression allowEmpty,
+}) {
+  return EncodingPolicy(
+    encodeAny: (receiver) =>
+        refer('encodeAnyToMatrix', 'package:tonik_util/tonik_util.dart').call(
+          [receiver, paramName],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
+    neverThrow: _neverThrow,
+  );
+}
+
+/// Policy that routes `AnyModel` label-style encoding through
+/// `encodeAnyToLabel` with the supplied [explode] and [allowEmpty]
+/// arguments.
+EncodingPolicy labelEncodingPolicy({
+  required Expression explode,
+  required Expression allowEmpty,
+}) {
+  return EncodingPolicy(
+    encodeAny: (receiver) =>
+        refer('encodeAnyToLabel', 'package:tonik_util/tonik_util.dart').call(
+          [receiver],
+          {
+            'explode': explode,
+            'allowEmpty': allowEmpty,
+          },
+        ),
+    neverThrow: _neverThrow,
+  );
+}

--- a/packages/tonik_generate/lib/src/util/encoding_policy.dart
+++ b/packages/tonik_generate/lib/src/util/encoding_policy.dart
@@ -1,54 +1,25 @@
 import 'package:code_builder/code_builder.dart';
-import 'package:tonik_generate/src/util/exception_code_generator.dart';
 
-/// Per-encoding-style policy for emitting `AnyModel` and `NeverModel` arms.
+/// Per-encoding-style policy for emitting `AnyModel` arms.
 ///
 /// Centralizes the choice of runtime helper for each encoding style so that
 /// every value-level and parameter-level generator routes through one table.
 /// Adding a new style or fixing an edge case is a single edit point here.
-///
-/// The closure-based shape lets each style express its own runtime-helper
-/// signature (matrix's `paramName`, simple/form/label/matrix's
-/// `explode`/`allowEmpty`) without leaking per-style arms back into call
-/// sites.
 class EncodingPolicy {
-  const EncodingPolicy({required this.encodeAny, required this.neverThrow});
+  const EncodingPolicy({required this.encodeAny});
 
-  /// Builds the expression that encodes an `AnyModel` value via the
-  /// runtime helper configured for the chosen encoding style.
   final Expression Function(Expression receiver) encodeAny;
-
-  /// Builds a throw expression for `NeverModel` values that carry no
-  /// per-site context.
-  ///
-  /// Reserved for an upcoming consolidation that will route every
-  /// `NeverModel` arm through this policy as well; not yet wired into call
-  /// sites, which continue to inline the literal throw at each `NeverModel`
-  /// arm.
-  final Expression Function() neverThrow;
 }
 
-/// Standard message used by every catch-all NeverModel encoding throw.
-const String _neverModelMessage =
-    'Cannot encode NeverModel - this type does not permit any value.';
-
-Expression _neverThrow() =>
-    generateEncodingExceptionExpression(_neverModelMessage);
-
-/// Policy that routes `AnyModel` JSON encoding through `encodeAnyToJson`.
 EncodingPolicy jsonEncodingPolicy() {
   return EncodingPolicy(
     encodeAny: (receiver) => refer(
       'encodeAnyToJson',
       'package:tonik_util/tonik_util.dart',
     ).call([receiver]),
-    neverThrow: _neverThrow,
   );
 }
 
-/// Policy that routes `AnyModel` simple-style encoding through
-/// `encodeAnyToSimple` with the supplied [explode] and [allowEmpty]
-/// arguments.
 EncodingPolicy simpleEncodingPolicy({
   required Expression explode,
   required Expression allowEmpty,
@@ -62,19 +33,12 @@ EncodingPolicy simpleEncodingPolicy({
             'allowEmpty': allowEmpty,
           },
         ),
-    neverThrow: _neverThrow,
   );
 }
 
-/// Policy that routes `AnyModel` form-style encoding through
-/// `encodeAnyToForm` with the supplied [explode] and [allowEmpty]
-/// arguments.
-///
-/// When [useQueryComponent] is non-null, it is forwarded to the runtime
-/// helper so that primitives use `Uri.encodeQueryComponent` (spaces → `+`)
-/// instead of `Uri.encodeComponent` (spaces → `%20`). Generators that emit
-/// form-urlencoded request bodies pass `literalBool(true)`; generators that
-/// emit form-style query parameters omit the argument.
+/// When [useQueryComponent] is non-null, it is forwarded to the runtime helper
+/// so primitives use `Uri.encodeQueryComponent` (spaces → `+`) instead of
+/// `Uri.encodeComponent` (spaces → `%20`).
 EncodingPolicy formEncodingPolicy({
   required Expression explode,
   required Expression allowEmpty,
@@ -90,13 +54,9 @@ EncodingPolicy formEncodingPolicy({
             'useQueryComponent': ?useQueryComponent,
           },
         ),
-    neverThrow: _neverThrow,
   );
 }
 
-/// Policy that routes `AnyModel` matrix-style encoding through
-/// `encodeAnyToMatrix` with the supplied [paramName], [explode], and
-/// [allowEmpty] arguments.
 EncodingPolicy matrixEncodingPolicy({
   required Expression paramName,
   required Expression explode,
@@ -111,13 +71,9 @@ EncodingPolicy matrixEncodingPolicy({
             'allowEmpty': allowEmpty,
           },
         ),
-    neverThrow: _neverThrow,
   );
 }
 
-/// Policy that routes `AnyModel` label-style encoding through
-/// `encodeAnyToLabel` with the supplied [explode] and [allowEmpty]
-/// arguments.
 EncodingPolicy labelEncodingPolicy({
   required Expression explode,
   required Expression allowEmpty,
@@ -131,6 +87,5 @@ EncodingPolicy labelEncodingPolicy({
             'allowEmpty': allowEmpty,
           },
         ),
-    neverThrow: _neverThrow,
   );
 }

--- a/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 
@@ -22,15 +23,12 @@ Code buildToDeepObjectQueryParameterCode(
   final allowEmpty = parameter.allowEmptyValue;
 
   if (model is AnyModel) {
-    return refer('encodeAnyToDeepObject', 'package:tonik_util/tonik_util.dart')
-        .call(
-          [refer(parameterName), specLiteralString(rawName)],
-          {
-            'explode': literalBool(explode),
-            'allowEmpty': literalBool(allowEmpty),
-          },
-        )
-        .code;
+    return encodeAnyToDeepObjectExpression(
+      refer(parameterName),
+      paramName: specLiteralString(rawName),
+      explode: literalBool(explode),
+      allowEmpty: literalBool(allowEmpty),
+    ).code;
   }
 
   // Handle MapModel (including aliases to MapModel) before the general

--- a/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
@@ -69,10 +69,11 @@ Expression buildFormParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => formEncodingPolicy(
+    AnyModel() => encodeAnyToFormExpression(
+      valueExpression,
       explode: explode,
       allowEmpty: allowEmpty,
-    ).encodeAny(valueExpression),
+    ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be form-encoded',
     ),

--- a/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -68,14 +69,10 @@ Expression buildFormParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() =>
-      refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart').call(
-        [valueExpression],
-        {
-          'explode': explode,
-          'allowEmpty': allowEmpty,
-        },
-      ),
+    AnyModel() => formEncodingPolicy(
+      explode: explode,
+      allowEmpty: allowEmpty,
+    ).encodeAny(valueExpression),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be form-encoded',
     ),

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -313,8 +313,8 @@ String? _getFormSerializationSuffix(
 
     Base64Model() => '.toBase64String().toForm($paramString)',
 
-    // Follow-up: route through formEncodingPolicy — same anti-pattern this
-    // PR removes from value-level generators.
+    // AnyModel falls back to toString here; structural form encoding lives in
+    // encodeAnyToForm but is not yet wired into the query-suffix path.
     AnyModel() => '?.toString() ?? ""',
     NeverModel() => null,
     BinaryModel() => null,

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
@@ -102,17 +103,11 @@ List<Code> buildToFormQueryParameterCode(
       const Code(r'_$entries.add(('),
       Code('name: ${specLiteralStringCode(parameter.rawName)}, '),
       const Code('value: '),
-      refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart')
-          .call(
-            [
-              refer(parameterName),
-            ],
-            {
-              'explode': literalBool(explode),
-              'allowEmpty': literalBool(allowEmpty),
-            },
-          )
-          .code,
+      encodeAnyToFormExpression(
+        refer(parameterName),
+        explode: literalBool(explode),
+        allowEmpty: literalBool(allowEmpty),
+      ).code,
       const Code(',),);'),
     ];
   }
@@ -178,14 +173,10 @@ List<Code> buildToFormQueryParameterCode(
         const Code('value: '),
         refer(parameterName).code,
         const Code('.map((e) => '),
-        refer('encodeAnyToUri', 'package:tonik_util/tonik_util.dart')
-            .call(
-              [refer('e')],
-              {
-                'allowEmpty': literalBool(allowEmpty),
-              },
-            )
-            .code,
+        encodeAnyToUriExpression(
+          refer('e'),
+          allowEmpty: literalBool(allowEmpty),
+        ).code,
         const Code(').toList().toForm('),
         Code('explode: $explode, allowEmpty: $allowEmpty),),);'),
       ];
@@ -313,9 +304,10 @@ String? _getFormSerializationSuffix(
 
     Base64Model() => '.toBase64String().toForm($paramString)',
 
-    // AnyModel falls back to toString here; structural form encoding lives in
-    // encodeAnyToForm but is not yet wired into the query-suffix path.
-    AnyModel() => '?.toString() ?? ""',
+    // AnyModel cannot be encoded via the suffix path; falls through to
+    // EncodingException so callers see an explicit failure rather than a
+    // silent toString.
+    AnyModel() => null,
     NeverModel() => null,
     BinaryModel() => null,
 
@@ -356,15 +348,12 @@ String? _handleListExpression(
       return '.map($elementMapBody).toList().toForm($paramString)';
     }(),
 
-    AnyModel() => () {
-      final suffix = _getFormSerializationSuffix(
-        contentModel,
-        explode: explode,
-        allowEmpty: allowEmpty,
-      );
-      final elementMapBody = '(e) => e$suffix';
-      return '.map($elementMapBody).toList().toForm($paramString)';
-    }(),
+    // AnyModel cannot be encoded via the suffix path; the top-level
+    // ListModel branch routes List<AnyModel> through encodeAnyToUri, so
+    // returning null here causes any unexpected fall-through (e.g., a
+    // List<List<AnyModel>>) to produce an EncodingException rather than
+    // silently emitting wrong code.
+    AnyModel() => null,
 
     AliasModel() => _handleListExpression(
       contentModel.model,
@@ -418,10 +407,10 @@ List<Code> _buildExplodedListCode(
       ),
       Code('name: $nameCode, '),
       const Code('value: '),
-      refer(
-        'encodeAnyToUri',
-        'package:tonik_util/tonik_util.dart',
-      ).call([refer('e')], {'allowEmpty': literalBool(allowEmpty)}).code,
+      encodeAnyToUriExpression(
+        refer('e'),
+        allowEmpty: literalBool(allowEmpty),
+      ).code,
       const Code(',),),);'),
     ];
   }

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -313,6 +313,8 @@ String? _getFormSerializationSuffix(
 
     Base64Model() => '.toBase64String().toForm($paramString)',
 
+    // Follow-up: route through formEncodingPolicy — same anti-pattern this
+    // PR removes from value-level generators.
     AnyModel() => '?.toString() ?? ""',
     NeverModel() => null,
     BinaryModel() => null,

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -23,13 +23,24 @@ Expression buildToFormPropertyExpression(
     useQueryComponent: useQueryComponent,
   );
 
-  // For required but nullable properties, provide empty string fallback
-  if (property.isRequired && property.isNullable) {
+  // For required but nullable properties, provide empty string fallback.
+  // Skip the wrap when the underlying model is AnyModel: encodeAnyToForm
+  // returns a non-nullable String, so `?? ''` would be a dead null-aware
+  // expression in the consumer's analyzer.
+  if (property.isRequired &&
+      property.isNullable &&
+      !_resolvesToAnyModel(model)) {
     return expr.ifNullThen(literalString(''));
   }
 
   return expr;
 }
+
+bool _resolvesToAnyModel(Model model) => switch (model) {
+      AnyModel() => true,
+      AliasModel(:final model) => _resolvesToAnyModel(model),
+      _ => false,
+    };
 
 /// Creates a Dart expression that correctly serializes any model
 /// to its form-encoded representation, including complex types.
@@ -128,11 +139,6 @@ Expression _buildFormSerializationExpression(
       'Form encoding not supported for binary types.',
     ),
 
-    // Null is handled by the runtime helper itself (which returns the
-    // empty string when allowEmpty is true), so the surrounding
-    // `.ifNullThen(literalString(''))` wrap in [buildToFormPropertyExpression]
-    // is a no-op for this branch (encodeAnyToForm returns String, not
-    // String?).
     AnyModel() => formEncodingPolicy(
       explode: explodeArg,
       allowEmpty: allowEmptyArg,

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -29,18 +29,12 @@ Expression buildToFormPropertyExpression(
   // expression in the consumer's analyzer.
   if (property.isRequired &&
       property.isNullable &&
-      !_resolvesToAnyModel(model)) {
+      model.resolved is! AnyModel) {
     return expr.ifNullThen(literalString(''));
   }
 
   return expr;
 }
-
-bool _resolvesToAnyModel(Model model) => switch (model) {
-      AnyModel() => true,
-      AliasModel(:final model) => _resolvesToAnyModel(model),
-      _ => false,
-    };
 
 /// Creates a Dart expression that correctly serializes any model
 /// to its form-encoded representation, including complex types.

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -139,11 +139,12 @@ Expression _buildFormSerializationExpression(
       'Form encoding not supported for binary types.',
     ),
 
-    AnyModel() => formEncodingPolicy(
+    AnyModel() => encodeAnyToFormExpression(
+      receiver,
       explode: explodeArg,
       allowEmpty: allowEmptyArg,
       useQueryComponent: useQueryComponent ? literalBool(true) : null,
-    ).encodeAny(receiver),
+    ),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for form encoding.',

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 
 /// Creates a Dart expression that correctly serializes a property
@@ -66,15 +67,18 @@ Expression _buildFormSerializationExpression(
   bool? explodeLiteral,
   bool? allowEmptyLiteral,
 }) {
+  final explodeArg = explodeLiteral != null
+      ? literalBool(explodeLiteral)
+      : refer('explode');
+  final allowEmptyArg = allowEmptyLiteral != null
+      ? literalBool(allowEmptyLiteral)
+      : refer('allowEmpty');
+
   Expression callToForm(Expression target, {required bool nullAware}) {
     const methodName = 'toForm';
     final args = <String, Expression>{
-      'explode': explodeLiteral != null
-          ? literalBool(explodeLiteral)
-          : refer('explode'),
-      'allowEmpty': allowEmptyLiteral != null
-          ? literalBool(allowEmptyLiteral)
-          : refer('allowEmpty'),
+      'explode': explodeArg,
+      'allowEmpty': allowEmptyArg,
     };
     if (useQueryComponent) {
       args['useQueryComponent'] = literalBool(true);
@@ -124,7 +128,16 @@ Expression _buildFormSerializationExpression(
       'Form encoding not supported for binary types.',
     ),
 
-    AnyModel() => receiver, // Pass through as-is
+    // Null is handled by the runtime helper itself (which returns the
+    // empty string when allowEmpty is true), so the surrounding
+    // `.ifNullThen(literalString(''))` wrap in [buildToFormPropertyExpression]
+    // is a no-op for this branch (encodeAnyToForm returns String, not
+    // String?).
+    AnyModel() => formEncodingPolicy(
+      explode: explodeArg,
+      allowEmpty: allowEmptyArg,
+      useQueryComponent: useQueryComponent ? literalBool(true) : null,
+    ).encodeAny(receiver),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for form encoding.',

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -163,7 +163,7 @@ Expression _buildSerializationExpression(
       useImmutableCollections: useImmutableCollections,
     ),
     PrimitiveModel() => directReceiver,
-    AnyModel() => jsonEncodingPolicy().encodeAny(directReceiver),
+    AnyModel() => encodeAnyToJsonExpression(directReceiver),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for JSON encoding.',
     ),

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 
 /// Creates a Dart expression that correctly serializes a property
@@ -162,10 +163,7 @@ Expression _buildSerializationExpression(
       useImmutableCollections: useImmutableCollections,
     ),
     PrimitiveModel() => directReceiver,
-    AnyModel() => refer(
-      'encodeAnyToJson',
-      'package:tonik_util/tonik_util.dart',
-    ).call([directReceiver]),
+    AnyModel() => jsonEncodingPolicy().encodeAny(directReceiver),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for JSON encoding.',
     ),

--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -153,10 +153,10 @@ Expression _buildListLabelExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer(
-                  'encodeAnyToUri',
-                  'package:tonik_util/tonik_util.dart',
-                ).call([refer('e')], {'allowEmpty': allowEmpty}).code,
+                ..body = encodeAnyToUriExpression(
+                  refer('e'),
+                  allowEmpty: allowEmpty,
+                ).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -49,11 +50,10 @@ Expression buildLabelParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => _buildAnyModelLabelExpression(
-      valueExpression,
+    AnyModel() => labelEncodingPolicy(
       explode: explode,
       allowEmpty: allowEmpty,
-    ),
+    ).encodeAny(valueExpression),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))
@@ -301,18 +301,4 @@ Expression _buildListMapContentLabelExpression(
           'alreadyEncoded': literalTrue,
         },
       );
-}
-
-Expression _buildAnyModelLabelExpression(
-  Expression valueExpression, {
-  required Expression explode,
-  required Expression allowEmpty,
-}) {
-  return refer('encodeAnyToLabel', 'package:tonik_util/tonik_util.dart').call(
-    [valueExpression],
-    {
-      'explode': explode,
-      'allowEmpty': allowEmpty,
-    },
-  );
 }

--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -50,10 +50,11 @@ Expression buildLabelParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => labelEncodingPolicy(
+    AnyModel() => encodeAnyToLabelExpression(
+      valueExpression,
       explode: explode,
       allowEmpty: allowEmpty,
-    ).encodeAny(valueExpression),
+    ),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -29,9 +30,10 @@ Expression buildToLabelPathParameterExpression(
   final model = parameter.model;
 
   if (model is AnyModel) {
-    return refer('encodeAnyToLabel', 'package:tonik_util/tonik_util.dart').call(
-      [valueRef],
-      {'explode': explode, 'allowEmpty': allowEmpty},
+    return encodeAnyToLabelExpression(
+      valueRef,
+      explode: explode,
+      allowEmpty: allowEmpty,
     );
   }
 
@@ -143,10 +145,10 @@ Expression buildToLabelPathParameterExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer(
-                  'encodeAnyToUri',
-                  'package:tonik_util/tonik_util.dart',
-                ).call([refer('e')], {'allowEmpty': allowEmpty}).code,
+                ..body = encodeAnyToUriExpression(
+                  refer('e'),
+                  allowEmpty: allowEmpty,
+                ).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -52,12 +53,11 @@ Expression buildMatrixParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => _buildAnyModelMatrixExpression(
-      valueExpression,
+    AnyModel() => matrixEncodingPolicy(
       paramName: paramName,
       explode: explode,
       allowEmpty: allowEmpty,
-    ),
+    ).encodeAny(valueExpression),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))
@@ -115,21 +115,6 @@ bool _listMatrixContentUsesValue(Model content) {
     AliasModel(:final model) => _listMatrixContentUsesValue(model),
     _ => true,
   };
-}
-
-Expression _buildAnyModelMatrixExpression(
-  Expression valueExpression, {
-  required Expression paramName,
-  required Expression explode,
-  required Expression allowEmpty,
-}) {
-  return refer('encodeAnyToMatrix', 'package:tonik_util/tonik_util.dart').call(
-    [valueExpression, paramName],
-    {
-      'explode': explode,
-      'allowEmpty': allowEmpty,
-    },
-  );
 }
 
 Expression _buildListMatrixExpression(

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -53,11 +53,12 @@ Expression buildMatrixParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => matrixEncodingPolicy(
+    AnyModel() => encodeAnyToMatrixExpression(
+      valueExpression,
       paramName: paramName,
       explode: explode,
       allowEmpty: allowEmpty,
-    ).encodeAny(valueExpression),
+    ),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -196,16 +196,10 @@ Expression _buildListMatrixExpression(
                   ..requiredParameters.add(
                     Parameter((b) => b..name = 'e'),
                   )
-                  ..body =
-                      refer(
-                            'encodeAnyToUri',
-                            'package:tonik_util/tonik_util.dart',
-                          )
-                          .call(
-                            [refer('e')],
-                            {'allowEmpty': allowEmpty},
-                          )
-                          .code,
+                  ..body = encodeAnyToUriExpression(
+                    refer('e'),
+                    allowEmpty: allowEmpty,
+                  ).code,
               ).closure,
             ],
             {},

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -49,14 +50,10 @@ Expression buildSimpleParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() =>
-      refer('encodeAnyToSimple', 'package:tonik_util/tonik_util.dart').call(
-        [valueExpression],
-        {
-          'explode': explode,
-          'allowEmpty': allowEmpty,
-        },
-      ),
+    AnyModel() => simpleEncodingPolicy(
+      explode: explode,
+      allowEmpty: allowEmpty,
+    ).encodeAny(valueExpression),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -50,10 +50,11 @@ Expression buildSimpleParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
     ),
-    AnyModel() => simpleEncodingPolicy(
+    AnyModel() => encodeAnyToSimpleExpression(
+      valueExpression,
       explode: explode,
       allowEmpty: allowEmpty,
-    ).encodeAny(valueExpression),
+    ),
     Base64Model() => (isNullable
             ? valueExpression.nullSafeProperty('toBase64String')
             : valueExpression.property('toBase64String'))

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -156,10 +156,10 @@ Expression _buildListSimpleExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer(
-                  'encodeAnyToUri',
-                  'package:tonik_util/tonik_util.dart',
-                ).call([refer('e')], {'allowEmpty': allowEmpty}).code,
+                ..body = encodeAnyToUriExpression(
+                  refer('e'),
+                  allowEmpty: allowEmpty,
+                ).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -157,10 +157,11 @@ Expression _buildSimpleSerializationExpression(
       allowEmpty: allowEmpty,
     ),
 
-    AnyModel() => simpleEncodingPolicy(
+    AnyModel() => encodeAnyToSimpleExpression(
+      receiver,
       explode: literalBool(explode),
       allowEmpty: literalBool(allowEmpty),
-    ).encodeAny(receiver),
+    ),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for simple encoding.',

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -156,12 +157,10 @@ Expression _buildSimpleSerializationExpression(
       allowEmpty: allowEmpty,
     ),
 
-    // AnyModel (Object?) - convert to String representation
-    AnyModel() =>
-      receiver
-          .nullSafeProperty('toString')
-          .call([])
-          .ifNullThen(literalString('')),
+    AnyModel() => simpleEncodingPolicy(
+      explode: literalBool(explode),
+      allowEmpty: literalBool(allowEmpty),
+    ).encodeAny(receiver),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for simple encoding.',

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
@@ -30,15 +31,10 @@ Expression buildUriEncodeExpression(
       },
     ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
-      refer(
-        'encodeAnyToUri',
-        'package:tonik_util/tonik_util.dart',
-      ).call(
-        [valueExpression],
-        {
-          'allowEmpty': allowEmpty,
-          'useQueryComponent': ?useQueryComponent,
-        },
+      encodeAnyToUriExpression(
+        valueExpression,
+        allowEmpty: allowEmpty,
+        useQueryComponent: useQueryComponent,
       ),
     MapModel() => _buildMapUriEncodeExpression(
       valueExpression,
@@ -134,19 +130,11 @@ Expression _buildListUriEncodeExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body =
-                    refer(
-                          'encodeAnyToUri',
-                          'package:tonik_util/tonik_util.dart',
-                        )
-                        .call(
-                          [refer('e')],
-                          {
-                            'allowEmpty': allowEmpty,
-                            'useQueryComponent': ?useQueryComponent,
-                          },
-                        )
-                        .code,
+                ..body = encodeAnyToUriExpression(
+                  refer('e'),
+                  allowEmpty: allowEmpty,
+                  useQueryComponent: useQueryComponent,
+                ).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/test/src/util/encoding_policy_test.dart
+++ b/packages/tonik_generate/test/src/util/encoding_policy_test.dart
@@ -182,49 +182,4 @@ void main() {
       );
     });
   });
-
-  group('neverThrow', () {
-    // Each factory returns its own EncodingPolicy, but they all share the
-    // same `neverThrow` closure. One parameterised assertion covers every
-    // factory; if a future refactor splits the closures the loop still
-    // surfaces a regression at the diverging factory.
-    final factories = <String, EncodingPolicy Function()>{
-      'jsonEncodingPolicy': jsonEncodingPolicy,
-      'simpleEncodingPolicy': () => simpleEncodingPolicy(
-            explode: refer('explode'),
-            allowEmpty: refer('allowEmpty'),
-          ),
-      'formEncodingPolicy': () => formEncodingPolicy(
-            explode: refer('explode'),
-            allowEmpty: refer('allowEmpty'),
-          ),
-      'matrixEncodingPolicy': () => matrixEncodingPolicy(
-            paramName: refer('paramName'),
-            explode: refer('explode'),
-            allowEmpty: refer('allowEmpty'),
-          ),
-      'labelEncodingPolicy': () => labelEncodingPolicy(
-            explode: refer('explode'),
-            allowEmpty: refer('allowEmpty'),
-          ),
-    };
-
-    final expectedThrow = formatStatement(
-      "throw EncodingException('Cannot encode NeverModel - this type "
-      "does not permit any value.')",
-    );
-
-    for (final entry in factories.entries) {
-      test('${entry.key} neverThrow emits the standard NeverModel throw', () {
-        final policy = entry.value();
-
-        final actual = formatExpression(policy.neverThrow());
-
-        expect(
-          collapseWhitespace(actual),
-          collapseWhitespace(expectedThrow),
-        );
-      });
-    }
-  });
 }

--- a/packages/tonik_generate/test/src/util/encoding_policy_test.dart
+++ b/packages/tonik_generate/test/src/util/encoding_policy_test.dart
@@ -19,11 +19,11 @@ void main() {
 
   String formatStatement(String body) => format('final result = $body;');
 
-  group('jsonEncodingPolicy', () {
-    test('encodeAny calls encodeAnyToJson with the receiver', () {
-      final policy = jsonEncodingPolicy();
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
+  group('encodeAnyToJsonExpression', () {
+    test('emits encodeAnyToJson(receiver)', () {
+      final actual = formatExpression(
+        encodeAnyToJsonExpression(refer('value')),
+      );
       final expected = formatStatement('encodeAnyToJson(value)');
 
       expect(
@@ -33,31 +33,15 @@ void main() {
     });
   });
 
-  group('simpleEncodingPolicy', () {
-    test('encodeAny calls encodeAnyToSimple with named arguments', () {
-      final policy = simpleEncodingPolicy(
-        explode: refer('explode'),
-        allowEmpty: refer('allowEmpty'),
+  group('encodeAnyToSimpleExpression', () {
+    test('emits encodeAnyToSimple with named arguments', () {
+      final actual = formatExpression(
+        encodeAnyToSimpleExpression(
+          refer('value'),
+          explode: literalBool(true),
+          allowEmpty: literalBool(false),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
-      final expected = formatStatement(
-        'encodeAnyToSimple(value, explode: explode, allowEmpty: allowEmpty)',
-      );
-
-      expect(
-        collapseWhitespace(actual),
-        collapseWhitespace(expected),
-      );
-    });
-
-    test('encodeAny accepts boolean literals for explode and allowEmpty', () {
-      final policy = simpleEncodingPolicy(
-        explode: literalBool(true),
-        allowEmpty: literalBool(false),
-      );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
         'encodeAnyToSimple(value, explode: true, allowEmpty: false)',
       );
@@ -69,16 +53,17 @@ void main() {
     });
   });
 
-  group('formEncodingPolicy', () {
-    test('encodeAny calls encodeAnyToForm with named arguments', () {
-      final policy = formEncodingPolicy(
-        explode: refer('explode'),
-        allowEmpty: refer('allowEmpty'),
+  group('encodeAnyToFormExpression', () {
+    test('omits useQueryComponent when caller does not supply it', () {
+      final actual = formatExpression(
+        encodeAnyToFormExpression(
+          refer('value'),
+          explode: literalBool(true),
+          allowEmpty: literalBool(true),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
-        'encodeAnyToForm(value, explode: explode, allowEmpty: allowEmpty)',
+        'encodeAnyToForm(value, explode: true, allowEmpty: true)',
       );
 
       expect(
@@ -87,31 +72,15 @@ void main() {
       );
     });
 
-    test('encodeAny accepts boolean literals for explode and allowEmpty', () {
-      final policy = formEncodingPolicy(
-        explode: literalBool(false),
-        allowEmpty: literalBool(true),
+    test('threads useQueryComponent: true into encodeAnyToForm', () {
+      final actual = formatExpression(
+        encodeAnyToFormExpression(
+          refer('value'),
+          explode: literalBool(true),
+          allowEmpty: literalBool(true),
+          useQueryComponent: literalBool(true),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
-      final expected = formatStatement(
-        'encodeAnyToForm(value, explode: false, allowEmpty: true)',
-      );
-
-      expect(
-        collapseWhitespace(actual),
-        collapseWhitespace(expected),
-      );
-    });
-
-    test('encodeAny threads useQueryComponent into encodeAnyToForm', () {
-      final policy = formEncodingPolicy(
-        explode: literalBool(true),
-        allowEmpty: literalBool(true),
-        useQueryComponent: literalBool(true),
-      );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
         'encodeAnyToForm(value, explode: true, allowEmpty: true, '
         'useQueryComponent: true)',
@@ -123,16 +92,18 @@ void main() {
       );
     });
 
-    test('encodeAny omits useQueryComponent when caller does not supply it',
-        () {
-      final policy = formEncodingPolicy(
-        explode: literalBool(true),
-        allowEmpty: literalBool(true),
+    test('threads useQueryComponent: false into encodeAnyToForm', () {
+      final actual = formatExpression(
+        encodeAnyToFormExpression(
+          refer('value'),
+          explode: literalBool(false),
+          allowEmpty: literalBool(false),
+          useQueryComponent: literalBool(false),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
-        'encodeAnyToForm(value, explode: true, allowEmpty: true)',
+        'encodeAnyToForm(value, explode: false, allowEmpty: false, '
+        'useQueryComponent: false)',
       );
 
       expect(
@@ -142,16 +113,16 @@ void main() {
     });
   });
 
-  group('matrixEncodingPolicy', () {
-    test('encodeAny calls encodeAnyToMatrix with paramName and named args',
-        () {
-      final policy = matrixEncodingPolicy(
-        paramName: refer('paramName'),
-        explode: refer('explode'),
-        allowEmpty: refer('allowEmpty'),
+  group('encodeAnyToMatrixExpression', () {
+    test('emits encodeAnyToMatrix with paramName and named args', () {
+      final actual = formatExpression(
+        encodeAnyToMatrixExpression(
+          refer('value'),
+          paramName: refer('paramName'),
+          explode: refer('explode'),
+          allowEmpty: refer('allowEmpty'),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
         'encodeAnyToMatrix(value, paramName, explode: explode, '
         'allowEmpty: allowEmpty)',
@@ -164,14 +135,15 @@ void main() {
     });
   });
 
-  group('labelEncodingPolicy', () {
-    test('encodeAny calls encodeAnyToLabel with named arguments', () {
-      final policy = labelEncodingPolicy(
-        explode: refer('explode'),
-        allowEmpty: refer('allowEmpty'),
+  group('encodeAnyToLabelExpression', () {
+    test('emits encodeAnyToLabel with named arguments', () {
+      final actual = formatExpression(
+        encodeAnyToLabelExpression(
+          refer('value'),
+          explode: refer('explode'),
+          allowEmpty: refer('allowEmpty'),
+        ),
       );
-
-      final actual = formatExpression(policy.encodeAny(refer('value')));
       final expected = formatStatement(
         'encodeAnyToLabel(value, explode: explode, allowEmpty: allowEmpty)',
       );

--- a/packages/tonik_generate/test/src/util/encoding_policy_test.dart
+++ b/packages/tonik_generate/test/src/util/encoding_policy_test.dart
@@ -1,0 +1,230 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_generate/src/util/encoding_policy.dart';
+
+void main() {
+  late DartEmitter emitter;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  setUp(() {
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  String formatExpression(Expression expr) =>
+      format('final result = ${expr.accept(emitter)};');
+
+  String formatStatement(String body) => format('final result = $body;');
+
+  group('jsonEncodingPolicy', () {
+    test('encodeAny calls encodeAnyToJson with the receiver', () {
+      final policy = jsonEncodingPolicy();
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement('encodeAnyToJson(value)');
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('simpleEncodingPolicy', () {
+    test('encodeAny calls encodeAnyToSimple with named arguments', () {
+      final policy = simpleEncodingPolicy(
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToSimple(value, explode: explode, allowEmpty: allowEmpty)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('encodeAny accepts boolean literals for explode and allowEmpty', () {
+      final policy = simpleEncodingPolicy(
+        explode: literalBool(true),
+        allowEmpty: literalBool(false),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToSimple(value, explode: true, allowEmpty: false)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('formEncodingPolicy', () {
+    test('encodeAny calls encodeAnyToForm with named arguments', () {
+      final policy = formEncodingPolicy(
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToForm(value, explode: explode, allowEmpty: allowEmpty)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('encodeAny accepts boolean literals for explode and allowEmpty', () {
+      final policy = formEncodingPolicy(
+        explode: literalBool(false),
+        allowEmpty: literalBool(true),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToForm(value, explode: false, allowEmpty: true)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('encodeAny threads useQueryComponent into encodeAnyToForm', () {
+      final policy = formEncodingPolicy(
+        explode: literalBool(true),
+        allowEmpty: literalBool(true),
+        useQueryComponent: literalBool(true),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToForm(value, explode: true, allowEmpty: true, '
+        'useQueryComponent: true)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('encodeAny omits useQueryComponent when caller does not supply it',
+        () {
+      final policy = formEncodingPolicy(
+        explode: literalBool(true),
+        allowEmpty: literalBool(true),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToForm(value, explode: true, allowEmpty: true)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('matrixEncodingPolicy', () {
+    test('encodeAny calls encodeAnyToMatrix with paramName and named args',
+        () {
+      final policy = matrixEncodingPolicy(
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToMatrix(value, paramName, explode: explode, '
+        'allowEmpty: allowEmpty)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('labelEncodingPolicy', () {
+    test('encodeAny calls encodeAnyToLabel with named arguments', () {
+      final policy = labelEncodingPolicy(
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final actual = formatExpression(policy.encodeAny(refer('value')));
+      final expected = formatStatement(
+        'encodeAnyToLabel(value, explode: explode, allowEmpty: allowEmpty)',
+      );
+
+      expect(
+        collapseWhitespace(actual),
+        collapseWhitespace(expected),
+      );
+    });
+  });
+
+  group('neverThrow', () {
+    // Each factory returns its own EncodingPolicy, but they all share the
+    // same `neverThrow` closure. One parameterised assertion covers every
+    // factory; if a future refactor splits the closures the loop still
+    // surfaces a regression at the diverging factory.
+    final factories = <String, EncodingPolicy Function()>{
+      'jsonEncodingPolicy': jsonEncodingPolicy,
+      'simpleEncodingPolicy': () => simpleEncodingPolicy(
+            explode: refer('explode'),
+            allowEmpty: refer('allowEmpty'),
+          ),
+      'formEncodingPolicy': () => formEncodingPolicy(
+            explode: refer('explode'),
+            allowEmpty: refer('allowEmpty'),
+          ),
+      'matrixEncodingPolicy': () => matrixEncodingPolicy(
+            paramName: refer('paramName'),
+            explode: refer('explode'),
+            allowEmpty: refer('allowEmpty'),
+          ),
+      'labelEncodingPolicy': () => labelEncodingPolicy(
+            explode: refer('explode'),
+            allowEmpty: refer('allowEmpty'),
+          ),
+    };
+
+    final expectedThrow = formatStatement(
+      "throw EncodingException('Cannot encode NeverModel - this type "
+      "does not permit any value.')",
+    );
+
+    for (final entry in factories.entries) {
+      test('${entry.key} neverThrow emits the standard NeverModel throw', () {
+        final policy = entry.value();
+
+        final actual = formatExpression(policy.neverThrow());
+
+        expect(
+          collapseWhitespace(actual),
+          collapseWhitespace(expectedThrow),
+        );
+      });
+    }
+  });
+}

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -620,5 +620,136 @@ void main() {
         },
       );
     });
+
+    group('AnyModel encoding', () {
+      test('generates encodeAnyToForm for top-level AnyModel parameter', () {
+        final parameter = createParameter(
+          name: 'anyParam',
+          rawName: 'anyParam',
+          model: AnyModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToFormQueryParameterCode(
+          'anyParam',
+          parameter,
+        );
+
+        final generated = emitCodes(codes);
+        final expected = format(r'''
+          test() {
+            _$entries.add((
+              name: r'anyParam',
+              value: _i1.encodeAnyToForm(
+                anyParam,
+                explode: false,
+                allowEmpty: true,
+              ),
+            ));
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
+        );
+      });
+
+      test(
+        'generates encodeAnyToUri map for non-exploded List<AnyModel>',
+        () {
+          final parameter = createParameter(
+            name: 'anyList',
+            rawName: 'anyList',
+            model: ListModel(
+              content: AnyModel(context: context),
+              context: context,
+            ),
+            explode: false,
+            allowEmpty: true,
+          );
+
+          final codes = buildToFormQueryParameterCode(
+            'anyList',
+            parameter,
+          );
+
+          final generated = emitCodes(codes);
+          final expected = format(r'''
+            test() {
+              _$entries.add((
+                name: r'anyList',
+                value: anyList
+                    .map((e) => _i1.encodeAnyToUri(e, allowEmpty: true))
+                    .toList()
+                    .toForm(explode: false, allowEmpty: true),
+              ));
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+
+      test(
+        'generates encodeAnyToUri addAll for exploded List<OneOfModel>',
+        () {
+          final parameter = createParameter(
+            name: 'oneOfList',
+            rawName: 'oneOfList',
+            model: ListModel(
+              content: OneOfModel(
+                isDeprecated: false,
+                context: context,
+                name: 'StringOrInt',
+                models: {
+                  (
+                    discriminatorValue: 's',
+                    model: StringModel(context: context),
+                  ),
+                  (
+                    discriminatorValue: 'i',
+                    model: IntegerModel(context: context),
+                  ),
+                },
+              ),
+              context: context,
+            ),
+            explode: true,
+            allowEmpty: false,
+          );
+
+          final codes = buildToFormQueryParameterCode(
+            'oneOfList',
+            parameter,
+            explode: true,
+            allowEmpty: false,
+          );
+
+          final generated = emitCodes(codes);
+          final expected = format(r'''
+            test() {
+              _$entries.addAll(
+                oneOfList.map(
+                  (e) => (
+                    name: r'oneOfList',
+                    value: _i1.encodeAnyToUri(e, allowEmpty: false),
+                  ),
+                ),
+              );
+            }
+          ''');
+
+          expect(
+            collapseWhitespace(generated),
+            collapseWhitespace(expected),
+          );
+        },
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -598,6 +598,109 @@ void main() {
       });
     });
 
+    group('AnyModel', () {
+      test('generates encodeAnyToForm call referencing scope variables', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('nullable AnyModel still routes through encodeAnyToForm', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: false,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('uses literal explode/allowEmpty when buildToFormValueExpression '
+          'is called with literals', () {
+        final result = buildToFormValueExpression(
+          'value',
+          AnyModel(context: context),
+          useQueryComponent: false,
+          explodeLiteral: true,
+          allowEmptyLiteral: false,
+        );
+        expect(
+          emit(result),
+          'encodeAnyToForm(value, explode: true, allowEmpty: false, )',
+        );
+      });
+
+      test('threads useQueryComponent: true into encodeAnyToForm when set', () {
+        final result = buildToFormValueExpression(
+          'value',
+          AnyModel(context: context),
+          useQueryComponent: true,
+          explodeLiteral: true,
+          allowEmptyLiteral: true,
+        );
+        expect(
+          emit(result),
+          'encodeAnyToForm(value, explode: true, allowEmpty: true, '
+          'useQueryComponent: true, )',
+        );
+      });
+
+      test('omits useQueryComponent from encodeAnyToForm when false', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        // Default useQueryComponent=false omits the named arg.
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('required + nullable AnyModel emits ifNullThen wrap (no-op for '
+          'encodeAnyToForm which already returns String)', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        // The wrap is emitted because the property is required + nullable;
+        // the runtime helper already returns String (never null) so the
+        // fallback never fires, but the surrounding wrap is consistent with
+        // every other primitive branch.
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )'
+          " ?? ''",
+        );
+      });
+    });
+
     group('useQueryComponent parameter', () {
       test('omits useQueryComponent when false (default)', () {
         final property = Property(

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -671,15 +671,13 @@ void main() {
         );
 
         final result = buildToFormPropertyExpression('data', property);
-        // Default useQueryComponent=false omits the named arg.
         expect(
           emit(result),
           'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
         );
       });
 
-      test('required + nullable AnyModel emits ifNullThen wrap (no-op for '
-          'encodeAnyToForm which already returns String)', () {
+      test('required + nullable AnyModel does NOT emit ifNullThen wrap', () {
         final property = Property(
           name: 'data',
           model: AnyModel(context: context),
@@ -689,15 +687,37 @@ void main() {
         );
 
         final result = buildToFormPropertyExpression('data', property);
-        // The wrap is emitted because the property is required + nullable;
-        // the runtime helper already returns String (never null) so the
-        // fallback never fires, but the surrounding wrap is consistent with
-        // every other primitive branch.
+        final emitted = emit(result);
+
         expect(
-          emit(result),
-          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )'
-          " ?? ''",
+          emitted,
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
         );
+        expect(emitted.contains("?? ''"), isFalse);
+      });
+
+      test('required + nullable AnyModel through AliasModel does NOT emit '
+          'ifNullThen wrap', () {
+        final property = Property(
+          name: 'data',
+          model: AliasModel(
+            name: 'AnyAlias',
+            model: AnyModel(context: context),
+            context: context,
+          ),
+          isRequired: true,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        final emitted = emit(result);
+
+        expect(
+          emitted,
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+        expect(emitted.contains("?? ''"), isFalse);
       });
     });
 

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -693,7 +693,6 @@ void main() {
           emitted,
           'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
         );
-        expect(emitted.contains("?? ''"), isFalse);
       });
 
       test('required + nullable AnyModel through AliasModel does NOT emit '
@@ -717,7 +716,6 @@ void main() {
           emitted,
           'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
         );
-        expect(emitted.contains("?? ''"), isFalse);
       });
     });
 

--- a/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
@@ -584,6 +584,28 @@ void main() {
         );
       },
     );
+
+    test(
+      'generates encodeAnyToLabel for scalar AnyModel path parameter',
+      () {
+        final parameter = PathParameterObject(
+          name: 'anyValue',
+          rawName: 'anyValue',
+          description: 'Any value parameter',
+          model: AnyModel(context: context),
+          encoding: PathParameterEncoding.label,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+        );
+        expect(
+          emit(buildToLabelPathParameterExpression('anyValue', parameter)),
+          'encodeAnyToLabel(anyValue, explode: false, allowEmpty: false, )',
+        );
+      },
+    );
   });
 
   group('MapModel direct support', () {

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -367,6 +367,54 @@ void main() {
       });
     });
 
+    group('AnyModel', () {
+      test('generates encodeAnyToSimple call with literal explode/allowEmpty',
+          () {
+        final model = AnyModel(context: context);
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: true,
+          allowEmpty: false,
+        );
+
+        final generated = format(
+          'final result = ${expression.accept(emitter)};',
+        );
+        const expected = '''
+          final result = encodeAnyToSimple(value, explode: true, allowEmpty: false);
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expected)),
+        );
+      });
+
+      test('passes through explode/allowEmpty unchanged when nullable', () {
+        final model = AnyModel(context: context);
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+          isNullable: true,
+        );
+
+        final generated = format(
+          'final result = ${expression.accept(emitter)};',
+        );
+        const expected = '''
+          final result = encodeAnyToSimple(value, explode: false, allowEmpty: true);
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expected)),
+        );
+      });
+    });
+
     group('MapModel', () {
       test('generates toSimple for MapModel with StringModel values', () {
         final model = MapModel(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -101,6 +101,17 @@ String encodeAnyToLabel(
 /// Handles runtime type detection for values of unknown type.
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
+///
+/// `List` values are encoded comma-separated (the explode setting does not
+/// affect simple-style list serialisation per RFC 6570). `Map` values are
+/// encoded as `k1=v1,k2=v2` when explode=true and `k1,v1,k2,v2` when
+/// explode=false, with each element pre-encoded recursively via
+/// [encodeAnyToSimple] so nested lists / maps / primitives all work.
+///
+/// [allowEmpty] applies to the whole structure: when `false`, an empty inner
+/// list / map / null value at any depth raises [EmptyValueException]. The
+/// flag is threaded through the recursion so that `{'k': []}` with
+/// `allowEmpty: false` throws rather than silently producing `'k,'`.
 String encodeAnyToSimple(
   Object? value, {
   required bool explode,
@@ -136,6 +147,43 @@ String encodeAnyToSimple(
   if (value is BigDecimal) {
     return value.toSimple(explode: explode, allowEmpty: allowEmpty);
   }
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyToSimple(
+          entry.value,
+          explode: explode,
+          allowEmpty: allowEmpty,
+        ),
+    };
+    return encoded.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = value
+        .map(
+          (item) => encodeAnyToSimple(
+            item,
+            explode: explode,
+            allowEmpty: allowEmpty,
+          ),
+        )
+        .toList();
+    return encoded.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to simple style',
   );
@@ -146,10 +194,28 @@ String encodeAnyToSimple(
 /// Handles runtime type detection for values of unknown type.
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
+///
+/// `List` values are encoded comma-separated for explode=false (the
+/// repeated-key explode=true form is handled at the parameter encoder
+/// layer, not here). `Map` values are encoded as `k1=v1&k2=v2` when
+/// explode=true and `k1,v1,k2,v2` when explode=false, with each element
+/// pre-encoded recursively via [encodeAnyToForm] so nested collections
+/// work.
+///
+/// [allowEmpty] applies to the whole structure: when `false`, an empty inner
+/// list / map / null value at any depth raises [EmptyValueException]. The
+/// flag is threaded through the recursion so that `{'k': []}` with
+/// `allowEmpty: false` throws rather than silently producing `'k,'`.
+///
+/// When [useQueryComponent] is true, primitives use
+/// `Uri.encodeQueryComponent` (spaces become `+`) instead of
+/// `Uri.encodeComponent` (spaces become `%20`); the same flag is threaded
+/// into recursive list/map element encoding.
 String encodeAnyToForm(
   Object? value, {
   required bool explode,
   required bool allowEmpty,
+  bool useQueryComponent = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -158,28 +224,101 @@ String encodeAnyToForm(
     return '';
   }
   if (value is ParameterEncodable) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is String) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is int) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is double) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is bool) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is DateTime) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is Uri) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is BigDecimal) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyToForm(
+          entry.value,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+        ),
+    };
+    return encoded.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = value
+        .map(
+          (item) => encodeAnyToForm(
+            item,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+          ),
+        )
+        .toList();
+    return encoded.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
   }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to form style',

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -102,11 +102,12 @@ String encodeAnyToLabel(
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
 ///
-/// `List` values are encoded comma-separated (the explode setting does not
-/// affect simple-style list serialisation per RFC 6570). `Map` values are
-/// encoded as `k1=v1,k2=v2` when explode=true and `k1,v1,k2,v2` when
-/// explode=false, with each element pre-encoded recursively via
-/// [encodeAnyToSimple] so nested lists / maps / primitives all work.
+/// `List` values are encoded comma-separated (at the immediate list level —
+/// explode still propagates into nested maps/lists, where it can affect
+/// their internal rendering). `Map` values are encoded as `k1=v1,k2=v2`
+/// when explode=true and `k1,v1,k2,v2` when explode=false, with each
+/// element pre-encoded recursively via [encodeAnyToSimple] so nested lists
+/// / maps / primitives all work.
 ///
 /// [allowEmpty] applies to the whole structure: when `false`, an empty inner
 /// list / map / null value at any depth raises [EmptyValueException]. The
@@ -199,12 +200,12 @@ String encodeAnyToSimple(
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
 ///
-/// `List` values are encoded comma-separated for explode=false (the
-/// repeated-key explode=true form is handled at the parameter encoder
-/// layer, not here). `Map` values are encoded as `k1=v1&k2=v2` when
-/// explode=true and `k1,v1,k2,v2` when explode=false, with each element
-/// pre-encoded recursively via [encodeAnyToForm] so nested collections
-/// work.
+/// `List` values are always encoded comma-separated within this helper,
+/// regardless of explode. The repeated-key form for explode=true is
+/// applied at the parameter-encoder layer above, not here. `Map` values
+/// are encoded as `k1=v1&k2=v2` when explode=true and `k1,v1,k2,v2` when
+/// explode=false, with each element pre-encoded recursively via
+/// [encodeAnyToForm] so nested collections work.
 ///
 /// [allowEmpty] applies to the whole structure: when `false`, an empty inner
 /// list / map / null value at any depth raises [EmptyValueException]. The

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -112,6 +112,10 @@ String encodeAnyToLabel(
 /// list / map / null value at any depth raises [EmptyValueException]. The
 /// flag is threaded through the recursion so that `{'k': []}` with
 /// `allowEmpty: false` throws rather than silently producing `'k,'`.
+///
+/// Note: when an unsupported nested element raises [EncodingException], the
+/// message identifies only the inner type — no path / key context is attached
+/// to indicate where in the structure the failure originated.
 String encodeAnyToSimple(
   Object? value, {
   required bool explode,
@@ -211,6 +215,10 @@ String encodeAnyToSimple(
 /// `Uri.encodeQueryComponent` (spaces become `+`) instead of
 /// `Uri.encodeComponent` (spaces become `%20`); the same flag is threaded
 /// into recursive list/map element encoding.
+///
+/// Note: when an unsupported nested element raises [EncodingException], the
+/// message identifies only the inner type — no path / key context is attached
+/// to indicate where in the structure the failure originated.
 String encodeAnyToForm(
   Object? value, {
   required bool explode,

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -860,6 +860,29 @@ void main() {
           throwsA(isA<EncodingException>()),
         );
       });
+
+      test('throws for Map<dynamic, dynamic> (type guard requires '
+          'Map<String, dynamic>)', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic, dynamic>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('encodes Map<String, int> (covariant Map<String, dynamic>)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, int>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1',
+        );
+      });
     });
 
     group('recursive allowEmpty propagation', () {
@@ -1466,6 +1489,29 @@ void main() {
         expect(
           () => encodeAnyToForm(Object(), explode: false, allowEmpty: false),
           throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for Map<dynamic, dynamic> (type guard requires '
+          'Map<String, dynamic>)', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic, dynamic>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('encodes Map<String, int> (covariant Map<String, dynamic>)', () {
+        expect(
+          encodeAnyToForm(
+            <String, int>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1',
         );
       });
     });

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -790,10 +790,6 @@ void main() {
       });
 
       test('encodes map of lists recursively', () {
-        // Inner list is comma-joined first; the outer map then comma-joins
-        // key,value pairs (the comma is shared between inner-list separator
-        // and outer-map separator -- this is an inherent limitation of
-        // simple-style for nested structures).
         expect(
           encodeAnyToSimple(
             <String, dynamic>{
@@ -803,6 +799,56 @@ void main() {
             allowEmpty: true,
           ),
           'tags,a,b',
+        );
+      });
+
+      test('encodes map of map with explode=false (true nesting)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'outer,inner,v',
+        );
+      });
+
+      test('encodes map of map with explode=true (true nesting)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: true,
+            allowEmpty: true,
+          ),
+          'outer=inner=v',
+        );
+      });
+
+      test('encodes map with null inner value when allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+    });
+
+    group('null inner element with allowEmpty=true', () {
+      test('encodes list with leading null when allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[null, 'a'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          ',a',
         );
       });
     });
@@ -1096,6 +1142,17 @@ void main() {
         );
       });
 
+      test('uses %20 for spaces by default on list elements', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
+        );
+      });
+
       test('encodes empty list with allowEmpty=true', () {
         expect(
           encodeAnyToForm(
@@ -1179,6 +1236,17 @@ void main() {
         );
       });
 
+      test('uses %20 for spaces by default on map values', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'q=hello%20world',
+        );
+      });
+
       test('encodes empty map with allowEmpty=true', () {
         expect(
           encodeAnyToForm(
@@ -1211,6 +1279,159 @@ void main() {
             allowEmpty: true,
           ),
           'tags,a,b',
+        );
+      });
+
+      test('encodes map of map with explode=false (true nesting)', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'outer,inner,v',
+        );
+      });
+
+      test('encodes map of map with explode=true (true nesting)', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: true,
+            allowEmpty: true,
+          ),
+          'outer=inner=v',
+        );
+      });
+
+      test('encodes map with null inner value when allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': null},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=',
+        );
+      });
+    });
+
+    group('null inner element with allowEmpty=true', () {
+      test('encodes list with leading null when allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[null, 'a'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          ',a',
+        );
+      });
+    });
+
+    group('useQueryComponent recursion', () {
+      test('threads + into list elements inside a map value', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'q': <dynamic>['hello world', 'foo bar'],
+            },
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q,hello+world,foo+bar',
+        );
+      });
+
+      test('uses %20 for list elements inside a map value by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'q': <dynamic>['hello world', 'foo bar'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world,foo%20bar',
+        );
+      });
+
+      test('threads + into map values inside a list', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'q': 'hello world'},
+            ],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q,hello+world',
+        );
+      });
+
+      test('uses %20 for map values inside a list by default', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'q': 'hello world'},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('threads + into map keys', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'has space': 'v'},
+            explode: true,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'has+space=v',
+        );
+      });
+
+      test('uses %20 for map keys by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'has space': 'v'},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'has%20space=v',
+        );
+      });
+
+      test('threads + into ParameterEncodable elements inside a list', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[const QueryComponentAwareEncodable('hello world')],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('uses %20 for ParameterEncodable elements inside a list by default',
+          () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[const QueryComponentAwareEncodable('hello world')],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
         );
       });
     });

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -91,6 +91,53 @@ enum TestUriEncodableEnum implements UriEncodable {
   }
 }
 
+/// A ParameterEncodable stub whose `toForm` actually branches on
+/// `useQueryComponent`. Used to verify the flag is forwarded by
+/// `encodeAnyToForm` instead of being silently dropped.
+class QueryComponentAwareEncodable implements ParameterEncodable {
+  const QueryComponentAwareEncodable(this.rawValue);
+
+  final String rawValue;
+
+  @override
+  String toForm({
+    required bool explode,
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+  }) {
+    return useQueryComponent
+        ? Uri.encodeQueryComponent(rawValue)
+        : Uri.encodeComponent(rawValue);
+  }
+
+  @override
+  String toMatrix(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  String toLabel({required bool explode, required bool allowEmpty}) =>
+      throw UnimplementedError();
+
+  @override
+  String toSimple({required bool explode, required bool allowEmpty}) =>
+      throw UnimplementedError();
+
+  @override
+  List<ParameterEntry> toDeepObject(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Object? toJson() => throw UnimplementedError();
+}
+
 void main() {
   group('encodeAnyToMatrix', () {
     group('ParameterEncodable', () {
@@ -602,11 +649,247 @@ void main() {
       });
     });
 
+    group('List<dynamic>', () {
+      test('encodes a primitive list as comma-separated values', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[1, 2, 3],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('explode=true still produces comma-separated values', () {
+        // Per RFC 6570 simple-style, list items use a single comma separator
+        // regardless of explode (the multi-instance form does not apply).
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[1, 2, 3],
+            explode: true,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('encodes mixed-type list', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>['a', 1, true],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,true',
+        );
+      });
+
+      test('URL-encodes string elements', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>['hello world', 'foo&bar'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world,foo%26bar',
+        );
+      });
+
+      test('encodes empty list with allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty list with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes nested list of maps recursively', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[
+              <String, dynamic>{'a': 1},
+              <String, dynamic>{'b': 2},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,b,2',
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('encodes map with explode=false as k1,v1,k2,v2', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,value,count,5',
+        );
+      });
+
+      test('encodes map with explode=true as k1=v1,k2=v2', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=value,count=5',
+        );
+      });
+
+      test('URL-encodes string values', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'q': 'hello world'},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('encodes empty map with allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty map with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes map of lists recursively', () {
+        // Inner list is comma-joined first; the outer map then comma-joins
+        // key,value pairs (the comma is shared between inner-list separator
+        // and outer-map separator -- this is an inherent limitation of
+        // simple-style for nested structures).
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'tags': <dynamic>['a', 'b'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'tags,a,b',
+        );
+      });
+    });
+
     group('unsupported types', () {
       test('throws for unsupported type', () {
         expect(
           () => encodeAnyToSimple(Object(), explode: false, allowEmpty: false),
           throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+
+    group('recursive allowEmpty propagation', () {
+      // The caller's allowEmpty must apply at every depth. An inner empty
+      // list / map / null inside a non-empty outer container must throw when
+      // the caller asked for no empty values.
+      test('throws for non-empty map with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty list with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with empty inner map and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': <String, dynamic>{}},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with null inner value and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes non-empty map with empty inner list when '
+          'allowEmpty=true', () {
+        // The bifurcation check: same shape, opposite flag must succeed.
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+
+      test('encodes non-empty list with empty inner list when '
+          'allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
         );
       });
     });
@@ -628,6 +911,26 @@ void main() {
           encodeAnyToForm(model, explode: false, allowEmpty: false),
           'name,test,value,42',
         );
+      });
+
+      test('forwards useQueryComponent to ParameterEncodable.toForm', () {
+        const model = QueryComponentAwareEncodable('hello world');
+
+        final withoutQuery = encodeAnyToForm(
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+        final withQuery = encodeAnyToForm(
+          model,
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+        );
+
+        expect(withoutQuery, 'hello%20world');
+        expect(withQuery, 'hello+world');
+        expect(withoutQuery == withQuery, isFalse);
       });
     });
 
@@ -745,11 +1048,281 @@ void main() {
       });
     });
 
+    group('List<dynamic>', () {
+      test('encodes a primitive list as comma-separated values', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[1, 2, 3],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('explode=true still produces comma-separated values', () {
+        // The explode=true repeated-key form is handled at the parameter
+        // encoder layer; this helper returns a single string.
+        expect(
+          encodeAnyToForm(
+            <dynamic>[1, 2, 3],
+            explode: true,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('URL-encodes string elements with %20 by default', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world', 'foo&bar'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world,foo%26bar',
+        );
+      });
+
+      test('uses + for spaces with useQueryComponent=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world'],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('encodes empty list with allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty list with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes nested list of maps recursively', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'a': 1},
+              <String, dynamic>{'b': 2},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,b,2',
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('encodes map with explode=false as k1,v1,k2,v2', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,value,count,5',
+        );
+      });
+
+      test('encodes map with explode=true as k1=v1&k2=v2', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=value&count=5',
+        );
+      });
+
+      test('URL-encodes string values with %20 by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('uses + for spaces with useQueryComponent=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: true,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q=hello+world',
+        );
+      });
+
+      test('encodes empty map with allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty map with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes map of lists recursively', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'tags': <dynamic>['a', 'b'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'tags,a,b',
+        );
+      });
+    });
+
+    group('useQueryComponent on primitives', () {
+      test('uses + for spaces with useQueryComponent=true on String', () {
+        expect(
+          encodeAnyToForm(
+            'hello world',
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('uses %20 for spaces by default on String', () {
+        expect(
+          encodeAnyToForm(
+            'hello world',
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
+        );
+      });
+    });
+
     group('unsupported types', () {
       test('throws for unsupported type', () {
         expect(
           () => encodeAnyToForm(Object(), explode: false, allowEmpty: false),
           throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+
+    group('recursive allowEmpty propagation', () {
+      // The caller's allowEmpty must apply at every depth. An inner empty
+      // list / map / null inside a non-empty outer container must throw when
+      // the caller asked for no empty values.
+      test('throws for non-empty map with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty list with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with empty inner map and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': <String, dynamic>{}},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with null inner value and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes non-empty map with empty inner list when '
+          'allowEmpty=true', () {
+        // The bifurcation check: same shape, opposite flag must succeed.
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+
+      test('encodes non-empty list with empty inner list when '
+          'allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
         );
       });
     });


### PR DESCRIPTION
## Summary

- Adds five top-level `encodeAnyTo*Expression(...)` functions in `packages/tonik_generate/lib/src/util/encoding_policy.dart`, each returning an `Expression` that calls the matching `encodeAnyTo*` runtime helper. Centralizes AnyModel encoding emission across the value- and parameter-level generators that previously each handled the `AnyModel` switch arm differently.
- Replaces two buggy `AnyModel` emission shapes:
  - `to_simple_value_expression_generator.dart` previously emitted `value?.toString().ifNullThen('')` — the forbidden `.toString()` fallback. Now emits `encodeAnyToSimple(...)`.
  - `to_form_value_expression_generator.dart` previously emitted silent pass-through (`AnyModel() => receiver`). Now emits `encodeAnyToForm(..., useQueryComponent: ...)`.
  - `to_json_value_expression_generator.dart` and the four parameter generators (`to_simple_parameter`, `to_label_parameter`, `to_matrix_parameter`, `to_form_parameter`) routed through the new functions as no-op refactors. Two local helpers (`_buildAnyModelLabelExpression`, `_buildAnyModelMatrixExpression`) deleted.
- Suppresses the dead `?? ''` wrap that the form-value generator was emitting for required-and-nullable AnyModel properties (the wrap triggered `dead_null_aware_expression` lint in consumer code because `encodeAnyToForm` returns non-nullable `String`).
- Fixes runtime gaps in `packages/tonik_util/lib/src/encoding/any_encoding.dart` that the bug fix exposed:
  - `encodeAnyToSimple` and `encodeAnyToForm` now handle `List<dynamic>` and `Map<String, dynamic>` per RFC 6570 simple-style and form-style rules. Without this, `AnyModel` headers/paths/query-params holding arrays or objects threw `EncodingException` at runtime.
  - `allowEmpty` is threaded through the recursive `List`/`Map` calls so nested empty-value violations surface as `EmptyValueException` instead of being silently swallowed.
  - `useQueryComponent` is now threaded through the `ParameterEncodable` branch and accepted by `encodeAnyToForm` itself for form-urlencoded bodies (default `false` preserves backward compat for existing callers).

## Test plan

- [x] `fvm dart analyze` (`packages/tonik_generate`, `packages/tonik_util`) — clean
- [x] `fvm dart test` per package — all unit tests pass
- [x] `./scripts/setup_integration_tests.sh` — regenerates without errors
- [x] `melos run test` — all integration suites pass
- [x] Critical regressions verified: `boolean_schemas` `getHeaderAnyExplode`/`getPathAnyExplode` with array and object values pass (these failed before the runtime gap fix)
- [x] Patch coverage: 100% on touched files
- [x] New tests cover: List/Map handling for both helpers, explode true/false, allowEmpty edge cases, nested cases (list-of-maps / map-of-lists / map-of-maps / null inner with allowEmpty true and false), recursive `allowEmpty` propagation throwing `EmptyValueException`, `ParameterEncodable` stub branching on `useQueryComponent`, `useQueryComponent` thread-through into recursive map values, list elements, and map keys

## Out of scope

- Decoder-side `from_*_value` generators — currently pass-through and internally consistent.
- Composite generators (`class_generator`, `all_of_generator`, `any_of_generator`, `one_of_generator`) and `to_multipart_expression_generator.dart` — distinct algorithms, not part of this consolidation.
- The remaining `?.toString() ?? ""` AnyModel shape in `to_form_query_parameter_expression_generator.dart:318` — same anti-pattern. The query-suffix path returns `List<Code>` (not `Expression`) and has different list-handling semantics, so it's not a mechanical port. Deserves a dedicated change.
- Recursion-path breadcrumbs in nested `EncodingException` — documented as a known limitation in the runtime helper dartdoc.