### PR TITLE
fix(tonik_parse): apply $ref siblings + parse OAS 3.2 dataValue/serializedValue

### DIFF
--- a/packages/tonik_parse/lib/src/example_importer.dart
+++ b/packages/tonik_parse/lib/src/example_importer.dart
@@ -87,8 +87,21 @@ class ExampleImporter {
     }
     if (examples != null) {
       for (final entry in examples.entries) {
-        final resolved = _resolveExample(entry.value, <String>[]);
-        final converted = _convert(name: entry.key, example: resolved);
+        final wrapper = entry.value;
+        // OAS 3.1+: a Reference's summary/description override the target's.
+        final summaryOverride = wrapper is Reference<Example>
+            ? wrapper.summary
+            : null;
+        final descriptionOverride = wrapper is Reference<Example>
+            ? wrapper.description
+            : null;
+        final resolved = _resolveExample(wrapper, <String>[]);
+        final converted = _convert(
+          name: entry.key,
+          example: resolved,
+          summaryOverride: summaryOverride,
+          descriptionOverride: descriptionOverride,
+        );
         if (converted != null) {
           result.add(converted);
         }
@@ -129,22 +142,39 @@ class ExampleImporter {
     }
   }
 
-  core.Example? _convert({required String name, required Example example}) {
-    if (example.value == null && example.externalValue != null) {
+  core.Example? _convert({
+    required String name,
+    required Example example,
+    String? summaryOverride,
+    String? descriptionOverride,
+  }) {
+    final hasData = example.hasExplicitDataValue || example.hasExplicitValue;
+    final effectiveValue = example.hasExplicitDataValue
+        ? example.dataValue
+        : example.value;
+
+    // externalValue and serializedValue are non-native forms tonik can't
+    // consume; drop silently when one of them is the only payload.
+    if (!hasData &&
+        (example.externalValue != null || example.serializedValue != null)) {
       return null;
     }
-    if (!example.hasExplicitValue && example.externalValue == null) {
+
+    if (!hasData &&
+        example.externalValue == null &&
+        example.serializedValue == null) {
       log.warning(
-        'Skipping Example "$name" - neither `value` nor `externalValue` '
-        'is set.',
+        'Skipping Example "$name" - none of `value`, `dataValue`, '
+        '`serializedValue`, or `externalValue` is set.',
       );
       return null;
     }
+
     return core.Example(
       name: name,
-      summary: example.summary,
-      description: example.description,
-      value: example.value,
+      summary: summaryOverride ?? example.summary,
+      description: descriptionOverride ?? example.description,
+      value: effectiveValue,
     );
   }
 }

--- a/packages/tonik_parse/lib/src/model/example.dart
+++ b/packages/tonik_parse/lib/src/model/example.dart
@@ -3,33 +3,44 @@ class Example {
     this.summary,
     this.description,
     this.value,
+    this.dataValue,
+    this.serializedValue,
     this.externalValue,
     this.hasExplicitValue = false,
+    this.hasExplicitDataValue = false,
   });
 
   factory Example.fromJson(Map<String, dynamic> json) {
     final hasValue = json.containsKey('value');
+    final hasDataValue = json.containsKey('dataValue');
     return Example(
       summary: json['summary'] as String?,
       description: json['description'] as String?,
       value: hasValue ? json['value'] : null,
+      dataValue: hasDataValue ? json['dataValue'] : null,
+      serializedValue: json['serializedValue'] as String?,
       externalValue: json['externalValue'] as String?,
       hasExplicitValue: hasValue,
+      hasExplicitDataValue: hasDataValue,
     );
   }
 
   final String? summary;
   final String? description;
   final Object? value;
+  final Object? dataValue;
+  final String? serializedValue;
   final String? externalValue;
 
   /// Whether the source JSON contained an explicit `value` key (even if its
   /// value was `null`). Used by the example importer to distinguish an
   /// empty Example object from one whose value is intentionally null.
   final bool hasExplicitValue;
+  final bool hasExplicitDataValue;
 
   @override
   String toString() =>
       'Example{summary: $summary, description: $description, '
-      'value: $value, externalValue: $externalValue}';
+      'value: $value, dataValue: $dataValue, '
+      'serializedValue: $serializedValue, externalValue: $externalValue}';
 }

--- a/packages/tonik_parse/test/example_importer_test.dart
+++ b/packages/tonik_parse/test/example_importer_test.dart
@@ -454,4 +454,257 @@ void main() {
       ]);
     });
   });
+
+  group(r'ExampleImporter - $ref Reference siblings (OAS 3.1+ §4.8.23)', () {
+    OpenApiObject loadApi({Map<String, dynamic> components = const {}}) {
+      return OpenApiObject.fromJson(<String, dynamic>{
+        'openapi': '3.1.0',
+        'info': {'title': 'T', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': components,
+      });
+    }
+
+    MediaType media(Map<String, dynamic> json) => MediaType.fromJson(json);
+
+    test(r'$ref summary and description siblings override target', () {
+      final api = loadApi(
+        components: {
+          'examples': {
+            'Shared': {
+              'summary': 'target summary',
+              'description': 'target desc',
+              'value': {'k': 'v'},
+            },
+          },
+        },
+      );
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'shared': {
+              r'$ref': '#/components/examples/Shared',
+              'summary': 'site summary',
+              'description': 'site desc',
+            },
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'shared',
+          summary: 'site summary',
+          description: 'site desc',
+          value: {'k': 'v'},
+        ),
+      ]);
+    });
+
+    test(r'$ref summary alone overrides; description falls through', () {
+      final api = loadApi(
+        components: {
+          'examples': {
+            'Shared': {
+              'summary': 'target summary',
+              'description': 'target desc',
+              'value': 1,
+            },
+          },
+        },
+      );
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'shared': {
+              r'$ref': '#/components/examples/Shared',
+              'summary': 'site summary',
+            },
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'shared',
+          summary: 'site summary',
+          description: 'target desc',
+          value: 1,
+        ),
+      ]);
+    });
+
+    test(r'$ref description alone overrides; summary falls through', () {
+      final api = loadApi(
+        components: {
+          'examples': {
+            'Shared': {
+              'summary': 'target summary',
+              'description': 'target desc',
+              'value': 1,
+            },
+          },
+        },
+      );
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'shared': {
+              r'$ref': '#/components/examples/Shared',
+              'description': 'site desc',
+            },
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'shared',
+          summary: 'target summary',
+          description: 'site desc',
+          value: 1,
+        ),
+      ]);
+    });
+
+    test(r'$ref without siblings falls through to target', () {
+      final api = loadApi(
+        components: {
+          'examples': {
+            'Shared': {
+              'summary': 'target summary',
+              'description': 'target desc',
+              'value': 1,
+            },
+          },
+        },
+      );
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'shared': {r'$ref': '#/components/examples/Shared'},
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'shared',
+          summary: 'target summary',
+          description: 'target desc',
+          value: 1,
+        ),
+      ]);
+    });
+  });
+
+  group('ExampleImporter - OAS 3.2 dataValue and serializedValue', () {
+    OpenApiObject loadApi({Map<String, dynamic> components = const {}}) {
+      return OpenApiObject.fromJson(<String, dynamic>{
+        'openapi': '3.2.0',
+        'info': {'title': 'T', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': components,
+      });
+    }
+
+    MediaType media(Map<String, dynamic> json) => MediaType.fromJson(json);
+
+    test('dataValue becomes the core Example value', () {
+      final api = loadApi();
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'a': {
+              'summary': 's',
+              'dataValue': {'k': 1},
+            },
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'a',
+          summary: 's',
+          description: null,
+          value: {'k': 1},
+        ),
+      ]);
+    });
+
+    test('dataValue takes precedence over legacy value when both present', () {
+      final api = loadApi();
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'a': {'dataValue': 'data', 'value': 'legacy'},
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'a',
+          summary: null,
+          description: null,
+          value: 'data',
+        ),
+      ]);
+    });
+
+    test('explicit dataValue: null is preserved', () {
+      final api = loadApi();
+      final importer = ExampleImporter(openApiObject: api);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'nullData': {'dataValue': null, 'summary': 'explicit null'},
+          },
+        }),
+      );
+
+      expect(result, const [
+        core.Example(
+          name: 'nullData',
+          summary: 'explicit null',
+          description: null,
+          value: null,
+        ),
+      ]);
+    });
+
+    test('serializedValue alone is silently dropped (no warning)', () {
+      final api = loadApi();
+      final importer = ExampleImporter(openApiObject: api);
+
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+      addTearDown(sub.cancel);
+
+      final result = importer.fromMediaType(
+        media({
+          'examples': {
+            'wire': {'serializedValue': '"hello"'},
+          },
+        }),
+      );
+
+      expect(result, isEmpty);
+      expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+    });
+  });
 }


### PR DESCRIPTION
Follow-up to #142 fixing two real spec gaps surfaced when validating the example/examples plumbing against OAS 3.0/3.1/3.2.

## What

### 1. `$ref` Reference siblings now override the target (OAS 3.1+ §4.8.23 / 3.2 §4.23)

A Reference Object's own `summary`/`description` "apply to the referencing location, regardless of any such fields specified by the target." Previously these siblings were parsed into `Reference<Example>` but discarded — `_resolveExample` returned the target only and `_convert` used the target's fields. Now the outermost wrapper's siblings (when set) override the resolved target's fields.

### 2. OAS 3.2 Example Object — parse `dataValue` and `serializedValue`

3.2 introduced `dataValue` (structured data, preferred over `value` for non-JSON targets) and `serializedValue` (pre-serialized string form). Previously a 3.2 spec using either field was silently dropped with a warning, because the parser saw no `value`/`externalValue` and treated the Example as empty.

- `dataValue` is parsed and used as the structured-data payload; takes precedence over legacy `value` when both are present.
- `serializedValue` alone is dropped silently, mirroring the existing `externalValue`-only behaviour — tonik can't faithfully consume a pre-serialized form.
- The "empty Example" warning now mentions all four payload fields.

## Out of scope

- The 3.2 spec also removed the "media-level example SHALL override schema-level" rule from MediaType/Parameter/Header. We continue to override (still a defensible reading; spec is now silent). Tracked for the codegen follow-up.
- The 3.2 spec moved `example`/`examples` to Common Fixed Fields on Parameter/Header, allowing them alongside `content`. Moot today — tonik rejects `content`-style parameters.

## Test plan

- [x] 8 new unit tests in `example_importer_test.dart` cover both fixes (4 each).
- [x] All 25 tests in the file pass; 604 tests in `tonik_parse` pass; 264 tests in `tonik_core` pass.
- [x] `fvm dart analyze packages/tonik_parse` clean.
