### PR TITLE
Fix AnyModel encoding: runtime List/Map gaps and three callsite bugs

### DIFF
--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -313,7 +313,7 @@ String? _getFormSerializationSuffix(
 
     Base64Model() => '.toBase64String().toForm($paramString)',
 
-    AnyModel() => '?.toString() ?? ""',
+    AnyModel() => null,
     NeverModel() => null,
     BinaryModel() => null,
 

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -22,8 +22,13 @@ Expression buildToFormPropertyExpression(
     useQueryComponent: useQueryComponent,
   );
 
-  // For required but nullable properties, provide empty string fallback
-  if (property.isRequired && property.isNullable) {
+  // Skip the empty-string fallback when the underlying model is AnyModel:
+  // encodeAnyToForm returns a non-nullable String, so `?? ''` would be dead
+  // code and trigger a `dead_null_aware_expression` lint in the generated
+  // output.
+  if (property.isRequired &&
+      property.isNullable &&
+      property.model.resolved is! AnyModel) {
     return expr.ifNullThen(literalString(''));
   }
 
@@ -124,7 +129,21 @@ Expression _buildFormSerializationExpression(
       'Form encoding not supported for binary types.',
     ),
 
-    AnyModel() => receiver, // Pass through as-is
+    AnyModel() => refer(
+      'encodeAnyToForm',
+      'package:tonik_util/tonik_util.dart',
+    ).call(
+      [receiver],
+      {
+        'explode': explodeLiteral != null
+            ? literalBool(explodeLiteral)
+            : refer('explode'),
+        'allowEmpty': allowEmptyLiteral != null
+            ? literalBool(allowEmptyLiteral)
+            : refer('allowEmpty'),
+        if (useQueryComponent) 'useQueryComponent': literalBool(true),
+      },
+    ),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for form encoding.',

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -156,12 +156,14 @@ Expression _buildSimpleSerializationExpression(
       allowEmpty: allowEmpty,
     ),
 
-    // AnyModel (Object?) - convert to String representation
     AnyModel() =>
-      receiver
-          .nullSafeProperty('toString')
-          .call([])
-          .ifNullThen(literalString('')),
+      refer('encodeAnyToSimple', 'package:tonik_util/tonik_util.dart').call(
+        [receiver],
+        {
+          'explode': literalBool(explode),
+          'allowEmpty': literalBool(allowEmpty),
+        },
+      ),
 
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for simple encoding.',

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -598,6 +598,127 @@ void main() {
       });
     });
 
+    group('AnyModel', () {
+      test('generates encodeAnyToForm call referencing scope variables', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('nullable AnyModel still routes through encodeAnyToForm', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: false,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('uses literal explode/allowEmpty when buildToFormValueExpression '
+          'is called with literals', () {
+        final result = buildToFormValueExpression(
+          'value',
+          AnyModel(context: context),
+          useQueryComponent: false,
+          explodeLiteral: true,
+          allowEmptyLiteral: false,
+        );
+        expect(
+          emit(result),
+          'encodeAnyToForm(value, explode: true, allowEmpty: false, )',
+        );
+      });
+
+      test('threads useQueryComponent: true into encodeAnyToForm when set', () {
+        final result = buildToFormValueExpression(
+          'value',
+          AnyModel(context: context),
+          useQueryComponent: true,
+          explodeLiteral: true,
+          allowEmptyLiteral: true,
+        );
+        expect(
+          emit(result),
+          'encodeAnyToForm(value, explode: true, allowEmpty: true, '
+          'useQueryComponent: true, )',
+        );
+      });
+
+      test('omits useQueryComponent from encodeAnyToForm when false', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        expect(
+          emit(result),
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('required + nullable AnyModel does NOT emit ifNullThen wrap', () {
+        final property = Property(
+          name: 'data',
+          model: AnyModel(context: context),
+          isRequired: true,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        final emitted = emit(result);
+
+        expect(
+          emitted,
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+
+      test('required + nullable AnyModel through AliasModel does NOT emit '
+          'ifNullThen wrap', () {
+        final property = Property(
+          name: 'data',
+          model: AliasModel(
+            name: 'AnyAlias',
+            model: AnyModel(context: context),
+            context: context,
+          ),
+          isRequired: true,
+          isNullable: true,
+          isDeprecated: false,
+        );
+
+        final result = buildToFormPropertyExpression('data', property);
+        final emitted = emit(result);
+
+        expect(
+          emitted,
+          'encodeAnyToForm(data, explode: explode, allowEmpty: allowEmpty, )',
+        );
+      });
+    });
+
     group('useQueryComponent parameter', () {
       test('omits useQueryComponent when false (default)', () {
         final property = Property(

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -367,6 +367,54 @@ void main() {
       });
     });
 
+    group('AnyModel', () {
+      test('generates encodeAnyToSimple call with literal explode/allowEmpty',
+          () {
+        final model = AnyModel(context: context);
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: true,
+          allowEmpty: false,
+        );
+
+        final generated = format(
+          'final result = ${expression.accept(emitter)};',
+        );
+        const expected = '''
+          final result = encodeAnyToSimple(value, explode: true, allowEmpty: false);
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expected)),
+        );
+      });
+
+      test('passes through explode/allowEmpty unchanged when nullable', () {
+        final model = AnyModel(context: context);
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+          isNullable: true,
+        );
+
+        final generated = format(
+          'final result = ${expression.accept(emitter)};',
+        );
+        const expected = '''
+          final result = encodeAnyToSimple(value, explode: false, allowEmpty: true);
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expected)),
+        );
+      });
+    });
+
     group('MapModel', () {
       test('generates toSimple for MapModel with StringModel values', () {
         final model = MapModel(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -101,6 +101,22 @@ String encodeAnyToLabel(
 /// Handles runtime type detection for values of unknown type.
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
+///
+/// `List` values are encoded comma-separated (at the immediate list level —
+/// explode still propagates into nested maps/lists, where it can affect
+/// their internal rendering). `Map` values are encoded as `k1=v1,k2=v2`
+/// when explode=true and `k1,v1,k2,v2` when explode=false, with each
+/// element pre-encoded recursively via [encodeAnyToSimple] so nested lists
+/// / maps / primitives all work.
+///
+/// [allowEmpty] applies to the whole structure: when `false`, an empty inner
+/// list / map / null value at any depth raises [EmptyValueException]. The
+/// flag is threaded through the recursion so that `{'k': []}` with
+/// `allowEmpty: false` throws rather than silently producing `'k,'`.
+///
+/// Note: when an unsupported nested element raises [EncodingException], the
+/// message identifies only the inner type — no path / key context is attached
+/// to indicate where in the structure the failure originated.
 String encodeAnyToSimple(
   Object? value, {
   required bool explode,
@@ -136,6 +152,43 @@ String encodeAnyToSimple(
   if (value is BigDecimal) {
     return value.toSimple(explode: explode, allowEmpty: allowEmpty);
   }
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyToSimple(
+          entry.value,
+          explode: explode,
+          allowEmpty: allowEmpty,
+        ),
+    };
+    return encoded.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = value
+        .map(
+          (item) => encodeAnyToSimple(
+            item,
+            explode: explode,
+            allowEmpty: allowEmpty,
+          ),
+        )
+        .toList();
+    return encoded.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+    );
+  }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to simple style',
   );
@@ -146,10 +199,32 @@ String encodeAnyToSimple(
 /// Handles runtime type detection for values of unknown type.
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
+///
+/// `List` values are always encoded comma-separated within this helper,
+/// regardless of explode. The repeated-key form for explode=true is
+/// applied at the parameter-encoder layer above, not here. `Map` values
+/// are encoded as `k1=v1&k2=v2` when explode=true and `k1,v1,k2,v2` when
+/// explode=false, with each element pre-encoded recursively via
+/// [encodeAnyToForm] so nested collections work.
+///
+/// [allowEmpty] applies to the whole structure: when `false`, an empty inner
+/// list / map / null value at any depth raises [EmptyValueException]. The
+/// flag is threaded through the recursion so that `{'k': []}` with
+/// `allowEmpty: false` throws rather than silently producing `'k,'`.
+///
+/// When [useQueryComponent] is true, primitives use
+/// `Uri.encodeQueryComponent` (spaces become `+`) instead of
+/// `Uri.encodeComponent` (spaces become `%20`); the same flag is threaded
+/// into recursive list/map element encoding.
+///
+/// Note: when an unsupported nested element raises [EncodingException], the
+/// message identifies only the inner type — no path / key context is attached
+/// to indicate where in the structure the failure originated.
 String encodeAnyToForm(
   Object? value, {
   required bool explode,
   required bool allowEmpty,
+  bool useQueryComponent = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -158,28 +233,101 @@ String encodeAnyToForm(
     return '';
   }
   if (value is ParameterEncodable) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is String) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is int) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is double) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is bool) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is DateTime) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is Uri) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
   }
   if (value is BigDecimal) {
-    return value.toForm(explode: explode, allowEmpty: allowEmpty);
+    return value.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyToForm(
+          entry.value,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+        ),
+    };
+    return encoded.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final encoded = value
+        .map(
+          (item) => encodeAnyToForm(
+            item,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+          ),
+        )
+        .toList();
+    return encoded.toForm(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      alreadyEncoded: true,
+      useQueryComponent: useQueryComponent,
+    );
   }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to form style',

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -91,6 +91,53 @@ enum TestUriEncodableEnum implements UriEncodable {
   }
 }
 
+/// A ParameterEncodable stub whose `toForm` actually branches on
+/// `useQueryComponent`. Used to verify the flag is forwarded by
+/// `encodeAnyToForm` instead of being silently dropped.
+class QueryComponentAwareEncodable implements ParameterEncodable {
+  const QueryComponentAwareEncodable(this.rawValue);
+
+  final String rawValue;
+
+  @override
+  String toForm({
+    required bool explode,
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+  }) {
+    return useQueryComponent
+        ? Uri.encodeQueryComponent(rawValue)
+        : Uri.encodeComponent(rawValue);
+  }
+
+  @override
+  String toMatrix(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  String toLabel({required bool explode, required bool allowEmpty}) =>
+      throw UnimplementedError();
+
+  @override
+  String toSimple({required bool explode, required bool allowEmpty}) =>
+      throw UnimplementedError();
+
+  @override
+  List<ParameterEntry> toDeepObject(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) =>
+      throw UnimplementedError();
+
+  @override
+  Object? toJson() => throw UnimplementedError();
+}
+
 void main() {
   group('encodeAnyToMatrix', () {
     group('ParameterEncodable', () {
@@ -602,11 +649,316 @@ void main() {
       });
     });
 
+    group('List<dynamic>', () {
+      test('encodes a primitive list as comma-separated values', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[1, 2, 3],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('explode=true still produces comma-separated values', () {
+        // Per RFC 6570 simple-style, list items use a single comma separator
+        // regardless of explode (the multi-instance form does not apply).
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[1, 2, 3],
+            explode: true,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('encodes mixed-type list', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>['a', 1, true],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,true',
+        );
+      });
+
+      test('URL-encodes string elements', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>['hello world', 'foo&bar'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world,foo%26bar',
+        );
+      });
+
+      test('encodes empty list with allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty list with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes nested list of maps recursively', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[
+              <String, dynamic>{'a': 1},
+              <String, dynamic>{'b': 2},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,b,2',
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('encodes map with explode=false as k1,v1,k2,v2', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,value,count,5',
+        );
+      });
+
+      test('encodes map with explode=true as k1=v1,k2=v2', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=value,count=5',
+        );
+      });
+
+      test('URL-encodes string values', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'q': 'hello world'},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('encodes empty map with allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty map with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes map of lists recursively', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'tags': <dynamic>['a', 'b'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'tags,a,b',
+        );
+      });
+
+      test('encodes map of map with explode=false (true nesting)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'outer,inner,v',
+        );
+      });
+
+      test('encodes map of map with explode=true (true nesting)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: true,
+            allowEmpty: true,
+          ),
+          'outer=inner=v',
+        );
+      });
+
+      test('encodes map with null inner value when allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+    });
+
+    group('null inner element with allowEmpty=true', () {
+      test('encodes list with leading null when allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[null, 'a'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          ',a',
+        );
+      });
+    });
+
     group('unsupported types', () {
       test('throws for unsupported type', () {
         expect(
           () => encodeAnyToSimple(Object(), explode: false, allowEmpty: false),
           throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for Map<dynamic, dynamic> (type guard requires '
+          'Map<String, dynamic>)', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic, dynamic>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('encodes Map<String, int> (covariant Map<String, dynamic>)', () {
+        expect(
+          encodeAnyToSimple(
+            <String, int>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1',
+        );
+      });
+    });
+
+    group('recursive allowEmpty propagation', () {
+      // The caller's allowEmpty must apply at every depth. An inner empty
+      // list / map / null inside a non-empty outer container must throw when
+      // the caller asked for no empty values.
+      test('throws for non-empty map with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty list with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with empty inner map and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': <String, dynamic>{}},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with null inner value and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSimple(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes non-empty map with empty inner list when '
+          'allowEmpty=true', () {
+        // The bifurcation check: same shape, opposite flag must succeed.
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+
+      test('encodes non-empty list with empty inner list when '
+          'allowEmpty=true', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
         );
       });
     });
@@ -628,6 +980,26 @@ void main() {
           encodeAnyToForm(model, explode: false, allowEmpty: false),
           'name,test,value,42',
         );
+      });
+
+      test('forwards useQueryComponent to ParameterEncodable.toForm', () {
+        const model = QueryComponentAwareEncodable('hello world');
+
+        final withoutQuery = encodeAnyToForm(
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+        final withQuery = encodeAnyToForm(
+          model,
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+        );
+
+        expect(withoutQuery, 'hello%20world');
+        expect(withQuery, 'hello+world');
+        expect(withoutQuery == withQuery, isFalse);
       });
     });
 
@@ -745,11 +1117,479 @@ void main() {
       });
     });
 
+    group('List<dynamic>', () {
+      test('encodes a primitive list as comma-separated values', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[1, 2, 3],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('explode=true still produces comma-separated values', () {
+        // The explode=true repeated-key form is handled at the parameter
+        // encoder layer; this helper returns a single string.
+        expect(
+          encodeAnyToForm(
+            <dynamic>[1, 2, 3],
+            explode: true,
+            allowEmpty: true,
+          ),
+          '1,2,3',
+        );
+      });
+
+      test('URL-encodes string elements with %20 by default', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world', 'foo&bar'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world,foo%26bar',
+        );
+      });
+
+      test('uses + for spaces with useQueryComponent=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world'],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('uses %20 for spaces by default on list elements', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['hello world'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
+        );
+      });
+
+      test('encodes empty list with allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty list with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic>[],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes nested list of maps recursively', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'a': 1},
+              <String, dynamic>{'b': 2},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1,b,2',
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('encodes map with explode=false as k1,v1,k2,v2', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,value,count,5',
+        );
+      });
+
+      test('encodes map with explode=true as k1=v1&k2=v2', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': 'value', 'count': 5},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=value&count=5',
+        );
+      });
+
+      test('URL-encodes string values with %20 by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('uses + for spaces with useQueryComponent=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: true,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q=hello+world',
+        );
+      });
+
+      test('uses %20 for spaces by default on map values', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'q': 'hello world'},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'q=hello%20world',
+        );
+      });
+
+      test('encodes empty map with allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
+        );
+      });
+
+      test('throws for empty map with allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes map of lists recursively', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'tags': <dynamic>['a', 'b'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'tags,a,b',
+        );
+      });
+
+      test('encodes map of map with explode=false (true nesting)', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'outer,inner,v',
+        );
+      });
+
+      test('encodes map of map with explode=true (true nesting)', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'outer': <String, dynamic>{'inner': 'v'},
+            },
+            explode: true,
+            allowEmpty: true,
+          ),
+          'outer=inner=v',
+        );
+      });
+
+      test('encodes map with null inner value when allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': null},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'key=',
+        );
+      });
+    });
+
+    group('null inner element with allowEmpty=true', () {
+      test('encodes list with leading null when allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[null, 'a'],
+            explode: false,
+            allowEmpty: true,
+          ),
+          ',a',
+        );
+      });
+    });
+
+    group('useQueryComponent recursion', () {
+      test('threads + into list elements inside a map value', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'q': <dynamic>['hello world', 'foo bar'],
+            },
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q,hello+world,foo+bar',
+        );
+      });
+
+      test('uses %20 for list elements inside a map value by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'q': <dynamic>['hello world', 'foo bar'],
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world,foo%20bar',
+        );
+      });
+
+      test('threads + into map values inside a list', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'q': 'hello world'},
+            ],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'q,hello+world',
+        );
+      });
+
+      test('uses %20 for map values inside a list by default', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[
+              <String, dynamic>{'q': 'hello world'},
+            ],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'q,hello%20world',
+        );
+      });
+
+      test('threads + into map keys', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'has space': 'v'},
+            explode: true,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'has+space=v',
+        );
+      });
+
+      test('uses %20 for map keys by default', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'has space': 'v'},
+            explode: true,
+            allowEmpty: true,
+          ),
+          'has%20space=v',
+        );
+      });
+
+      test('threads + into ParameterEncodable elements inside a list', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[const QueryComponentAwareEncodable('hello world')],
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('uses %20 for ParameterEncodable elements inside a list by default',
+          () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[const QueryComponentAwareEncodable('hello world')],
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
+        );
+      });
+    });
+
+    group('useQueryComponent on primitives', () {
+      test('uses + for spaces with useQueryComponent=true on String', () {
+        expect(
+          encodeAnyToForm(
+            'hello world',
+            explode: false,
+            allowEmpty: true,
+            useQueryComponent: true,
+          ),
+          'hello+world',
+        );
+      });
+
+      test('uses %20 for spaces by default on String', () {
+        expect(
+          encodeAnyToForm(
+            'hello world',
+            explode: false,
+            allowEmpty: true,
+          ),
+          'hello%20world',
+        );
+      });
+    });
+
     group('unsupported types', () {
       test('throws for unsupported type', () {
         expect(
           () => encodeAnyToForm(Object(), explode: false, allowEmpty: false),
           throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for Map<dynamic, dynamic> (type guard requires '
+          'Map<String, dynamic>)', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic, dynamic>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('encodes Map<String, int> (covariant Map<String, dynamic>)', () {
+        expect(
+          encodeAnyToForm(
+            <String, int>{'a': 1},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'a,1',
+        );
+      });
+    });
+
+    group('recursive allowEmpty propagation', () {
+      // The caller's allowEmpty must apply at every depth. An inner empty
+      // list / map / null inside a non-empty outer container must throw when
+      // the caller asked for no empty values.
+      test('throws for non-empty map with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty list with empty inner list and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with empty inner map and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': <String, dynamic>{}},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for non-empty map with null inner value and '
+          'allowEmpty=false', () {
+        expect(
+          () => encodeAnyToForm(
+            <String, dynamic>{'key': null},
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('encodes non-empty map with empty inner list when '
+          'allowEmpty=true', () {
+        // The bifurcation check: same shape, opposite flag must succeed.
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'key': <dynamic>[]},
+            explode: false,
+            allowEmpty: true,
+          ),
+          'key,',
+        );
+      });
+
+      test('encodes non-empty list with empty inner list when '
+          'allowEmpty=true', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>[<dynamic>[]],
+            explode: false,
+            allowEmpty: true,
+          ),
+          '',
         );
       });
     });


### PR DESCRIPTION
## Summary

Fixes the AnyModel runtime gap that breaks `boolean_schemas` integration tests on `main` (4 tests asserting `getHeaderAnyExplode` and `getPathAnyExplode` with array/object values) plus three concrete generator-side encoding bugs. No new abstractions — each callsite gets the right inline `refer('encodeAnyTo*', util).call(...)` shape.

### Runtime (`tonik_util`)
- `encodeAnyToSimple` and `encodeAnyToForm` now handle `List<dynamic>` and `Map<String, dynamic>` per RFC 6570 simple-style and form-style rules. Previously these threw `EncodingException` for arrays/objects, breaking `AnyModel` headers, paths, and query parameters.
- `encodeAnyToForm` accepts `useQueryComponent` (default `false`) and threads it through every primitive branch, the `ParameterEncodable` branch, and the new recursive list/map branches — so form-urlencoded bodies encode spaces as `+` end-to-end.
- `allowEmpty` is threaded through recursive list/map calls so nested empty values surface as `EmptyValueException` instead of silently encoding to `''`.
- Two doc-string factual corrections.

### Generator callsite bugs (`tonik_generate`)
- `to_simple_value_expression_generator.dart` AnyModel arm replaced `value?.toString().ifNullThen('')` (the forbidden `.toString()` fallback) with a direct `encodeAnyToSimple(...)` call.
- `to_form_value_expression_generator.dart` AnyModel arm replaced silent pass-through (`AnyModel() => receiver`) with a direct `encodeAnyToForm(..., useQueryComponent: ...)` call. The surrounding `ifNullThen('')` wrap now skips AnyModel because `encodeAnyToForm` returns non-nullable `String` — otherwise generated code would contain `... ?? ''` and trigger `dead_null_aware_expression`.
- `to_form_query_parameter_expression_generator.dart` AnyModel suffix-path: changed `'?.toString() ?? ""'` to `null` so the existing `EncodingException` throw at the caller fires instead of silently emitting `[a, b].toString()` for arrays via the `AliasModel(AnyModel)` recursion path.

## Out of scope (no abstraction, no dragnet)
- No `EncodingPolicy` table or other generator-side wrapper. The 11 callsites that route to runtime helpers stay as inline `refer(...).call(...)`.
- No `NeverModel` literal dedupe.
- No decoder-side, composite, multipart, parameter-generator collapse, or `tonik_core`/`tonik_parse` changes.
- No `Date` (date-only) or `Map<dynamic, dynamic>` first-class support in `encodeAnyTo*` helpers (pre-existing gaps; out of scope).

## Test plan
- [x] `mcp__dart__analyze_files` clean across all touched files
- [x] `tonik_util` unit tests — 1064/1064 pass (~570 LOC of new tests covering List/Map handling, useQueryComponent thread-through including `ParameterEncodable` stub, allowEmpty recursion bifurcation matrix, `Map<dynamic, dynamic>` fall-through)
- [x] `tonik_generate` unit tests — 2298/2298 pass (new AnyModel arm tests for the 3 callsite fixes, including `required + nullable + AnyModel` and `required + nullable + AliasModel(AnyModel)` wrap-suppression assertions)
- [x] `./scripts/setup_integration_tests.sh` regenerates without errors
- [x] Critical regression fixed: `boolean_schemas/header_parameters_test.dart` `getHeaderAnyExplode` array/object, `path_parameters_test.dart` `getPathAnyExplode` array/object — all pass (110/110 boolean_schemas tests pass)
- [x] Full `melos run test` integration suite passes