### PR TITLE
fix: handle byte/binary cookie params instead of emitting toForm on TonikFile

### DIFF
--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -752,4 +752,41 @@ void main() {
       expect(getCookieHeader(response), 'items=a,1,true');
     });
   });
+
+  group('base64 (byte) cookies', () {
+    test('scalar and array base64 cookies encode as base64 form', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.getBase64Cookies(
+        binaryToken: const TonikFileBytes([104, 105]),
+        binaryTokens: const [
+          TonikFileBytes([97]),
+          TonikFileBytes([98, 99]),
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      expect(
+        getCookieHeader(response),
+        'binaryToken=aGk%3D; binaryTokens=YQ%3D%3D,YmM%3D',
+      );
+    });
+  });
+
+  group('binary cookies', () {
+    test('binary scalar cookie returns encoding error', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.getBinaryCookies(
+        binaryData: const TonikFileBytes([1, 2, 3]),
+      );
+
+      expect(response, isA<TonikError<void>>());
+      final error = response as TonikError<void>;
+      expect(error.type, TonikErrorType.encoding);
+      expect(error.error, isA<EncodingException>());
+      expect(
+        (error.error as EncodingException).message,
+        'Binary data cannot be form-encoded for cookie binaryData',
+      );
+    });
+  });
 }

--- a/integration_test/cookies/cookies_test/test/cookies_test.dart
+++ b/integration_test/cookies/cookies_test/test/cookies_test.dart
@@ -788,5 +788,24 @@ void main() {
         'Binary data cannot be form-encoded for cookie binaryData',
       );
     });
+
+    test('binary array cookie returns encoding error', () async {
+      final api = buildCookiesApi(responseStatus: '204');
+      final response = await api.getBinaryCookiesArray(
+        binaryDataList: const [
+          TonikFileBytes([1, 2, 3]),
+          TonikFileBytes([4, 5, 6]),
+        ],
+      );
+
+      expect(response, isA<TonikError<void>>());
+      final error = response as TonikError<void>;
+      expect(error.type, TonikErrorType.encoding);
+      expect(error.error, isA<EncodingException>());
+      expect(
+        (error.error as EncodingException).message,
+        'Binary data cannot be form-encoded for cookie binaryDataList',
+      );
+    });
   });
 }

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -832,14 +832,14 @@ paths:
         '204':
           description: No content
 
-  # Binary/Base64 cookie parameters (byte and binary formats).
-  /binary-cookies:
+  # Base64 (byte) cookie parameters — scalar and array success paths.
+  /base64-cookies:
     get:
-      operationId: getBinaryCookies
+      operationId: getBase64Cookies
       tags:
         - cookies
-      summary: Test binary/base64 cookie parameters
-      description: Demonstrates cookie parameters with string/byte (Base64) and string/binary formats, both scalar and array
+      summary: Test base64 cookie parameters
+      description: Demonstrates cookie parameters with string/byte (Base64) format, both scalar and array
       parameters:
         - name: binaryToken
           in: cookie
@@ -847,12 +847,6 @@ paths:
           schema:
             type: string
             format: byte
-        - name: binaryData
-          in: cookie
-          required: true
-          schema:
-            type: string
-            format: binary
         - name: binaryTokens
           in: cookie
           required: true
@@ -861,14 +855,27 @@ paths:
             items:
               type: string
               format: byte
-        - name: binaryDataList
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  # Binary cookie parameter — scalar throw path.
+  /binary-cookies:
+    get:
+      operationId: getBinaryCookies
+      tags:
+        - cookies
+      summary: Test binary cookie parameter
+      description: Demonstrates a cookie parameter with string/binary format which cannot be form-encoded
+      parameters:
+        - name: binaryData
           in: cookie
           required: true
           schema:
-            type: array
-            items:
-              type: string
-              format: binary
+            type: string
+            format: binary
       responses:
         '200':
           description: OK

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -832,7 +832,7 @@ paths:
         '204':
           description: No content
 
-  # Base64 (byte) cookie parameters — scalar and array success paths.
+  # Base64 cookies
   /base64-cookies:
     get:
       operationId: getBase64Cookies
@@ -861,7 +861,7 @@ paths:
         '204':
           description: No content
 
-  # Binary cookie parameter — scalar throw path.
+  # Binary cookie
   /binary-cookies:
     get:
       operationId: getBinaryCookies
@@ -876,6 +876,28 @@ paths:
           schema:
             type: string
             format: binary
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
+  /binary-cookies-array:
+    get:
+      operationId: getBinaryCookiesArray
+      tags:
+        - cookies
+      summary: Test binary array cookie parameter
+      description: Demonstrates an array cookie parameter with string/binary items which cannot be form-encoded
+      parameters:
+        - name: binaryDataList
+          in: cookie
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: binary
       responses:
         '200':
           description: OK

--- a/integration_test/cookies/openapi.yaml
+++ b/integration_test/cookies/openapi.yaml
@@ -832,6 +832,49 @@ paths:
         '204':
           description: No content
 
+  # Binary/Base64 cookie parameters (byte and binary formats).
+  /binary-cookies:
+    get:
+      operationId: getBinaryCookies
+      tags:
+        - cookies
+      summary: Test binary/base64 cookie parameters
+      description: Demonstrates cookie parameters with string/byte (Base64) and string/binary formats, both scalar and array
+      parameters:
+        - name: binaryToken
+          in: cookie
+          required: true
+          schema:
+            type: string
+            format: byte
+        - name: binaryData
+          in: cookie
+          required: true
+          schema:
+            type: string
+            format: binary
+        - name: binaryTokens
+          in: cookie
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: byte
+        - name: binaryDataList
+          in: cookie
+          required: true
+          schema:
+            type: array
+            items:
+              type: string
+              format: binary
+      responses:
+        '200':
+          description: OK
+        '204':
+          description: No content
+
 components:
   schemas:
     ThemeEnum:

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -421,6 +421,46 @@ class OptionsGenerator {
     if (resolvedModel is ListModel) {
       final contentModel = resolvedModel.content.resolved;
 
+      if (contentModel is Base64Model) {
+        final encodedValue = refer(paramName)
+            .property('map')
+            .call([
+              Method(
+                (b) => b
+                  ..lambda = true
+                  ..requiredParameters.add(
+                    Parameter((b) => b..name = 'e'),
+                  )
+                  ..body = refer('e').property('toBase64String').call([]).code,
+              ).closure,
+            ])
+            .property('toList')
+            .call([])
+            .property('toForm')
+            .call([], {
+              'explode': literalBool(explode),
+              'allowEmpty': literalBool(true),
+            });
+        bodyStatements.add(
+          refer(r'_$cookieParts').property('add').call([
+            literalList([
+              specLiteralString('$rawName='),
+              encodedValue,
+            ]).property('join').call([]),
+          ]).statement,
+        );
+        return;
+      }
+
+      if (contentModel is BinaryModel) {
+        bodyStatements.add(
+          generateEncodingExceptionExpression(
+            'Binary data cannot be form-encoded for cookie $rawName',
+          ).statement,
+        );
+        return;
+      }
+
       if (contentModel is StringModel) {
         final encodedValue = refer(paramName).property('toForm').call([], {
           'explode': literalBool(explode),
@@ -558,6 +598,35 @@ class OptionsGenerator {
             encodedValue,
           ]).property('join').call([]),
         ]).statement,
+      );
+      return;
+    }
+
+    if (resolvedModel is Base64Model) {
+      final encodedValue = refer(paramName)
+          .property('toBase64String')
+          .call([])
+          .property('toForm')
+          .call([], {
+            'explode': literalBool(explode),
+            'allowEmpty': literalBool(true),
+          });
+      bodyStatements.add(
+        refer(r'_$cookieParts').property('add').call([
+          literalList([
+            specLiteralString('$rawName='),
+            encodedValue,
+          ]).property('join').call([]),
+        ]).statement,
+      );
+      return;
+    }
+
+    if (resolvedModel is BinaryModel) {
+      bodyStatements.add(
+        generateEncodingExceptionExpression(
+          'Binary data cannot be form-encoded for cookie $rawName',
+        ).statement,
       );
       return;
     }

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -631,7 +631,6 @@ class OptionsGenerator {
       return;
     }
 
-    // For non-list, non-map types, use toForm directly.
     final encodedValue = refer(paramName).property('toForm').call([], {
       'explode': literalBool(explode),
       'allowEmpty': literalBool(true),

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -2177,6 +2177,307 @@ void main() {
       },
     );
 
+    test('generates Cookie header for optional Base64 cookie parameter', () {
+      final cookieParam = CookieParameterObject(
+        name: 'token',
+        rawName: 'token',
+        description: 'Optional Base64 token',
+        isRequired: false,
+        isDeprecated: false,
+        explode: true,
+        model: Base64Model(context: context),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withOptionalBase64Cookie',
+        context: context,
+        summary: 'With optional base64 cookie',
+        description: 'Operation with optional Base64 cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/optional-base64-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'token', parameter: cookieParam),
+      ]);
+
+      final param = method.optionalParameters.firstWhere(
+        (p) => p.name == 'token',
+      );
+      expect(param.required, isFalse);
+      expect(param.type?.accept(emitter).toString(), 'TonikFile?');
+
+      const expectedMethod = r'''
+        Options _options({TonikFile? token}) {
+          final _$headers = <String, dynamic>{};
+          _$headers['Accept'] = r'*/*';
+          final _$cookieParts = <String>[];
+          if (token != null) {
+            _$cookieParts.add(
+              [
+                r'token=',
+                token.toBase64String().toForm(explode: true, allowEmpty: true),
+              ].join(),
+            );
+          }
+          if (_$cookieParts.isNotEmpty) {
+            _$headers[r'Cookie'] = _$cookieParts.join('; ');
+          }
+          return Options(
+            method: 'GET',
+            headers: _$headers,
+            responseType: ResponseType.bytes,
+            validateStatus: (_) => true,
+          );
+        }
+      ''';
+
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test(
+      'generates EncodingException for optional Binary cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'token',
+          rawName: 'token',
+          description: 'Optional Binary token',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: BinaryModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalBinaryCookie',
+          context: context,
+          summary: 'With optional binary cookie',
+          description: 'Operation with optional Binary cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-binary-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'token', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'token',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'TonikFile?');
+
+        const expectedMethod = r'''
+          Options _options({TonikFile? token}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (token != null) {
+              throw EncodingException(
+                'Binary data cannot be form-encoded for cookie token',
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates Cookie header for optional list of Base64 cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'tokens',
+          rawName: 'tokens',
+          description: 'Optional list of Base64 tokens',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: ListModel(
+            content: Base64Model(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalListBase64Cookie',
+          context: context,
+          summary: 'With optional list base64 cookie',
+          description: 'Operation with optional list of Base64 cookies',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-list-base64-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'tokens', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'tokens',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'List<TonikFile>?');
+
+        const expectedMethod = r'''
+          Options _options({List<TonikFile>? tokens}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (tokens != null) {
+              _$cookieParts.add(
+                [
+                  r'tokens=',
+                  tokens
+                      .map((e) => e.toBase64String())
+                      .toList()
+                      .toForm(explode: false, allowEmpty: true),
+                ].join(),
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates EncodingException for optional list of '
+      'Binary cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'files',
+          rawName: 'files',
+          description: 'Optional list of binary files',
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: ListModel(
+            content: BinaryModel(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withOptionalListBinaryCookie',
+          context: context,
+          summary: 'With optional list binary cookie',
+          description: 'Operation with optional list of Binary cookies',
+          tags: const {},
+          isDeprecated: false,
+          path: '/optional-list-binary-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'files', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'files',
+        );
+        expect(param.required, isFalse);
+        expect(param.type?.accept(emitter).toString(), 'List<TonikFile>?');
+
+        const expectedMethod = r'''
+          Options _options({List<TonikFile>? files}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            if (files != null) {
+              throw EncodingException(
+                'Binary data cannot be form-encoded for cookie files',
+              );
+            }
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
     group('alias-wrapped cookie parameters', () {
       test(
         'alias to list of strings routes through list path',
@@ -3085,6 +3386,157 @@ void main() {
           collapseWhitespace(format(expectedMethod)),
         );
       });
+
+      test(
+        'generates Cookie header for alias-wrapped Base64 cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'token',
+            rawName: 'token',
+            description: 'Alias to Base64',
+            isRequired: true,
+            isDeprecated: false,
+            explode: true,
+            model: AliasModel(
+              name: 'BinaryToken',
+              model: Base64Model(context: context),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasBase64Cookie',
+            context: context,
+            summary: 'With alias base64 cookie',
+            description: 'Operation with alias-to-Base64 cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-base64-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'token', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'token',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'BinaryToken');
+
+          const expectedMethod = r'''
+            Options _options({required BinaryToken token}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [
+                  r'token=',
+                  token.toBase64String().toForm(explode: true, allowEmpty: true),
+                ].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates EncodingException for alias-wrapped Binary cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'blob',
+            rawName: 'blob',
+            description: 'Alias to Binary',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'BinaryBlob',
+              model: BinaryModel(context: context),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasBinaryCookie',
+            context: context,
+            summary: 'With alias binary cookie',
+            description: 'Operation with alias-to-Binary cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-binary-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'blob', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'blob',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'BinaryBlob');
+
+          const expectedMethod = r'''
+            Options _options({required BinaryBlob blob}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              throw EncodingException(
+                'Binary data cannot be form-encoded for cookie blob',
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
     });
 
     group('multipart content type', () {

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -2478,6 +2478,90 @@ void main() {
       },
     );
 
+    test(
+      'generates throw plus adjacent cookie code for operation with '
+      'mixed Binary and String cookies',
+      () {
+        final binaryCookie = CookieParameterObject(
+          name: 'binaryData',
+          rawName: 'binaryData',
+          description: 'Binary cookie',
+          isRequired: true,
+          isDeprecated: false,
+          explode: true,
+          model: BinaryModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final stringCookie = CookieParameterObject(
+          name: 'tracker',
+          rawName: 'tracker',
+          description: 'Tracker cookie',
+          isRequired: true,
+          isDeprecated: false,
+          explode: true,
+          model: StringModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withMixedBinaryStringCookies',
+          context: context,
+          summary: 'With mixed binary and string cookies',
+          description: 'Operation with mixed Binary and String cookies',
+          tags: const {},
+          isDeprecated: false,
+          path: '/mixed-binary-string-cookies',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {binaryCookie, stringCookie},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'binaryData', parameter: binaryCookie),
+          (normalizedName: 'tracker', parameter: stringCookie),
+        ]);
+
+        const expectedMethod = r'''
+          Options _options({
+            required TonikFile binaryData,
+            required String tracker,
+          }) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            throw EncodingException(
+              'Binary data cannot be form-encoded for cookie binaryData',
+            );
+            _$cookieParts.add(
+              [r'tracker=', tracker.toForm(explode: true, allowEmpty: true)].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
     group('alias-wrapped cookie parameters', () {
       test(
         'alias to list of strings routes through list path',
@@ -3518,6 +3602,497 @@ void main() {
               throw EncodingException(
                 'Binary data cannot be form-encoded for cookie blob',
               );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates Cookie header for alias-wrapped list of '
+        'Base64 cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'tokens',
+            rawName: 'tokens',
+            description: 'Alias to list of Base64',
+            isRequired: true,
+            isDeprecated: false,
+            explode: true,
+            model: AliasModel(
+              name: 'TokenList',
+              model: ListModel(
+                content: Base64Model(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasListBase64Cookie',
+            context: context,
+            summary: 'With alias list base64 cookie',
+            description: 'Operation with alias-to-list-of-Base64 cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-list-base64-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'tokens', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'tokens',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'TokenList');
+
+          const expectedMethod = r'''
+            Options _options({required TokenList tokens}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              _$cookieParts.add(
+                [
+                  r'tokens=',
+                  tokens
+                      .map((e) => e.toBase64String())
+                      .toList()
+                      .toForm(explode: true, allowEmpty: true),
+                ].join(),
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates EncodingException for alias-wrapped list of '
+        'Binary cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'blobs',
+            rawName: 'blobs',
+            description: 'Alias to list of Binary',
+            isRequired: true,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'BlobList',
+              model: ListModel(
+                content: BinaryModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withAliasListBinaryCookie',
+            context: context,
+            summary: 'With alias list binary cookie',
+            description: 'Operation with alias-to-list-of-Binary cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/alias-list-binary-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'blobs', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'blobs',
+          );
+          expect(param.required, isTrue);
+          expect(param.type?.symbol, 'BlobList');
+
+          const expectedMethod = r'''
+            Options _options({required BlobList blobs}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              throw EncodingException(
+                'Binary data cannot be form-encoded for cookie blobs',
+              );
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates Cookie header for optional alias-wrapped '
+        'Base64 cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'token',
+            rawName: 'token',
+            description: 'Optional alias to Base64',
+            isRequired: false,
+            isDeprecated: false,
+            explode: true,
+            model: AliasModel(
+              name: 'BinaryToken',
+              model: Base64Model(context: context),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withOptionalAliasBase64Cookie',
+            context: context,
+            summary: 'With optional alias base64 cookie',
+            description: 'Operation with optional alias-to-Base64 cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-alias-base64-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'token', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'token',
+          );
+          expect(param.required, isFalse);
+          expect(param.type?.symbol, 'BinaryToken');
+          expect((param.type! as TypeReference).isNullable, isTrue);
+
+          const expectedMethod = r'''
+            Options _options({BinaryToken? token}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              if (token != null) {
+                _$cookieParts.add(
+                  [
+                    r'token=',
+                    token.toBase64String().toForm(explode: true, allowEmpty: true),
+                  ].join(),
+                );
+              }
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates EncodingException for optional alias-wrapped '
+        'Binary cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'blob',
+            rawName: 'blob',
+            description: 'Optional alias to Binary',
+            isRequired: false,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'BinaryBlob',
+              model: BinaryModel(context: context),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withOptionalAliasBinaryCookie',
+            context: context,
+            summary: 'With optional alias binary cookie',
+            description: 'Operation with optional alias-to-Binary cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-alias-binary-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'blob', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'blob',
+          );
+          expect(param.required, isFalse);
+          expect(param.type?.symbol, 'BinaryBlob');
+          expect((param.type! as TypeReference).isNullable, isTrue);
+
+          const expectedMethod = r'''
+            Options _options({BinaryBlob? blob}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              if (blob != null) {
+                throw EncodingException(
+                  'Binary data cannot be form-encoded for cookie blob',
+                );
+              }
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates Cookie header for optional alias-wrapped list of '
+        'Base64 cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'tokens',
+            rawName: 'tokens',
+            description: 'Optional alias to list of Base64',
+            isRequired: false,
+            isDeprecated: false,
+            explode: true,
+            model: AliasModel(
+              name: 'TokenList',
+              model: ListModel(
+                content: Base64Model(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withOptionalAliasListBase64Cookie',
+            context: context,
+            summary: 'With optional alias list base64 cookie',
+            description:
+                'Operation with optional alias-to-list-of-Base64 cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-alias-list-base64-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'tokens', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'tokens',
+          );
+          expect(param.required, isFalse);
+          expect(param.type?.symbol, 'TokenList');
+          expect((param.type! as TypeReference).isNullable, isTrue);
+
+          const expectedMethod = r'''
+            Options _options({TokenList? tokens}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              if (tokens != null) {
+                _$cookieParts.add(
+                  [
+                    r'tokens=',
+                    tokens
+                        .map((e) => e.toBase64String())
+                        .toList()
+                        .toForm(explode: true, allowEmpty: true),
+                  ].join(),
+                );
+              }
+              if (_$cookieParts.isNotEmpty) {
+                _$headers[r'Cookie'] = _$cookieParts.join('; ');
+              }
+              return Options(
+                method: 'GET',
+                headers: _$headers,
+                responseType: ResponseType.bytes,
+                validateStatus: (_) => true,
+              );
+            }
+          ''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'generates EncodingException for optional alias-wrapped list of '
+        'Binary cookie parameter',
+        () {
+          final cookieParam = CookieParameterObject(
+            name: 'blobs',
+            rawName: 'blobs',
+            description: 'Optional alias to list of Binary',
+            isRequired: false,
+            isDeprecated: false,
+            explode: false,
+            model: AliasModel(
+              name: 'BlobList',
+              model: ListModel(
+                content: BinaryModel(context: context),
+                context: context,
+              ),
+              context: context,
+            ),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+          );
+
+          final operation = Operation(
+            operationId: 'withOptionalAliasListBinaryCookie',
+            context: context,
+            summary: 'With optional alias list binary cookie',
+            description:
+                'Operation with optional alias-to-list-of-Binary cookie',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-alias-list-binary-cookie',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: {cookieParam},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final method = generator.generateOptionsMethod(operation, [], [
+            (normalizedName: 'blobs', parameter: cookieParam),
+          ]);
+
+          final param = method.optionalParameters.firstWhere(
+            (p) => p.name == 'blobs',
+          );
+          expect(param.required, isFalse);
+          expect(param.type?.symbol, 'BlobList');
+          expect((param.type! as TypeReference).isNullable, isTrue);
+
+          const expectedMethod = r'''
+            Options _options({BlobList? blobs}) {
+              final _$headers = <String, dynamic>{};
+              _$headers['Accept'] = r'*/*';
+              final _$cookieParts = <String>[];
+              if (blobs != null) {
+                throw EncodingException(
+                  'Binary data cannot be form-encoded for cookie blobs',
+                );
+              }
               if (_$cookieParts.isNotEmpty) {
                 _$headers[r'Cookie'] = _$cookieParts.join('; ');
               }

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1884,6 +1884,299 @@ void main() {
       },
     );
 
+    test('generates Cookie header for required Base64 cookie parameter', () {
+      final cookieParam = CookieParameterObject(
+        name: 'token',
+        rawName: 'token',
+        description: 'Base64 token',
+        isRequired: true,
+        isDeprecated: false,
+        explode: true,
+        model: Base64Model(context: context),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+      );
+
+      final operation = Operation(
+        operationId: 'withBase64Cookie',
+        context: context,
+        summary: 'With base64 cookie',
+        description: 'Operation with Base64 cookie',
+        tags: const {},
+        isDeprecated: false,
+        path: '/base64-cookie',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: {cookieParam},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      final method = generator.generateOptionsMethod(operation, [], [
+        (normalizedName: 'token', parameter: cookieParam),
+      ]);
+
+      final param = method.optionalParameters.firstWhere(
+        (p) => p.name == 'token',
+      );
+      expect(param.required, isTrue);
+      expect(param.type?.accept(emitter).toString(), 'TonikFile');
+
+      const expectedMethod = r'''
+        Options _options({required TonikFile token}) {
+          final _$headers = <String, dynamic>{};
+          _$headers['Accept'] = r'*/*';
+          final _$cookieParts = <String>[];
+          _$cookieParts.add(
+            [
+              r'token=',
+              token.toBase64String().toForm(explode: true, allowEmpty: true),
+            ].join(),
+          );
+          if (_$cookieParts.isNotEmpty) {
+            _$headers[r'Cookie'] = _$cookieParts.join('; ');
+          }
+          return Options(
+            method: 'GET',
+            headers: _$headers,
+            responseType: ResponseType.bytes,
+            validateStatus: (_) => true,
+          );
+        }
+      ''';
+
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test(
+      'generates EncodingException for required Binary cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'token',
+          rawName: 'token',
+          description: 'Binary token',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: BinaryModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withBinaryCookie',
+          context: context,
+          summary: 'With binary cookie',
+          description: 'Operation with Binary cookie',
+          tags: const {},
+          isDeprecated: false,
+          path: '/binary-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'token', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'token',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.accept(emitter).toString(), 'TonikFile');
+
+        const expectedMethod = r'''
+          Options _options({required TonikFile token}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            throw EncodingException(
+              'Binary data cannot be form-encoded for cookie token',
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates Cookie header for required list of Base64 cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'tokens',
+          rawName: 'tokens',
+          description: 'List of Base64 tokens',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: ListModel(
+            content: Base64Model(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withListBase64Cookie',
+          context: context,
+          summary: 'With list base64 cookie',
+          description: 'Operation with list of Base64 cookies',
+          tags: const {},
+          isDeprecated: false,
+          path: '/list-base64-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'tokens', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'tokens',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.accept(emitter).toString(), 'List<TonikFile>');
+
+        const expectedMethod = r'''
+          Options _options({required List<TonikFile> tokens}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            _$cookieParts.add(
+              [
+                r'tokens=',
+                tokens
+                    .map((e) => e.toBase64String())
+                    .toList()
+                    .toForm(explode: false, allowEmpty: true),
+              ].join(),
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates EncodingException for required list of '
+      'Binary cookie parameter',
+      () {
+        final cookieParam = CookieParameterObject(
+          name: 'files',
+          rawName: 'files',
+          description: 'List of binary files',
+          isRequired: true,
+          isDeprecated: false,
+          explode: false,
+          model: ListModel(
+            content: BinaryModel(context: context),
+            context: context,
+          ),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+        );
+
+        final operation = Operation(
+          operationId: 'withListBinaryCookie',
+          context: context,
+          summary: 'With list binary cookie',
+          description: 'Operation with list of Binary cookies',
+          tags: const {},
+          isDeprecated: false,
+          path: '/list-binary-cookie',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: {cookieParam},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateOptionsMethod(operation, [], [
+          (normalizedName: 'files', parameter: cookieParam),
+        ]);
+
+        final param = method.optionalParameters.firstWhere(
+          (p) => p.name == 'files',
+        );
+        expect(param.required, isTrue);
+        expect(param.type?.accept(emitter).toString(), 'List<TonikFile>');
+
+        const expectedMethod = r'''
+          Options _options({required List<TonikFile> files}) {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            final _$cookieParts = <String>[];
+            throw EncodingException(
+              'Binary data cannot be form-encoded for cookie files',
+            );
+            if (_$cookieParts.isNotEmpty) {
+              _$headers[r'Cookie'] = _$cookieParts.join('; ');
+            }
+            return Options(
+              method: 'GET',
+              headers: _$headers,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
     group('alias-wrapped cookie parameters', () {
       test(
         'alias to list of strings routes through list path',


### PR DESCRIPTION
## Summary
- Cookie parameters with `format: byte` (`Base64Model`) or `format: binary` (`BinaryModel`), scalar or array, were generating Dart that called `.toForm(...)` on a `TonikFile`. `TonikFile` does not implement `FormEncodable`, so the regenerated client failed analysis with `The method 'toForm' isn't defined for the type 'TonikFile'`.
- Adds four dedicated branches in `_addCookieEncodingStatement` mirroring the existing query and simple-encoding paths: Base64 (scalar) encodes via `toBase64String().toForm(...)`; list-of-Base64 maps elements through `toBase64String()` before form-encoding the resulting `List<String>`; Binary (scalar and list) throws `EncodingException`, since binary payloads cannot be form-encoded into a Cookie header.
- New branches read `resolvedModel` / `contentModel`, so cookie params declared via `$ref` to a byte/binary schema route correctly.

## Test plan
- [x] Four new full-method-body unit tests in `options_generator_test.dart` under `cookie header generation` (scalar Base64, scalar Binary, list-of-Base64, list-of-Binary)
- [x] `fvm dart analyze` from project root — zero errors
- [x] All unit suites: tonik_core, tonik_parse, tonik_generate, tonik_util, tonik (4470 tests)
- [x] `integration_test/cookies/openapi.yaml` extended with `/binary-cookies` (byte scalar, binary scalar, byte array, binary array); clients regenerated via `./scripts/setup_integration_tests.sh`
- [x] Regenerated `cookies_api` client analyzes cleanly — no `toForm` on `TonikFile`
- [x] `melos run test` — 40/40 integration suites pass
- [x] Patch coverage: 100%
