### PR TITLE
test: integration tests for Map<String,String> path param with literal suffix

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1482,6 +1482,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  /simple/encode-suffix/map-string/{m}.json:
+    get:
+      operationId: testSimpleMapStringWithSuffix
+      tags: [simple]
+      summary: Simple-style string-value map with literal suffix (positive case)
+      description: |
+        Regression guard for the original bug: a Map<String, String> path
+        parameter followed by a literal '.json' suffix must generate valid
+        encoding code, not `throw EncodingException(...) + '.json'`.
+        explode=false: key,value pairs separated by commas.
+      parameters:
+        - name: m
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/encode-suffix/map-string-explode/{m}.json:
+    get:
+      operationId: testSimpleMapStringExplodeWithSuffix
+      tags: [simple]
+      summary: Simple-style string-value map (explode=true) with literal suffix
+      description: |
+        Companion to testSimpleMapStringWithSuffix with explode=true.
+        explode=true: key=value pairs separated by commas.
+      parameters:
+        - name: m
+          in: path
+          required: true
+          style: simple
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
 components:
   schemas:
     StatusEnum:

--- a/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
@@ -22,6 +22,38 @@ void main() {
     );
   }
 
+  group('Simple style - string-value map with literal suffix', () {
+    test('map (explode=false) encodes key,value pairs before suffix', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleMapStringWithSuffix(
+        m: const {'k': 'v'},
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/simple/encode-suffix/map-string/k,v.json',
+      );
+    });
+
+    test('map (explode=true) encodes key=value pairs before suffix', () async {
+      final api = buildSimpleApi();
+      final response = await api.testSimpleMapStringExplodeWithSuffix(
+        m: const {'k': 'v'},
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/simple/encode-suffix/map-string-explode/k=v.json',
+      );
+    });
+  });
+
   group('Simple style - Special character property names', () {
     test(
       'special keys (explode=false) encodes keys with URI encoding',


### PR DESCRIPTION
## Summary

- Adds two integration tests for a `Map<String, String>` path parameter followed by a literal `.json` suffix (`explode=false` and `explode=true`)
- Closes the coverage gap left by PR #132: the fix for bug 002 was verified for complex/list/oneOf value maps, but never for the original reproducing spec (`additionalProperties: type: string`)
- Both new tests pass against the current generator

## Test plan
- `test/simple_test.dart: Simple style - string-value map with literal suffix` — both cases run green
- Full `test-integration-path-encoding` suite: 53/53 passing