### PR TITLE
fix(tonik_generate): escape spec-derived names in generated string literals

### DIFF
--- a/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
@@ -228,6 +228,52 @@ void main() {
     });
   });
 
+  group('multipart URL-encoded complex-object with quoted property name', () {
+    test('constructs request body data class without throwing', () {
+      const body = UploadUrlencodedQuotedPropPostBodyBodyModel(
+        itsForm: UploadUrlencodedQuotedPropPostBodyBodyItsFormModel(
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+        ),
+      );
+
+      expect(body.itsForm.firstName, 'Ada');
+      expect(body.itsForm.lastName, 'Lovelace');
+    });
+
+    test('toJson preserves the quoted property key on the outer body', () {
+      const body = UploadUrlencodedQuotedPropPostBodyBodyModel(
+        itsForm: UploadUrlencodedQuotedPropPostBodyBodyItsFormModel(
+          firstName: 'Ada',
+          lastName: 'Lovelace',
+        ),
+      );
+
+      final json = body.toJson()! as Map<String, Object?>;
+      expect(json.containsKey("it's-form"), isTrue);
+    });
+  });
+
+  group('multipart URL-encoded free-form map with quoted property name', () {
+    test('constructs request body data class without throwing', () {
+      const body = UploadUrlencodedQuotedMapPostBodyBodyModel(
+        itsMeta: {'a': '1', 'b': '2'},
+      );
+
+      expect(body.itsMeta['a'], '1');
+      expect(body.itsMeta['b'], '2');
+    });
+
+    test('toJson preserves the quoted property key on the outer body', () {
+      const body = UploadUrlencodedQuotedMapPostBodyBodyModel(
+        itsMeta: {'a': '1'},
+      );
+
+      final json = body.toJson()! as Map<String, Object?>;
+      expect(json.containsKey("it's-meta"), isTrue);
+    });
+  });
+
   group('object with quoted property name', () {
     test('toJson uses quoted property key', () {
       const obj = ObjectWithQuotedProp(id: 'x');

--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -101,6 +101,69 @@ paths:
         '200':
           description: OK
 
+  # Multipart with URL-encoded complex-object property whose rawName
+  # contains a single quote. Without escaping, the property name leaks
+  # into a Dart single-quoted string literal in the generated source.
+  /upload-urlencoded-quoted-prop:
+    post:
+      operationId: uploadUrlencodedQuotedProp
+      tags:
+        - adversarial
+      summary: URL-encoded complex-object property with quote in name
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - "it's-form"
+              properties:
+                "it's-form":
+                  type: object
+                  required:
+                    - firstName
+                    - lastName
+                  properties:
+                    firstName:
+                      type: string
+                    lastName:
+                      type: string
+            encoding:
+              "it's-form":
+                contentType: application/x-www-form-urlencoded
+      responses:
+        '200':
+          description: OK
+
+  # Multipart with URL-encoded free-form map property whose rawName
+  # contains a single quote.
+  /upload-urlencoded-quoted-map:
+    post:
+      operationId: uploadUrlencodedQuotedMap
+      tags:
+        - adversarial
+      summary: URL-encoded free-form map property with quote in name
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - "it's-meta"
+              properties:
+                "it's-meta":
+                  type: object
+                  additionalProperties:
+                    type: string
+            encoding:
+              "it's-meta":
+                contentType: application/x-www-form-urlencoded
+      responses:
+        '200':
+          description: OK
+
   # 1j. Query parameters with adversarial rawName (delimited encoding)
   /search:
     get:

--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -400,31 +400,29 @@ class ServerGenerator {
       }
 
       if (earliestVariable == null) {
-        // No more placeholders — escape and append the rest.
-        parts.add(escapeForSingleQuotedDartString(remaining));
+        parts.add(specLiteralStringCode(remaining));
         break;
       }
 
-      // Escape the literal segment before this placeholder.
       final literal = remaining.substring(0, earliestIndex);
       if (literal.isNotEmpty) {
-        parts.add(escapeForSingleQuotedDartString(literal));
+        parts.add(specLiteralStringCode(literal));
       }
 
-      // Append the Dart interpolation expression (unescaped).
       final placeholder = '{${earliestVariable.name}}';
       final dartName = variableNameMap[earliestVariable.name]!;
       final hasEnum =
           earliestVariable.enumValues != null &&
           earliestVariable.enumValues!.isNotEmpty;
       parts.add(
-        hasEnum ? '\${$dartName.value}' : '\${$dartName}',
+        hasEnum ? "'\${$dartName.value}'" : "'\${$dartName}'",
       );
 
       remaining = remaining.substring(earliestIndex + placeholder.length);
     }
 
-    return "'${parts.join()}'";
+    if (parts.isEmpty) return "''";
+    return parts.join(' ');
   }
 
   Class _generateCustomServerClass(String className, String baseClassName) {

--- a/packages/tonik_generate/lib/src/util/spec_literal_string.dart
+++ b/packages/tonik_generate/lib/src/util/spec_literal_string.dart
@@ -51,18 +51,11 @@ String specLiteralStringCode(String value) {
     return 'r"""$value"""';
   }
 
-  // Fall back to a regular single-quoted string with escaping.
-  final escaped = escapeForSingleQuotedDartString(value);
+  final escaped = _escapeForSingleQuotedDartString(value);
   return "'$escaped'";
 }
 
-/// Escapes a string for embedding inside a Dart single-quoted (non-raw) string.
-///
-/// Handles `\`, `'`, `$`, `\n`, and `\r` — the characters that are special
-/// or invalid inside single-quoted Dart strings. This is useful both for the
-/// fallback path in [specLiteralStringCode] and for building interpolated
-/// strings like templated server URLs.
-String escapeForSingleQuotedDartString(String value) {
+String _escapeForSingleQuotedDartString(String value) {
   return value
       .replaceAll(r'\', r'\\')
       .replaceAll("'", r"\'")

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -1190,7 +1190,8 @@ Code _buildUrlEncodedMapFileAddition(
       refer('EncodingException', 'package:tonik_util/tonik_util.dart').code,
       Code(
         "('Standard URL encoding does not support nested values "
-        '(property: $rawName, key: \${entry.key}). '
+        "(property: ' ${specLiteralStringCode(rawName)} "
+        r"', key: ${entry.key}). "
         "Only flat key=value pairs are allowed.');",
       ),
     ]),
@@ -1343,7 +1344,8 @@ Code _buildUrlEncodedObjectFileAddition(
       refer('EncodingException', 'package:tonik_util/tonik_util.dart').code,
       Code(
         "('Standard URL encoding does not support nested values "
-        '(property: $rawName, key: \${entry.key}). '
+        "(property: ' ${specLiteralStringCode(rawName)} "
+        r"', key: ${entry.key}). "
         "Only flat key=value pairs are allowed.');",
       ),
     ]),

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -162,6 +162,7 @@ Code? _buildFieldCode(
     NeverModel() => generateEncodingExceptionExpression(
       "Cannot encode NeverModel property '$rawName' "
       '- this type does not permit any value.',
+      raw: true,
     ).statement,
 
     IntegerModel() ||
@@ -593,6 +594,7 @@ Code _buildListFieldAddition(
     return generateEncodingExceptionExpression(
       'deepObject style is not supported for array '
       'multipart properties (property: $rawName).',
+      raw: true,
     ).statement;
   }
 
@@ -728,6 +730,7 @@ Code _buildContentBasedListAddition(
     return generateEncodingExceptionExpression(
       'Arrays of arrays are not supported for multipart encoding '
       '(property: $rawName).',
+      raw: true,
     ).statement;
   }
 
@@ -745,6 +748,7 @@ Code _buildContentBasedListAddition(
       'Unsupported contentType "$explicitRaw" for array multipart '
       'property "$rawName". Only application/json is supported for '
       'content-based array serialization.',
+      raw: true,
     ).statement;
   }
 
@@ -1095,6 +1099,7 @@ Code _buildMapModelFileAddition(
       'deepObject style is not supported for map '
       'multipart properties (property: $rawName). '
       'Maps do not implement ParameterEncodable.toDeepObject().',
+      raw: true,
     ).statement;
   }
 

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -130,7 +130,7 @@ void main() {
           .toString();
       expect(
         initCode,
-        r"super(baseUrl: 'https://regional.example.com/${region.value}')",
+        r"super(baseUrl: r'https://regional.example.com/' '${region.value}')",
       );
     });
 
@@ -142,7 +142,7 @@ void main() {
             this.region = RegionalServerRegion.usEast,
             super.serverConfig = const ServerConfig(),
           }) : super(
-            baseUrl: 'https://regional.example.com/${region.value}',
+            baseUrl: r'https://regional.example.com/' '${region.value}',
           );
 
           final RegionalServerRegion region;
@@ -202,7 +202,7 @@ void main() {
           .toString();
       expect(
         initCode,
-        r"super(baseUrl: 'https://environment.example.com/${env}')",
+        r"super(baseUrl: r'https://environment.example.com/' '${env}')",
       );
     });
 
@@ -213,7 +213,7 @@ void main() {
           EnvironmentServer({
             this.env = r'prod',
             super.serverConfig = const ServerConfig(),
-          }) : super(baseUrl: 'https://environment.example.com/${env}');
+          }) : super(baseUrl: r'https://environment.example.com/' '${env}');
 
           final String env;
         }
@@ -306,7 +306,7 @@ void main() {
           .toString();
       expect(
         initCode,
-        r"super(baseUrl: 'https://configurable.example.com/${host}:${port.value}/api')",
+        r"super(baseUrl: r'https://configurable.example.com/' '${host}' r':' '${port.value}' r'/api')",
       );
     });
 
@@ -319,7 +319,7 @@ void main() {
             this.port = ConfigurableServerPort.eightThousandEighty,
             super.serverConfig = const ServerConfig(),
           }) : super(
-            baseUrl: 'https://configurable.example.com/${host}:${port.value}/api',
+            baseUrl: r'https://configurable.example.com/' '${host}' r':' '${port.value}' r'/api',
           );
 
           final String host;
@@ -435,8 +435,10 @@ void main() {
 
       // Verify URL interpolation.
       expect(
-        result.code,
-        contains(r'https://regional.example.com/${region.value}:${port}'),
+        collapseWhitespace(result.code),
+        contains(
+          r"r'https://regional.example.com/' '${region.value}' r':' '${port}'",
+        ),
       );
     });
   });

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -491,4 +491,26 @@ void main() {
       expect(code, contains(r'${$default}'));
     });
   });
+
+  group('ServerGenerator edge cases', () {
+    test('empty URL template with variables emits empty baseUrl literal', () {
+      // An empty url combined with any variables means no placeholders match
+      // and no literal segments are appended, so the helper falls back to ''.
+      final servers = [
+        const Server(
+          url: '',
+          description: 'Empty url',
+          variables: [
+            ServerVariable(name: 'env', defaultValue: 'prod'),
+          ],
+        ),
+      ];
+
+      final classes = generator.generateClasses(servers);
+      final serverClass = classes[1];
+      final initializer = serverClass.constructors.first.initializers.first;
+
+      expect(initializer.accept(emitter).toString(), "super(baseUrl: '')");
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -492,8 +492,8 @@ void main() {
     });
   });
 
-  group('ServerGenerator edge cases', () {
-    test('empty URL template with variables emits empty baseUrl literal', () {
+  group('ServerGenerator templated URLs with empty url template', () {
+    test('emits empty baseUrl literal when no placeholders are present', () {
       // An empty url combined with any variables means no placeholders match
       // and no literal segments are appended, so the helper falls back to ''.
       final servers = [

--- a/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
+++ b/packages/tonik_generate/test/src/util/spec_literal_string_test.dart
@@ -234,30 +234,4 @@ it's "here"
     });
   });
 
-  group('escapeForSingleQuotedDartString', () {
-    test('escapes newline to literal backslash-n', () {
-      const input = '''
-hello
-world''';
-      expect(
-        escapeForSingleQuotedDartString(input),
-        r'hello\nworld',
-      );
-    });
-
-    test(r'escapes \r to literal backslash-r', () {
-      expect(escapeForSingleQuotedDartString('hello\rworld'), r'hello\rworld');
-    });
-
-    test(
-      'escapes combined newlines, single quote, dollar, and backslash',
-      () {
-        const input = "a\\b'c\$d\ne\rf";
-        final result = escapeForSingleQuotedDartString(input);
-        // Backslash must be escaped first to avoid double-escaping.
-        // Then single quote, dollar, \n, and \r.
-        expect(result, r"a\\b\'c\$d\ne\rf");
-      },
-    );
-  });
 }

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -674,7 +674,7 @@ void main() {
           void test() {
             final _$formData = FormData();
             throw EncodingException(
-              'Cannot encode NeverModel property \'impossible\' - this type does not permit any value.',
+              r"Cannot encode NeverModel property 'impossible' - this type does not permit any value.",
             );
             return _$formData;
           }
@@ -682,6 +682,67 @@ void main() {
         ),
       );
     });
+
+    test(
+      'NeverModel property name with dollar sign emits raw literal',
+      () {
+        final model = ClassModel(
+          name: 'TestForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: r'$total',
+              model: NeverModel(context: testContext),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            r'$total': const MultipartPropertyEncoding(
+              contentType: ContentType.text,
+              rawContentType: 'text/plain',
+              style: MultipartEncodingStyle.form,
+              explode: true,
+              allowReserved: false,
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              throw EncodingException(
+                r"Cannot encode NeverModel property '$total' - this type does not permit any value.",
+              );
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
   });
 
   group('primitive types', () {
@@ -4546,7 +4607,75 @@ void main() {
             void test() {
               final _$formData = FormData();
               throw EncodingException(
-                'deepObject style is not supported for map multipart properties (property: metadata). Maps do not implement ParameterEncodable.toDeepObject().',
+                r'deepObject style is not supported for map multipart properties (property: metadata). Maps do not implement ParameterEncodable.toDeepObject().',
+              );
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
+
+    test(
+      'deepObject error for MapModel uses raw literal when property name '
+      'has special characters',
+      () {
+        final mapModel = MapModel(
+          valueModel: StringModel(context: testContext),
+          context: testContext,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          name: 'ResourceForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: "it's-meta",
+              model: mapModel,
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            "it's-meta": const MultipartPropertyEncoding(
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              style: MultipartEncodingStyle.deepObject,
+              explode: true,
+              allowReserved: false,
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              throw EncodingException(
+                r"deepObject style is not supported for map multipart properties (property: it's-meta). Maps do not implement ParameterEncodable.toDeepObject().",
               );
               return _$formData;
             }
@@ -5437,7 +5566,7 @@ void main() {
           void test() {
             final _$formData = FormData();
             throw EncodingException(
-              'deepObject style is not supported for array multipart properties (property: tags).',
+              r'deepObject style is not supported for array multipart properties (property: tags).',
             );
             return _$formData;
           }
@@ -5445,6 +5574,72 @@ void main() {
         ),
       );
     });
+
+    test(
+      'deepObject error for list uses raw literal when property name '
+      'has special characters',
+      () {
+        final model = ClassModel(
+          name: 'TestForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: "it's-tags",
+              model: ListModel(
+                content: StringModel(context: testContext),
+                context: testContext,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            "it's-tags": const MultipartPropertyEncoding(
+              contentType: ContentType.text,
+              rawContentType: 'text/plain',
+              style: MultipartEncodingStyle.deepObject,
+              explode: false,
+              allowReserved: false,
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              throw EncodingException(
+                r"deepObject style is not supported for array multipart properties (property: it's-tags).",
+              );
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
 
     // --- Enum tests ---
 
@@ -7194,7 +7389,74 @@ void main() {
               void test() {
                 final _$formData = FormData();
                 throw EncodingException(
-                  'Arrays of arrays are not supported for multipart encoding (property: matrix).',
+                  r'Arrays of arrays are not supported for multipart encoding (property: matrix).',
+                );
+                return _$formData;
+              }
+            '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'arrays-of-arrays error uses raw literal when property name '
+        'has special characters',
+        () {
+          final model = ClassModel(
+            name: 'TestForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: r'$matrix',
+                model: ListModel(
+                  content: ListModel(
+                    content: IntegerModel(context: testContext),
+                    context: testContext,
+                    examples: const [],
+                  ),
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final content = RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            encoding: {
+              r'$matrix': const MultipartPropertyEncoding(
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+              ),
+            },
+            examples: const [],
+          );
+
+          final result = buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          );
+
+          final code = emitStatements(result);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+              void test() {
+                final _$formData = FormData();
+                throw EncodingException(
+                  r'Arrays of arrays are not supported for multipart encoding (property: $matrix).',
                 );
                 return _$formData;
               }
@@ -7258,7 +7520,70 @@ void main() {
               void test() {
                 final _$formData = FormData();
                 throw EncodingException(
-                  'Unsupported contentType "application/x-www-form-urlencoded" for array multipart property "items". Only application/json is supported for content-based array serialization.',
+                  r'Unsupported contentType "application/x-www-form-urlencoded" for array multipart property "items". Only application/json is supported for content-based array serialization.',
+                );
+                return _$formData;
+              }
+            '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'unsupported contentType error uses raw literal when property name '
+        'has special characters',
+        () {
+          final model = ClassModel(
+            name: 'TestForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: "it's-items",
+                model: ListModel(
+                  content: StringModel(context: testContext),
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final content = RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            encoding: {
+              "it's-items": const MultipartPropertyEncoding(
+                contentType: ContentType.form,
+                rawContentType: 'application/x-www-form-urlencoded',
+              ),
+            },
+            examples: const [],
+          );
+
+          final result = buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          );
+
+          final code = emitStatements(result);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+              void test() {
+                final _$formData = FormData();
+                throw EncodingException(
+                  r"""Unsupported contentType "application/x-www-form-urlencoded" for array multipart property "it's-items". Only application/json is supported for content-based array serialization.""",
                 );
                 return _$formData;
               }

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -3627,7 +3627,7 @@ void main() {
                   if (value == null) continue;
                   if (value is Map || value is List) {
                     throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: address, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      'Standard URL encoding does not support nested values (property: ' r'address' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                     );
                   }
                   addressParts.add(
@@ -3715,7 +3715,7 @@ void main() {
                   if (value == null) continue;
                   if (value is Map || value is List) {
                     throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: address, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      'Standard URL encoding does not support nested values (property: ' r'address' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                     );
                   }
                   addressParts.add(
@@ -3729,6 +3729,274 @@ void main() {
                   r'address',
                   MultipartFile.fromString(
                     addressParts.join('&'),
+                    contentType: DioMediaType.parse(
+                      r'application/x-www-form-urlencoded',
+                    ),
+                  ),
+                ));
+                return _$formData;
+              }
+            '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'URL-encoded ClassModel property with single quote in rawName escapes '
+        'rawName in the EncodingException literal',
+        () {
+          final innerClass = ClassModel(
+            name: 'PersonName',
+            isDeprecated: false,
+            properties: [],
+            context: testContext,
+            examples: const [],
+          );
+
+          final model = ClassModel(
+            name: 'PersonForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: "it's-form",
+                model: innerClass,
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final content = RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            encoding: {
+              "it's-form": const MultipartPropertyEncoding(
+                contentType: ContentType.form,
+                rawContentType: 'application/x-www-form-urlencoded',
+              ),
+            },
+            examples: const [],
+          );
+
+          final result = buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          );
+
+          final code = emitStatements(result);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+              void test() {
+                final _$formData = FormData();
+                final itsFormParts = <String>[];
+                for (final entry in ((body.itsForm.toJson() as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: ' r"it's-form" ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  itsFormParts.add(
+                    [
+                      Uri.encodeQueryComponent(entry.key.toString()),
+                      Uri.encodeQueryComponent(value.toString()),
+                    ].join('='),
+                  );
+                }
+                _$formData.files.add(MapEntry(
+                  r"it's-form",
+                  MultipartFile.fromString(
+                    itsFormParts.join('&'),
+                    contentType: DioMediaType.parse(
+                      r'application/x-www-form-urlencoded',
+                    ),
+                  ),
+                ));
+                return _$formData;
+              }
+            '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'URL-encoded ClassModel property with backslash in rawName escapes '
+        'rawName in the EncodingException literal',
+        () {
+          final innerClass = ClassModel(
+            name: 'PathTo',
+            isDeprecated: false,
+            properties: [],
+            context: testContext,
+            examples: const [],
+          );
+
+          final model = ClassModel(
+            name: 'PersonForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: r'path\form',
+                model: innerClass,
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final content = RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            encoding: {
+              r'path\form': const MultipartPropertyEncoding(
+                contentType: ContentType.form,
+                rawContentType: 'application/x-www-form-urlencoded',
+              ),
+            },
+            examples: const [],
+          );
+
+          final result = buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          );
+
+          final code = emitStatements(result);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+              void test() {
+                final _$formData = FormData();
+                final pathBackslashFormParts = <String>[];
+                for (final entry
+                    in ((body.pathBackslashForm.toJson() as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: ' r'path\form' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  pathBackslashFormParts.add(
+                    [
+                      Uri.encodeQueryComponent(entry.key.toString()),
+                      Uri.encodeQueryComponent(value.toString()),
+                    ].join('='),
+                  );
+                }
+                _$formData.files.add(MapEntry(
+                  r'path\form',
+                  MultipartFile.fromString(
+                    pathBackslashFormParts.join('&'),
+                    contentType: DioMediaType.parse(
+                      r'application/x-www-form-urlencoded',
+                    ),
+                  ),
+                ));
+                return _$formData;
+              }
+            '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'URL-encoded ClassModel property with dollar sign in rawName escapes '
+        'rawName in the EncodingException literal',
+        () {
+          final innerClass = ClassModel(
+            name: 'DollarForm',
+            isDeprecated: false,
+            properties: [],
+            context: testContext,
+            examples: const [],
+          );
+
+          final model = ClassModel(
+            name: 'PersonForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: r'$total',
+                model: innerClass,
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final content = RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            encoding: {
+              r'$total': const MultipartPropertyEncoding(
+                contentType: ContentType.form,
+                rawContentType: 'application/x-www-form-urlencoded',
+              ),
+            },
+            examples: const [],
+          );
+
+          final result = buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          );
+
+          final code = emitStatements(result);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+              void test() {
+                final _$formData = FormData();
+                final $totalParts = <String>[];
+                for (final entry in ((body.$total.toJson() as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: ' r'$total' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  $totalParts.add(
+                    [
+                      Uri.encodeQueryComponent(entry.key.toString()),
+                      Uri.encodeQueryComponent(value.toString()),
+                    ].join('='),
+                  );
+                }
+                _$formData.files.add(MapEntry(
+                  r'$total',
+                  MultipartFile.fromString(
+                    $totalParts.join('&'),
                     contentType: DioMediaType.parse(
                       r'application/x-www-form-urlencoded',
                     ),
@@ -3802,7 +4070,7 @@ void main() {
                   if (value == null) continue;
                   if (value is Map || value is List) {
                     throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: address, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      'Standard URL encoding does not support nested values (property: ' r'address' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                     );
                   }
                   addressParts.add(
@@ -3984,7 +4252,7 @@ void main() {
                   if (value == null) continue;
                   if (value is Map || value is List) {
                     throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: address, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      'Standard URL encoding does not support nested values (property: ' r'address' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                     );
                   }
                   addressParts.add(
@@ -4347,7 +4615,7 @@ void main() {
                 if (value == null) continue;
                 if (value is Map || value is List) {
                   throw EncodingException(
-                    'Standard URL encoding does not support nested values (property: metadata, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    'Standard URL encoding does not support nested values (property: ' r'metadata' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                   );
                 }
                 metadataParts.add(
@@ -4434,7 +4702,7 @@ void main() {
                   if (value == null) continue;
                   if (value is Map || value is List) {
                     throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: metadata, key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      'Standard URL encoding does not support nested values (property: ' r'metadata' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
                     );
                   }
                   metadataParts.add(
@@ -4454,6 +4722,267 @@ void main() {
                   ),
                 ));
               }
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
+
+    test(
+      'URL-encoded MapModel property with single quote in rawName escapes '
+      'rawName in the EncodingException literal',
+      () {
+        final mapModel = MapModel(
+          valueModel: StringModel(context: testContext),
+          context: testContext,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          name: 'ResourceForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: "it's-meta",
+              model: mapModel,
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            "it's-meta": const MultipartPropertyEncoding(
+              contentType: ContentType.form,
+              rawContentType: 'application/x-www-form-urlencoded',
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              final itsMetaParts = <String>[];
+              for (final entry in ((body.itsMeta as Map)).entries) {
+                final value = entry.value;
+                if (value == null) continue;
+                if (value is Map || value is List) {
+                  throw EncodingException(
+                    'Standard URL encoding does not support nested values (property: ' r"it's-meta" ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                  );
+                }
+                itsMetaParts.add(
+                  [
+                    Uri.encodeQueryComponent(entry.key.toString()),
+                    Uri.encodeQueryComponent(value.toString()),
+                  ].join('='),
+                );
+              }
+              _$formData.files.add(MapEntry(
+                r"it's-meta",
+                MultipartFile.fromString(
+                  itsMetaParts.join('&'),
+                  contentType: DioMediaType.parse(
+                    r'application/x-www-form-urlencoded',
+                  ),
+                ),
+              ));
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
+
+    test(
+      'URL-encoded MapModel property with backslash in rawName escapes '
+      'rawName in the EncodingException literal',
+      () {
+        final mapModel = MapModel(
+          valueModel: StringModel(context: testContext),
+          context: testContext,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          name: 'ResourceForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: r'path\to',
+              model: mapModel,
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            r'path\to': const MultipartPropertyEncoding(
+              contentType: ContentType.form,
+              rawContentType: 'application/x-www-form-urlencoded',
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              final pathBackslashToParts = <String>[];
+              for (final entry in ((body.pathBackslashTo as Map)).entries) {
+                final value = entry.value;
+                if (value == null) continue;
+                if (value is Map || value is List) {
+                  throw EncodingException(
+                    'Standard URL encoding does not support nested values (property: ' r'path\to' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                  );
+                }
+                pathBackslashToParts.add(
+                  [
+                    Uri.encodeQueryComponent(entry.key.toString()),
+                    Uri.encodeQueryComponent(value.toString()),
+                  ].join('='),
+                );
+              }
+              _$formData.files.add(MapEntry(
+                r'path\to',
+                MultipartFile.fromString(
+                  pathBackslashToParts.join('&'),
+                  contentType: DioMediaType.parse(
+                    r'application/x-www-form-urlencoded',
+                  ),
+                ),
+              ));
+              return _$formData;
+            }
+          '''),
+          ),
+        );
+      },
+    );
+
+    test(
+      'URL-encoded MapModel property with dollar sign in rawName escapes '
+      'rawName in the EncodingException literal',
+      () {
+        final mapModel = MapModel(
+          valueModel: StringModel(context: testContext),
+          context: testContext,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          name: 'ResourceForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: r'$total',
+              model: mapModel,
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          encoding: {
+            r'$total': const MultipartPropertyEncoding(
+              contentType: ContentType.form,
+              rawContentType: 'application/x-www-form-urlencoded',
+            ),
+          },
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+            void test() {
+              final _$formData = FormData();
+              final $totalParts = <String>[];
+              for (final entry in ((body.$total as Map)).entries) {
+                final value = entry.value;
+                if (value == null) continue;
+                if (value is Map || value is List) {
+                  throw EncodingException(
+                    'Standard URL encoding does not support nested values (property: ' r'$total' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                  );
+                }
+                $totalParts.add(
+                  [
+                    Uri.encodeQueryComponent(entry.key.toString()),
+                    Uri.encodeQueryComponent(value.toString()),
+                  ].join('='),
+                );
+              }
+              _$formData.files.add(MapEntry(
+                r'$total',
+                MultipartFile.fromString(
+                  $totalParts.join('&'),
+                  contentType: DioMediaType.parse(
+                    r'application/x-www-form-urlencoded',
+                  ),
+                ),
+              ));
               return _$formData;
             }
           '''),


### PR DESCRIPTION
## Summary

- Multipart properties whose name contains `'`, `\`, or `$` no longer break codegen. Both URL-encoded fallbacks (`_buildUrlEncodedMapFileAddition`, `_buildUrlEncodedObjectFileAddition`) now route the raw name through `specLiteralStringCode`, which prefers a raw string and falls back to escaping.
- Templated server URL generation (`ServerGenerator._buildUrlExpression`) is migrated to the same helper. URLs like `https://it's-a-{env}.example.com/v1` now emit as `r"https://it's-a-" '${env}' r'.example.com/v1'` (adjacent-literal concat) rather than escaping into a single non-raw literal.
- With both callers cleaned up, `escapeForSingleQuotedDartString` becomes a private implementation detail (`_escapeForSingleQuotedDartString`) of `spec_literal_string.dart`.

## Test plan

- [x] `fvm dart analyze packages/` — clean
- [x] `to_multipart_expression_generator_test.dart` — 132/132 (existing URL-encoded expectations updated to the adjacent-concat emit; six new adversarial cases for `'`, `\`, `$` × MapModel/ClassModel)
- [x] `spec_literal_string_test.dart` — 23/23 (three direct tests of the now-private helper removed; coverage preserved by existing `specLiteralStringCode` tests that exercise the same escape paths)
- [x] `server_generator_variables_test.dart` — 27/27 (templated URL expectations updated)
- [x] `server_generator_test.dart` — 18/18 (static URL path unchanged)
- [x] `./scripts/setup_integration_tests.sh` — clean
- [x] `adversarial_strings` integration tests — 31/31, including new fixture entries for two multipart operations with quoted property names
