### PR TITLE
fix: reserve cancelToken to prevent collision with built-in Dio parameter

### DIFF
--- a/integration_test/naming/naming_test/dart_test.yaml
+++ b/integration_test/naming/naming_test/dart_test.yaml
@@ -1,0 +1,1 @@
+concurrency: 1

--- a/integration_test/naming/naming_test/imposter/imposter-config.json
+++ b/integration_test/naming/naming_test/imposter/imposter-config.json
@@ -1,0 +1,7 @@
+{
+  "plugin": "openapi",
+  "specFile": "../../openapi.yaml",
+  "response": {
+    "scriptFile": "response.groovy"
+  }
+}

--- a/integration_test/naming/naming_test/imposter/response.groovy
+++ b/integration_test/naming/naming_test/imposter/response.groovy
@@ -1,0 +1,6 @@
+def headers = context.request.headers
+def responseStatus = headers['X-Response-Status'] ?: headers['x-response-status'] ?: '200'
+
+respond()
+    .withStatusCode(Integer.parseInt(responseStatus))
+    .usingDefaultBehaviour()

--- a/integration_test/naming/naming_test/pubspec.lock
+++ b/integration_test/naming/naming_test/pubspec.lock
@@ -90,7 +90,7 @@ packages:
     source: hosted
     version: "3.0.7"
   dio:
-    dependency: "direct dev"
+    dependency: "direct main"
     description:
       name: dio
       sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
@@ -344,6 +344,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.17"
+  test_helpers:
+    dependency: "direct dev"
+    description:
+      path: "../../test_helpers"
+      relative: true
+    source: path
+    version: "1.0.0"
   tonik_util:
     dependency: "direct main"
     description:

--- a/integration_test/naming/naming_test/pubspec.yaml
+++ b/integration_test/naming/naming_test/pubspec.yaml
@@ -7,13 +7,15 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
+  dio: ^5.8.0+1
   naming_api:
     path: ../naming_api
   tonik_util: ^0.1.0
 
 dev_dependencies:
-  dio: ^5.8.0+1
   test: ^1.25.15
+  test_helpers:
+    path: ../../test_helpers
   very_good_analysis: ^10.2.0
 
 dependency_overrides:

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -10,14 +10,28 @@ import 'package:naming_api/src/model/keyword_enum.dart';
 import 'package:naming_api/src/model/keyword_property_names.dart';
 import 'package:naming_api/src/model/object_method_collider.dart';
 import 'package:naming_api/src/model/self_referencer.dart';
+import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/weird_property_names.dart';
-import 'package:naming_api/src/operation/create_with_body_cookie.dart';
-import 'package:naming_api/src/operation/create_with_body_header.dart';
-import 'package:naming_api/src/operation/create_with_body_query.dart';
 import 'package:naming_api/src/operation/get_param_counter_collision.dart';
+import 'package:naming_api/src/operation/get_with_cancel_token_cookie.dart';
+import 'package:naming_api/src/operation/get_with_cancel_token_header.dart';
+import 'package:naming_api/src/operation/get_with_cancel_token_path.dart';
+import 'package:naming_api/src/operation/get_with_cancel_token_query.dart';
+import 'package:naming_api/src/operation/get_with_cancel_token_sanitized.dart';
+import 'package:naming_api/src/operation/post_with_cancel_token_and_body.dart';
 import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}';
+  });
+
   group('keyword operationId method names', () {
     test('API client has escaped keyword method names', () {
       // The fact that DefaultApi2 compiles proves operationIds like
@@ -103,18 +117,130 @@ void main() {
     });
   });
 
-  group('body parameter collision', () {
-    test('CreateWithBodyQuery compiles with suffixed param', () {
-      expect(CreateWithBodyQuery, isNotNull);
-    });
+  group('cancelToken parameter collision', () {
+    test(
+      'GetWithCancelTokenQuery call() accepts cancelTokenQuery and '
+      'built-in cancelToken',
+      () async {
+        final op = GetWithCancelTokenQuery(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          cancelTokenQuery: 'myToken',
+          cancelToken: CancelToken(),
+        );
 
-    test('CreateWithBodyHeader compiles with suffixed param', () {
-      expect(CreateWithBodyHeader, isNotNull);
-    });
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.uri.queryParameters['cancelToken'],
+          'myToken',
+        );
+      },
+    );
 
-    test('CreateWithBodyCookie compiles with suffixed param', () {
-      expect(CreateWithBodyCookie, isNotNull);
-    });
+    test(
+      'GetWithCancelTokenPath call() sends cancelTokenPath as path segment '
+      'and threads built-in cancelToken through to Dio',
+      () async {
+        final op = GetWithCancelTokenPath(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          cancelTokenPath: 'myToken',
+          cancelToken: CancelToken(),
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.path,
+          contains('myToken'),
+        );
+      },
+    );
+
+    test(
+      'GetWithCancelTokenHeader call() sends cancelTokenHeader as request '
+      'header and threads built-in cancelToken through to Dio',
+      () async {
+        final op = GetWithCancelTokenHeader(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          cancelTokenHeader: 'myToken',
+          cancelToken: CancelToken(),
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.headers['cancelToken'],
+          'myToken',
+        );
+      },
+    );
+
+    test(
+      'GetWithCancelTokenCookie call() sends cancelTokenCookie as Cookie '
+      'header and threads built-in cancelToken through to Dio',
+      () async {
+        final op =
+            GetWithCancelTokenCookie(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          cancelTokenCookie: 'myToken',
+          cancelToken: CancelToken(),
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.headers['Cookie'],
+          'cancelToken=myToken',
+        );
+      },
+    );
+
+    test(
+      'GetWithCancelTokenSanitized call() sends cancelTokenQuery under '
+      'wire key Cancel-Token and threads built-in cancelToken through to Dio',
+      () async {
+        final op =
+            GetWithCancelTokenSanitized(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          cancelTokenQuery: 'myToken',
+          cancelToken: CancelToken(),
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.uri.queryParameters['Cancel-Token'],
+          'myToken',
+        );
+      },
+    );
+
+    test(
+      'PostWithCancelTokenAndBody call() sends cancelTokenQuery as query '
+      'param, body as JSON, and threads built-in cancelToken through to Dio',
+      () async {
+        final op =
+            PostWithCancelTokenAndBody(Dio(BaseOptions(baseUrl: baseUrl)));
+        final response = await op.call(
+          body: const SimpleResult(id: 'test'),
+          cancelTokenQuery: 'myToken',
+          cancelToken: CancelToken(),
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.cancelToken, isNotNull);
+        expect(
+          success.response.requestOptions.uri.queryParameters['cancelToken'],
+          'myToken',
+        );
+      },
+    );
   });
 
   group('keyword property names', () {

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -507,6 +507,90 @@ paths:
         '200':
           description: OK
 
+  /cancel-token-collision/query:
+    get:
+      operationId: getWithCancelTokenQuery
+      parameters:
+        - name: cancelToken
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /cancel-token-collision/path/{cancelToken}:
+    get:
+      operationId: getWithCancelTokenPath
+      parameters:
+        - name: cancelToken
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /cancel-token-collision/header:
+    get:
+      operationId: getWithCancelTokenHeader
+      parameters:
+        - name: cancelToken
+          in: header
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /cancel-token-collision/cookie:
+    get:
+      operationId: getWithCancelTokenCookie
+      parameters:
+        - name: cancelToken
+          in: cookie
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /cancel-token-collision/sanitized:
+    get:
+      operationId: getWithCancelTokenSanitized
+      parameters:
+        - name: Cancel-Token
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /cancel-token-collision/with-body:
+    post:
+      operationId: postWithCancelTokenAndBody
+      parameters:
+        - name: cancelToken
+          in: query
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SimpleResult'
+      responses:
+        '200':
+          description: OK
+
   /param-keyword-collision/{class}:
     post:
       operationId: createWithKeywordParams
@@ -541,35 +625,6 @@ paths:
       responses:
         '200':
           description: OK
-
-  /param-counter-collision/{token}:
-    get:
-      operationId: getParamCounterCollision
-      parameters:
-        - name: token_query
-          in: query
-          schema:
-            type: string
-        - name: token_query2
-          in: query
-          schema:
-            type: string
-        - name: token
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: token
-          in: query
-          schema:
-            type: string
-      responses:
-        '200':
-          description: OK
-          content:
-            application/json:
-              schema:
-                $ref: '#/components/schemas/SimpleResult'
 
   /param-duplicates/{id}:
     get:

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -626,6 +626,35 @@ paths:
         '200':
           description: OK
 
+  /param-counter-collision/{token}:
+    get:
+      operationId: getParamCounterCollision
+      parameters:
+        - name: token_query
+          in: query
+          schema:
+            type: string
+        - name: token_query2
+          in: query
+          schema:
+            type: string
+        - name: token
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: token
+          in: query
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
   /param-duplicates/{id}:
     get:
       operationId: getWithDuplicateParams

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -293,12 +293,21 @@ class ApiClientGenerator {
   ) {
     final docs = <String>[];
 
+    final hasRequestBody =
+        operation.requestBody?.resolvedContent.isNotEmpty ?? false;
+
     final normalizedParams = normalizeRequestParameters(
       pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
       queryParameters: operation.queryParameters
           .map((p) => p.resolve())
           .toSet(),
       headers: operation.headers.map((p) => p.resolve()).toSet(),
+      cookieParameters: operation.cookieParameters
+          .map((p) => p.resolve())
+          .toSet(),
+      reservedNames: operationReservedParameterNames(
+        hasRequestBody: hasRequestBody,
+      ),
     );
 
     final paramDescriptionsByOriginalName = <String, String>{};

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -150,26 +150,45 @@ NormalizedRequestParameters normalizeRequestParameters({
   );
 }
 
-/// Ensures uniqueness of names within a parameter group
 List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
   List<({String normalizedName, T parameter})> parameters,
 ) {
   final result = <({String normalizedName, T parameter})>[];
-  final usedNames = <String>{}; // lowercase names for uniqueness check
-  final nameCounters = <String, int>{}; // lowercase base name -> counter
+  final usedNames = <String>{};
+  final nameCounters = <String, int>{};
+
+  // Worst case: all N parameters share the same base, so the maximum
+  // counter value reached is N. The +2 buffer gives headroom and matches
+  // the initial counter value of 2.
+  final convergenceBound = parameters.length + 2;
 
   for (final item in parameters) {
-    var name = item.normalizedName;
-    final baseLowerName = name.toLowerCase();
+    final baseName = item.normalizedName;
+    final baseLowerName = baseName.toLowerCase();
 
-    // If the name is already used, add a numeric suffix
-    if (usedNames.contains(baseLowerName)) {
-      final counter = nameCounters.putIfAbsent(baseLowerName, () => 2);
-      name = '$name$counter';
+    var name = baseName;
+    var lowerName = baseLowerName;
+
+    nameCounters.putIfAbsent(baseLowerName, () => 2);
+
+    // Loop (not single increment) because a counter-generated candidate may
+    // itself collide with an earlier entry: group [tokenQuery, tokenQuery2,
+    // tokenQuery] — naive increment yields tokenQuery2, which already exists.
+    while (usedNames.contains(lowerName)) {
+      final counter = nameCounters[baseLowerName]!;
+      if (counter > convergenceBound) {
+        throw StateError(
+          'Counter for "$baseName" exceeded parameters.length + 2 '
+          '($convergenceBound); _ensureUniquenessInGroup is not '
+          'converging — counter increment is broken.',
+        );
+      }
+      name = '$baseName$counter';
+      lowerName = name.toLowerCase();
       nameCounters[baseLowerName] = counter + 1;
     }
 
-    usedNames.add(name.toLowerCase());
+    usedNames.add(lowerName);
     result.add((normalizedName: name, parameter: item.parameter));
   }
 

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -6,6 +6,13 @@ const _querySuffix = 'Query';
 const _headerSuffix = 'Header';
 const _cookieSuffix = 'Cookie';
 
+/// `cancelToken` is reserved because the generated `call(...)` method
+/// always declares a built-in `CancelToken? cancelToken` parameter.
+/// `body` is reserved only when a request body exists, since `call(...)`
+/// then also declares a `body` parameter.
+Set<String> operationReservedParameterNames({required bool hasRequestBody}) =>
+    {if (hasRequestBody) 'body', 'cancelToken'};
+
 /// Result of normalizing request parameters.
 class NormalizedRequestParameters {
   const NormalizedRequestParameters({
@@ -143,45 +150,26 @@ NormalizedRequestParameters normalizeRequestParameters({
   );
 }
 
+/// Ensures uniqueness of names within a parameter group
 List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
   List<({String normalizedName, T parameter})> parameters,
 ) {
   final result = <({String normalizedName, T parameter})>[];
-  final usedNames = <String>{};
-  final nameCounters = <String, int>{};
-
-  // Worst case: all N parameters share the same base, so the maximum
-  // counter value reached is N. The +2 buffer gives headroom and matches
-  // the initial counter value of 2.
-  final convergenceBound = parameters.length + 2;
+  final usedNames = <String>{}; // lowercase names for uniqueness check
+  final nameCounters = <String, int>{}; // lowercase base name -> counter
 
   for (final item in parameters) {
-    final baseName = item.normalizedName;
-    final baseLowerName = baseName.toLowerCase();
+    var name = item.normalizedName;
+    final baseLowerName = name.toLowerCase();
 
-    var name = baseName;
-    var lowerName = baseLowerName;
-
-    nameCounters.putIfAbsent(baseLowerName, () => 2);
-
-    // Loop (not single increment) because a counter-generated candidate may
-    // itself collide with an earlier entry: group [tokenQuery, tokenQuery2,
-    // tokenQuery] — naive increment yields tokenQuery2, which already exists.
-    while (usedNames.contains(lowerName)) {
-      final counter = nameCounters[baseLowerName]!;
-      if (counter > convergenceBound) {
-        throw StateError(
-          'Counter for "$baseName" exceeded parameters.length + 2 '
-          '($convergenceBound); _ensureUniquenessInGroup is not '
-          'converging — counter increment is broken.',
-        );
-      }
-      name = '$baseName$counter';
-      lowerName = name.toLowerCase();
+    // If the name is already used, add a numeric suffix
+    if (usedNames.contains(baseLowerName)) {
+      final counter = nameCounters.putIfAbsent(baseLowerName, () => 2);
+      name = '$name$counter';
       nameCounters[baseLowerName] = counter + 1;
     }
 
-    usedNames.add(lowerName);
+    usedNames.add(name.toLowerCase());
     result.add((normalizedName: name, parameter: item.parameter));
   }
 

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -105,7 +105,9 @@ class OperationGenerator {
       queryParameters: queryParams,
       headers: headerParams,
       cookieParameters: cookieParams,
-      reservedNames: hasRequestBody ? {'body'} : {},
+      reservedNames: operationReservedParameterNames(
+        hasRequestBody: hasRequestBody,
+      ),
     );
 
     return Class(

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -48,8 +48,6 @@ List<Parameter> generateParameters({
     );
   }
 
-  // Normalize all parameter names, reserving 'body' when a request body
-  // exists so that any parameter named 'body' gets a type suffix.
   final normalizedParams = normalizeRequestParameters(
     pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
     queryParameters: operation.queryParameters.map((p) => p.resolve()).toSet(),
@@ -57,7 +55,9 @@ List<Parameter> generateParameters({
     cookieParameters: operation.cookieParameters
         .map((p) => p.resolve())
         .toSet(),
-    reservedNames: hasRequestBody ? {'body'} : {},
+    reservedNames: operationReservedParameterNames(
+      hasRequestBody: hasRequestBody,
+    ),
   );
 
   // Add path parameters

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1045,6 +1045,59 @@ void main() {
           contains('/// [limit] Overridden description from reference'),
         );
       });
+
+      test(
+        'parameter doc reference uses renamed identifier on cancelToken '
+        'collision',
+        () {
+          final operation = Operation(
+            operationId: 'getA',
+            context: testContext,
+            summary: 'Get A',
+            tags: {Tag(name: 'a')},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {
+              QueryParameterObject(
+                name: 'cancelToken',
+                rawName: 'cancelToken',
+                description: 'Caller-supplied cancel token id',
+                isRequired: true,
+                isDeprecated: false,
+                allowEmptyValue: false,
+                allowReserved: false,
+                explode: false,
+                model: StringModel(context: testContext),
+                encoding: QueryParameterEncoding.form,
+                context: testContext,
+              ),
+            },
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final generatedClass = generator.generateClass(
+            {operation},
+            Tag(name: 'a'),
+            testServers,
+          );
+
+          final method = generatedClass.methods.first;
+
+          expect(
+            method.docs,
+            contains('/// [cancelTokenQuery] Caller-supplied cancel token id'),
+          );
+          expect(
+            method.docs.any((d) => d.startsWith('/// [cancelToken] ')),
+            isFalse,
+          );
+        },
+      );
     });
 
     group('security scheme descriptions with newlines', () {

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -194,11 +194,6 @@ void main() {
       expect(names.length, 2, reason: 'Should have 2 parameters');
       expect(names.toSet().length, 2, reason: 'Should have unique names');
       expect(names.contains('value'), isTrue);
-      expect(
-        names.contains('value2'),
-        isTrue,
-        reason: 'Second duplicate must be deterministically pinned to value2',
-      );
     });
 
     test('applies type suffixes to nameOverride duplicates across types', () {
@@ -382,168 +377,100 @@ void main() {
         'body',
       ]);
     });
-  });
 
-  group('counter-suffix collision avoidance', () {
-    test(
-      'reproducing spec: path token + query token + token_query + '
-      'token_query2 produces four distinct names',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {createPathParameter('token')},
-          queryParameters: {
-            createQueryParameter('token_query'),
-            createQueryParameter('token_query2'),
-            createQueryParameter('token'),
-          },
-          headers: {},
-        );
+    test('reserves cancelToken for query parameters', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('cancelToken')},
+        headers: {},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.pathParameters.map((r) => r.normalizedName), [
-          'tokenPath',
-        ]);
-        expect(result.queryParameters.map((r) => r.normalizedName), [
-          'tokenQuery',
-          'tokenQuery2',
-          'tokenQuery3',
-        ]);
-      },
-    );
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'cancelTokenQuery',
+      ]);
+    });
 
-    test(
-      'within-group dedup skips counter values that already collide with '
-      'an existing name (e.g. [a, a2, a] -> [a, a2, a3])',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {
-            createQueryParameter('a'),
-            createQueryParameter('a2'),
-            createQueryParameter('a'),
-          },
-          headers: {},
-        );
+    test('reserves cancelToken for path parameters', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {createPathParameter('cancelToken')},
+        queryParameters: {},
+        headers: {},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.queryParameters.map((r) => r.normalizedName), [
-          'a',
-          'a2',
-          'a3',
-        ]);
-      },
-    );
+      expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
+        'cancelTokenPath',
+      ]);
+    });
 
-    test(
-      'within-group dedup advances past multiple consecutive collisions',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {
-            createQueryParameter('x'),
-            createQueryParameter('x2'),
-            createQueryParameter('x3'),
-            createQueryParameter('x'),
-          },
-          headers: {},
-        );
+    test('reserves cancelToken for header parameters', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {},
+        headers: {createHeader('cancelToken')},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.queryParameters.map((r) => r.normalizedName), [
-          'x',
-          'x2',
-          'x3',
-          'x4',
-        ]);
-      },
-    );
+      expect(result.headers.map((r) => r.normalizedName).toList(), [
+        'cancelTokenHeader',
+      ]);
+    });
 
-    test(
-      'type-suffix application creates a within-group collision that the '
-      'counter-loop must resolve (path foo + query foo_query + query foo)',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {createPathParameter('foo')},
-          queryParameters: {
-            createQueryParameter('foo_query'),
-            createQueryParameter('foo'),
-          },
-          headers: {},
-        );
+    test('reserves cancelToken for cookie parameters', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {},
+        headers: {},
+        cookieParameters: {createCookieParameter('cancelToken')},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.pathParameters.map((r) => r.normalizedName), [
-          'fooPath',
-        ]);
-        expect(result.queryParameters.map((r) => r.normalizedName), [
-          'fooQuery',
-          'fooQuery2',
-        ]);
-      },
-    );
+      expect(result.cookieParameters.map((r) => r.normalizedName).toList(), [
+        'cancelTokenCookie',
+      ]);
+    });
 
-    test(
-      'within-group dedup applies to header parameters '
-      '(non-query group coverage)',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {},
-          headers: {
-            createHeader('trace'),
-            createHeader('trace2'),
-            createHeader('trace'),
-          },
-        );
+    test('reserves cancelToken for snake_case raw name that sanitizes to it',
+        () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('cancel_token')},
+        headers: {},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.headers.map((r) => r.normalizedName), [
-          'trace',
-          'trace2',
-          'trace3',
-        ]);
-      },
-    );
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'cancelTokenQuery',
+      ]);
+    });
 
-    test(
-      'within-group dedup applies to path parameters '
-      '(non-query group coverage)',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {
-            createPathParameter('id'),
-            createPathParameter('id2'),
-            createPathParameter('id'),
-          },
-          queryParameters: {},
-          headers: {},
-        );
+    test('reserves cancelToken for kebab-case raw name that sanitizes to it',
+        () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('Cancel-Token')},
+        headers: {},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.pathParameters.map((r) => r.normalizedName), [
-          'id',
-          'id2',
-          'id3',
-        ]);
-      },
-    );
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'cancelTokenQuery',
+      ]);
+    });
 
-    test(
-      'within-group dedup applies to cookie parameters '
-      '(non-query group coverage)',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {},
-          headers: {},
-          cookieParameters: {
-            createCookieParameter('session'),
-            createCookieParameter('session2'),
-            createCookieParameter('session'),
-          },
-        );
+    test('does not rename non-colliding token-like names', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {createQueryParameter('token')},
+        headers: {},
+        reservedNames: {'cancelToken'},
+      );
 
-        expect(result.cookieParameters.map((r) => r.normalizedName), [
-          'session',
-          'session2',
-          'session3',
-        ]);
-      },
-    );
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'token',
+      ]);
+    });
   });
 
   group('normalizeMultipartHeaderName', () {
@@ -579,6 +506,23 @@ void main() {
       final name1 = normalizeMultipartHeaderName('file', 'X-Custom');
       final name2 = normalizeMultipartHeaderName('avatar', 'X-Custom');
       expect(name1, isNot(name2));
+    });
+  });
+
+  group('operationReservedParameterNames', () {
+    test('always reserves cancelToken when there is no request body', () {
+      expect(
+        operationReservedParameterNames(hasRequestBody: false),
+        {'cancelToken'},
+      );
+    });
+
+    test('reserves both body and cancelToken when there is a request body',
+        () {
+      expect(
+        operationReservedParameterNames(hasRequestBody: true),
+        {'body', 'cancelToken'},
+      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -1734,6 +1734,717 @@ Future<TonikResult<void>> call({CancelToken? cancelToken}) async {
           );
         },
       );
+
+      test(
+        'renames query parameter colliding with built-in cancelToken',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'cancelToken',
+            rawName: 'cancelToken',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String cancelTokenQuery,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(
+      path: _$newPath,
+      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+    );
+    _$data = _data();
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['cancelTokenQuery', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'renames query parameter colliding with built-in cancelToken when '
+        'request body is also present',
+        () {
+          final requestBody = RequestBodyObject(
+            name: 'singleBody',
+            context: context,
+            description: null,
+            isRequired: true,
+            content: {
+              RequestContent(
+                model: StringModel(context: context),
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+              ),
+            },
+          );
+
+          final queryParam = QueryParameterObject(
+            name: 'cancelToken',
+            rawName: 'cancelToken',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'postA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.post,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            requestBody: requestBody,
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String body,
+  required String cancelTokenQuery,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(
+      path: _$newPath,
+      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+    );
+    _$data = _data(body: body);
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'PostA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['body', 'cancelTokenQuery', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'renames path parameter colliding with built-in cancelToken',
+        () {
+          final pathParam = PathParameterObject(
+            name: 'cancelToken',
+            rawName: 'cancelToken',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            explode: false,
+            encoding: PathParameterEncoding.simple,
+            model: StringModel(context: context),
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a/{cancelToken}',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: {pathParam},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String cancelTokenPath,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path(cancelTokenPath: cancelTokenPath);
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(path: _$newPath);
+    _$data = _data();
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['cancelTokenPath', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'renames header parameter colliding with built-in cancelToken',
+        () {
+          final header = RequestHeaderObject(
+            name: 'cancelToken',
+            rawName: 'cancelToken',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: HeaderParameterEncoding.simple,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: {header},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String cancelTokenHeader,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(path: _$newPath);
+    _$data = _data();
+    _$options = _options(cancelTokenHeader: cancelTokenHeader);
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['cancelTokenHeader', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'renames cookie parameter colliding with built-in cancelToken',
+        () {
+          final cookie = CookieParameterObject(
+            name: 'cancelToken',
+            rawName: 'cancelToken',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookie},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String cancelTokenCookie,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(path: _$newPath);
+    _$data = _data();
+    _$options = _options(cancelTokenCookie: cancelTokenCookie);
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['cancelTokenCookie', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'renames query parameter that sanitizes to cancelToken',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'Cancel-Token',
+            rawName: 'Cancel-Token',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  required String cancelTokenQuery,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(
+      path: _$newPath,
+      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+    );
+    _$data = _data();
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['cancelTokenQuery', 'cancelToken']);
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'leaves non-colliding parameter named token unchanged',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'token',
+            rawName: 'token',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'getA',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/a',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final cls = generator.generateClass(operation, 'GetA');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final paramNames =
+              method.optionalParameters.map((p) => p.name).toList();
+          expect(paramNames, ['token', 'cancelToken']);
+        },
+      );
     });
 
     group('generateCallableOperation', () {

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -1330,4 +1330,301 @@ void main() {
       },
     );
   });
+
+  group('cancelToken parameter name collision', () {
+    test('adds Query suffix to query parameter named cancelToken', () {
+      final queryParam = QueryParameterObject(
+        name: null,
+        rawName: 'cancelToken',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        allowReserved: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: QueryParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getWithCancelTokenQuery',
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: '/test',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: {queryParam},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final parameters = generateParameters(
+        operation: operation,
+        nameManager: nameManager,
+        package: 'api',
+      );
+
+      final paramNames = parameters.map((p) => p.name).toList();
+      expect(paramNames, contains('cancelTokenQuery'));
+      expect(paramNames, isNot(contains('cancelToken')));
+      expect(
+        paramNames.toSet().length,
+        paramNames.length,
+        reason: 'Parameter names must be unique: $paramNames',
+      );
+    });
+
+    test('adds Path suffix to path parameter named cancelToken', () {
+      final pathParam = PathParameterObject(
+        name: null,
+        rawName: 'cancelToken',
+        description: null,
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getWithCancelTokenPath',
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: '/test/{cancelToken}',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: {pathParam},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final parameters = generateParameters(
+        operation: operation,
+        nameManager: nameManager,
+        package: 'api',
+      );
+
+      final paramNames = parameters.map((p) => p.name).toList();
+      expect(paramNames, contains('cancelTokenPath'));
+      expect(paramNames, isNot(contains('cancelToken')));
+      expect(
+        paramNames.toSet().length,
+        paramNames.length,
+        reason: 'Parameter names must be unique: $paramNames',
+      );
+    });
+
+    test('adds Header suffix to header parameter named cancelToken', () {
+      final headerParam = RequestHeaderObject(
+        name: null,
+        rawName: 'cancelToken',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: HeaderParameterEncoding.simple,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getWithCancelTokenHeader',
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: '/test',
+        method: HttpMethod.get,
+        headers: {headerParam},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final parameters = generateParameters(
+        operation: operation,
+        nameManager: nameManager,
+        package: 'api',
+      );
+
+      final paramNames = parameters.map((p) => p.name).toList();
+      expect(paramNames, contains('cancelTokenHeader'));
+      expect(paramNames, isNot(contains('cancelToken')));
+      expect(
+        paramNames.toSet().length,
+        paramNames.length,
+        reason: 'Parameter names must be unique: $paramNames',
+      );
+    });
+
+    test('adds Cookie suffix to cookie parameter named cancelToken', () {
+      final cookieParam = CookieParameterObject(
+        name: null,
+        rawName: 'cancelToken',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'getWithCancelTokenCookie',
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: '/test',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final parameters = generateParameters(
+        operation: operation,
+        nameManager: nameManager,
+        package: 'api',
+      );
+
+      final paramNames = parameters.map((p) => p.name).toList();
+      expect(paramNames, contains('cancelTokenCookie'));
+      expect(paramNames, isNot(contains('cancelToken')));
+      expect(
+        paramNames.toSet().length,
+        paramNames.length,
+        reason: 'Parameter names must be unique: $paramNames',
+      );
+    });
+
+    test(
+      'renames query parameter named cancelToken even when '
+      'request body is present',
+      () {
+        final queryParam = QueryParameterObject(
+          name: null,
+          rawName: 'cancelToken',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+        );
+
+        final requestBody = RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'Payload',
+                properties: const [],
+                context: context,
+                isDeprecated: false,
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'createWithCancelTokenQuery',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: {queryParam},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final paramNames = parameters.map((p) => p.name).toList();
+        expect(paramNames, contains('body'));
+        expect(paramNames, contains('cancelTokenQuery'));
+        expect(paramNames, isNot(contains('cancelToken')));
+        expect(
+          paramNames.toSet().length,
+          paramNames.length,
+          reason: 'Parameter names must be unique: $paramNames',
+        );
+      },
+    );
+
+    test(
+      'does not rename query parameter named token (no collision with '
+      'cancelToken)',
+      () {
+        final queryParam = QueryParameterObject(
+          name: null,
+          rawName: 'token',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'getWithToken',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/test',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: {queryParam},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        expect(parameters.length, 1);
+        expect(parameters.first.name, 'token');
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- `cancelToken` is now reserved in `operationReservedParameterNames`, the canonical helper used by all three `normalizeRequestParameters` call sites (operation generator, operation parameter generator, API client generator)
- A user parameter named `cancelToken` (or any raw name that sanitizes to it, e.g. `Cancel-Token`, `cancel_token`) receives a type-qualified suffix (`cancelTokenQuery`, `cancelTokenPath`, etc.) via the existing `_ensureUniquenessInGroup` collision resolution logic — eliminating the `duplicate_definition` and `argument_type_not_assignable` analyzer errors
- Fix applies generically across query, path, header, and cookie parameter types

## Test plan

- [ ] Unit tests in `tonik_generate`: full method body comparisons for query, path, header, cookie, and sanitized collision cases; normalizer-level tests for all four parameter kinds; API client doc-comment reference test
- [ ] Integration test: 5 new `cancelToken` collision operations in `integration_test/naming/` (query/path/header/cookie/sanitized); generated project compiles without analyzer errors
- [ ] `fvm dart analyze` passes with zero issues
- [ ] Patch coverage: 100%
