### PR TITLE
feat(tonik_generate): render OpenAPI examples as dartdoc

### DIFF
--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -7,6 +7,7 @@ import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/operation_parameter_generator.dart';
 import 'package:tonik_generate/src/util/response_type_generator.dart';
@@ -156,6 +157,35 @@ class ApiClientGenerator {
     final paramDocs = _generateParameterDocs(operation, nameManager);
     if (paramDocs.isNotEmpty) {
       docs.addAll(paramDocs);
+    }
+
+    final requestBody = operation.requestBody;
+    if (requestBody != null) {
+      for (final content in requestBody.resolvedContent) {
+        final exampleDocs = formatExamplesAsDocs(content.examples);
+        if (exampleDocs.isEmpty) continue;
+        docs
+          ..add('///')
+          ..add('/// Request body (${content.rawContentType}):')
+          ..addAll(exampleDocs);
+      }
+    }
+
+    final sortedResponses = operation.responses.entries.toList()
+      ..sort(_compareResponses);
+    for (final entry in sortedResponses) {
+      final resolved = entry.value.resolved;
+      for (final body in resolved.bodies) {
+        final exampleDocs = formatExamplesAsDocs(body.examples);
+        if (exampleDocs.isEmpty) continue;
+        docs
+          ..add('///')
+          ..add(
+            '/// Response ${_formatStatus(entry.key)} '
+            '(${body.rawContentType}):',
+          )
+          ..addAll(exampleDocs);
+      }
     }
 
     return Method(
@@ -446,4 +476,28 @@ class ApiClientGenerator {
       CookieParameterObject(:final description) => description,
     };
   }
+
+  String _formatStatus(ResponseStatus status) => switch (status) {
+    ExplicitResponseStatus(:final statusCode) => '$statusCode',
+    RangeResponseStatus(:final min, :final max) => '$min–$max',
+    DefaultResponseStatus() => 'default',
+  };
+
+  /// Orders explicit and range statuses by their numeric start; `default`
+  /// sorts last so the fallback case appears at the end of the doc.
+  int _compareResponses(
+    MapEntry<ResponseStatus, Response> a,
+    MapEntry<ResponseStatus, Response> b,
+  ) {
+    final aDefault = a.key is DefaultResponseStatus;
+    final bDefault = b.key is DefaultResponseStatus;
+    if (aDefault != bDefault) return aDefault ? 1 : -1;
+    return _numericStart(a.key).compareTo(_numericStart(b.key));
+  }
+
+  int _numericStart(ResponseStatus status) => switch (status) {
+    ExplicitResponseStatus(:final statusCode) => statusCode,
+    RangeResponseStatus(:final min) => min,
+    DefaultResponseStatus() => 0,
+  };
 }

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -483,8 +483,6 @@ class ApiClientGenerator {
     DefaultResponseStatus() => 'default',
   };
 
-  /// Orders explicit and range statuses by their numeric start; `default`
-  /// sorts last so the fallback case appears at the end of the doc.
   int _compareResponses(
     MapEntry<ResponseStatus, Response> a,
     MapEntry<ResponseStatus, Response> b,

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -8,8 +8,8 @@ import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/composite_guard_builders.dart';
 import 'package:tonik_generate/src/util/composite_library_builder.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_json_value_expression_generator.dart';
@@ -148,7 +148,9 @@ class AllOfGenerator {
       (b) {
         b
           ..name = actualClassName
-          ..docs.addAll(formatDocComment(model.description))
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          )
           ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
           ..implements.add(
             refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -7,8 +7,8 @@ import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/composite_guard_builders.dart';
 import 'package:tonik_generate/src/util/composite_library_builder.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_json_value_expression_generator.dart';
@@ -229,7 +229,9 @@ class AnyOfGenerator {
       (b) {
         b
           ..name = actualClassName
-          ..docs.addAll(formatDocComment(model.description))
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          )
           ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
           ..implements.add(
             refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -9,8 +9,8 @@ import 'package:tonik_generate/src/util/additional_properties_helpers.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
@@ -171,7 +171,9 @@ class ClassGenerator {
       (b) {
         b
           ..name = className
-          ..docs.addAll(formatDocComment(model.description))
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          )
           ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
           ..implements.add(
             refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),
@@ -931,7 +933,9 @@ class ClassGenerator {
   }) {
     final fieldBuilder = FieldBuilder()
       ..name = normalizedName
-      ..docs.addAll(formatDocComment(property.description))
+      ..docs.addAll(
+        formatDocsWithExamples(property.description, property.examples),
+      )
       ..modifier = FieldModifier.final$
       ..type = classModel != null
           ? _getSchemaAwareTypeReference(property, classModel)

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -6,7 +6,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
@@ -93,7 +93,9 @@ class EnumGenerator {
       (b) {
         b
           ..name = actualEnumName
-          ..docs.addAll(formatDocComment(model.description))
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          )
           ..implements.addAll([
             refer('MatrixEncodable', 'package:tonik_util/tonik_util.dart'),
             refer('LabelEncodable', 'package:tonik_util/tonik_util.dart'),

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -5,8 +5,8 @@ import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/composite_guard_builders.dart';
 import 'package:tonik_generate/src/util/composite_library_builder.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_json_value_expression_generator.dart';
@@ -94,7 +94,9 @@ class OneOfGenerator {
         b
           ..name = className
           ..sealed = true
-          ..docs.addAll(formatDocComment(model.description))
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          )
           ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
           ..implements.add(
             refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),

--- a/packages/tonik_generate/lib/src/model/typedef_generator.dart
+++ b/packages/tonik_generate/lib/src/model/typedef_generator.dart
@@ -5,7 +5,7 @@ import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
-import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/recursion_detector.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
@@ -50,7 +50,9 @@ class TypedefGenerator {
         b
           ..name = nameManager.modelName(model)
           ..definition = baseType
-          ..docs.addAll(formatDocComment(model.description));
+          ..docs.addAll(
+            formatDocsWithExamples(model.description, model.examples),
+          );
 
         if (model.isDeprecated) {
           b.annotations.add(
@@ -82,7 +84,8 @@ class TypedefGenerator {
     return TypeDef(
       (b) => b
         ..name = nameManager.modelName(model)
-        ..definition = baseType,
+        ..definition = baseType
+        ..docs.addAll(formatDocsWithExamples(null, model.examples)),
     );
   }
 
@@ -106,7 +109,8 @@ class TypedefGenerator {
     return TypeDef(
       (b) => b
         ..name = nameManager.modelName(model)
-        ..definition = baseType,
+        ..definition = baseType
+        ..docs.addAll(formatDocsWithExamples(null, model.examples)),
     );
   }
 

--- a/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
+++ b/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
@@ -1,0 +1,106 @@
+import 'dart:convert';
+
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
+
+const _jsonEncoder = JsonEncoder.withIndent('  ');
+
+/// Joins [description] doc lines with [examples] doc lines, inserting a
+/// blank `///` separator between them when both are non-empty.
+List<String> formatDocsWithExamples(
+  String? description,
+  List<Example> examples,
+) {
+  final descriptionDocs = formatDocComment(description);
+  final exampleDocs = formatExamplesAsDocs(examples);
+  return [
+    ...descriptionDocs,
+    if (descriptionDocs.isNotEmpty && exampleDocs.isNotEmpty) '///',
+    ...exampleDocs,
+  ];
+}
+
+/// Renders [examples] as `/// …` doc-comment lines for an Examples block.
+List<String> formatExamplesAsDocs(List<Example> examples) {
+  if (examples.isEmpty) return const [];
+
+  final entries = <List<String>>[];
+  for (final example in examples) {
+    final entry = _formatExample(example);
+    if (entry != null) entries.add(entry);
+  }
+
+  if (entries.isEmpty) return const [];
+
+  final result = <String>[];
+  for (var i = 0; i < entries.length; i++) {
+    if (i > 0) result.add('///');
+    result.addAll(entries[i]);
+  }
+  return result;
+}
+
+List<String>? _formatExample(Example example) {
+  final hasSummary =
+      example.summary != null && example.summary!.isNotEmpty;
+  final hasDescription =
+      example.description != null && example.description!.isNotEmpty;
+  final hasHeadingContent =
+      example.name != null || hasSummary || hasDescription;
+
+  if (example.value == null && !hasHeadingContent) return null;
+
+  final lines = <String>[_heading(example, hasSummary: hasSummary)];
+
+  if (hasDescription) {
+    for (final line in example.description!.split('\n')) {
+      lines.add(line.isEmpty ? '///' : '/// $line');
+    }
+    lines.add('///');
+  }
+
+  lines.addAll(_renderValue(example.value));
+  return lines;
+}
+
+String _heading(Example example, {required bool hasSummary}) {
+  final buf = StringBuffer('/// **Example**');
+  if (example.name != null) {
+    buf.write(' "${example.name}"');
+  }
+  if (hasSummary) {
+    buf.write(' — ${example.summary}');
+  }
+  buf.write(':');
+  return buf.toString();
+}
+
+List<String> _renderValue(Object? value) {
+  final isString = value is String;
+  final payload = isString ? value : _jsonEncoder.convert(value);
+  final fenceLang = isString ? '' : 'json';
+
+  final fenceLen = _maxBacktickRun(payload) + 1;
+  final fence = '`' * (fenceLen < 3 ? 3 : fenceLen);
+
+  final lines = <String>['/// $fence$fenceLang'];
+  for (final line in payload.split('\n')) {
+    lines.add(line.isEmpty ? '///' : '/// $line');
+  }
+  lines.add('/// $fence');
+  return lines;
+}
+
+int _maxBacktickRun(String s) {
+  var max = 0;
+  var current = 0;
+  for (var i = 0; i < s.length; i++) {
+    if (s.codeUnitAt(i) == 0x60) {
+      current++;
+      if (current > max) max = current;
+    } else {
+      current = 0;
+    }
+  }
+  return max;
+}

--- a/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
+++ b/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
@@ -5,8 +5,6 @@ import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 
 const _jsonEncoder = JsonEncoder.withIndent('  ');
 
-/// Joins [description] doc lines with [examples] doc lines, inserting a
-/// blank `///` separator between them when both are non-empty.
 List<String> formatDocsWithExamples(
   String? description,
   List<Example> examples,
@@ -20,7 +18,6 @@ List<String> formatDocsWithExamples(
   ];
 }
 
-/// Renders [examples] as `/// …` doc-comment lines for an Examples block.
 List<String> formatExamplesAsDocs(List<Example> examples) {
   if (examples.isEmpty) return const [];
 
@@ -54,7 +51,14 @@ List<String>? _formatExample(Example example) {
 
   if (hasDescription) {
     for (final line in example.description!.split('\n')) {
-      lines.add(line.isEmpty ? '///' : '/// $line');
+      if (line.isEmpty) {
+        lines.add('///');
+      } else {
+        // Escape a line that would open a markdown fenced code block,
+        // otherwise the example's own fence below would render as content.
+        final escaped = line.startsWith('```') ? r'\' + line : line;
+        lines.add('/// $escaped');
+      }
     }
     lines.add('///');
   }

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1131,6 +1131,182 @@ void main() {
       );
     });
 
+    group('body examples in method docs', () {
+      test('renders request body examples under a Request body heading', () {
+        final operation = Operation(
+          operationId: 'createUser',
+          context: testContext,
+          summary: 'Create user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: RequestBodyObject(
+            description: null,
+            isRequired: true,
+            name: 'createUser',
+            content: {
+              RequestContent(
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+                model: ClassModel(
+                  isDeprecated: false,
+                  name: 'CreateUserRequestBody',
+                  properties: const [],
+                  context: testContext,
+                  examples: const [],
+                ),
+                examples: const [
+                  Example(
+                    name: 'minimal',
+                    summary: null,
+                    description: null,
+                    value: {'name': 'alice'},
+                  ),
+                ],
+              ),
+            },
+            context: testContext,
+          ),
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        expect(method.docs, containsAllInOrder([
+          '/// Request body (application/json):',
+          '/// **Example** "minimal":',
+          '/// ```json',
+          '/// {',
+          '///   "name": "alice"',
+          '/// }',
+          '/// ```',
+        ]));
+      });
+
+      test('renders response examples grouped by status and content-type', () {
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          summary: 'Get user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{id}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: testContext,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: testContext),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [
+                    Example(
+                      name: null,
+                      summary: null,
+                      description: null,
+                      value: {'id': 1, 'name': 'alice'},
+                    ),
+                  ],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        expect(method.docs, containsAllInOrder([
+          '/// Response 200 (application/json):',
+          '/// **Example**:',
+          '/// ```json',
+          '/// {',
+          '///   "id": 1,',
+          '///   "name": "alice"',
+          '/// }',
+          '/// ```',
+        ]));
+      });
+
+      test('omits body sections when no examples are present', () {
+        final operation = Operation(
+          operationId: 'createUser',
+          context: testContext,
+          summary: 'Create user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: RequestBodyObject(
+            description: null,
+            isRequired: true,
+            name: 'createUser',
+            content: {
+              RequestContent(
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+                model: ClassModel(
+                  isDeprecated: false,
+                  name: 'CreateUserRequestBody',
+                  properties: const [],
+                  context: testContext,
+                  examples: const [],
+                ),
+                examples: const [],
+              ),
+            },
+            context: testContext,
+          ),
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        expect(
+          method.docs.any((d) => d.contains('Request body')),
+          isFalse,
+        );
+        expect(
+          method.docs.any((d) => d.contains('Response ')),
+          isFalse,
+        );
+      });
+    });
+
     group('security scheme descriptions with newlines', () {
       test('multi-line API key description produces valid doc comments', () {
         final operation = Operation(

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1183,7 +1183,9 @@ void main() {
         );
         final method = klass.methods.first;
 
-        expect(method.docs, containsAllInOrder([
+        expect(method.docs, [
+          '/// Create user',
+          '///',
           '/// Request body (application/json):',
           '/// **Example** "minimal":',
           '/// ```json',
@@ -1191,7 +1193,7 @@ void main() {
           '///   "name": "alice"',
           '/// }',
           '/// ```',
-        ]));
+        ]);
       });
 
       test('renders response examples grouped by status and content-type', () {
@@ -1240,7 +1242,9 @@ void main() {
         );
         final method = klass.methods.first;
 
-        expect(method.docs, containsAllInOrder([
+        expect(method.docs, [
+          '/// Get user',
+          '///',
           '/// Response 200 (application/json):',
           '/// **Example**:',
           '/// ```json',
@@ -1249,7 +1253,172 @@ void main() {
           '///   "name": "alice"',
           '/// }',
           '/// ```',
-        ]));
+        ]);
+      });
+
+      test('sorts response sections by status with default last', () {
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          summary: 'Get user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{id}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const DefaultResponseStatus(): ResponseObject(
+              name: null,
+              context: testContext,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: testContext),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [
+                    Example(
+                      name: null,
+                      summary: null,
+                      description: null,
+                      value: 'fallback',
+                    ),
+                  ],
+                ),
+              },
+            ),
+            const RangeResponseStatus(min: 500, max: 599): ResponseObject(
+              name: null,
+              context: testContext,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: testContext),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [
+                    Example(
+                      name: null,
+                      summary: null,
+                      description: null,
+                      value: 'server-error',
+                    ),
+                  ],
+                ),
+              },
+            ),
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: testContext,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: testContext),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [
+                    Example(
+                      name: null,
+                      summary: null,
+                      description: null,
+                      value: 'ok',
+                    ),
+                  ],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        final statusLines = method.docs
+            .where((d) => d.startsWith('/// Response '))
+            .toList();
+        expect(statusLines, [
+          '/// Response 200 (application/json):',
+          '/// Response 500–599 (application/json):',
+          '/// Response default (application/json):',
+        ]);
+      });
+
+      test('renders multiple content types on a request body', () {
+        final operation = Operation(
+          operationId: 'createUser',
+          context: testContext,
+          summary: 'Create user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: RequestBodyObject(
+            description: null,
+            isRequired: true,
+            name: 'createUser',
+            content: {
+              RequestContent(
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+                model: StringModel(context: testContext),
+                examples: const [
+                  Example(
+                    name: null,
+                    summary: null,
+                    description: null,
+                    value: 'json-form',
+                  ),
+                ],
+              ),
+              RequestContent(
+                contentType: ContentType.json,
+                rawContentType: 'application/hal+json',
+                model: StringModel(context: testContext),
+                examples: const [
+                  Example(
+                    name: null,
+                    summary: null,
+                    description: null,
+                    value: 'hal-form',
+                  ),
+                ],
+              ),
+            },
+            context: testContext,
+          ),
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        final bodyLines = method.docs
+            .where((d) => d.startsWith('/// Request body'))
+            .toList();
+        expect(bodyLines, [
+          '/// Request body (application/json):',
+          '/// Request body (application/hal+json):',
+        ]);
       });
 
       test('omits body sections when no examples are present', () {

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -196,6 +196,61 @@ void main() {
 
         expect(combinedClass.docs, isEmpty);
       });
+
+      test('renders class-level examples', () {
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'Combined',
+          models: {StringModel(context: context)},
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+          ],
+        );
+
+        final combinedClass = generator.generateClass(model);
+
+        expect(combinedClass.docs, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('appends examples after description', () {
+        final model = AllOfModel(
+          isDeprecated: false,
+          description: 'A combined model',
+          name: 'Combined',
+          models: {StringModel(context: context)},
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+          ],
+        );
+
+        final combinedClass = generator.generateClass(model);
+
+        expect(combinedClass.docs, [
+          '/// A combined model',
+          '///',
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
     });
 
     test('generates getter for mixed allOf', () {

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -187,6 +187,67 @@ void main() {
 
         expect(klass.docs, isEmpty);
       });
+
+      test('renders class-level examples', () {
+        final model = AnyOfModel(
+          isDeprecated: false,
+          name: 'FlexibleModel',
+          models: {
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+            (discriminatorValue: null, model: StringModel(context: context)),
+          },
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+          ],
+        );
+
+        final klass = generator.generateClass(model);
+
+        expect(klass.docs, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('appends examples after description', () {
+        final model = AnyOfModel(
+          isDeprecated: false,
+          description: 'A flexible model',
+          name: 'FlexibleModel',
+          models: {
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+            (discriminatorValue: null, model: StringModel(context: context)),
+          },
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+          ],
+        );
+
+        final klass = generator.generateClass(model);
+
+        expect(klass.docs, [
+          '/// A flexible model',
+          '///',
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
     });
 
     test(

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -376,6 +376,161 @@ void main() {
           expect(field.annotations, hasLength(1));
         },
       );
+
+      test('renders class-level examples', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: const [],
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: {'id': 1, 'name': 'alice'},
+            ),
+          ],
+        );
+
+        final result = generator.generateClass(model);
+
+        expect(result.docs, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// {',
+          '///   "id": 1,',
+          '///   "name": "alice"',
+          '/// }',
+          '/// ```',
+        ]);
+      });
+
+      test('appends class-level examples after description', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          description: 'A user in the system',
+          name: 'User',
+          properties: const [],
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+          ],
+        );
+
+        final result = generator.generateClass(model);
+
+        expect(result.docs, [
+          '/// A user in the system',
+          '///',
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('renders property-level examples', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [
+            Property(
+              name: 'id',
+              model: IntegerModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [
+                Example(
+                  name: null,
+                  summary: null,
+                  description: null,
+                  value: 42,
+                ),
+              ],
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final field = result.fields.first;
+
+        expect(field.docs, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// 42',
+          '/// ```',
+        ]);
+      });
+
+      test('appends property-level examples after description', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [
+            Property(
+              description: 'The unique identifier',
+              name: 'id',
+              model: IntegerModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [
+                Example(
+                  name: null,
+                  summary: null,
+                  description: null,
+                  value: 42,
+                ),
+              ],
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final field = result.fields.first;
+
+        expect(field.docs, [
+          '/// The unique identifier',
+          '///',
+          '/// **Example**:',
+          '/// ```json',
+          '/// 42',
+          '/// ```',
+        ]);
+      });
+
+      test('skips example separator when example list collapses to empty', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          description: 'A user in the system',
+          name: 'User',
+          properties: const [],
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: null,
+            ),
+          ],
+        );
+
+        final result = generator.generateClass(model);
+
+        expect(result.docs, ['/// A user in the system']);
+      });
     });
 
     test('generates currentEncodingShape getter for class with properties', () {

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -502,6 +502,69 @@ void main() {
 
         expect(generated.enumValue.docs, isEmpty);
       });
+
+      test('renders enum-level examples', () {
+        final model = EnumModel<String>(
+          isDeprecated: false,
+          name: 'Color',
+          values: {
+            const EnumEntry(value: 'red'),
+            const EnumEntry(value: 'green'),
+            const EnumEntry(value: 'blue'),
+          },
+          isNullable: false,
+          context: Context.initial(),
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 'red',
+            ),
+          ],
+        );
+
+        final generated = generator.generateEnum(model, 'Color');
+
+        expect(generated.enumValue.docs, [
+          '/// **Example**:',
+          '/// ```',
+          '/// red',
+          '/// ```',
+        ]);
+      });
+
+      test('appends examples after description', () {
+        final model = EnumModel<String>(
+          isDeprecated: false,
+          description: 'A color',
+          name: 'Color',
+          values: {
+            const EnumEntry(value: 'red'),
+          },
+          isNullable: false,
+          context: Context.initial(),
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 'red',
+            ),
+          ],
+        );
+
+        final generated = generator.generateEnum(model, 'Color');
+
+        expect(generated.enumValue.docs, [
+          '/// A color',
+          '///',
+          '/// **Example**:',
+          '/// ```',
+          '/// red',
+          '/// ```',
+        ]);
+      });
     });
 
     group('enum value name normalization', () {

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -196,6 +196,69 @@ void main() {
         expect(baseClass.docs, isEmpty);
       },
     );
+
+    test('renders sealed-class-level examples', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+        examples: const [
+          Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 1,
+          ),
+        ],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+
+      expect(baseClass.docs, [
+        '/// **Example**:',
+        '/// ```json',
+        '/// 1',
+        '/// ```',
+      ]);
+    });
+
+    test('appends examples after description', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        description: 'A flexible value',
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+        examples: const [
+          Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 1,
+          ),
+        ],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+
+      expect(baseClass.docs, [
+        '/// A flexible value',
+        '///',
+        '/// **Example**:',
+        '/// ```json',
+        '/// 1',
+        '/// ```',
+      ]);
+    });
   });
 
   test(

--- a/packages/tonik_generate/test/src/model/typedef_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/typedef_generator_test.dart
@@ -951,6 +951,122 @@ void main() {
           'typedef UserId = String;',
         );
       });
+
+      test('renders examples on alias typedef', () {
+        final model = AliasModel(
+          name: 'UserId',
+          model: StringModel(context: context),
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 'abc-123',
+            ),
+          ],
+        );
+
+        final typedef = generator.generateAliasTypedef(model);
+
+        expect(
+          typedef.accept(emitter).toString().trim(),
+          '/// **Example**:\n'
+          '/// ```\n'
+          '/// abc-123\n'
+          '/// ```\n'
+          'typedef UserId = String;',
+        );
+      });
+
+      test('appends examples after description on alias typedef', () {
+        final model = AliasModel(
+          name: 'UserId',
+          model: StringModel(context: context),
+          context: context,
+          description: 'A user id.',
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: 'abc-123',
+            ),
+          ],
+        );
+
+        final typedef = generator.generateAliasTypedef(model);
+
+        expect(
+          typedef.accept(emitter).toString().trim(),
+          '/// A user id.\n'
+          '///\n'
+          '/// **Example**:\n'
+          '/// ```\n'
+          '/// abc-123\n'
+          '/// ```\n'
+          'typedef UserId = String;',
+        );
+      });
+
+      test('renders examples on list typedef', () {
+        final model = ListModel(
+          name: 'Tags',
+          content: StringModel(context: context),
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: ['red', 'green'],
+            ),
+          ],
+        );
+
+        final typedef = generator.generateListTypedef(model);
+
+        expect(
+          typedef.accept(emitter).toString().trim(),
+          '/// **Example**:\n'
+          '/// ```json\n'
+          '/// [\n'
+          '///   "red",\n'
+          '///   "green"\n'
+          '/// ]\n'
+          '/// ```\n'
+          'typedef Tags = List<String>;',
+        );
+      });
+
+      test('renders examples on map typedef', () {
+        final model = MapModel(
+          name: 'Scores',
+          valueModel: IntegerModel(context: context),
+          context: context,
+          examples: const [
+            Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: {'a': 1},
+            ),
+          ],
+        );
+
+        final typedef = generator.generateMapTypedef(model);
+
+        expect(
+          typedef.accept(emitter).toString().trim(),
+          '/// **Example**:\n'
+          '/// ```json\n'
+          '/// {\n'
+          '///   "a": 1\n'
+          '/// }\n'
+          '/// ```\n'
+          'typedef Scores = Map<String,int>;',
+        );
+      });
     });
 
     group('useImmutableCollections', () {

--- a/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
+++ b/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
@@ -83,6 +83,22 @@ void main() {
 
         expect(result.first, '/// **Example** "admin":');
       });
+
+      test('passes through markdown-special chars in name and summary', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'a "quoted" name',
+            summary: 'has *stars* and `ticks`',
+            description: null,
+            value: 1,
+          ),
+        ]);
+
+        expect(
+          result.first,
+          '/// **Example** "a "quoted" name" — has *stars* and `ticks`:',
+        );
+      });
     });
 
     group('description', () {
@@ -139,6 +155,29 @@ void main() {
 
         expect(result, [
           '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('escapes a description line that opens a markdown fence', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: 'See:\n```json\n{"x":1}\n```',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// See:',
+          r'/// \```json',
+          '/// {"x":1}',
+          r'/// \```',
+          '///',
           '/// ```json',
           '/// 1',
           '/// ```',

--- a/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
+++ b/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
@@ -1,0 +1,433 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/example_doc_formatter.dart';
+
+void main() {
+  group('formatExamplesAsDocs', () {
+    test('returns empty list when given no examples', () {
+      expect(formatExamplesAsDocs(const []), isEmpty);
+    });
+
+    group('headings', () {
+      test('renders bare Example heading when name/summary absent', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'hi',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```',
+          '/// hi',
+          '/// ```',
+        ]);
+      });
+
+      test('includes name in heading when set', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'admin',
+            summary: null,
+            description: null,
+            value: 42,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example** "admin":',
+          '/// ```json',
+          '/// 42',
+          '/// ```',
+        ]);
+      });
+
+      test('appends summary after em dash when set', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'admin',
+            summary: 'an admin user',
+            description: null,
+            value: 1,
+          ),
+        ]);
+
+        expect(result.first, '/// **Example** "admin" — an admin user:');
+      });
+
+      test('renders summary without name', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: 'happy path',
+            description: null,
+            value: 1,
+          ),
+        ]);
+
+        expect(result.first, '/// **Example** — happy path:');
+      });
+
+      test('treats empty summary as absent', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'admin',
+            summary: '',
+            description: null,
+            value: 1,
+          ),
+        ]);
+
+        expect(result.first, '/// **Example** "admin":');
+      });
+    });
+
+    group('description', () {
+      test('renders description block between heading and code fence', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: 'A typical admin user.',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// A typical admin user.',
+          '///',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('prefixes each description line', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: 'line one\nline two',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// line one',
+          '/// line two',
+          '///',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('treats empty description as absent', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: '',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+    });
+
+    group('value rendering', () {
+      test('renders string value in an untagged fence', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'plain text',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```',
+          '/// plain text',
+          '/// ```',
+        ]);
+      });
+
+      test('renders multi-line string value with each line prefixed', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'first\nsecond',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```',
+          '/// first',
+          '/// second',
+          '/// ```',
+        ]);
+      });
+
+      test('renders int value as JSON', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 42,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// 42',
+          '/// ```',
+        ]);
+      });
+
+      test('renders bool value as JSON', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: true,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// true',
+          '/// ```',
+        ]);
+      });
+
+      test('renders list value as pretty JSON', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: [1, 2, 3],
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// [',
+          '///   1,',
+          '///   2,',
+          '///   3',
+          '/// ]',
+          '/// ```',
+        ]);
+      });
+
+      test('renders map value as pretty JSON', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: {'id': 1, 'name': 'alice'},
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```json',
+          '/// {',
+          '///   "id": 1,',
+          '///   "name": "alice"',
+          '/// }',
+          '/// ```',
+        ]);
+      });
+
+      test(
+        'renders explicit-null value as JSON null when heading is present',
+        () {
+          final result = formatExamplesAsDocs([
+            const Example(
+              name: 'absent',
+              summary: null,
+              description: null,
+              value: null,
+            ),
+          ]);
+
+          expect(result, [
+            '/// **Example** "absent":',
+            '/// ```json',
+            '/// null',
+            '/// ```',
+          ]);
+        },
+      );
+
+      test(
+        'skips an example whose value is null and has no other metadata',
+        () {
+          final result = formatExamplesAsDocs([
+            const Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: null,
+            ),
+          ]);
+
+          expect(result, isEmpty);
+        },
+      );
+    });
+
+    group('fence escaping', () {
+      test('uses a longer fence when value contains a triple-backtick run', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'before ``` after',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ````',
+          '/// before ``` after',
+          '/// ````',
+        ]);
+      });
+
+      test('uses a fence one longer than the longest backtick run', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'a ```` b',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// `````',
+          '/// a ```` b',
+          '/// `````',
+        ]);
+      });
+    });
+
+    group('multiple examples', () {
+      test(
+        'separates entries with a blank /// line and preserves source order',
+        () {
+          final result = formatExamplesAsDocs([
+            const Example(
+              name: 'a',
+              summary: null,
+              description: null,
+              value: 1,
+            ),
+            const Example(
+              name: 'b',
+              summary: null,
+              description: null,
+              value: 2,
+            ),
+          ]);
+
+          expect(result, [
+            '/// **Example** "a":',
+            '/// ```json',
+            '/// 1',
+            '/// ```',
+            '///',
+            '/// **Example** "b":',
+            '/// ```json',
+            '/// 2',
+            '/// ```',
+          ]);
+        },
+      );
+
+      test('omits skipped null-only entries from the output', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'kept',
+            summary: null,
+            description: null,
+            value: 1,
+          ),
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: null,
+          ),
+          const Example(
+            name: 'also-kept',
+            summary: null,
+            description: null,
+            value: 2,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example** "kept":',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+          '///',
+          '/// **Example** "also-kept":',
+          '/// ```json',
+          '/// 2',
+          '/// ```',
+        ]);
+      });
+
+      test(
+        'returns empty list when every entry is skipped',
+        () {
+          final result = formatExamplesAsDocs([
+            const Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: null,
+            ),
+            const Example(
+              name: null,
+              summary: null,
+              description: null,
+              value: null,
+            ),
+          ]);
+
+          expect(result, isEmpty);
+        },
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Parse-side example/examples plumbing (#142, #145) was previously generator-invisible — all generators constructed core models with `examples: const []` and emitted no doc output. This PR wires `List<Example>` through to dartdoc on every model symbol and on operation method docs in the api_client.

### What renders, and where

| Site | Generator |
|---|---|
| Class top + per-field | `class_generator.dart` |
| Enum class-level | `enum_generator.dart` |
| AllOf / AnyOf / OneOf class-level | `all_of_generator.dart`, `any_of_generator.dart`, `one_of_generator.dart` |
| Alias / List / Map typedef | `typedef_generator.dart` |
| Operation method (Request body + Response, grouped by content-type) | `api_client_generator.dart` |

### Output shape

```
/// **Example**[ "name"][ — summary]:
/// description (multi-line `/// `-prefixed)
///
/// ```json
/// <pretty-printed JSON value>
/// ```
```

- String values use an untagged fence; non-string values use `json` with two-space indent.
- Fence length grows to one more than the longest backtick run in the payload, so spec-embedded code fences cannot break out.
- Examples whose value is `null` and carry no name/summary/description are dropped.
- Multiple entries on one symbol are separated by a blank `///` line.
- For api_client: responses sorted by status (default last); only emitted when examples exist on that body/content.

### Shared helper

`formatDocsWithExamples(description, examples)` joins description + example doc blocks with a `///` separator when both are present; all eight call sites use it.

### Out of scope (follow-up PR)

- Parameter-level examples (path/query/header/cookie param docs)
- Heading-noise cleanup once real-spec output is observed at scale

### Real-spec samples to eyeball

- `petstore` `pet.dart` — primitive field examples + description-then-example combination
- `asana` `tasks_api.dart::addProjectForTask` — four named examples on one request body
- `asana` `project_base_color_model.dart` — typedef alias with enum description + example
- `medama` `event_api.dart` — operation-level `Response 200 (text/plain)` example block

## Test plan

- [x] 22 unit tests for the new helper (`example_doc_formatter_test.dart`) — heading shapes, description block, value rendering (string/number/bool/list/map/null), fence escaping for embedded backticks, multi-example layout, skipped-entry behaviour
- [x] 17 new generator tests covering each wired site (class, property, enum, all_of, any_of, one_of, alias/list/map typedef, api_client request body + response)
- [x] Full `tonik_generate` suite: 2560/2560 pass
- [x] `fvm dart analyze packages/tonik_generate` clean
- [x] Regenerated all integration tests via `./scripts/setup_integration_tests.sh`; analyzed `ref_siblings_api`, `petstore_api`, `medama_api`, `asana_api`, `cloudflare_api` — clean
- [x] Ran integration suites: `ref_siblings` (49 tests), `petstore` (65 tests), `medama` (373 tests) — all pass
