### PR TITLE
fix: handle empty oneOf without producing invalid Dart

### DIFF
--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -4417,4 +4417,49 @@ void main() {
       });
     });
   });
+
+  group('EmptyOneOf', () {
+    Matcher hasMessage(String fragment) => predicate<Object>(
+      (e) => e.toString().contains(fragment),
+      'toString contains "$fragment"',
+    );
+
+    test('fromJson throws JsonDecodingException with structural message', () {
+      expect(
+        () => EmptyOneOf.fromJson(const <String, Object?>{}),
+        throwsA(
+          allOf(
+            isA<JsonDecodingException>(),
+            hasMessage('EmptyOneOf has no variants and cannot be decoded.'),
+          ),
+        ),
+      );
+    });
+
+    test('fromSimple throws SimpleDecodingException with structural '
+        'message', () {
+      expect(
+        () => EmptyOneOf.fromSimple('anything', explode: false),
+        throwsA(
+          allOf(
+            isA<SimpleDecodingException>(),
+            hasMessage('EmptyOneOf has no variants and cannot be decoded.'),
+          ),
+        ),
+      );
+    });
+
+    test('fromForm throws FormDecodingException with structural '
+        'message', () {
+      expect(
+        () => EmptyOneOf.fromForm('anything', explode: false),
+        throwsA(
+          allOf(
+            isA<FormDecodingException>(),
+            hasMessage('EmptyOneOf has no variants and cannot be decoded.'),
+          ),
+        ),
+      );
+    });
+  });
 }

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -81,12 +81,15 @@ components:
         - $ref: '#/components/schemas/Class1'
         - $ref: '#/components/schemas/Class2'
 
-    OneOfEnum: 
+    OneOfEnum:
       oneOf:
         - $ref: '#/components/schemas/Enum1'
         - $ref: '#/components/schemas/Enum2'
 
-    AllOfPrimitive: 
+    EmptyOneOf:
+      oneOf: []
+
+    AllOfPrimitive:
       allOf:
         - type: object
           properties:

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -179,7 +179,10 @@ class OneOfGenerator {
               buildReadOnlyToMatrixMethod(throwBody)
             else
               _generateToMatrixMethod(className, model, variantNames),
-            buildToDeepObjectMethod(),
+            if (useThrowBody)
+              buildReadOnlyToDeepObjectMethod(throwBody)
+            else
+              buildToDeepObjectMethod(),
             if (useThrowBody)
               buildReadOnlyUriEncodeMethod(throwBody)
             else

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -116,6 +116,18 @@ class OneOfGenerator {
           raw: true,
         ).code;
 
+        // Empty `oneOf: []` produces `switch (this) {}` which the analyzer
+        // infers as `Object?` — toJson's record-destructuring then fails
+        // `pattern_type_mismatch_in_irrefutable_context`. Route every
+        // encoder through a throwing body instead.
+        final useThrowBody = model.isReadOnly || model.models.isEmpty;
+        final throwBody = model.isReadOnly
+            ? encodingExceptionBody
+            : generateEncodingExceptionExpression(
+                '$className has no variants and cannot be encoded.',
+                raw: true,
+              ).code;
+
         b
           ..constructors.add(Constructor((b) => b..constant = true))
           ..constructors.add(
@@ -139,37 +151,53 @@ class OneOfGenerator {
                   ),
           )
           ..methods.addAll([
-            if (model.isReadOnly)
-              buildReadOnlyCurrentEncodingShapeGetter(encodingExceptionBody)
+            if (useThrowBody)
+              buildReadOnlyCurrentEncodingShapeGetter(throwBody)
             else
               _generateCurrentEncodingShapeGetter(model, variantNames),
-            if (model.isReadOnly)
-              buildReadOnlyParameterPropertiesMethod(encodingExceptionBody)
+            if (useThrowBody)
+              buildReadOnlyParameterPropertiesMethod(throwBody)
             else
               _generateParameterPropertiesMethod(
                 className,
                 model,
                 variantNames,
               ),
-            _generateToSimpleMethod(className, model, variantNames),
-            _generateToFormMethod(className, model, variantNames),
-            _generateToLabelMethod(className, model, variantNames),
-            _generateToMatrixMethod(className, model, variantNames),
+            if (useThrowBody)
+              buildReadOnlyToSimpleMethod(throwBody)
+            else
+              _generateToSimpleMethod(className, model, variantNames),
+            if (useThrowBody)
+              buildReadOnlyToFormMethod(throwBody)
+            else
+              _generateToFormMethod(className, model, variantNames),
+            if (useThrowBody)
+              buildReadOnlyToLabelMethod(throwBody)
+            else
+              _generateToLabelMethod(className, model, variantNames),
+            if (useThrowBody)
+              buildReadOnlyToMatrixMethod(throwBody)
+            else
+              _generateToMatrixMethod(className, model, variantNames),
             buildToDeepObjectMethod(),
-            if (model.isReadOnly)
-              buildReadOnlyUriEncodeMethod(encodingExceptionBody)
+            if (useThrowBody)
+              buildReadOnlyUriEncodeMethod(throwBody)
             else
               _generateUriEncodeMethod(className, model, variantNames),
-            Method(
-              (b) => b
-                ..annotations.add(refer('override', 'dart:core'))
-                ..name = 'toJson'
-                ..returns = refer('Object?', 'dart:core')
-                ..body = model.isReadOnly
-                    ? encodingExceptionBody
-                    : _generateToJsonBody(className, model, variantNames)
-                ..lambda = model.isReadOnly,
-            ),
+            if (useThrowBody)
+              buildReadOnlyToJsonMethod(throwBody)
+            else
+              Method(
+                (b) => b
+                  ..annotations.add(refer('override', 'dart:core'))
+                  ..name = 'toJson'
+                  ..returns = refer('Object?', 'dart:core')
+                  ..body = _generateToJsonBody(
+                    className,
+                    model,
+                    variantNames,
+                  ),
+              ),
           ])
           ..constructors.add(
             model.isWriteOnly
@@ -368,6 +396,13 @@ class OneOfGenerator {
     OneOfModel model,
     Map<DiscriminatedModel, String> variantNames,
   ) {
+    if (model.models.isEmpty) {
+      return generateJsonDecodingExceptionExpression(
+        '$className has no variants and cannot be decoded.',
+        raw: true,
+      ).statement;
+    }
+
     final helperContext = InlineHelperContext(nameManager: nameManager);
     final inlineHelpers = <InlineHelper>[];
     final blocks = <Code>[];
@@ -589,6 +624,32 @@ class OneOfGenerator {
     final constructorName = isForm ? 'fromForm' : 'fromSimple';
     final encodingStyleName = isForm ? 'form' : 'simple';
     final bodyBlocks = <Code>[];
+
+    if (model.models.isEmpty) {
+      return Constructor(
+        (b) => b
+          ..factory = true
+          ..name = constructorName
+          ..requiredParameters.add(
+            Parameter(
+              (b) => b
+                ..name = 'value'
+                ..type = refer('String?', 'dart:core'),
+            ),
+          )
+          ..optionalParameters.add(
+            buildBoolParameter('explode', required: true),
+          )
+          ..lambda = true
+          ..body = (isForm
+                  ? generateFormDecodingExceptionExpression
+                  : generateSimpleDecodingExceptionExpression)(
+                '$className has no variants and cannot be decoded.',
+                raw: true,
+              )
+              .code,
+      );
+    }
 
     if (model.discriminator != null) {
       final hasDiscriminatedComplexTypes = model.models.any(

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1232,46 +1232,134 @@ void main() {
       );
     });
 
-    test('every encoder method throws for empty oneOf', () {
+    group('encoder method bodies for empty oneOf', () {
+      late String generatedCode;
+
+      setUp(() {
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Empty',
+          models: const <DiscriminatedModel>{},
+          context: context,
+        );
+
+        final generatedClasses = generator.generateClasses(model);
+        final baseClass = generatedClasses.firstWhere(
+          (c) => c.name == 'Empty',
+        );
+        generatedCode = format(baseClass.accept(emitter).toString());
+      });
+
+      void expectContainsBody(String body) {
+        expect(
+          collapseWhitespace(generatedCode),
+          contains(collapseWhitespace(body)),
+        );
+      }
+
+      const throwExpr =
+          "throw EncodingException(r'Empty has no variants and cannot be "
+          "encoded.');";
+
+      test('toSimple', () {
+        expectContainsBody(
+          'String toSimple({required bool explode, required bool '
+          'allowEmpty}) => $throwExpr',
+        );
+      });
+
+      test('toForm', () {
+        expectContainsBody(
+          'String toForm({ required bool explode, required bool allowEmpty, '
+          'bool useQueryComponent = false, }) => $throwExpr',
+        );
+      });
+
+      test('toLabel', () {
+        expectContainsBody(
+          'String toLabel({required bool explode, required bool '
+          'allowEmpty}) => $throwExpr',
+        );
+      });
+
+      test('toMatrix', () {
+        expectContainsBody(
+          'String toMatrix( String paramName, { required bool explode, '
+          'required bool allowEmpty, }) => $throwExpr',
+        );
+      });
+
+      test('uriEncode', () {
+        expectContainsBody(
+          'String uriEncode({ required bool allowEmpty, bool '
+          'useQueryComponent = false, }) => $throwExpr',
+        );
+      });
+
+      test('currentEncodingShape', () {
+        expectContainsBody(
+          'EncodingShape get currentEncodingShape => $throwExpr',
+        );
+      });
+
+      test('parameterProperties', () {
+        expectContainsBody(
+          'Map<String, String> parameterProperties({ bool allowEmpty = true, '
+          'bool allowLists = true, }) => $throwExpr',
+        );
+      });
+
+      test('toDeepObject', () {
+        expectContainsBody(
+          'List<ParameterEntry> toDeepObject( String paramName, { required '
+          'bool explode, required bool allowEmpty, }) => $throwExpr',
+        );
+      });
+    });
+
+    test('writeOnly takes precedence over empty for decoders', () {
       final model = OneOfModel(
         isDeprecated: false,
         name: 'Empty',
         models: const <DiscriminatedModel>{},
         context: context,
+        isWriteOnly: true,
       );
 
       final generatedClasses = generator.generateClasses(model);
       final baseClass = generatedClasses.firstWhere((c) => c.name == 'Empty');
       final generatedCode = format(baseClass.accept(emitter).toString());
 
-      const message = "r'Empty has no variants and cannot be encoded.'";
-
-      for (final methodName in const [
-        'toJson',
-        'toSimple',
-        'toForm',
-        'toLabel',
-        'toMatrix',
-        'uriEncode',
-        'currentEncodingShape',
-        'parameterProperties',
-      ]) {
-        expect(
-          generatedCode,
-          contains(methodName),
-          reason: 'expected generated code to declare $methodName',
-        );
-      }
+      const expectedFromJson = '''
+        factory Empty.fromJson(Object? json) =>
+          throw JsonDecodingException(
+            r'Empty is write-only and cannot be decoded.',
+          );
+      ''';
+      const expectedFromSimple = '''
+        factory Empty.fromSimple(String? value, {required bool explode}) =>
+          throw SimpleDecodingException(
+            r'Empty is write-only and cannot be decoded.',
+          );
+      ''';
+      const expectedFromForm = '''
+        factory Empty.fromForm(String? value, {required bool explode}) =>
+          throw FormDecodingException(
+            r'Empty is write-only and cannot be decoded.',
+          );
+      ''';
 
       expect(
-        generatedCode,
-        contains(message),
-        reason: 'expected throw message in generated code',
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedFromJson)),
       );
       expect(
         collapseWhitespace(generatedCode),
-        isNot(contains('switch (this) {}')),
-        reason: 'no method body should leave an empty switch in place',
+        contains(collapseWhitespace(expectedFromSimple)),
+      );
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedFromForm)),
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1159,4 +1159,120 @@ void main() {
       );
     });
   });
+
+  group('empty oneOf variants', () {
+    test('toJson throws EncodingException for empty oneOf', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Empty',
+        models: const <DiscriminatedModel>{},
+        context: context,
+      );
+
+      final generatedClasses = generator.generateClasses(model);
+      final baseClass = generatedClasses.firstWhere((c) => c.name == 'Empty');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod =
+          "Object? toJson() => throw EncodingException(r'Empty has no "
+          "variants and cannot be encoded.');";
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('readOnly takes precedence over empty when both apply', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Empty',
+        models: const <DiscriminatedModel>{},
+        context: context,
+        isReadOnly: true,
+      );
+
+      final generatedClasses = generator.generateClasses(model);
+      final baseClass = generatedClasses.firstWhere((c) => c.name == 'Empty');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod =
+          "Object? toJson() => throw EncodingException(r'Empty is "
+          "read-only and cannot be encoded.');";
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('fromJson throws JsonDecodingException for empty oneOf', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Empty',
+        models: const <DiscriminatedModel>{},
+        context: context,
+      );
+
+      final generatedClasses = generator.generateClasses(model);
+      final baseClass = generatedClasses.firstWhere((c) => c.name == 'Empty');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const expectedFactory = '''
+        factory Empty.fromJson(Object? json) {
+          throw JsonDecodingException(
+            r'Empty has no variants and cannot be decoded.',
+          );
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedFactory)),
+      );
+    });
+
+    test('every encoder method throws for empty oneOf', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Empty',
+        models: const <DiscriminatedModel>{},
+        context: context,
+      );
+
+      final generatedClasses = generator.generateClasses(model);
+      final baseClass = generatedClasses.firstWhere((c) => c.name == 'Empty');
+      final generatedCode = format(baseClass.accept(emitter).toString());
+
+      const message = "r'Empty has no variants and cannot be encoded.'";
+
+      for (final methodName in const [
+        'toJson',
+        'toSimple',
+        'toForm',
+        'toLabel',
+        'toMatrix',
+        'uriEncode',
+        'currentEncodingShape',
+        'parameterProperties',
+      ]) {
+        expect(
+          generatedCode,
+          contains(methodName),
+          reason: 'expected generated code to declare $methodName',
+        );
+      }
+
+      expect(
+        generatedCode,
+        contains(message),
+        reason: 'expected throw message in generated code',
+      );
+      expect(
+        collapseWhitespace(generatedCode),
+        isNot(contains('switch (this) {}')),
+        reason: 'no method body should leave an empty switch in place',
+      );
+    });
+  });
 }

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -582,6 +582,14 @@ class ModelImporter {
     final modelContext = context.push(name);
     final alternatives = schema.oneOf!;
 
+    if (alternatives.isEmpty) {
+      log.warning(
+        'oneOf for $name is empty. Per JSON Schema, oneOf must be a '
+        'non-empty array. The generated $name class will throw on all '
+        'encode and decode operations.',
+      );
+    }
+
     final effectiveDiscriminator =
         schema.discriminator ?? _findInheritedDiscriminator(alternatives);
 

--- a/packages/tonik_parse/test/model/model_oneof_test.dart
+++ b/packages/tonik_parse/test/model/model_oneof_test.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_parse/tonik_parse.dart';
@@ -288,6 +289,51 @@ void main() {
               as OneOfModel;
 
       expect(model.description, isNull);
+    });
+  });
+
+  group('empty oneOf', () {
+    const emptyOneOfSpec = {
+      'openapi': '3.0.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'EmptyOneOf': {
+            'oneOf': <Map<String, dynamic>>[],
+          },
+        },
+      },
+    };
+
+    test('logs warning when oneOf is empty', () {
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+      addTearDown(sub.cancel);
+
+      Importer().import(emptyOneOfSpec);
+
+      expect(
+        logs.any(
+          (r) =>
+              r.level == Level.WARNING &&
+              r.message.contains('EmptyOneOf') &&
+              r.message.contains('empty'),
+        ),
+        isTrue,
+        reason: 'expected a warning about empty oneOf for EmptyOneOf',
+      );
+    });
+
+    test('still produces a OneOfModel with empty models set', () {
+      final api = Importer().import(emptyOneOfSpec);
+      final model =
+          api.models.firstWhere(
+                (m) => m is NamedModel && m.name == 'EmptyOneOf',
+              )
+              as OneOfModel;
+
+      expect(model.models, isEmpty);
     });
   });
 }


### PR DESCRIPTION
## Summary

An OpenAPI schema declared with `oneOf: []` made Tonik emit a sealed class whose `toJson` destructured an empty `switch (this) {}` into a `(dynamic, String?)` record. The empty switch is inferred as `Object?`, so `dart analyze` rejected the irrefutable pattern with `pattern_type_mismatch_in_irrefutable_context`:

```
error - lib/src/model/empty_one_of.dart:100:32 -
  The matched value of type 'Object?' isn't assignable to the required type
  'String?'. Try changing the required type of the pattern, or the matched
  value type. - pattern_type_mismatch_in_irrefutable_context
```

The class itself is dead code (no concrete subtypes, every factory throws), but the analyzer error blocked the whole generated package from compiling.

## Changes

- Parser (`tonik_parse`) logs a `WARNING` when `oneOf` is an empty array. Per JSON Schema, `oneOf` must be a non-empty array; the warning surfaces the problem at codegen time instead of letting it sneak into runtime. Matches the pattern already used for the unsupported `not` keyword in the same file.
- Generator (`tonik_generate`) replaces every encoder method body (`toJson`, `toSimple`, `toForm`, `toLabel`, `toMatrix`, `uriEncode`, `currentEncodingShape`, `parameterProperties`) with a throwing body when `model.models.isEmpty`. Previously only `toJson` failed analyze; the other methods compiled because their `String` / `EncodingShape` return type absorbed the `Never` of the empty switch, but they were silently degenerate and would have regressed under future refactors.
- `fromJson` / `fromSimple` / `fromForm` short-circuit to a structural message — `$className has no variants and cannot be decoded.` — instead of the previous misleading `Invalid JSON for $className` (the value isn't invalid; the type has no variants) or `parameterProperties not supported for $className: only contains primitive types` (which was outright factually wrong for empty oneOf).
- Method-builder is consolidated to use the existing `buildReadOnlyToJson/toSimple/...` helpers in `composite_guard_builders.dart` for both the read-only and empty-variant cases, with a shared `useThrowBody` predicate and a `throwBody` that picks the right message based on which case applies.

## Test plan

- [x] New parser unit tests in `model_oneof_test.dart` (warning is logged, OneOfModel still produced with empty `models` set).
- [x] New generator unit tests in `one_of_json_generator_test.dart` — toJson body, readOnly+empty priority, fromJson body, every encoder method asserted.
- [x] New integration fixture `EmptyOneOf: { oneOf: [] }` in `composition/openapi.yaml` plus tests in `one_of_test.dart` asserting each from-factory throws with the structural message.
- [x] `fvm dart analyze` from project root: zero new issues (31 pre-existing cloudflare `unreachable_switch_case` warnings unchanged).
- [x] Full `packages/tonik_generate` suite (2484 tests) passes.
- [x] Full `integration_test/composition` suite (1751 tests) passes.
- [x] Pre-fix: regenerating with the new fixture reproduces the exact `pattern_type_mismatch_in_irrefutable_context` error from the bug report; post-fix the generated package analyzes clean.
