### PR TITLE
fix: avoid duplicate parameter names when counter suffix collides with existing name

### DIFF
--- a/integration_test/naming/naming_test/pubspec.lock
+++ b/integration_test/naming/naming_test/pubspec.lock
@@ -90,7 +90,7 @@ packages:
     source: hosted
     version: "3.0.7"
   dio:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: dio
       sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c

--- a/integration_test/naming/naming_test/pubspec.yaml
+++ b/integration_test/naming/naming_test/pubspec.yaml
@@ -12,6 +12,7 @@ dependencies:
   tonik_util: ^0.1.0
 
 dev_dependencies:
+  dio: ^5.8.0+1
   test: ^1.25.15
   very_good_analysis: ^10.2.0
 

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -1,3 +1,4 @@
+import 'package:dio/dio.dart';
 import 'package:naming_api/src/api_client/default_api2.dart';
 import 'package:naming_api/src/model/_function.dart';
 import 'package:naming_api/src/model/camel_case_collider.dart';
@@ -13,6 +14,7 @@ import 'package:naming_api/src/model/weird_property_names.dart';
 import 'package:naming_api/src/operation/create_with_body_cookie.dart';
 import 'package:naming_api/src/operation/create_with_body_header.dart';
 import 'package:naming_api/src/operation/create_with_body_query.dart';
+import 'package:naming_api/src/operation/get_param_counter_collision.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -220,5 +222,76 @@ void main() {
       expect(model.a, 'single');
       expect(model.kebabCaseName, 'hyphenated');
     });
+  });
+
+  group('parameter counter-suffix collision (GetParamCounterCollision)', () {
+    test(
+      'exposes four distinct Dart parameter names — tokenPath, tokenQuery, '
+      'tokenQuery2, tokenQuery3 — and tokenQuery3 still serialises under the '
+      'wire key "token"',
+      () async {
+        final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+        Uri? capturedUri;
+        dio.interceptors.add(
+          InterceptorsWrapper(
+            onRequest: (options, handler) {
+              capturedUri = options.uri;
+              handler.reject(
+                DioException(
+                  requestOptions: options,
+                  type: DioExceptionType.cancel,
+                ),
+              );
+            },
+          ),
+        );
+
+        final operation = GetParamCounterCollision(dio);
+
+        // The named-arg call site IS the compile-time check on Dart names:
+        // if any of the four were renamed, this wouldn't compile.
+        await operation.call(
+          tokenPath: 'P',
+          tokenQuery: 'A',
+          tokenQuery2: 'B',
+          tokenQuery3: 'C',
+        );
+
+        expect(capturedUri, isNotNull);
+        final uri = capturedUri!;
+
+        expect(
+          uri.path,
+          contains('/param-counter-collision/P'),
+        );
+
+        final params = uri.queryParametersAll;
+
+        expect(
+          params['token'],
+          ['C'],
+          reason:
+              'tokenQuery3 must serialise under wire key "token" — the '
+              'Dart-side counter rename must not change the on-the-wire name.',
+        );
+        expect(
+          params['token_query'],
+          ['A'],
+          reason: 'tokenQuery must keep its raw wire name "token_query".',
+        );
+        expect(
+          params['token_query2'],
+          ['B'],
+          reason: 'tokenQuery2 must keep its raw wire name "token_query2".',
+        );
+        expect(
+          params.containsKey('token_query3'),
+          isFalse,
+          reason:
+              'No query key should adopt the renamed Dart identifier — that '
+              'would corrupt the outgoing request.',
+        );
+      },
+    );
   });
 }

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -542,6 +542,35 @@ paths:
         '200':
           description: OK
 
+  /param-counter-collision/{token}:
+    get:
+      operationId: getParamCounterCollision
+      parameters:
+        - name: token_query
+          in: query
+          schema:
+            type: string
+        - name: token_query2
+          in: query
+          schema:
+            type: string
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
   /param-duplicates/{id}:
     get:
       operationId: getWithDuplicateParams

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -143,26 +143,31 @@ NormalizedRequestParameters normalizeRequestParameters({
   );
 }
 
-/// Ensures uniqueness of names within a parameter group
 List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
   List<({String normalizedName, T parameter})> parameters,
 ) {
   final result = <({String normalizedName, T parameter})>[];
-  final usedNames = <String>{}; // lowercase names for uniqueness check
-  final nameCounters = <String, int>{}; // lowercase base name -> counter
+  final usedNames = <String>{};
+  final nameCounters = <String, int>{};
 
   for (final item in parameters) {
-    var name = item.normalizedName;
-    final baseLowerName = name.toLowerCase();
+    final baseName = item.normalizedName;
+    final baseLowerName = baseName.toLowerCase();
 
-    // If the name is already used, add a numeric suffix
-    if (usedNames.contains(baseLowerName)) {
+    var name = baseName;
+    var lowerName = baseLowerName;
+
+    // Loop (not single increment) because a counter-generated candidate may
+    // itself collide with an earlier entry: group [tokenQuery, tokenQuery2,
+    // tokenQuery] — naive increment yields tokenQuery2, which already exists.
+    while (usedNames.contains(lowerName)) {
       final counter = nameCounters.putIfAbsent(baseLowerName, () => 2);
-      name = '$name$counter';
+      name = '$baseName$counter';
+      lowerName = name.toLowerCase();
       nameCounters[baseLowerName] = counter + 1;
     }
 
-    usedNames.add(name.toLowerCase());
+    usedNames.add(lowerName);
     result.add((normalizedName: name, parameter: item.parameter));
   }
 

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -150,6 +150,11 @@ List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
   final usedNames = <String>{};
   final nameCounters = <String, int>{};
 
+  // Worst case: all N parameters share the same base, so the maximum
+  // counter value reached is N. The +2 buffer gives headroom and matches
+  // the initial counter value of 2.
+  final convergenceBound = parameters.length + 2;
+
   for (final item in parameters) {
     final baseName = item.normalizedName;
     final baseLowerName = baseName.toLowerCase();
@@ -157,17 +162,20 @@ List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
     var name = baseName;
     var lowerName = baseLowerName;
 
+    nameCounters.putIfAbsent(baseLowerName, () => 2);
+
     // Loop (not single increment) because a counter-generated candidate may
     // itself collide with an earlier entry: group [tokenQuery, tokenQuery2,
     // tokenQuery] — naive increment yields tokenQuery2, which already exists.
     while (usedNames.contains(lowerName)) {
-      final counter = nameCounters.putIfAbsent(baseLowerName, () => 2);
-      assert(
-        counter <= parameters.length + 2,
-        'Counter for "$baseName" exceeded parameters.length + 2 '
-        '(${parameters.length + 2}); _ensureUniquenessInGroup is not '
-        'converging — counter increment is broken.',
-      );
+      final counter = nameCounters[baseLowerName]!;
+      if (counter > convergenceBound) {
+        throw StateError(
+          'Counter for "$baseName" exceeded parameters.length + 2 '
+          '($convergenceBound); _ensureUniquenessInGroup is not '
+          'converging — counter increment is broken.',
+        );
+      }
       name = '$baseName$counter';
       lowerName = name.toLowerCase();
       nameCounters[baseLowerName] = counter + 1;

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -162,6 +162,12 @@ List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
     // tokenQuery] — naive increment yields tokenQuery2, which already exists.
     while (usedNames.contains(lowerName)) {
       final counter = nameCounters.putIfAbsent(baseLowerName, () => 2);
+      assert(
+        counter <= parameters.length + 2,
+        'Counter for "$baseName" exceeded parameters.length + 2 '
+        '(${parameters.length + 2}); _ensureUniquenessInGroup is not '
+        'converging — counter increment is broken.',
+      );
       name = '$baseName$counter';
       lowerName = name.toLowerCase();
       nameCounters[baseLowerName] = counter + 1;

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -194,6 +194,11 @@ void main() {
       expect(names.length, 2, reason: 'Should have 2 parameters');
       expect(names.toSet().length, 2, reason: 'Should have unique names');
       expect(names.contains('value'), isTrue);
+      expect(
+        names.contains('value2'),
+        isTrue,
+        reason: 'Second duplicate must be deterministically pinned to value2',
+      );
     });
 
     test('applies type suffixes to nameOverride duplicates across types', () {
@@ -446,6 +451,73 @@ void main() {
           'x2',
           'x3',
           'x4',
+        ]);
+      },
+    );
+
+    test(
+      'type-suffix application creates a within-group collision that the '
+      'counter-loop must resolve (path foo + query foo_query + query foo)',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {createPathParameter('foo')},
+          queryParameters: {
+            createQueryParameter('foo_query'),
+            createQueryParameter('foo'),
+          },
+          headers: {},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName), [
+          'fooPath',
+        ]);
+        expect(result.queryParameters.map((r) => r.normalizedName), [
+          'fooQuery',
+          'fooQuery2',
+        ]);
+      },
+    );
+
+    test(
+      'within-group dedup applies to header parameters '
+      '(non-query group coverage)',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {},
+          queryParameters: {},
+          headers: {
+            createHeader('trace'),
+            createHeader('trace2'),
+            createHeader('trace'),
+          },
+        );
+
+        expect(result.headers.map((r) => r.normalizedName), [
+          'trace',
+          'trace2',
+          'trace3',
+        ]);
+      },
+    );
+
+    test(
+      'within-group dedup applies to path parameters '
+      '(non-query group coverage)',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {
+            createPathParameter('id'),
+            createPathParameter('id2'),
+            createPathParameter('id'),
+          },
+          queryParameters: {},
+          headers: {},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName), [
+          'id',
+          'id2',
+          'id3',
         ]);
       },
     );

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -379,6 +379,78 @@ void main() {
     });
   });
 
+  group('counter-suffix collision avoidance', () {
+    test(
+      'reproducing spec: path token + query token + token_query + '
+      'token_query2 produces four distinct names',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {createPathParameter('token')},
+          queryParameters: {
+            createQueryParameter('token_query'),
+            createQueryParameter('token_query2'),
+            createQueryParameter('token'),
+          },
+          headers: {},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName), [
+          'tokenPath',
+        ]);
+        expect(result.queryParameters.map((r) => r.normalizedName), [
+          'tokenQuery',
+          'tokenQuery2',
+          'tokenQuery3',
+        ]);
+      },
+    );
+
+    test(
+      'within-group dedup skips counter values that already collide with '
+      'an existing name (e.g. [a, a2, a] -> [a, a2, a3])',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {},
+          queryParameters: {
+            createQueryParameter('a'),
+            createQueryParameter('a2'),
+            createQueryParameter('a'),
+          },
+          headers: {},
+        );
+
+        expect(result.queryParameters.map((r) => r.normalizedName), [
+          'a',
+          'a2',
+          'a3',
+        ]);
+      },
+    );
+
+    test(
+      'within-group dedup advances past multiple consecutive collisions',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {},
+          queryParameters: {
+            createQueryParameter('x'),
+            createQueryParameter('x2'),
+            createQueryParameter('x3'),
+            createQueryParameter('x'),
+          },
+          headers: {},
+        );
+
+        expect(result.queryParameters.map((r) => r.normalizedName), [
+          'x',
+          'x2',
+          'x3',
+          'x4',
+        ]);
+      },
+    );
+  });
+
   group('normalizeMultipartHeaderName', () {
     test('combines property name and header name', () {
       expect(

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -521,6 +521,29 @@ void main() {
         ]);
       },
     );
+
+    test(
+      'within-group dedup applies to cookie parameters '
+      '(non-query group coverage)',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {},
+          queryParameters: {},
+          headers: {},
+          cookieParameters: {
+            createCookieParameter('session'),
+            createCookieParameter('session2'),
+            createCookieParameter('session'),
+          },
+        );
+
+        expect(result.cookieParameters.map((r) => r.normalizedName), [
+          'session',
+          'session2',
+          'session3',
+        ]);
+      },
+    );
   });
 
   group('normalizeMultipartHeaderName', () {


### PR DESCRIPTION
## Summary

- `_ensureUniquenessInGroup` in `parameter_name_normalizer.dart` generated a counter-suffixed name (e.g. `tokenQuery2`) without checking if that name was already taken, producing `duplicate_definition` errors in generated Dart code
- Replace the single-increment counter with a loop that advances until the candidate name is genuinely unused — matching the existing approach in `ensureUniqueness` (name_utils.dart)
- Add unit tests for the exact order-dependent reproducing scenario and the general counter-collision case, plus an integration test spec

## Test plan

- [ ] `fvm dart analyze` passes with zero issues in package code
- [ ] `parameter_name_normalizer_test.dart` — new tests for the reproducing scenario and general collision case pass
- [ ] Integration tests pass (including new `/param-counter-collision/{token}` operation in `naming/openapi.yaml`)
- [ ] Patch coverage 100%
