### PR TITLE
fix: hoist throw expressions for unsupported simple/matrix path params

### DIFF
--- a/.claude/agents/tonik-generator.md
+++ b/.claude/agents/tonik-generator.md
@@ -37,6 +37,7 @@ The four preloaded skills (code-builder, testing, integration-tests, openapi-spe
 12. **Never use `melos run analyze` per-package loops.** Run `fvm dart analyze` ONCE from the project root.
 13. **Never chain bash commands with `&&` or `;`.** Run them one at a time.
 14. **No infrastructure / script changes mixed into a feature commit.** Bug-fix and feature PRs touch only the feature scope.
+15. **Comments explain WHY, never WHAT.** Default to no comments. Do not narrate code lines, restate type signatures, summarise switch cases, or describe what a function does when its name and parameters already make that clear. Only write a comment when a reader of the code could not infer the reasoning — a hidden constraint, a non-obvious invariant, an operator-precedence trap, a workaround for a specific bug. If removing the comment would not confuse a future reader, do not write it. This applies to inline comments AND doc comments — a one-line doc on a helper whose name already explains it is noise. Apply this in Phase 5 cleanup: re-read every comment in your diff and delete the ones that explain WHAT.
 
 ## Your Workflow
 
@@ -84,7 +85,7 @@ Before declaring done, re-read every file you changed and verify:
 - All tests pass: `melos run test`
 - Patch coverage >= 90%: `bash scripts/coverage.sh --diff main`
 
-**Comment accuracy:** Every comment accurately describes the code it refers to. No misleading terminology, no stale references. Default to no comments unless the WHY is non-obvious.
+**Comment accuracy & quantity:** Every comment accurately describes the code it refers to. No misleading terminology, no stale references. Default to NO comments. Only keep a comment when it captures WHY (a hidden constraint, non-obvious invariant, operator-precedence trap, bug workaround) — never WHAT the code does. Delete comments that restate the code, summarise switch cases, or document obvious helpers. See HARD RULE 15.
 
 **Naming:** State variable and function names are semantically accurate.
 

--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1301,6 +1301,90 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  # =============================================================================
+  # SIMPLE STYLE - LITERAL SUFFIX AFTER THROW-PRODUCING PARAMETERS
+  # =============================================================================
+
+  /simple/throw-suffix/map-complex/{m}.json:
+    get:
+      operationId: testSimpleMapComplexWithSuffix
+      tags: [simple]
+      summary: Simple-style map with complex value type and literal suffix
+      description: |
+        Path parameter is a map whose values are objects (complex). Simple
+        encoding cannot represent such maps, so the generator must emit a
+        runtime throw without concatenating it with the literal `.json`
+        suffix.
+      parameters:
+        - name: m
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              $ref: '#/components/schemas/SimpleObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/throw-suffix/map-list/{m}.json:
+    get:
+      operationId: testSimpleMapListWithSuffix
+      tags: [simple]
+      summary: Simple-style map with list value type and literal suffix
+      parameters:
+        - name: m
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              type: array
+              items:
+                type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/throw-suffix/map-oneof-simple/{m}.json:
+    get:
+      operationId: testSimpleMapOneOfSimpleWithSuffix
+      tags: [simple]
+      summary: Simple-style map with oneOf-of-simple-members value type and literal suffix
+      description: |
+        Locks the gap that pre-PR `encodingShape != EncodingShape.simple` missed:
+        a oneOf composed of all-simple members has shape `simple`, but the
+        underlying encoder still rejects it. Generator must emit a runtime
+        throw without concatenating it with the literal `.json` suffix.
+      parameters:
+        - name: m
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: object
+            additionalProperties:
+              oneOf:
+                - type: string
+                - type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
 components:
   schemas:
     StatusEnum:

--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1385,6 +1385,103 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  /simple/throw-suffix/binary/{p}.json:
+    get:
+      operationId: testSimpleBinaryWithSuffix
+      tags: [simple]
+      summary: Simple-style binary path parameter with literal suffix
+      description: |
+        Generator must emit a runtime throw for binary path parameters
+        without concatenating it with the literal `.json` suffix.
+      parameters:
+        - name: p
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: string
+            format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/throw-suffix/list-binary/{p}.json:
+    get:
+      operationId: testSimpleListBinaryWithSuffix
+      tags: [simple]
+      summary: Simple-style list-of-binary path parameter with literal suffix
+      parameters:
+        - name: p
+          in: path
+          required: true
+          style: simple
+          schema:
+            type: array
+            items:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/throw-suffix/alias-map-complex/{p}.json:
+    get:
+      operationId: testSimpleAliasMapComplexWithSuffix
+      tags: [simple]
+      summary: Simple-style aliased map of complex objects with literal suffix
+      description: |
+        Path parameter is a $ref to a named component map; the sibling
+        description on the parameter schema forces parser to wrap in
+        AliasModel. Generator must unwrap the alias and emit a throw.
+      parameters:
+        - name: p
+          in: path
+          required: true
+          style: simple
+          schema:
+            $ref: '#/components/schemas/AliasedComplexMap'
+            description: Wrap forces alias.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/throw-suffix/alias-never/{p}.json:
+    get:
+      operationId: testSimpleAliasNeverWithSuffix
+      tags: [simple]
+      summary: Simple-style aliased never-typed path parameter with literal suffix
+      description: |
+        Path parameter is a $ref to a never-typed component; the sibling
+        description annotation forces parser to wrap in AliasModel. Generator
+        must unwrap the alias and emit a throw without concatenation.
+      parameters:
+        - name: p
+          in: path
+          required: true
+          style: simple
+          schema:
+            $ref: '#/components/schemas/NeverSchema'
+            description: Wrap forces alias.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
 components:
   schemas:
     StatusEnum:
@@ -1495,6 +1592,13 @@ components:
           type: integer
         name:
           type: string
+
+    AliasedComplexMap:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/SimpleObject'
+
+    NeverSchema: false
 
     EchoResponse:
       type: object

--- a/integration_test/path_encoding/path_encoding_test/test/throw_suffix_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/throw_suffix_test.dart
@@ -1,0 +1,118 @@
+import 'package:dio/dio.dart';
+import 'package:path_encoding_api/path_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+/// Runtime checks that operations whose path parameter cannot be simple-
+/// encoded surface an `EncodingException` (wrapped in `TonikError` with
+/// type `encoding`) instead of producing an invalid URL like `<throw>.json`.
+///
+/// These tests pair with the `/simple/throw-suffix/...` fixtures: those only
+/// verify the generated code compiles. These tests verify it BEHAVES.
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  SimpleApi buildSimpleApi() {
+    return SimpleApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(baseOptions: BaseOptions()),
+      ),
+    );
+  }
+
+  void expectEncodingError(
+    TonikResult<EchoResponse> response, {
+    required String parameterName,
+  }) {
+    expect(response, isA<TonikError<EchoResponse>>());
+    final error = response as TonikError<EchoResponse>;
+    expect(error.type, TonikErrorType.encoding);
+    expect(error.error, isA<EncodingException>());
+    final exception = error.error as EncodingException;
+    expect(
+      exception.message.contains('path parameter $parameterName'),
+      isTrue,
+      reason:
+          'message "${exception.message}" should reference '
+          'path parameter $parameterName',
+    );
+  }
+
+  group('Simple style - throw-producing path parameters with suffix', () {
+    test('map with complex (object) value type returns encoding error',
+        () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleMapComplexWithSuffix(
+        m: const {'k': SimpleObject(name: 'n', count: 1)},
+      );
+
+      expectEncodingError(response, parameterName: 'm');
+    });
+
+    test('map with list value type returns encoding error', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleMapListWithSuffix(
+        m: const {
+          'k': ['a', 'b'],
+        },
+      );
+
+      expectEncodingError(response, parameterName: 'm');
+    });
+
+    test('map with oneOf-of-simple-members value type returns encoding error',
+        () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleMapOneOfSimpleWithSuffix(
+        m: const {
+          'k': SimpleThrowSuffixMapOneofSimpleMJsonParametersMapOneOfModelInt(
+            42,
+          ),
+        },
+      );
+
+      expectEncodingError(response, parameterName: 'm');
+    });
+
+    test('binary path parameter returns encoding error', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleBinaryWithSuffix(
+        p: const TonikFileBytes([1, 2, 3]),
+      );
+
+      expectEncodingError(response, parameterName: 'p');
+    });
+
+    test('list of binary path parameter returns encoding error', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleListBinaryWithSuffix(
+        p: const [TonikFileBytes([1, 2, 3])],
+      );
+
+      expectEncodingError(response, parameterName: 'p');
+    });
+
+    test('aliased map of complex objects returns encoding error', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleAliasMapComplexWithSuffix(
+        p: const {'k': SimpleObject(name: 'n', count: 1)},
+      );
+
+      expectEncodingError(response, parameterName: 'p');
+    });
+
+    // testSimpleAliasNeverWithSuffix is intentionally skipped: its path
+    // parameter has type `NeverSchema` (a typedef for `Never`), which has
+    // no inhabitants — there is no value the test could pass to invoke it.
+    // The fixture file still verifies the generated code compiles and that
+    // `_path` would throw if it were ever reachable.
+  });
+}

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -3,13 +3,11 @@ import 'package:collection/collection.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
-import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_label_path_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_matrix_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
-import 'package:tonik_util/tonik_util.dart';
 
 /// Generator for creating path method for operations.
 class PathGenerator {
@@ -108,6 +106,10 @@ class PathGenerator {
       // they produce their own prefix (. or ;).
       final currentConcatParts = <Expression>[];
 
+      // Labelled so that throw-emitting branches can break out of the for
+      // loop from inside the encoding switch. A bare `break` would only exit
+      // the switch and the loop would continue appending literal suffixes
+      // (e.g. `.json`) after the emitted throw statement.
       partLoop:
       for (final part in parts.where((p) => p.isNotEmpty)) {
         if (!part.startsWith('{') || !part.endsWith('}')) {
@@ -129,25 +131,16 @@ class PathGenerator {
 
         switch (param.parameter.encoding) {
           case PathParameterEncoding.simple:
-            final model = param.parameter.model;
-
-            final invalidSimpleReason = switch (model.resolved) {
-              ListModel(:final content)
-                  when content.encodingShape != EncodingShape.simple =>
-                'list with complex elements',
-              MapModel(:final valueModel)
-                  when !isMapValueTypeSimplyEncodable(valueModel) =>
-                'map with complex value types',
-              _ => null,
-            };
-
-            if (invalidSimpleReason != null) {
+            final throwReason = simpleEncodingThrowReason(
+              param.parameter.model,
+            );
+            if (throwReason != null) {
               // `throw X + literal` parses as `throw (X + literal)`; emit the
               // throw as a standalone statement instead.
               currentConcatParts.clear();
               body.add(
                 generateEncodingExceptionExpression(
-                  'Simple encoding does not support $invalidSimpleReason '
+                  'Simple encoding does not support $throwReason '
                   'for path parameter ${param.parameter.rawName}',
                 ).statement,
               );

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -92,117 +92,7 @@ class PathGenerator {
     final segments = operation.path.split('/').where((s) => s.isNotEmpty);
 
     for (final segment in segments) {
-      final parts = segment.splitAndKeep(RegExp(r'\{[^}]+\}'));
-
-      // Pure literal segment — no parameters at all.
-      if (!parts.any((p) => p.startsWith('{') && p.endsWith('}'))) {
-        pathPartExpressions.add(specLiteralString(segment));
-        continue;
-      }
-
-      // Process parts within the segment. Simple-encoded parameters and
-      // adjacent literals are concatenated into a single list entry. Label
-      // and matrix parameters always become their own list entries because
-      // they produce their own prefix (. or ;).
-      final currentConcatParts = <Expression>[];
-
-      // Labelled so that throw-emitting branches can break out of the for
-      // loop from inside the encoding switch. A bare `break` would only exit
-      // the switch and the loop would continue appending literal suffixes
-      // (e.g. `.json`) after the emitted throw statement.
-      partLoop:
-      for (final part in parts.where((p) => p.isNotEmpty)) {
-        if (!part.startsWith('{') || !part.endsWith('}')) {
-          // Literal text within the segment — accumulate for concatenation.
-          currentConcatParts.add(specLiteralString(part));
-          continue;
-        }
-
-        final paramName = part.substring(1, part.length - 1);
-        final param = pathParameters.firstWhereOrNull(
-          (p) => p.parameter.rawName == paramName,
-        );
-
-        if (param == null) {
-          // Unknown parameter reference — treat as literal.
-          currentConcatParts.add(specLiteralString(part));
-          continue;
-        }
-
-        switch (param.parameter.encoding) {
-          case PathParameterEncoding.simple:
-            final throwReason = simpleEncodingThrowReason(
-              param.parameter.model,
-            );
-            if (throwReason != null) {
-              // `throw X + literal` parses as `throw (X + literal)`; emit the
-              // throw as a standalone statement instead.
-              currentConcatParts.clear();
-              body.add(
-                generateEncodingExceptionExpression(
-                  'Simple encoding does not support $throwReason '
-                  'for path parameter ${param.parameter.rawName}',
-                ).statement,
-              );
-              break partLoop;
-            }
-
-            final valueExpression = buildToSimplePathParameterExpression(
-              param.normalizedName,
-              param.parameter,
-              explode: param.parameter.explode,
-              allowEmpty: param.parameter.allowEmptyValue,
-            );
-            // Simple parameters concatenate with adjacent literals.
-            currentConcatParts.add(valueExpression);
-          case PathParameterEncoding.label:
-            // Flush any accumulated concat parts before the label parameter.
-            _flushConcatParts(currentConcatParts, pathPartExpressions);
-
-            final valueExpression = buildToLabelPathParameterExpression(
-              param.normalizedName,
-              param.parameter,
-            );
-            pathPartExpressions.add(valueExpression);
-          case PathParameterEncoding.matrix:
-            // Flush any accumulated concat parts before the matrix parameter.
-            _flushConcatParts(currentConcatParts, pathPartExpressions);
-
-            // `.resolved` is only needed for this pre-flight type test —
-            // `isEffectivelyNullable` and `buildMatrixParameterExpression`
-            // handle aliases.
-            final model = param.parameter.model.resolved;
-            if (model is ListModel && model.content.resolved is ListModel) {
-              currentConcatParts.clear();
-              body.add(
-                generateEncodingExceptionExpression(
-                  'Matrix encoding does not support arrays of objects or '
-                  'nested arrays for path parameter '
-                  '${param.parameter.rawName}',
-                ).statement,
-              );
-              break partLoop;
-            }
-
-            final isModelNullable = param.parameter.model.isEffectivelyNullable;
-            // Path params are required; use ! assertion for nullable types.
-            final matrixReceiver = isModelNullable
-                ? refer(param.normalizedName).nullChecked
-                : refer(param.normalizedName);
-            final matrixExpression = buildMatrixParameterExpression(
-              matrixReceiver,
-              param.parameter.model,
-              paramName: specLiteralString(param.parameter.rawName),
-              explode: literalBool(param.parameter.explode),
-              allowEmpty: literalBool(param.parameter.allowEmptyValue),
-            );
-            pathPartExpressions.add(matrixExpression);
-        }
-      }
-
-      // Flush any remaining concat parts after the last parameter in the
-      // segment.
-      _flushConcatParts(currentConcatParts, pathPartExpressions);
+      _processSegment(segment, pathParameters, pathPartExpressions, body);
     }
 
     if (hasTrailingSlash) {
@@ -227,10 +117,110 @@ class PathGenerator {
     );
   }
 
-  /// Flushes accumulated concatenation parts into a single expression and
-  /// adds it to [target]. If there is exactly one part, it is added directly.
-  /// If there are multiple parts, they are joined with '+' to form a single
-  /// concatenated expression. After flushing, [parts] is cleared.
+  void _processSegment(
+    String segment,
+    List<({String normalizedName, PathParameterObject parameter})>
+    pathParameters,
+    List<Expression> pathPartExpressions,
+    List<Code> body,
+  ) {
+    final parts = segment.splitAndKeep(RegExp(r'\{[^}]+\}'));
+
+    if (!parts.any((p) => p.startsWith('{') && p.endsWith('}'))) {
+      pathPartExpressions.add(specLiteralString(segment));
+      return;
+    }
+
+    // Simple-encoded parameters and adjacent literals are concatenated into a
+    // single list entry. Label and matrix parameters always become their own
+    // list entries because they produce their own prefix (. or ;).
+    final currentConcatParts = <Expression>[];
+
+    for (final part in parts.where((p) => p.isNotEmpty)) {
+      if (!part.startsWith('{') || !part.endsWith('}')) {
+        currentConcatParts.add(specLiteralString(part));
+        continue;
+      }
+
+      final paramName = part.substring(1, part.length - 1);
+      final param = pathParameters.firstWhereOrNull(
+        (p) => p.parameter.rawName == paramName,
+      );
+
+      if (param == null) {
+        currentConcatParts.add(specLiteralString(part));
+        continue;
+      }
+
+      switch (param.parameter.encoding) {
+        case PathParameterEncoding.simple:
+          final throwReason = simpleEncodingThrowReason(param.parameter.model);
+          if (throwReason != null) {
+            // `throw X + literal` parses as `throw (X + literal)`; emit the
+            // throw as a standalone statement instead.
+            currentConcatParts.clear();
+            body.add(
+              generateEncodingExceptionExpression(
+                'Simple encoding does not support $throwReason '
+                'for path parameter ${param.parameter.rawName}',
+              ).statement,
+            );
+            return;
+          }
+
+          final valueExpression = buildToSimplePathParameterExpression(
+            param.normalizedName,
+            param.parameter,
+            explode: param.parameter.explode,
+            allowEmpty: param.parameter.allowEmptyValue,
+          );
+          currentConcatParts.add(valueExpression);
+        case PathParameterEncoding.label:
+          _flushConcatParts(currentConcatParts, pathPartExpressions);
+
+          final valueExpression = buildToLabelPathParameterExpression(
+            param.normalizedName,
+            param.parameter,
+          );
+          pathPartExpressions.add(valueExpression);
+        case PathParameterEncoding.matrix:
+          _flushConcatParts(currentConcatParts, pathPartExpressions);
+
+          // `.resolved` is only needed for this pre-flight type test —
+          // `isEffectivelyNullable` and `buildMatrixParameterExpression`
+          // handle aliases.
+          final model = param.parameter.model.resolved;
+          if (model is ListModel && model.content.resolved is ListModel) {
+            currentConcatParts.clear();
+            body.add(
+              generateEncodingExceptionExpression(
+                'Matrix encoding does not support arrays of objects or '
+                'nested arrays for path parameter '
+                '${param.parameter.rawName}',
+              ).statement,
+            );
+            return;
+          }
+
+          final isModelNullable = param.parameter.model.isEffectivelyNullable;
+          // Path params are required; use ! assertion for nullable types.
+          final matrixReceiver = isModelNullable
+              ? refer(param.normalizedName).nullChecked
+              : refer(param.normalizedName);
+          final matrixExpression = buildMatrixParameterExpression(
+            matrixReceiver,
+            param.parameter.model,
+            paramName: specLiteralString(param.parameter.rawName),
+            explode: literalBool(param.parameter.explode),
+            allowEmpty: literalBool(param.parameter.allowEmptyValue),
+          );
+          pathPartExpressions.add(matrixExpression);
+      }
+    }
+
+    _flushConcatParts(currentConcatParts, pathPartExpressions);
+  }
+
   void _flushConcatParts(List<Expression> parts, List<Expression> target) {
     if (parts.isEmpty) return;
 

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -3,6 +3,7 @@ import 'package:collection/collection.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_label_path_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_matrix_parameter_expression_generator.dart';
@@ -107,6 +108,7 @@ class PathGenerator {
       // they produce their own prefix (. or ;).
       final currentConcatParts = <Expression>[];
 
+      partLoop:
       for (final part in parts.where((p) => p.isNotEmpty)) {
         if (!part.startsWith('{') || !part.endsWith('}')) {
           // Literal text within the segment — accumulate for concatenation.
@@ -128,17 +130,28 @@ class PathGenerator {
         switch (param.parameter.encoding) {
           case PathParameterEncoding.simple:
             final model = param.parameter.model;
-            if (model is ListModel &&
-                model.content.encodingShape != EncodingShape.simple) {
+
+            final invalidSimpleReason = switch (model.resolved) {
+              ListModel(:final content)
+                  when content.encodingShape != EncodingShape.simple =>
+                'list with complex elements',
+              MapModel(:final valueModel)
+                  when !isMapValueTypeSimplyEncodable(valueModel) =>
+                'map with complex value types',
+              _ => null,
+            };
+
+            if (invalidSimpleReason != null) {
+              // `throw X + literal` parses as `throw (X + literal)`; emit the
+              // throw as a standalone statement instead.
               currentConcatParts.clear();
               body.add(
                 generateEncodingExceptionExpression(
-                  'Simple encoding does not support list with complex elements '
+                  'Simple encoding does not support $invalidSimpleReason '
                   'for path parameter ${param.parameter.rawName}',
                 ).statement,
               );
-
-              continue;
+              break partLoop;
             }
 
             final valueExpression = buildToSimplePathParameterExpression(
@@ -162,17 +175,20 @@ class PathGenerator {
             // Flush any accumulated concat parts before the matrix parameter.
             _flushConcatParts(currentConcatParts, pathPartExpressions);
 
-            final model = param.parameter.model;
-            if (model is ListModel && model.content is ListModel) {
+            // `.resolved` is only needed for this pre-flight type test —
+            // `isEffectivelyNullable` and `buildMatrixParameterExpression`
+            // handle aliases.
+            final model = param.parameter.model.resolved;
+            if (model is ListModel && model.content.resolved is ListModel) {
               currentConcatParts.clear();
               body.add(
                 generateEncodingExceptionExpression(
                   'Matrix encoding does not support arrays of objects or '
-                  'nested arrays',
+                  'nested arrays for path parameter '
+                  '${param.parameter.rawName}',
                 ).statement,
               );
-
-              continue;
+              break partLoop;
             }
 
             final isModelNullable = param.parameter.model.isEffectivelyNullable;

--- a/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
@@ -29,12 +29,36 @@ Expression? buildMapToStringMapExpression(
   );
 }
 
+/// Single source of truth for which map value types simple encoding
+/// supports. Path-generator guards must use this — a parallel switch
+/// would drift and re-introduce the `throw + r'.json'` invalid-Dart bug.
+bool isMapValueTypeSimplyEncodable(Model valueModel) {
+  return switch (valueModel) {
+    StringModel() ||
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    DateModel() ||
+    DateTimeModel() ||
+    EnumModel() ||
+    Base64Model() ||
+    AnyModel() => true,
+    AliasModel(:final model) => isMapValueTypeSimplyEncodable(model),
+    _ => false,
+  };
+}
+
 Expression? _buildConversion(
   Expression receiver,
   Model valueModel, {
   required bool isNullable,
   required bool valueIsNullable,
 }) {
+  if (!isMapValueTypeSimplyEncodable(valueModel)) return null;
+
   return switch (valueModel) {
     StringModel() => receiver,
     IntegerModel() ||
@@ -101,18 +125,10 @@ Expression? _buildConversion(
       isNullable: isNullable,
       valueIsNullable: valueIsNullable,
     ),
-    ClassModel() ||
-    ListModel() ||
-    MapModel() ||
-    BinaryModel() ||
-    NeverModel() =>
-      null,
     _ => null,
   };
 }
 
-/// Wraps a conversion expression with a null check when the value
-/// is nullable: `v == null ? '' : <conversion>`.
 Expression _wrapNullable(Expression conversion, bool valueIsNullable) {
   if (!valueIsNullable) return conversion;
   return refer('v')
@@ -120,8 +136,6 @@ Expression _wrapNullable(Expression conversion, bool valueIsNullable) {
       .conditional(literalString(''), conversion);
 }
 
-/// Builds a `.map((k, v) => MapEntry(k, <valueExpr>))` call on the
-/// [receiver].
 Expression _buildMapCall(
   Expression receiver,
   Expression valueExpression, {

--- a/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
@@ -7,7 +7,7 @@ import 'package:tonik_core/tonik_core.dart';
 /// For StringModel values, returns the [receiver] unchanged (already
 /// `Map<String, String>`). For primitive values, emits a `.map()` call
 /// with the correct type-specific conversion. For unsupported values
-/// (ClassModel, ListModel, nested MapModel, BinaryModel, NeverModel),
+/// (see [isMapValueTypeSimplyEncodable] for the authoritative list),
 /// returns `null` -- the caller is responsible for throwing an
 /// `EncodingException`.
 ///
@@ -47,9 +47,24 @@ bool isMapValueTypeSimplyEncodable(Model valueModel) {
     Base64Model() ||
     AnyModel() => true,
     AliasModel(:final model) => isMapValueTypeSimplyEncodable(model),
-    _ => false,
+    NeverModel() ||
+    BinaryModel() ||
+    ListModel() ||
+    MapModel() ||
+    ClassModel() ||
+    AllOfModel() ||
+    OneOfModel() ||
+    AnyOfModel() => false,
+    // Catch-all throws so a newly-added Model subtype surfaces at runtime
+    // instead of silently returning false (drift protection). NamedModel and
+    // CompositeModel are mixins on the sealed Model, so the analyzer does
+    // not let us enumerate "every concrete subtype" exhaustively here.
+    _ => _unreachableModelType('isMapValueTypeSimplyEncodable'),
   };
 }
+
+Never _unreachableModelType(String fn) =>
+    throw UnsupportedError('Unreachable Model subtype in $fn');
 
 Expression? _buildConversion(
   Expression receiver,
@@ -125,7 +140,11 @@ Expression? _buildConversion(
       isNullable: isNullable,
       valueIsNullable: valueIsNullable,
     ),
-    _ => null,
+    // Catch-all throws so a model type the predicate forgot to filter
+    // surfaces at runtime instead of returning a wrong/null expression.
+    // The early-return guard above already rejects every model type not
+    // explicitly handled here; this arm is the drift-protection backstop.
+    _ => _unreachableModelType('_buildConversion'),
   };
 }
 

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -3,6 +3,83 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
+/// Returns a non-null reason if simple-encoding [model] would produce a
+/// throw expression rather than a real value. Path-generator pre-flight
+/// guards must use this — a parallel switch would drift and re-introduce
+/// the bug where a throw is concatenated with a literal path suffix.
+String? simpleEncodingThrowReason(Model model) {
+  return switch (model) {
+    NeverModel() => 'never-typed values',
+    BinaryModel() => 'binary values',
+    ListModel(:final content) => _listContentThrowReason(content),
+    MapModel(:final valueModel)
+        when !isMapValueTypeSimplyEncodable(valueModel) =>
+      'map with complex value types',
+    MapModel() => null,
+    AliasModel(:final model) => simpleEncodingThrowReason(model),
+    ClassModel() ||
+    EnumModel() ||
+    AllOfModel() ||
+    OneOfModel() ||
+    AnyOfModel() ||
+    StringModel() ||
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DateTimeModel() ||
+    DateModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    Base64Model() ||
+    AnyModel() => null,
+    // Catch-all throws so a newly-added Model subtype surfaces at runtime
+    // instead of silently returning null (drift protection). NamedModel and
+    // CompositeModel are mixins on the sealed Model, so the analyzer does
+    // not let us enumerate "every concrete subtype" exhaustively here.
+    _ => _unreachableModelType('simpleEncodingThrowReason'),
+  };
+}
+
+Never _unreachableModelType(String fn) =>
+    throw UnsupportedError('Unreachable Model subtype in $fn');
+
+String? _listContentThrowReason(Model content) {
+  const unsupported = 'lists with unsupported element types';
+  return switch (content) {
+    // _handleListExpression's AnyModel branch would emit
+    // `list.toSimple(...)` which has no extension on `List<Object?>` — the
+    // predicate intercepts before codegen so the bad code never lands.
+    NeverModel() ||
+    BinaryModel() ||
+    ListModel() ||
+    AnyModel() => unsupported,
+    MapModel(:final valueModel)
+        when !isMapValueTypeSimplyEncodable(valueModel) =>
+      unsupported,
+    MapModel() => null,
+    AliasModel(:final model) => _listContentThrowReason(model),
+    ClassModel() ||
+    EnumModel() ||
+    AllOfModel() ||
+    OneOfModel() ||
+    AnyOfModel() ||
+    StringModel() ||
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DateTimeModel() ||
+    DateModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    Base64Model() => null,
+    // Catch-all throws (same drift-protection rationale as
+    // simpleEncodingThrowReason).
+    _ => _unreachableModelType('_listContentThrowReason'),
+  };
+}
+
 /// Creates a Dart expression that correctly serializes a path parameter
 /// to its simple parameter encoding representation.
 ///

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
@@ -11,6 +12,10 @@ void main() {
   late DartEmitter emitter;
   late NameManager nameManager;
   late NameGenerator nameGenerator;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
 
   setUp(() {
     nameGenerator = NameGenerator();
@@ -1311,7 +1316,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required List<List<String>> matrix}) {
-          throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays');
+          throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays for path parameter matrix');
           return [r'data'];
         }
       ''';
@@ -2108,6 +2113,935 @@ void main() {
         collapseWhitespace(method.accept(emitter).toString()),
         collapseWhitespace(expectedMethod),
       );
+    });
+  });
+
+  group('throw-producing simple parameter with literal suffix', () {
+    void expectMethodMatches(Method method, String expected) {
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    }
+
+    test('MapModel with complex value type and literal suffix '
+        'emits throw statement without concatenation', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map of complex values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Reproduces map+suffix bug',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, AnonymousModel> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with ListModel value type and literal suffix '
+        'emits throw statement without concatenation', () {
+      final listValueModel = ListModel(
+        context: context,
+        content: StringModel(context: context),
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: listValueModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map with list values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of list values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, List<String>> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with OneOfModel value type and literal suffix '
+        'emits throw statement (composite has mixed encoding shape)', () {
+      final oneOfModel = OneOfModel(
+        isDeprecated: false,
+        name: 'StringOrInt',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              isDeprecated: false,
+              context: context,
+              properties: const [],
+            ),
+          ),
+        },
+        context: context,
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: oneOfModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map with oneOf values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of oneOf values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {pathParam.model, oneOfModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, StringOrInt> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with AllOfModel value type and literal suffix '
+        'emits throw statement', () {
+      final allOfModel = AllOfModel(
+        isDeprecated: false,
+        name: 'CombinedObject',
+        models: {
+          ClassModel(
+            isDeprecated: false,
+            context: context,
+            properties: const [],
+          ),
+        },
+        context: context,
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: allOfModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map with allOf values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of allOf values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {pathParam.model, allOfModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, CombinedObject> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with String value type and literal suffix '
+        'still concatenates correctly (regression guard)', () {
+      final mapModel = MapModel(
+        context: context,
+        valueModel: StringModel(context: context),
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map of string values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of strings with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/x/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, String> m}) {
+          return [r'x', m.toSimple(explode: false, allowEmpty: false) + r'.json'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with AnyModel value type and literal suffix '
+        'concatenates correctly (regression — AnyModel is supported)', () {
+      final mapModel = MapModel(
+        context: context,
+        valueModel: AnyModel(context: context),
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map of any values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of any-typed values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, Object?> m}) {
+          return [
+            r'r',
+            m
+                    .map(
+                      (k, v) =>
+                          MapEntry(k, encodeAnyValueToString(v, allowEmpty: false)),
+                    )
+                    .toSimple(explode: false, allowEmpty: false) +
+                r'.json',
+          ];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with OneOfModel of all-simple members and literal '
+        'suffix emits throw (composite has shape simple but encoder rejects)',
+        () {
+      final oneOfModel = OneOfModel(
+        isDeprecated: false,
+        name: 'StringOrIntSimple',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: oneOfModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map with all-simple oneOf values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of all-simple oneOf values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {pathParam.model, oneOfModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, StringOrIntSimple> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with AllOfModel of all-simple members and literal '
+        'suffix emits throw (composite has shape simple but encoder rejects)',
+        () {
+      final allOfModel = AllOfModel(
+        isDeprecated: false,
+        name: 'StringOnly',
+        models: {
+          StringModel(context: context),
+        },
+        context: context,
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: allOfModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map with all-simple allOf values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of all-simple allOf values with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {pathParam.model, allOfModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, StringOnly> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('AliasModel wrapping MapModel with complex value type and literal '
+        'suffix emits throw statement without concatenation', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+      final aliasModel = AliasModel(
+        name: 'MyMap',
+        model: mapModel,
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Aliased map of complex values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: aliasModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Aliased map with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {aliasModel, mapModel, classModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required MyMap m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('AliasModel wrapping ListModel with complex content and literal '
+        'suffix emits throw statement without concatenation', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final listModel = ListModel(
+        context: context,
+        content: classModel,
+      );
+      final aliasModel = AliasModel(
+        name: 'MyList',
+        model: listModel,
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'l',
+        rawName: 'l',
+        description: 'Aliased list of complex values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: aliasModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Aliased list with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{l}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {aliasModel, listModel, classModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required MyList l}) {
+          throw EncodingException('Simple encoding does not support list with complex elements for path parameter l');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'l', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('matrix encoding nested arrays throw includes path parameter '
+        'name', () {
+      final innerListModel = ListModel(
+        context: context,
+        content: StringModel(context: context),
+      );
+      final outerListModel = ListModel(
+        context: context,
+        content: innerListModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Nested list',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: PathParameterEncoding.matrix,
+        model: outerListModel,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Matrix nested list',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required List<List<String>> m}) {
+          throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('matrix encoding with AliasModel-wrapped nested arrays uses '
+        'rawName error message', () {
+      final innerListModel = ListModel(
+        context: context,
+        content: StringModel(context: context),
+      );
+      final outerListModel = ListModel(
+        context: context,
+        content: innerListModel,
+      );
+      final aliasModel = AliasModel(
+        name: 'NestedListAlias',
+        model: outerListModel,
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Alias-wrapped nested list',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: PathParameterEncoding.matrix,
+        model: aliasModel,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Matrix alias-wrapped nested list',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required NestedListAlias m}) {
+          throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('matrix encoding with alias-wrapped inner list still emits '
+        'rawName error message', () {
+      final innerListModel = ListModel(
+        context: context,
+        content: StringModel(context: context),
+      );
+      final innerAlias = AliasModel(
+        name: 'InnerListAlias',
+        model: innerListModel,
+        context: context,
+      );
+      final outerListModel = ListModel(
+        context: context,
+        content: innerAlias,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'List with alias-wrapped inner list',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: PathParameterEncoding.matrix,
+        model: outerListModel,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Matrix list with alias-wrapped inner list',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required List<InnerListAlias> m}) {
+          throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('MapModel with complex value type without suffix '
+        'also emits throw statement', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'm',
+        rawName: 'm',
+        description: 'Map of complex values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Map of complex values without suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{m}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, AnonymousModel> m}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter m');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
     });
   });
 }

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -974,7 +974,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required List<List<AnonymousModel>> matrix}) {
-          throw EncodingException('Simple encoding does not support list with complex elements for path parameter matrix');
+          throw EncodingException('Simple encoding does not support lists with unsupported element types for path parameter matrix');
           return [r'data'];
         }
       ''';
@@ -2728,16 +2728,15 @@ void main() {
       expectMethodMatches(method, expectedMethod);
     });
 
-    test('AliasModel wrapping ListModel with complex content and literal '
+    test('AliasModel wrapping ListModel of nested lists and literal '
         'suffix emits throw statement without concatenation', () {
-      final classModel = ClassModel(
-        isDeprecated: false,
+      final innerListModel = ListModel(
         context: context,
-        properties: const [],
+        content: StringModel(context: context),
       );
       final listModel = ListModel(
         context: context,
-        content: classModel,
+        content: innerListModel,
       );
       final aliasModel = AliasModel(
         name: 'MyList',
@@ -2748,7 +2747,7 @@ void main() {
       final pathParam = PathParameterObject(
         name: 'l',
         rawName: 'l',
-        description: 'Aliased list of complex values',
+        description: 'Aliased list of nested lists',
         isRequired: true,
         isDeprecated: false,
         allowEmptyValue: false,
@@ -2776,7 +2775,7 @@ void main() {
       );
 
       nameManager.prime(
-        models: {aliasModel, listModel, classModel},
+        models: {aliasModel, listModel, innerListModel},
         requestBodies: const [],
         responses: const [],
         operations: const [],
@@ -2786,7 +2785,7 @@ void main() {
 
       const expectedMethod = '''
         List<String> _path({required MyList l}) {
-          throw EncodingException('Simple encoding does not support list with complex elements for path parameter l');
+          throw EncodingException('Simple encoding does not support lists with unsupported element types for path parameter l');
           return [r'r'];
         }
       ''';
@@ -3037,6 +3036,556 @@ void main() {
       final pathParameters =
           <({String normalizedName, PathParameterObject parameter})>[
             (normalizedName: 'm', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('NeverModel with literal suffix emits throw statement '
+        'without concatenation', () {
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'Never-typed path parameter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: NeverModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'NeverModel with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Never p}) {
+          throw EncodingException('Simple encoding does not support never-typed values for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('BinaryModel with literal suffix emits throw statement '
+        'without concatenation', () {
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'Binary-typed path parameter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: BinaryModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'BinaryModel with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required TonikFile p}) {
+          throw EncodingException('Simple encoding does not support binary values for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('ListModel<NeverModel> with literal suffix emits throw statement '
+        'without concatenation', () {
+      final listModel = ListModel(
+        context: context,
+        content: NeverModel(context: context),
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'List of never values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: listModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'List<NeverModel> with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required List<Never> p}) {
+          throw EncodingException('Simple encoding does not support lists with unsupported element types for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('ListModel<BinaryModel> with literal suffix emits throw statement '
+        'without concatenation', () {
+      final listModel = ListModel(
+        context: context,
+        content: BinaryModel(context: context),
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'List of binary values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: listModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'List<BinaryModel> with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required List<TonikFile> p}) {
+          throw EncodingException('Simple encoding does not support lists with unsupported element types for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('AliasModel(NeverModel) with literal suffix emits throw statement '
+        'unwrapping at depth 1', () {
+      final aliasModel = AliasModel(
+        name: 'NeverAlias',
+        model: NeverModel(context: context),
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'Aliased never value',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: aliasModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'AliasModel(NeverModel) with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {aliasModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required NeverAlias p}) {
+          throw EncodingException('Simple encoding does not support never-typed values for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('AliasModel(AliasModel(NeverModel)) with literal suffix emits '
+        'throw statement unwrapping at depth 2', () {
+      final innerAlias = AliasModel(
+        name: 'NeverInner',
+        model: NeverModel(context: context),
+        context: context,
+      );
+      final outerAlias = AliasModel(
+        name: 'NeverOuter',
+        model: innerAlias,
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'Doubly aliased never value',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: outerAlias,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'AliasModel(AliasModel(NeverModel)) with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {outerAlias, innerAlias},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required NeverOuter p}) {
+          throw EncodingException('Simple encoding does not support never-typed values for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('AliasModel(AliasModel(MapModel(ClassModel))) with literal suffix '
+        'emits throw statement unwrapping at depth 2', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+      final innerAlias = AliasModel(
+        name: 'MapInner',
+        model: mapModel,
+        context: context,
+      );
+      final outerAlias = AliasModel(
+        name: 'MapOuter',
+        model: innerAlias,
+        context: context,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'p',
+        rawName: 'p',
+        description: 'Doubly aliased map of complex values',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: outerAlias,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'AliasModel(AliasModel(MapModel(ClassModel))) with suffix',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{p}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      nameManager.prime(
+        models: {outerAlias, innerAlias, mapModel, classModel},
+        requestBodies: const [],
+        responses: const [],
+        operations: const [],
+        tags: const [],
+        servers: const [],
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required MapOuter p}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter p');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'p', parameter: pathParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('multi-parameter same-segment with valid prefix and throwing '
+        'parameter emits throw without concatenation', () {
+      final goodParam = PathParameterObject(
+        name: 'good',
+        rawName: 'good',
+        description: 'Valid string parameter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+      final badParam = PathParameterObject(
+        name: 'badMap',
+        rawName: 'badMap',
+        description: 'Throw-producing map parameter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'Multi-parameter same-segment with throwing trailing',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{good}-{badMap}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {goodParam, badParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({
+          required String good,
+          required Map<String, AnonymousModel> badMap,
+        }) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter badMap');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'good', parameter: goodParam),
+            (normalizedName: 'badMap', parameter: badParam),
+          ];
+
+      final method = generator.generatePathMethod(operation, pathParameters);
+
+      expectMethodMatches(method, expectedMethod);
+    });
+
+    test('rawName != name divergence uses rawName in error message', () {
+      final classModel = ClassModel(
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+      );
+      final mapModel = MapModel(
+        context: context,
+        valueModel: classModel,
+      );
+
+      final pathParam = PathParameterObject(
+        name: 'mNorm',
+        rawName: 'M-RAW',
+        description: 'Map parameter with divergent rawName',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: mapModel,
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getR',
+        context: context,
+        summary: 'Get R',
+        description: 'rawName divergence test',
+        tags: const {},
+        isDeprecated: false,
+        path: '/r/{M-RAW}.json',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        responses: const {},
+        securitySchemes: const {},
+        cookieParameters: const {},
+      );
+
+      const expectedMethod = '''
+        List<String> _path({required Map<String, AnonymousModel> mNorm}) {
+          throw EncodingException('Simple encoding does not support map with complex value types for path parameter M-RAW');
+          return [r'r'];
+        }
+      ''';
+
+      final pathParameters =
+          <({String normalizedName, PathParameterObject parameter})>[
+            (normalizedName: 'mNorm', parameter: pathParam),
           ];
 
       final method = generator.generatePathMethod(operation, pathParameters);

--- a/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
@@ -585,4 +585,412 @@ void main() {
       });
     });
   });
+
+  group('isMapValueTypeSimplyEncodable', () {
+    test('StringModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(StringModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('IntegerModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(IntegerModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('DoubleModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(DoubleModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('NumberModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(NumberModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('BooleanModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(BooleanModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('DecimalModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(DecimalModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('UriModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(UriModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('DateModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(DateModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('DateTimeModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(DateTimeModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('EnumModel<String> is encodable', () {
+      final model = EnumModel<String>(
+        isDeprecated: false,
+        name: 'Status',
+        values: {
+          const EnumEntry(value: 'a'),
+          const EnumEntry(value: 'b'),
+        },
+        isNullable: false,
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isTrue);
+    });
+
+    test('EnumModel<int> is encodable', () {
+      final model = EnumModel<int>(
+        isDeprecated: false,
+        name: 'Priority',
+        values: {
+          const EnumEntry(value: 1),
+          const EnumEntry(value: 2),
+        },
+        isNullable: false,
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isTrue);
+    });
+
+    test('Base64Model is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(Base64Model(context: context)),
+        isTrue,
+      );
+    });
+
+    test('AnyModel is encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(AnyModel(context: context)),
+        isTrue,
+      );
+    });
+
+    test('AliasModel wrapping StringModel is encodable', () {
+      final model = AliasModel(
+        name: 'MyString',
+        model: StringModel(context: context),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isTrue);
+    });
+
+    test('AliasModel wrapping IntegerModel is encodable', () {
+      final model = AliasModel(
+        name: 'MyInt',
+        model: IntegerModel(context: context),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isTrue);
+    });
+
+    test('AliasModel wrapping ClassModel is not encodable', () {
+      final model = AliasModel(
+        name: 'MyClass',
+        model: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: const [],
+          context: context,
+        ),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('AliasModel wrapping ListModel is not encodable', () {
+      final model = AliasModel(
+        name: 'MyList',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+        ),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('AliasModel wrapping AliasModel wrapping ClassModel is not '
+        'encodable', () {
+      final model = AliasModel(
+        name: 'Outer',
+        model: AliasModel(
+          name: 'Inner',
+          model: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+          ),
+          context: context,
+        ),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('ClassModel is not encodable', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'User',
+        properties: const [],
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('ListModel is not encodable', () {
+      final model = ListModel(
+        content: StringModel(context: context),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('nested MapModel is not encodable', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('BinaryModel is not encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(BinaryModel(context: context)),
+        isFalse,
+      );
+    });
+
+    test('NeverModel is not encodable', () {
+      expect(
+        isMapValueTypeSimplyEncodable(NeverModel(context: context)),
+        isFalse,
+      );
+    });
+
+    test('OneOfModel of all-simple members is not encodable', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'StringOrInt',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('OneOfModel of mixed members is not encodable', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'StringOrClass',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: const [],
+              context: context,
+            ),
+          ),
+        },
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('AllOfModel of all-simple members is not encodable', () {
+      final model = AllOfModel(
+        isDeprecated: false,
+        name: 'StringOnly',
+        models: {StringModel(context: context)},
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+
+    test('AnyOfModel of all-simple members is not encodable', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'StringOrIntOrBool',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: BooleanModel(context: context)),
+        },
+        context: context,
+      );
+      expect(isMapValueTypeSimplyEncodable(model), isFalse);
+    });
+  });
+
+  group('predicate / builder parity', () {
+    /// Drift guard: predicate and builder must agree on every model.
+    /// Anything else re-introduces the path-suffix throw bug.
+    void expectParity(Model valueModel, {required String label}) {
+      final mapModel = MapModel(valueModel: valueModel, context: context);
+      final built = buildMapToStringMapExpression(
+        refer('x'),
+        mapModel,
+        isNullable: false,
+      );
+      final predicate = isMapValueTypeSimplyEncodable(valueModel);
+      if (built != null) {
+        expect(
+          predicate,
+          isTrue,
+          reason:
+              '$label: builder produced an expression but predicate said '
+              'unsupported',
+        );
+      } else {
+        expect(
+          predicate,
+          isFalse,
+          reason:
+              '$label: predicate says supported but builder returned null',
+        );
+      }
+    }
+
+    test('all supported and unsupported models agree', () {
+      expectParity(StringModel(context: context), label: 'StringModel');
+      expectParity(IntegerModel(context: context), label: 'IntegerModel');
+      expectParity(DoubleModel(context: context), label: 'DoubleModel');
+      expectParity(NumberModel(context: context), label: 'NumberModel');
+      expectParity(BooleanModel(context: context), label: 'BooleanModel');
+      expectParity(DecimalModel(context: context), label: 'DecimalModel');
+      expectParity(UriModel(context: context), label: 'UriModel');
+      expectParity(DateModel(context: context), label: 'DateModel');
+      expectParity(DateTimeModel(context: context), label: 'DateTimeModel');
+      expectParity(Base64Model(context: context), label: 'Base64Model');
+      expectParity(AnyModel(context: context), label: 'AnyModel');
+      expectParity(NeverModel(context: context), label: 'NeverModel');
+      expectParity(BinaryModel(context: context), label: 'BinaryModel');
+
+      expectParity(
+        EnumModel<String>(
+          isDeprecated: false,
+          name: 'StatusE',
+          values: {const EnumEntry(value: 'a')},
+          isNullable: false,
+          context: context,
+        ),
+        label: 'EnumModel<String>',
+      );
+      expectParity(
+        EnumModel<int>(
+          isDeprecated: false,
+          name: 'PriorityE',
+          values: {const EnumEntry(value: 1)},
+          isNullable: false,
+          context: context,
+        ),
+        label: 'EnumModel<int>',
+      );
+
+      expectParity(
+        AliasModel(
+          name: 'AliasOfString',
+          model: StringModel(context: context),
+          context: context,
+        ),
+        label: 'AliasModel(StringModel)',
+      );
+      expectParity(
+        AliasModel(
+          name: 'AliasOfClass',
+          model: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(ClassModel)',
+      );
+
+      expectParity(
+        ClassModel(
+          isDeprecated: false,
+          name: 'User2',
+          properties: const [],
+          context: context,
+        ),
+        label: 'ClassModel',
+      );
+      expectParity(
+        ListModel(content: StringModel(context: context), context: context),
+        label: 'ListModel',
+      );
+      expectParity(
+        MapModel(valueModel: StringModel(context: context), context: context),
+        label: 'nested MapModel',
+      );
+      expectParity(
+        OneOfModel(
+          isDeprecated: false,
+          name: 'OneOfAllSimple',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+          },
+          context: context,
+        ),
+        label: 'OneOfModel(all-simple)',
+      );
+      expectParity(
+        AllOfModel(
+          isDeprecated: false,
+          name: 'AllOfAllSimple',
+          models: {StringModel(context: context)},
+          context: context,
+        ),
+        label: 'AllOfModel(all-simple)',
+      );
+      expectParity(
+        AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfAllSimple',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (discriminatorValue: null, model: BooleanModel(context: context)),
+          },
+          context: context,
+        ),
+        label: 'AnyOfModel(all-simple)',
+      );
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/map_value_to_string_expression_builder_test.dart
@@ -942,6 +942,37 @@ void main() {
       );
 
       expectParity(
+        AliasModel(
+          name: 'OuterAlias',
+          model: AliasModel(
+            name: 'InnerAlias',
+            model: IntegerModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(AliasModel(IntegerModel))',
+      );
+
+      expectParity(
+        AliasModel(
+          name: 'OuterAliasC',
+          model: AliasModel(
+            name: 'InnerAliasC',
+            model: ClassModel(
+              isDeprecated: false,
+              name: 'User2',
+              properties: const [],
+              context: context,
+            ),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(AliasModel(ClassModel))',
+      );
+
+      expectParity(
         ClassModel(
           isDeprecated: false,
           name: 'User2',

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -1103,4 +1103,453 @@ void main() {
       },
     );
   });
+
+  group('simpleEncodingThrowReason', () {
+    void expectSupported(Model model, {required String label}) {
+      expect(
+        simpleEncodingThrowReason(model),
+        isNull,
+        reason: '$label should be supported (no throw)',
+      );
+    }
+
+    void expectThrowReason(
+      Model model, {
+      required String label,
+      required String containsText,
+    }) {
+      final reason = simpleEncodingThrowReason(model);
+      expect(
+        reason,
+        isNotNull,
+        reason: '$label should produce a throw reason',
+      );
+      expect(
+        reason!.contains(containsText),
+        isTrue,
+        reason:
+            '$label reason "$reason" should contain "$containsText"',
+      );
+    }
+
+    test('supported leaf models return null', () {
+      expectSupported(StringModel(context: context), label: 'StringModel');
+      expectSupported(IntegerModel(context: context), label: 'IntegerModel');
+      expectSupported(DoubleModel(context: context), label: 'DoubleModel');
+      expectSupported(NumberModel(context: context), label: 'NumberModel');
+      expectSupported(BooleanModel(context: context), label: 'BooleanModel');
+      expectSupported(DateTimeModel(context: context), label: 'DateTimeModel');
+      expectSupported(DateModel(context: context), label: 'DateModel');
+      expectSupported(DecimalModel(context: context), label: 'DecimalModel');
+      expectSupported(UriModel(context: context), label: 'UriModel');
+      expectSupported(Base64Model(context: context), label: 'Base64Model');
+      expectSupported(AnyModel(context: context), label: 'AnyModel');
+      expectSupported(
+        EnumModel<String>(
+          isDeprecated: false,
+          name: 'StatusE',
+          values: {const EnumEntry(value: 'a')},
+          isNullable: false,
+          context: context,
+        ),
+        label: 'EnumModel<String>',
+      );
+      expectSupported(
+        ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: const [],
+          context: context,
+        ),
+        label: 'ClassModel',
+      );
+      expectSupported(
+        AllOfModel(
+          isDeprecated: false,
+          name: 'AllOfX',
+          models: {StringModel(context: context)},
+          context: context,
+        ),
+        label: 'AllOfModel',
+      );
+      expectSupported(
+        OneOfModel(
+          isDeprecated: false,
+          name: 'OneOfX',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+          },
+          context: context,
+        ),
+        label: 'OneOfModel',
+      );
+      expectSupported(
+        AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfX',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+          },
+          context: context,
+        ),
+        label: 'AnyOfModel',
+      );
+    });
+
+    test('AliasModel chains delegate to underlying type', () {
+      expectSupported(
+        AliasModel(
+          name: 'A1',
+          model: StringModel(context: context),
+          context: context,
+        ),
+        label: 'AliasModel(StringModel)',
+      );
+      expectSupported(
+        AliasModel(
+          name: 'A2',
+          model: AliasModel(
+            name: 'A1',
+            model: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(AliasModel(StringModel))',
+      );
+    });
+
+    test('NeverModel returns never-typed reason', () {
+      expectThrowReason(
+        NeverModel(context: context),
+        label: 'NeverModel',
+        containsText: 'never-typed',
+      );
+    });
+
+    test('BinaryModel returns binary reason', () {
+      expectThrowReason(
+        BinaryModel(context: context),
+        label: 'BinaryModel',
+        containsText: 'binary',
+      );
+    });
+
+    test('ListModel<NeverModel> returns unsupported elements reason', () {
+      expectThrowReason(
+        ListModel(
+          content: NeverModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<NeverModel>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('ListModel<BinaryModel> returns unsupported elements reason', () {
+      expectThrowReason(
+        ListModel(
+          content: BinaryModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<BinaryModel>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('ListModel<ListModel<String>> returns unsupported elements reason '
+        '(nested list)', () {
+      expectThrowReason(
+        ListModel(
+          content: ListModel(
+            content: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<ListModel<String>>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('MapModel with complex value returns map complex reason', () {
+      expectThrowReason(
+        MapModel(
+          valueModel: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'MapModel(ClassModel)',
+        containsText: 'map with complex value types',
+      );
+    });
+
+    test('AliasModel(NeverModel) returns never-typed reason '
+        '(unwrap depth 1)', () {
+      expectThrowReason(
+        AliasModel(
+          name: 'NA',
+          model: NeverModel(context: context),
+          context: context,
+        ),
+        label: 'AliasModel(NeverModel)',
+        containsText: 'never-typed',
+      );
+    });
+
+    test('AliasModel(AliasModel(NeverModel)) returns never-typed reason '
+        '(unwrap depth 2)', () {
+      expectThrowReason(
+        AliasModel(
+          name: 'NA2',
+          model: AliasModel(
+            name: 'NA1',
+            model: NeverModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(AliasModel(NeverModel))',
+        containsText: 'never-typed',
+      );
+    });
+
+    test('AliasModel(MapModel(ClassModel)) returns map complex reason', () {
+      expectThrowReason(
+        AliasModel(
+          name: 'AM',
+          model: MapModel(
+            valueModel: ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: const [],
+              context: context,
+            ),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'AliasModel(MapModel(ClassModel))',
+        containsText: 'map with complex value types',
+      );
+    });
+
+    test('MapModel with simple value returns null', () {
+      expectSupported(
+        MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+        ),
+        label: 'MapModel<String>',
+      );
+      expectSupported(
+        MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+        ),
+        label: 'MapModel<Integer>',
+      );
+    });
+
+    test('ListModel<AnyModel> returns unsupported elements reason', () {
+      // List<AnyModel> compiles to List<Object?>, which has no toSimple
+      // extension in tonik_util. The pre-flight guard must throw.
+      expectThrowReason(
+        ListModel(
+          content: AnyModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<AnyModel>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('ListModel with complex map content returns unsupported reason', () {
+      expectThrowReason(
+        ListModel(
+          content: MapModel(
+            valueModel: ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: const [],
+              context: context,
+            ),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<MapModel<ClassModel>>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('ListModel<AliasModel(NeverModel)> unwraps and returns reason', () {
+      expectThrowReason(
+        ListModel(
+          content: AliasModel(
+            name: 'NA',
+            model: NeverModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<AliasModel(NeverModel)>',
+        containsText: 'lists with unsupported element types',
+      );
+    });
+
+    test('ListModel content arms backed by runtime support return null', () {
+      // These exercise every "supported" arm of _listContentThrowReason so it
+      // stays in lock-step with _handleListExpression's runtime support.
+      expectSupported(
+        ListModel(
+          content: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<ClassModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: EnumModel<String>(
+            isDeprecated: false,
+            name: 'StatusE',
+            values: {const EnumEntry(value: 'a')},
+            isNullable: false,
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<EnumModel<String>>',
+      );
+      expectSupported(
+        ListModel(
+          content: AllOfModel(
+            isDeprecated: false,
+            name: 'AllOfX',
+            models: {StringModel(context: context)},
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<AllOfModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: OneOfModel(
+            isDeprecated: false,
+            name: 'OneOfX',
+            models: {
+              (discriminatorValue: null, model: StringModel(context: context)),
+            },
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<OneOfModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: AnyOfModel(
+            isDeprecated: false,
+            name: 'AnyOfX',
+            models: {
+              (discriminatorValue: null, model: StringModel(context: context)),
+            },
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<AnyOfModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: DateTimeModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<DateTimeModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: DateModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<DateModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: DecimalModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<DecimalModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: UriModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<UriModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: Base64Model(context: context),
+          context: context,
+        ),
+        label: 'ListModel<Base64Model>',
+      );
+      expectSupported(
+        ListModel(
+          content: IntegerModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<IntegerModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: DoubleModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<DoubleModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: NumberModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<NumberModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: BooleanModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<BooleanModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: StringModel(context: context),
+          context: context,
+        ),
+        label: 'ListModel<StringModel>',
+      );
+      expectSupported(
+        ListModel(
+          content: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+          ),
+          context: context,
+        ),
+        label: 'ListModel<MapModel<String>>',
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

- Generalises the existing `ListModel` simple-encoding guard in `path_generator.dart` so any path parameter whose simple or matrix encoding would produce a `throw` expression is emitted as a **standalone statement**, preventing the `throw EncodingException(...) + r'.json'` invalid Dart that occurs when a path segment contains a literal suffix (e.g. `/r/{m}.json`).
- Closes the bug class for **every** throw-producing simple-encoded shape: `MapModel<complex>`, `ListModel<complex>`, `NeverModel`, `BinaryModel`, `List<NeverModel>`, `List<BinaryModel>`, `List<AnyModel>`, and `AliasModel` chains over any of them. The `boolean_schemas` integration suite — which had a pre-existing `List<AnyModel>` simple path parameter that the original fix iteration regressed — is now correctly handled.
- Introduces `simpleEncodingThrowReason(Model)` in `to_simple_value_expression_generator.dart` as the **single source of truth** for "would the simple encoder produce a throw expression?". `path_generator.dart` consults it once; the predicate mirrors every throw branch in `_buildSimpleSerializationExpression` and `_handleListExpression`.
- Co-located with the encoder, `isMapValueTypeSimplyEncodable(Model)` in `map_value_to_string_expression_builder.dart` is the source of truth for the Map-value subset; `_buildConversion` uses it as its first guard so the encoder and the path-generator hoist decision cannot drift.
- `model.resolved` is applied at outer and inner positions in both simple and matrix branches so `AliasModel` chains produced by `$ref` + sibling annotations no longer slip through.
- Both simple and matrix throw messages include the parameter `rawName` so runtime `EncodingException`s identify which path parameter triggered.
- Defensive switch arms throw `UnsupportedError` rather than fall back silently — a future `Model` subtype that isn't enumerated will surface loudly at codegen time rather than producing broken Dart.
- Adds HARD RULE 15 to `.claude/agents/tonik-generator.md` enforcing WHY-only comments on the gen-eval generator agent.

## Test plan

- [x] `fvm dart analyze` clean from project root
- [x] All unit tests pass: 4337/4337 across `tonik_core`, `tonik_parse`, `tonik_generate`, `tonik_util`, `tonik`
- [x] Integration tests pass after `./scripts/setup_integration_tests.sh` — all 33 suites green, including `boolean_schemas` (regression fixed) and `path_encoding` (new `throw_suffix_test.dart` 6/6)
- [x] Patch coverage 90% (every miss is a deliberately-unreachable defensive `_unreachableModelType` arm)
- [x] New `path_encoding/openapi.yaml` reproductions cover Map-complex, Map-list, Map-oneOf-simple, Binary, List<Binary>, Aliased-Map-complex, Aliased-Never — every one generates compilable Dart
- [x] Predicate parity test enforces predicate to `_buildConversion` agreement across every model type
- [x] Multi-parameter same-segment test (`/r/{good}-{badMap}.json`) and rawName-vs-name divergence test (`name: 'mNorm'`, `rawName: 'M-RAW'`) lock the throw-statement contract
- [x] Runtime `throw_suffix_test.dart` verifies every new throw-suffix operation throws `EncodingException` with the parameter name in the message
