### PR TITLE
chore: scope analyze to packages/ and add dart/flutter skills

### DIFF
--- a/.claude/agents/tonik-contract-verifier.md
+++ b/.claude/agents/tonik-contract-verifier.md
@@ -21,6 +21,7 @@ You are READ-ONLY. You do not fix anything. You do not opine. You report.
 4. **Layer-specific criteria require layer-specific evidence.** If the contract says "verify X in integration tests", evidence in a unit test does NOT satisfy it — that's FAIL.
 5. **Multi-part criteria require all parts.** If the contract says "verify A, B, C", and you only find evidence for A and B, that is FAIL — not partial.
 6. **No interpretation.** If a criterion is vague, mark it FAIL with the note "criterion is ambiguous, cannot verify mechanically". Do not infer intent.
+7. **If you run `fvm dart analyze` to verify a build-gate criterion, scope it to `packages/`** — never the project root. `fvm dart analyze packages/`. The `integration_test/*/` packages contain regenerated client SDKs whose deps are only resolved after `./scripts/setup_integration_tests.sh`; they drift between regen passes and produce hundreds of unrelated "issues" at project root. The test-runner agent already uses this scope; defer to its output when possible (`verified by test runner` in the table).
 
 ## Inputs in Your Task Prompt
 

--- a/.claude/agents/tonik-generator.md
+++ b/.claude/agents/tonik-generator.md
@@ -34,7 +34,7 @@ The four preloaded skills (code-builder, testing, integration-tests, openapi-spe
 9. **Tests use `isTrue` / `isFalse`, never bare `true` / `false`.**
 10. **When testing an `Expression`, wrap it in a `Method` to produce a formattable body** before comparing.
 11. **Never edit generated integration-test files manually.** Regenerate via `./scripts/setup_integration_tests.sh`.
-12. **Never use `melos run analyze` per-package loops.** Run `fvm dart analyze` ONCE from the project root.
+12. **Never use `melos run analyze` per-package loops.** Run `fvm dart analyze packages/` ONCE. **Never** scope to the project root (`fvm dart analyze` / `fvm dart analyze .`) — that pulls in `integration_test/*/` packages whose generated client SDKs drift between regen passes and surface hundreds of unrelated "issues". The `packages/` scope is the canonical verification target.
 13. **Never chain bash commands with `&&` or `;`.** Run them one at a time.
 14. **No infrastructure / script changes mixed into a feature commit.** Bug-fix and feature PRs touch only the feature scope.
 15. **Comments explain WHY, never WHAT.** Default to no comments. Do not narrate code lines, restate type signatures, summarise switch cases, or describe what a function does when its name and parameters already make that clear. Only write a comment when a reader of the code could not infer the reasoning — a hidden constraint, a non-obvious invariant, an operator-precedence trap, a workaround for a specific bug. If removing the comment would not confuse a future reader, do not write it. This applies to inline comments AND doc comments — a one-line doc on a helper whose name already explains it is noise. Apply this in Phase 5 cleanup: re-read every comment in your diff and delete the ones that explain WHAT.
@@ -81,7 +81,7 @@ Before declaring done, re-read every file you changed and verify:
 - Every error return is handled
 - Every null check is in place
 - All HARD RULES above are satisfied
-- Analysis passes with zero issues: `fvm dart analyze` (run ONCE from project root)
+- Analysis passes with zero issues: `fvm dart analyze packages/` (run ONCE; never project root — see HARD RULE 12)
 - All tests pass: `melos run test`
 - Patch coverage >= 90%: `bash scripts/coverage.sh --diff main`
 
@@ -107,7 +107,7 @@ Before reporting completion, run two built-in skills against your diff and addre
 
 **5c. Re-verify**
 After applying all `/simplify` and `/security-review` fixes:
-- `fvm dart analyze` — must pass with zero issues
+- `fvm dart analyze packages/` — must pass with zero issues (never project root)
 - `melos run test` — all tests pass
 - If integration tests apply: `./scripts/setup_integration_tests.sh && melos run test` — all pass
 

--- a/.claude/agents/tonik-test-runner.md
+++ b/.claude/agents/tonik-test-runner.md
@@ -11,11 +11,15 @@ You are a test execution agent. Your job is to run analysis and every test suite
 
 ## Step 1: Analysis
 
-Run static analysis across all packages:
+Run static analysis across the source packages only:
 
 ```sh
-fvm dart analyze
+fvm dart analyze packages/
 ```
+
+**Never** run `fvm dart analyze` (project root) or `fvm dart analyze .` — those scan `integration_test/` packages too. Those packages contain regenerated client SDKs whose `pubspec.yaml` deps are only resolved after `./scripts/setup_integration_tests.sh`, and they drift between regen passes. Project-root analyze produces hundreds of "issues" from stale `integration_test/` code that have nothing to do with the PR. `packages/` is the canonical scope for verification analyze.
+
+The exception is when integration tests have just been regenerated in Step 3 — at that point `melos exec -- "fvm dart analyze"` (run inside each integration package) is meaningful, but Step 1 is not the place for it.
 
 If analysis produces errors, report them immediately with the full output.
 
@@ -65,7 +69,7 @@ Report the patch coverage percentage and any files below 90%.
 ## Test Results
 
 ### Analysis
-- `fvm dart analyze`: PASS/FAIL
+- `fvm dart analyze packages/`: PASS/FAIL
   (include any errors or warnings)
 
 ### Unit Tests

--- a/.claude/skills/dart-fix-runtime-errors/SKILL.md
+++ b/.claude/skills/dart-fix-runtime-errors/SKILL.md
@@ -1,0 +1,166 @@
+---
+name: dart-fix-runtime-errors
+description: Uses get_runtime_errors and lsp to fetch an active stack trace, locate the failing line, apply a fix, and verify resolution via hot_reload.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Fri, 24 Apr 2026 15:13:22 GMT
+---
+# Resolving Dart Static Analysis Errors
+
+## Contents
+- [Core Concepts & Guidelines](#core-concepts--guidelines)
+  - [Type System & Soundness](#type-system--soundness)
+  - [Null Safety](#null-safety)
+  - [Error Handling](#error-handling)
+- [Workflows](#workflows)
+  - [Workflow: Static Analysis Resolution](#workflow-static-analysis-resolution)
+- [Examples](#examples)
+
+## Core Concepts & Guidelines
+
+### Type System & Soundness
+Enforce Dart's sound type system to prevent runtime invalid states.
+
+*   **Method Overrides:** Maintain sound return types (covariant) and parameter types (contravariant). Never tighten a parameter type in a subclass unless explicitly marked with the `covariant` keyword.
+*   **Generics & Collections:** Add explicit type annotations to generic classes (e.g., `List<T>`, `Map<K, V>`). Never assign a `List<dynamic>` to a typed list (e.g., `List<Cat>`).
+*   **Downcasting:** Avoid implicit downcasts from `dynamic`. Use explicit casts (e.g., `as List<Cat>`) when necessary, but ensure the underlying runtime type matches to prevent `TypeError` exceptions.
+*   **Strict Casts:** Enable `strict-casts: true` in `analysis_options.yaml` under `analyzer: language:` to force explicit casting and catch implicit downcast errors at compile time.
+
+### Null Safety
+Eliminate static errors related to null safety by correctly managing variable initialization and nullability.
+
+*   **Modifiers:** Apply `?` for nullable types, `!` for null assertions, and `required` for named parameters that cannot be null.
+*   **Late Initialization:** Use the `late` keyword for non-nullable variables guaranteed to be initialized before use. Apply this specifically to top-level or instance variables where Dart's control flow analysis cannot definitively prove initialization.
+*   **Wildcards:** Use the `_` wildcard variable (Dart 3.7+) for non-binding local variables or parameters to avoid unused variable warnings.
+
+### Error Handling
+Distinguish between recoverable exceptions and unrecoverable errors.
+
+*   **Catching:** Catch `Exception` subtypes for recoverable failures.
+*   **Errors:** Never explicitly catch `Error` or its subtypes (e.g., `TypeError`, `ArgumentError`). Errors indicate programming bugs that must be fixed, not caught. Enforce this by enabling the `avoid_catching_errors` linter rule.
+*   **Rethrowing:** Use `rethrow` inside a `catch` block to propagate an exception while preserving its original stack trace.
+
+## Workflows
+
+### Workflow: Static Analysis Resolution
+
+Use this sequential workflow to identify, fix, and verify static analysis errors in a Dart project. Copy the checklist to track your progress.
+
+**Task Progress:**
+- [ ] 1. Run static analyzer.
+- [ ] 2. Apply automated fixes.
+- [ ] 3. Resolve remaining errors manually.
+- [ ] 4. Verify fixes (Feedback Loop).
+
+**1. Run static analyzer**
+Execute the Dart analyzer to identify all static errors in the target directory or file.
+```bash
+dart analyze . --fatal-infos
+```
+
+**2. Apply automated fixes**
+Use the `dart fix` tool to automatically resolve standard linting and analysis issues.
+```bash
+# Preview changes
+dart fix --dry-run
+# Apply changes
+dart fix --apply
+```
+
+**3. Resolve remaining errors manually**
+Review the remaining analyzer output and apply conditional logic based on the error type:
+
+*   **If the error is a Null Safety issue (e.g., "Property cannot be accessed on a nullable receiver"):**
+    *   Verify if the variable can logically be null.
+    *   If yes, use optional chaining (`?.`) or provide a fallback (`??`).
+    *   If no, and initialization is guaranteed elsewhere, mark the declaration with `late`.
+*   **If the error is a Type Mismatch (e.g., "The argument type 'List<dynamic>' can't be assigned..."):**
+    *   Trace the variable's initialization.
+    *   Add explicit generic type annotations to the instantiation (e.g., `<int>[]` instead of `[]`).
+*   **If the error is an Invalid Override (e.g., "The parameter type doesn't match the overridden method"):**
+    *   Widen the parameter type to match the superclass, OR
+    *   Add the `covariant` keyword to the parameter if tightening the type is intentionally required by the domain logic.
+
+**4. Verify fixes (Feedback Loop)**
+Run the validator. Review errors. Fix.
+```bash
+dart analyze .
+dart test
+```
+*   **If `dart analyze` reports errors:** Return to Step 3.
+*   **If `dart test` fails with a `TypeError`:** You have introduced an invalid explicit cast (`as T`) or accessed an uninitialized `late` variable. Locate the runtime failure and correct the type hierarchy or initialization order.
+
+## Examples
+
+### Example: Fixing Dynamic List Assignments
+**Input (Fails Static Analysis):**
+```dart
+void printInts(List<int> a) => print(a);
+
+void main() {
+  final list = []; // Inferred as List<dynamic>
+  list.add(1);
+  list.add(2);
+  printInts(list); // Error: List<dynamic> can't be assigned to List<int>
+}
+```
+
+**Output (Passes Static Analysis):**
+```dart
+void printInts(List<int> a) => print(a);
+
+void main() {
+  final list = <int>[]; // Explicitly typed
+  list.add(1);
+  list.add(2);
+  printInts(list);
+}
+```
+
+### Example: Fixing Method Overrides (Contravariance)
+**Input (Fails Static Analysis):**
+```dart
+class Animal {
+  void chase(Animal a) {}
+}
+
+class Cat extends Animal {
+  @override
+  void chase(Mouse a) {} // Error: Tightening parameter type
+}
+```
+
+**Output (Passes Static Analysis):**
+```dart
+class Animal {
+  void chase(Animal a) {}
+}
+
+class Cat extends Animal {
+  @override
+  void chase(covariant Mouse a) {} // Explicitly marked covariant
+}
+```
+
+### Example: Fixing Null Safety with `late`
+**Input (Fails Static Analysis):**
+```dart
+class Thermometer {
+  String temperature; // Error: Non-nullable instance field must be initialized
+
+  void read() {
+    temperature = '20C';
+  }
+}
+```
+
+**Output (Passes Static Analysis):**
+```dart
+class Thermometer {
+  late String temperature; // Defers initialization check to runtime
+
+  void read() {
+    temperature = '20C';
+  }
+}
+```

--- a/.claude/skills/dart-generate-test-mocks/SKILL.md
+++ b/.claude/skills/dart-generate-test-mocks/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: dart-generate-test-mocks
+description: Define and generate mock objects for external dependencies using `package:mockito` and `build_runner`. Use when unit testing classes that depend on complex external services like APIs or databases.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Fri, 24 Apr 2026 15:13:58 GMT
+---
+# Testing and Mocking Dart Applications
+
+## Contents
+- [Structuring Code for Testability](#structuring-code-for-testability)
+- [Managing Dependencies](#managing-dependencies)
+- [Generating Mocks](#generating-mocks)
+- [Implementing Unit Tests](#implementing-unit-tests)
+- [Workflow: Creating and Running Mocked Tests](#workflow-creating-and-running-mocked-tests)
+- [Examples](#examples)
+
+## Structuring Code for Testability
+Design Dart classes to support dependency injection. Isolate complex external dependencies (like API clients or databases) so they can be replaced with mock objects during testing.
+
+- Inject external services (e.g., `http.Client`) through class constructors.
+- Represent URLs strictly as `Uri` objects using `Uri.parse(string)`.
+- Utilize Dart's object-oriented features (classes, mixins) to define clear interfaces for external interactions.
+
+## Managing Dependencies
+Configure the `pubspec.yaml` file with the necessary testing and code generation packages.
+
+- Add runtime dependencies (e.g., `package:http`) using `dart pub add http`.
+- Add testing dependencies using `dart pub add dev:test dev:mockito dev:build_runner`.
+- Import HTTP libraries with a prefix to avoid namespace collisions: `import 'package:http/http.dart' as http;`.
+
+## Generating Mocks
+Use `package:mockito` and `build_runner` to automatically generate mock classes for fixed scenarios and behavior verification.
+
+- Always use the `@GenerateNiceMocks` annotation (preferable to `@GenerateMocks` to avoid missing stub exceptions).
+- Place the annotation in the test file, passing a list of `MockSpec<Type>()` objects.
+- Import the generated file using the `.mocks.dart` extension.
+- Execute `build_runner` to generate the mock files: `dart run build_runner build`.
+
+## Implementing Unit Tests
+Isolate the system under test using the generated mock objects. Use `package:test` to structure the test suite.
+
+- **Stubbing:** Configure mock behavior before interacting with the system under test.
+  - Use `when(mock.method()).thenReturn(value)` for synchronous methods.
+  - **CRITICAL:** Always use `thenAnswer((_) async => value)` for methods returning a `Future` or `Stream`. Never use `thenReturn` for asynchronous returns.
+- **Verification:** Assert that the system under test interacted with the mock object correctly.
+  - Use `verify(mock.method()).called(1)` to check exact invocation counts.
+  - Use argument matchers like `any`, `anyNamed`, or `captureAny` for flexible verification.
+
+## Workflow: Creating and Running Mocked Tests
+
+Use the following checklist to implement and verify mocked unit tests.
+
+### Task Progress
+- [ ] 1. Identify the external dependency to mock (e.g., `http.Client`).
+- [ ] 2. Inject the dependency into the target class constructor.
+- [ ] 3. Create a test file (e.g., `target_test.dart`) and add `@GenerateNiceMocks([MockSpec<Dependency>()])`.
+- [ ] 4. Add the `part` or `import` directive for the generated `.mocks.dart` file.
+- [ ] 5. Run `dart run build_runner build` to generate the mock classes.
+- [ ] 6. Write the test cases using `group()` and `test()`.
+- [ ] 7. Stub required behaviors using `when()`.
+- [ ] 8. Execute the target method.
+- [ ] 9. Verify interactions using `verify()` and assert outcomes using `expect()`.
+- [ ] 10. Run the test suite using `dart test`.
+
+### Feedback Loop: Test Failures
+If tests fail or `build_runner` encounters errors:
+1. **Run validator:** Execute `dart test` or `dart run build_runner build`.
+2. **Review errors:** Check for missing stubs, mismatched argument matchers, or syntax errors in the generated files.
+3. **Fix:**
+   - If a mock method throws an unexpected null error, ensure you used `@GenerateNiceMocks`.
+   - If an async stub throws an `ArgumentError`, change `thenReturn` to `thenAnswer`.
+   - If `build_runner` fails, ensure the `.mocks.dart` import matches the file name exactly.
+4. Repeat until all tests pass.
+
+## Examples
+
+### High-Fidelity Mocking and Testing Example
+
+**1. System Under Test (`lib/api_service.dart`)**
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+class ApiService {
+  final http.Client client;
+
+  ApiService(this.client);
+
+  Future<String> fetchData(String urlString) async {
+    final uri = Uri.parse(urlString);
+    final response = await client.get(uri);
+
+    if (response.statusCode == 200) {
+      return jsonDecode(response.body)['data'];
+    } else {
+      throw Exception('Failed to load data');
+    }
+  }
+}
+```
+
+**2. Test Implementation (`test/api_service_test.dart`)**
+```dart
+import 'package:test/test.dart';
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+import 'package:http/http.dart' as http;
+import 'package:my_app/api_service.dart';
+
+// Generate the mock class for http.Client
+@GenerateNiceMocks([MockSpec<http.Client>()])
+import 'api_service_test.mocks.dart';
+
+void main() {
+  group('ApiService', () {
+    late ApiService apiService;
+    late MockClient mockHttpClient;
+
+    setUp(() {
+      mockHttpClient = MockClient();
+      apiService = ApiService(mockHttpClient);
+    });
+
+    test('returns data if the http call completes successfully', () async {
+      // Arrange: Stub the async HTTP GET request using thenAnswer
+      when(mockHttpClient.get(any)).thenAnswer(
+        (_) async => http.Response('{"data": "Success"}', 200),
+      );
+
+      // Act
+      final result = await apiService.fetchData('https://api.example.com/data');
+
+      // Assert
+      expect(result, 'Success');
+
+      // Verify the mock was called with the correct Uri
+      verify(mockHttpClient.get(Uri.parse('https://api.example.com/data'))).called(1);
+    });
+
+    test('throws an exception if the http call completes with an error', () {
+      // Arrange
+      when(mockHttpClient.get(any)).thenAnswer(
+        (_) async => http.Response('Not Found', 404),
+      );
+
+      // Act & Assert
+      expect(
+        apiService.fetchData('https://api.example.com/data'),
+        throwsException,
+      );
+    });
+  });
+}
+```

--- a/.claude/skills/dart-resolve-package-conflicts/SKILL.md
+++ b/.claude/skills/dart-resolve-package-conflicts/SKILL.md
@@ -1,0 +1,116 @@
+---
+name: dart-resolve-package-conflicts
+description: Workflow for fixing package version conflicts. Use this when `pub get` fails due to incompatible package versions.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Fri, 24 Apr 2026 15:11:14 GMT
+---
+# Managing Dart Dependencies
+
+## Contents
+- [Core Concepts](#core-concepts)
+- [Version Constraints](#version-constraints)
+- [Workflow: Auditing Dependencies](#workflow-auditing-dependencies)
+- [Workflow: Upgrading Dependencies](#workflow-upgrading-dependencies)
+- [Workflow: Resolving Version Conflicts](#workflow-resolving-version-conflicts)
+- [Examples](#examples)
+
+## Core Concepts
+
+Dart enforces a strict single-version rule for dependencies: a project and all its transitive dependencies must resolve to a single, shared version of any given package. This prevents runtime type mismatches but introduces the risk of "version lock."
+
+To mitigate version lock, Dart relies on version constraints rather than pinned versions in the `pubspec.yaml`. The `pubspec.lock` file maintains the exact resolved versions for reproducible builds.
+
+Understand the output columns of `dart pub outdated`:
+*   **Current:** The version currently recorded in `pubspec.lock`.
+*   **Upgradable:** The latest version allowed by the constraints in `pubspec.yaml`. `dart pub upgrade` resolves to this.
+*   **Resolvable:** The absolute latest version that can be resolved when factoring in all other dependencies in the project.
+*   **Latest:** The latest published version of the package (excluding prereleases).
+
+## Version Constraints
+
+*   **Use Caret Syntax:** Always use caret syntax (e.g., `^1.2.3`) for dependencies in `pubspec.yaml`. This allows `pub` to select newer, non-breaking versions (up to, but not including, the next major version) during resolution.
+*   **Tighten Dev Dependencies:** Set the lower bound of `dev_dependencies` to the exact version currently used. This reduces resolution complexity and prevents older, incompatible dev tools from being selected.
+*   **Enforce Lockfiles in CI:** Use `dart pub get --enforce-lockfile` in CI/CD pipelines to ensure the exact versions tested locally are used in production.
+
+## Workflow: Auditing Dependencies
+
+Run this workflow periodically to identify stale packages that may impact stability or performance.
+
+**Task Progress:**
+- [ ] Run `dart pub outdated`.
+- [ ] Review the **Upgradable** column to identify packages that can be updated without modifying `pubspec.yaml`.
+- [ ] Review the **Resolvable** column to identify packages that require constraint modifications in `pubspec.yaml` to update.
+- [ ] Identify any packages marked as retracted or discontinued.
+
+## Workflow: Upgrading Dependencies
+
+Use conditional logic based on the audit results to upgrade dependencies.
+
+**Task Progress:**
+- [ ] **If updating to "Upgradable" versions:**
+  - [ ] Run `dart pub upgrade`.
+  - [ ] Run `dart pub upgrade --tighten` to automatically update the lower bounds in `pubspec.yaml` to match the newly resolved versions.
+- [ ] **If updating to "Resolvable" versions (Major updates):**
+  - [ ] Manually edit `pubspec.yaml` to bump the version constraint to match the "Resolvable" column (e.g., change `^0.11.0` to `^0.12.1`).
+  - [ ] Run `dart pub upgrade` to resolve the new constraints and update `pubspec.lock`.
+- [ ] **Feedback Loop:**
+  - [ ] Run `dart analyze` -> review errors -> fix breaking API changes.
+  - [ ] Run `dart test` -> review failures -> fix regressions.
+
+## Workflow: Resolving Version Conflicts
+
+When `pub` cannot find a set of concrete versions that satisfy all constraints, or when dealing with a retracted package version, manipulate the lockfile surgically.
+
+**NEVER** delete the entire `pubspec.lock` file and run `dart pub get`. This causes uncontrolled upgrades across the entire dependency graph.
+
+**Task Progress:**
+- [ ] Open `pubspec.lock`.
+- [ ] Locate the specific YAML block for the conflicting or retracted package.
+- [ ] Delete ONLY that package's entry from the lockfile.
+- [ ] Run `dart pub get` to fetch the newest compatible, non-retracted version for that specific package.
+- [ ] **Feedback Loop:**
+  - [ ] Run `dart pub deps` -> verify the dependency graph resolves correctly.
+  - [ ] If resolution fails, identify the transitive dependency causing the lock, update its constraint in `pubspec.yaml`, and retry.
+
+## Examples
+
+### Tightening Constraints
+When `dart pub outdated` shows a package is resolvable to a higher minor/patch version, use the `--tighten` flag to update the `pubspec.yaml` automatically.
+
+**Input (`pubspec.yaml`):**
+```yaml
+dependencies:
+  http: ^0.13.0
+```
+
+**Command:**
+```bash
+dart pub upgrade --tighten http
+```
+
+**Output (`pubspec.yaml`):**
+```yaml
+dependencies:
+  http: ^0.13.5
+```
+
+### Surgical Lockfile Removal
+If `package_a` is retracted or locked in a conflict, remove only its block from `pubspec.lock`.
+
+**Before (`pubspec.lock`):**
+```yaml
+packages:
+  package_a:
+    dependency: "direct main"
+    description:
+      name: package_a
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.0" # Retracted version
+  package_b:
+    dependency: "direct main"
+    # ...
+```
+
+**Action:** Delete the `package_a` block entirely. Leave `package_b` untouched. Run `dart pub get`.

--- a/.claude/skills/dart-use-pattern-matching/SKILL.md
+++ b/.claude/skills/dart-use-pattern-matching/SKILL.md
@@ -1,0 +1,146 @@
+---
+name: dart-use-pattern-matching
+description: Use switch expressions and pattern matching where appropriate
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Fri, 24 Apr 2026 15:08:55 GMT
+---
+# Implementing Dart Patterns
+
+## Contents
+- [Pattern Selection Strategy](#pattern-selection-strategy)
+- [Switch Statements vs. Expressions](#switch-statements-vs-expressions)
+- [Core Pattern Implementations](#core-pattern-implementations)
+- [Workflows](#workflows)
+- [Examples](#examples)
+
+## Pattern Selection Strategy
+
+Apply specific pattern types based on the data structure and desired outcome. Follow these conditional guidelines:
+
+*   **If validating and extracting from deserialized data (e.g., JSON):** Use Map and List patterns to simultaneously check structure and destructure key-value pairs.
+*   **If handling multiple return values:** Use Record patterns to destructure fields directly into local variables.
+*   **If executing type-specific behavior (Algebraic Data Types):** Use Object patterns combined with `sealed` classes to ensure exhaustiveness.
+*   **If matching numeric ranges or conditions:** Use Relational (`>=`, `<=`) and Logical-and (`&&`) patterns.
+*   **If multiple cases share logic:** Use Logical-or (`||`) patterns to share a single case body or guard clause.
+*   **If ignoring specific values:** Use the Wildcard pattern (`_`) or a non-matching Rest element (`...`) in collections.
+
+## Switch Statements vs. Expressions
+
+Select the appropriate switch construct based on the execution context:
+
+*   **If producing a value:** Use a **switch expression**.
+    *   Syntax: `switch (value) { pattern => expression, }`
+    *   Rule: Each case must be a single expression. No implicit fallthrough. Must be exhaustive.
+*   **If executing statements or side effects:** Use a **switch statement**.
+    *   Syntax: `switch (value) { case pattern: statements; }`
+    *   Rule: Empty cases fall through to the next case. Non-empty cases implicitly break (no `break` keyword required).
+
+## Core Pattern Implementations
+
+Implement patterns using the following syntax and rules:
+
+*   **Logical-or (`||`):** `pattern1 || pattern2`. Both branches must define the exact same set of variables.
+*   **Logical-and (`&&`):** `pattern1 && pattern2`. Branches must *not* define overlapping variables.
+*   **Relational:** `==`, `!=`, `<`, `>`, `<=`, `>=` followed by a constant expression.
+*   **Cast (`as`):** `pattern as Type`. Throws if the value does not match the type. Use to forcibly assert types during destructuring.
+*   **Null-check (`?`):** `pattern?`. Fails the match if the value is null. Binds the variable to the non-nullable base type.
+*   **Null-assert (`!`):** `pattern!`. Throws if the value is null.
+*   **Variable:** `var name` or `Type name`. Binds the matched value to a new local variable.
+*   **Wildcard (`_`):** Matches any value and discards it.
+*   **List:** `[pattern1, pattern2]`. Matches lists of exact length unless a Rest element (`...` or `...var rest`) is used.
+*   **Map:** `{"key": pattern}`. Matches maps containing the specified keys. Ignores unmatched keys.
+*   **Record:** `(pattern1, named: pattern2)`. Matches records of the exact shape. Use `:var name` to infer the getter name.
+*   **Object:** `ClassName(field: pattern)`. Matches instances of `ClassName`. Use `:var field` to infer the getter name.
+
+## Workflows
+
+### Task Progress: Implementing Pattern Matching
+Copy this checklist to track progress when implementing complex pattern matching logic:
+
+- [ ] Identify the data structure being evaluated (JSON, Record, Class, Enum).
+- [ ] Select the appropriate switch construct (Expression for values, Statement for side-effects).
+- [ ] Define the required patterns (Object, Map, List, Record).
+- [ ] Extract required data using Variable patterns (`var x`, `:var y`).
+- [ ] Apply Guard clauses (`when condition`) for logic that cannot be expressed via patterns.
+- [ ] Handle unmatched cases using a Wildcard (`_`) or `default` clause (if not using a sealed class).
+- [ ] Run exhaustiveness validator.
+
+### Feedback Loop: Exhaustiveness Checking
+When switching over `sealed` classes or enums, you must ensure all subtypes are handled.
+
+1. **Run validator:** Execute `dart analyze`.
+2. **Review errors:** Look for "The type 'X' is not exhaustively matched by the switch cases" errors.
+3. **Fix:** Add the missing Object patterns for the unhandled subtypes, or add a Wildcard (`_`) case if a default fallback is acceptable.
+
+## Examples
+
+### JSON Validation and Destructuring
+Use Map and List patterns to validate structure and extract data in a single step.
+
+**Input:**
+```dart
+var data = {
+  'user': ['Lily', 13],
+};
+```
+
+**Implementation:**
+```dart
+if (data case {'user': [String name, int age]}) {
+  print('User $name is $age years old.');
+} else {
+  print('Invalid JSON structure.');
+}
+```
+
+### Algebraic Data Types (Sealed Classes)
+Use Object patterns with switch expressions to handle family types exhaustively.
+
+**Implementation:**
+```dart
+sealed class Shape {}
+
+class Square implements Shape {
+  final double length;
+  Square(this.length);
+}
+
+class Circle implements Shape {
+  final double radius;
+  Circle(this.radius);
+}
+
+// Switch expression guarantees exhaustiveness due to `sealed` modifier.
+double calculateArea(Shape shape) => switch (shape) {
+  Square(length: var l) => l * l,
+  Circle(:var radius)   => math.pi * radius * radius,
+};
+```
+
+### Variable Swapping and Destructuring
+Use variable assignment patterns to swap values or extract record fields without temporary variables.
+
+**Implementation:**
+```dart
+var (a, b) = ('left', 'right');
+(b, a) = (a, b); // Swap values
+
+// Destructuring a function return
+var (name, age) = getUserInfo();
+```
+
+### Guard Clauses and Logical-or
+Use `when` to evaluate arbitrary conditions after a pattern matches.
+
+**Implementation:**
+```dart
+switch (shape) {
+  case Square(size: var s) || Circle(size: var s) when s > 0:
+    print('Valid symmetric shape with size $s');
+  case Square() || Circle():
+    print('Invalid or empty shape');
+  default:
+    print('Unknown shape');
+}
+```

--- a/.claude/skills/flutter-implement-json-serialization/SKILL.md
+++ b/.claude/skills/flutter-implement-json-serialization/SKILL.md
@@ -1,0 +1,153 @@
+---
+name: flutter-implement-json-serialization
+description: Create model classes with `fromJson` and `toJson` methods using `dart:convert`. Use when manually mapping JSON keys to class properties for simple data structures.
+metadata:
+  model: models/gemini-3.1-pro-preview
+  last_modified: Tue, 21 Apr 2026 21:44:50 GMT
+---
+# Serializing JSON Manually in Flutter
+
+## Contents
+- [Core Guidelines](#core-guidelines)
+- [Workflow: Implementing a Serializable Model](#workflow-implementing-a-serializable-model)
+- [Workflow: Fetching and Parsing JSON](#workflow-fetching-and-parsing-json)
+- [Examples](#examples)
+
+## Core Guidelines
+
+- **Import `dart:convert`**: Utilize Flutter's built-in `dart:convert` library for manual JSON encoding (`jsonEncode`) and decoding (`jsonDecode`).
+- **Enforce Type Safety**: Always cast the `dynamic` result of `jsonDecode()` to the expected type, typically `Map<String, dynamic>` for objects or `List<dynamic>` for arrays.
+- **Encapsulate Serialization Logic**: Define plain model classes containing properties corresponding to the JSON structure. Implement a `fromJson` factory constructor and a `toJson` method within the model.
+- **Handle Background Parsing**: If parsing large JSON documents (execution time > 16ms), offload the parsing logic to a separate isolate using Flutter's `compute()` function to prevent UI jank.
+- **Throw Exceptions on Failure**: When handling HTTP responses, throw an exception if the status code is not successful (e.g., not 200 OK or 201 Created). Do not return `null`.
+
+## Workflow: Implementing a Serializable Model
+
+Use this checklist to implement manual JSON serialization for a data model.
+
+**Task Progress:**
+- [ ] Define the plain model class with `final` properties.
+- [ ] Implement the `factory Model.fromJson(Map<String, dynamic> json)` constructor.
+- [ ] Implement the `Map<String, dynamic> toJson()` method.
+- [ ] Write unit tests for both serialization methods.
+- [ ] Run validator -> review type mismatch errors -> fix casting logic.
+
+1. **Define the Model**: Create a class with properties matching the JSON keys.
+2. **Implement `fromJson`**: Extract values from the `Map` and cast them to the appropriate Dart types. Use pattern matching or explicit casting.
+3. **Implement `toJson`**: Return a `Map<String, dynamic>` mapping the class properties back to their JSON string keys.
+4. **Validate**: Execute unit tests to ensure type safety, autocompletion, and compile-time exception handling function correctly.
+
+## Workflow: Fetching and Parsing JSON
+
+Use this conditional workflow when retrieving and parsing JSON from a network request.
+
+**Task Progress:**
+- [ ] Execute the HTTP request.
+- [ ] Validate the response status code.
+- [ ] Determine parsing strategy (Synchronous vs. Isolate).
+- [ ] Decode and map the JSON to the model.
+
+1. **Execute Request**: Use the `http` package to perform the network call.
+2. **Validate Response**: 
+   - If `response.statusCode == 200` (or 201 for POST), proceed to parsing.
+   - If the status code indicates failure, throw an `Exception`.
+3. **Determine Parsing Strategy**:
+   - If parsing a **small payload** (e.g., a single object), parse synchronously on the main thread.
+   - If parsing a **large payload** (e.g., an array of thousands of objects), use `compute(parseFunction, response.body)` to parse in a background isolate.
+4. **Decode and Map**: Pass the decoded JSON to your model's `fromJson` constructor.
+
+## Examples
+
+### High-Fidelity Model Implementation
+
+```dart
+import 'dart:convert';
+
+class User {
+  final int id;
+  final String name;
+  final String email;
+
+  const User({
+    required this.id,
+    required this.name,
+    required this.email,
+  });
+
+  // Factory constructor for deserialization
+  factory User.fromJson(Map<String, dynamic> json) {
+    return switch (json) {
+      {
+        'id': int id,
+        'name': String name,
+        'email': String email,
+      } => 
+        User(
+          id: id,
+          name: name,
+          email: email,
+        ),
+      _ => throw const FormatException('Failed to load User.'),
+    };
+  }
+
+  // Method for serialization
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'email': email,
+    };
+  }
+}
+```
+
+### Synchronous Parsing (Small Payload)
+
+```dart
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+
+Future<User> fetchUser(http.Client client, int userId) async {
+  final response = await client.get(
+    Uri.parse('https://api.example.com/users/$userId'),
+    headers: {'Accept': 'application/json'},
+  );
+
+  if (response.statusCode == 200) {
+    // Decode returns dynamic, cast to Map<String, dynamic>
+    final Map<String, dynamic> jsonMap = jsonDecode(response.body) as Map<String, dynamic>;
+    return User.fromJson(jsonMap);
+  } else {
+    throw Exception('Failed to load user');
+  }
+}
+```
+
+### Background Parsing (Large Payload)
+
+```dart
+import 'dart:convert';
+import 'package:flutter/foundation.dart';
+import 'package:http/http.dart' as http;
+
+// Top-level function required for compute()
+List<User> parseUsers(String responseBody) {
+  final parsed = (jsonDecode(responseBody) as List<dynamic>).cast<Map<String, dynamic>>();
+  return parsed.map<User>((json) => User.fromJson(json)).toList();
+}
+
+Future<List<User>> fetchUsers(http.Client client) async {
+  final response = await client.get(
+    Uri.parse('https://api.example.com/users'),
+    headers: {'Accept': 'application/json'},
+  );
+
+  if (response.statusCode == 200) {
+    // Offload expensive parsing to a background isolate
+    return compute(parseUsers, response.body);
+  } else {
+    throw Exception('Failed to load users');
+  }
+}
+```

--- a/.claude/skills/gen-eval/SKILL.md
+++ b/.claude/skills/gen-eval/SKILL.md
@@ -27,7 +27,7 @@ Default max iterations: 3.
 | Agent | Purpose |
 |-------|---------|
 | `tonik-generator` | Implements the feature, then runs `/simplify` + `/security-review` as a Phase 5 cleanup pass before declaring done. Skills (`code-builder`, `testing`, `integration-tests`, `openapi-spec`) preloaded via frontmatter. |
-| `tonik-test-runner` | Runs `fvm dart analyze`, all unit tests per package, integration tests, and patch coverage. Read-only + Bash. |
+| `tonik-test-runner` | Runs `fvm dart analyze packages/` (scoped — never project root), all unit tests per package, integration tests, and patch coverage. Read-only + Bash. |
 
 **Specialist reviewers (fan out in parallel — Step 4b):**
 
@@ -99,7 +99,7 @@ Based on the task's acceptance criteria, write a numbered list of **concrete, te
 - [ ] Every test category the task mentions (unit per package, integration) is an explicit criterion
 - [ ] Test criteria are specific about coverage scope (which cases, which error conditions, which scenarios)
 - [ ] Test criteria are explicit about test layer (unit in package X, integration test in `integration_test/`)
-- [ ] There is a criterion for analysis passing (`fvm dart analyze`)
+- [ ] There is a criterion for analysis passing (`fvm dart analyze packages/` — never project root, integration_test/ packages drift between regens)
 - [ ] If generator changes are involved, there is a criterion for integration tests passing
 - [ ] There is a criterion for patch coverage >= 90% (`bash scripts/coverage.sh --diff main`)
 - [ ] Any criterion that produces emitted Dart code mentions explicitly that tests must be **full method body comparisons** with `collapseWhitespace()` + `DartFormatter` — not fragments


### PR DESCRIPTION
## Summary

Two tooling changes, both fallout from a recent gen-eval run that surfaced friction in the harness:

**Scope `dart analyze` to `packages/`.** Running analyze from the project root pulls in `integration_test/*/` packages whose regenerated client SDKs drift between `./scripts/setup_integration_tests.sh` invocations. The result is hundreds of "issues" in stripe/twilio/openai/totem/etc. that have nothing to do with the diff being reviewed. Every gen-eval agent that runs or verifies analyze now requires the `packages/` scope:
- `.claude/agents/tonik-test-runner.md` — Step 1 + output template
- `.claude/agents/tonik-generator.md` — HARD RULE 12 + Phase 4 self-check + Phase 5c re-verify
- `.claude/agents/tonik-contract-verifier.md` — new HARD RULE 7
- `.claude/skills/gen-eval/SKILL.md` — agent-table description + sprint-contract checklist criterion

**Add five reusable skills under `.claude/skills/`** for agents to draw on:
- From [dart-lang/skills](https://github.com/dart-lang/skills): `dart-fix-runtime-errors`, `dart-generate-test-mocks`, `dart-resolve-package-conflicts`, `dart-use-pattern-matching`
- From [flutter/skills](https://github.com/flutter/skills): `flutter-implement-json-serialization`

Skipped:
- `dart-add-unit-test` — project's `testing` skill is stricter (full method body comparisons, no trivial tests)
- `dart-build-cli-app` — one-off reference, `tonik` CLI already exists
- `dart-migrate-to-checks-package` — not on the roadmap
- `dart-collect-coverage` and `dart-run-static-analysis` — redundant with project's `scripts/coverage.sh` and the analyze-scope conventions hardened in the agent definitions above

## Test plan

- [x] No code changes — agent/skill files only
- [x] Skills self-trigger via frontmatter; verified all 5 appear in the Skill tool's available-skills list
- [x] Analyze-scope rule cross-referenced in every gen-eval agent that runs analyze
