### PR TITLE
feat(tonik_generate): render parameter examples in api_client docs

### DIFF
--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -159,6 +159,14 @@ class ApiClientGenerator {
       docs.addAll(paramDocs);
     }
 
+    final paramExampleDocs = _generateParameterExampleDocs(operation);
+    if (paramExampleDocs.isNotEmpty) {
+      docs
+        ..add('///')
+        ..add('/// Parameter examples:')
+        ..addAll(paramExampleDocs);
+    }
+
     final requestBody = operation.requestBody;
     if (requestBody != null) {
       for (final content in requestBody.resolvedContent) {
@@ -443,6 +451,80 @@ class ApiClientGenerator {
     }
 
     return docs;
+  }
+
+  List<String> _generateParameterExampleDocs(Operation operation) {
+    final hasRequestBody =
+        operation.requestBody?.resolvedContent.isNotEmpty ?? false;
+
+    final normalizedParams = normalizeRequestParameters(
+      pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
+      queryParameters: operation.queryParameters
+          .map((p) => p.resolve())
+          .toSet(),
+      headers: operation.headers.map((p) => p.resolve()).toSet(),
+      cookieParameters: operation.cookieParameters
+          .map((p) => p.resolve())
+          .toSet(),
+      reservedNames: operationReservedParameterNames(
+        hasRequestBody: hasRequestBody,
+      ),
+    );
+
+    final paramExamplesByOriginalName = <String, List<Example>>{};
+    for (final param in operation.pathParameters) {
+      final resolved = param.resolve();
+      if (resolved.examples.isNotEmpty && resolved.name != null) {
+        paramExamplesByOriginalName[resolved.name!] = resolved.examples;
+      }
+    }
+    for (final param in operation.queryParameters) {
+      final resolved = param.resolve();
+      if (resolved.examples.isNotEmpty && resolved.name != null) {
+        paramExamplesByOriginalName[resolved.name!] = resolved.examples;
+      }
+    }
+    for (final param in operation.headers) {
+      final resolved = param.resolve();
+      if (resolved.examples.isNotEmpty && resolved.name != null) {
+        paramExamplesByOriginalName[resolved.name!] = resolved.examples;
+      }
+    }
+    for (final param in operation.cookieParameters) {
+      final resolved = param.resolve();
+      if (resolved.examples.isNotEmpty && resolved.name != null) {
+        paramExamplesByOriginalName[resolved.name!] = resolved.examples;
+      }
+    }
+
+    final result = <String>[];
+    var first = true;
+    void appendIfExamples(String? originalName, String normalizedName) {
+      if (originalName == null) return;
+      final examples = paramExamplesByOriginalName[originalName];
+      if (examples == null || examples.isEmpty) return;
+      final exampleDocs = formatExamplesAsDocs(examples);
+      if (exampleDocs.isEmpty) return;
+      if (!first) result.add('///');
+      first = false;
+      result
+        ..add('/// [$normalizedName]:')
+        ..addAll(exampleDocs);
+    }
+
+    for (final p in normalizedParams.pathParameters) {
+      appendIfExamples(p.parameter.name, p.normalizedName);
+    }
+    for (final p in normalizedParams.queryParameters) {
+      appendIfExamples(p.parameter.name, p.normalizedName);
+    }
+    for (final p in normalizedParams.headers) {
+      appendIfExamples(p.parameter.name, p.normalizedName);
+    }
+    for (final p in normalizedParams.cookieParameters) {
+      appendIfExamples(p.parameter.name, p.normalizedName);
+    }
+    return result;
   }
 
   String? _getPathParameterDescription(PathParameter param) {

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1421,6 +1421,198 @@ void main() {
         ]);
       });
 
+      test('renders parameter examples in a Parameter examples block', () {
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          summary: 'Get user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{userId}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: {
+            QueryParameterObject(
+              name: 'limit',
+              rawName: 'limit',
+              description: 'Max results.',
+              isRequired: false,
+              isDeprecated: false,
+              allowEmptyValue: false,
+              allowReserved: false,
+              explode: false,
+              model: IntegerModel(context: testContext),
+              encoding: QueryParameterEncoding.form,
+              context: testContext,
+              examples: const [
+                Example(
+                  name: null,
+                  summary: null,
+                  description: null,
+                  value: 100,
+                ),
+              ],
+            ),
+          },
+          pathParameters: {
+            PathParameterObject(
+              name: 'userId',
+              rawName: 'userId',
+              description: 'The user id.',
+              isRequired: true,
+              isDeprecated: false,
+              allowEmptyValue: false,
+              explode: false,
+              model: StringModel(context: testContext),
+              encoding: PathParameterEncoding.simple,
+              context: testContext,
+              examples: const [
+                Example(
+                  name: 'admin',
+                  summary: null,
+                  description: null,
+                  value: 'abc-123',
+                ),
+              ],
+            ),
+          },
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        expect(method.docs, [
+          '/// Get user',
+          '/// [userId] The user id.',
+          '/// [limit] Max results.',
+          '///',
+          '/// Parameter examples:',
+          '/// [userId]:',
+          '/// **Example** "admin":',
+          '/// ```',
+          '/// abc-123',
+          '/// ```',
+          '///',
+          '/// [limit]:',
+          '/// **Example**:',
+          '/// ```json',
+          '/// 100',
+          '/// ```',
+        ]);
+      });
+
+      test(
+        'emits parameter examples even when the parameter has no description',
+        () {
+          final operation = Operation(
+            operationId: 'getUser',
+            context: testContext,
+            summary: 'Get user',
+            tags: {Tag(name: 'users')},
+            isDeprecated: false,
+            path: '/users/{userId}',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: {
+              PathParameterObject(
+                name: 'userId',
+                rawName: 'userId',
+                description: null,
+                isRequired: true,
+                isDeprecated: false,
+                allowEmptyValue: false,
+                explode: false,
+                model: StringModel(context: testContext),
+                encoding: PathParameterEncoding.simple,
+                context: testContext,
+                examples: const [
+                  Example(
+                    name: null,
+                    summary: null,
+                    description: null,
+                    value: 'abc-123',
+                  ),
+                ],
+              ),
+            },
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final klass = generator.generateClass(
+            {operation},
+            Tag(name: 'users'),
+            testServers,
+          );
+          final method = klass.methods.first;
+
+          expect(method.docs, [
+            '/// Get user',
+            '///',
+            '/// Parameter examples:',
+            '/// [userId]:',
+            '/// **Example**:',
+            '/// ```',
+            '/// abc-123',
+            '/// ```',
+          ]);
+        },
+      );
+
+      test('omits the Parameter examples block when no params carry examples',
+          () {
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          summary: 'Get user',
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{userId}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: {
+            PathParameterObject(
+              name: 'userId',
+              rawName: 'userId',
+              description: 'The user id.',
+              isRequired: true,
+              isDeprecated: false,
+              allowEmptyValue: false,
+              explode: false,
+              model: StringModel(context: testContext),
+              encoding: PathParameterEncoding.simple,
+              context: testContext,
+              examples: const [],
+            ),
+          },
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final klass = generator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final method = klass.methods.first;
+
+        expect(
+          method.docs.any((d) => d.contains('Parameter examples')),
+          isFalse,
+        );
+      });
+
       test('omits body sections when no examples are present', () {
         final operation = Operation(
           operationId: 'createUser',


### PR DESCRIPTION
## Summary

Follow-up to #147 (which lands example dartdoc on every model symbol + operation request/response bodies). This PR closes the remaining gap: **parameter examples** — path, query, header, and cookie parameters now render their examples in api_client method docs.

## Output shape

```
/// Get user
/// [userId] The user id.
/// [limit] Max results.
///
/// Parameter examples:
/// [userId]:
/// **Example** "admin":
/// ```
/// abc-123
/// ```
///
/// [limit]:
/// **Example**:
/// ```json
/// 100
/// ```
///
/// Request body (application/json):
/// ...
```

The block sits between parameter descriptions and request body / response sections so each `[paramName]` resolves against the method's parameter list. The whole block is omitted when no parameter carries examples. Parameters with examples but no description still emit (the bracket marker is sufficient attribution).

## Why a separate section instead of inline

OpenAPI parameter examples include not just scalar values but also named-and-summarized examples (e.g., a header with three named auth-token shapes). Inlining loses that structure. The labeled block format mirrors how the same PR already renders `Request body (...)` and `Response N (...)` sections — one consistent pattern across all example sources.

## Real-spec samples to eyeball

After regenerating integration tests, parameter example blocks appear in:

- `integration_test/medama/medama_api/lib/src/api_client/website_api.dart` — cookie param with an inline session-token example
- `integration_test/medama/medama_api/lib/src/api_client/authentication_api.dart`, `stats_api.dart`, `user_api.dart`
- `integration_test/github/github_api/lib/src/api_client/*.dart` — many endpoints
- `integration_test/cloudflare/cloudflare_api/lib/src/api_client/default_api.dart`

## Test plan

- [x] 3 new api_client tests: full method.docs assertion with mixed path + query params; emission when description is null; omission when no params carry examples
- [x] Full `tonik_generate` suite: 2567/2567 pass (was 2564 — +3 new)
- [x] `fvm dart analyze packages/tonik_generate` clean
- [x] Regenerated all integration tests; analyzed `medama_api`, `cloudflare_api`, `github_api` — clean
- [x] Ran `melos run test-integration-medama` — 373/373 pass

## Merge note

Targets `feat/openapi-examples-dartdoc` (#147) so the diff shows only the incremental change; will retarget to `main` once #147 lands.
