### PR TITLE
docs(features): document OpenAPI example dartdoc rendering

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -33,6 +33,7 @@ Tonik is a Dart code generator for OpenAPI 3 specifications. This document provi
     - [Composition](#composition)
     - [Supported Features](#supported-features)
     - [Not Supported](#not-supported)
+    - [Examples](#examples)
   - [Parameters](#parameters)
     - [Locations](#locations)
     - [Encoding Styles](#encoding-styles)
@@ -204,6 +205,7 @@ See [Composite Data Types](composite_data_types.md) for usage examples.
 | `nullable` / `type: [T, null]` | ✅ |
 | `required` array | ✅ |
 | `description` | ✅ (preserved in docs) |
+| `example` / `examples` | ✅ (rendered as dartdoc — see [Examples](#examples)) |
 | `deprecated` | ✅ (configurable) |
 | String & integer enums | ✅ |
 | `x-dart-enum` | ✅ |
@@ -218,6 +220,12 @@ See [Composite Data Types](composite_data_types.md) for usage examples.
 ### Not Supported
 
 Validation constraints (`minimum`, `maximum`, `pattern`, `minLength`, etc.) are parsed but not enforced at runtime. See [Roadmap](roadmap.md) for planned features.
+
+### Examples
+
+Tonik renders OpenAPI examples into dartdoc so they surface in the IDE and in `dart doc` output. Coverage: schema-level `example` (3.0) and `examples` (3.1 array), the named `examples` map at MediaType / Parameter / Header level, `$ref` into `components.examples` with OAS 3.1+ Reference-sibling overrides, and OAS 3.2's `dataValue`.
+
+Examples render on every class, enum, typedef, composite, and property, and on api_client method docs as `Parameter examples`, `Request body`, and `Response NNN` sections. `externalValue` URL fetching is not supported (see [Roadmap](roadmap.md) Non-goals).
 
 ---
 


### PR DESCRIPTION
## Summary

Documents the example dartdoc rendering added in #147 (schema / typedef / composite / operation request+response) and #148 (parameter examples). Three small edits to `docs/features.md`:

1. New entry in the TOC under Schema Features.
2. New row in the **Supported Features** table — `example` / `examples` ✅, linking to the subsection.
3. New **Examples** subsection (two paragraphs): coverage of all four spec mechanisms (schema-level singular + plural array, named map at MediaType/Parameter/Header, `$ref` into `components.examples` with sibling overrides, OAS 3.2 `dataValue`), the list of rendering targets, and the `externalValue`-not-supported caveat with a Roadmap link.

## Test plan

- [x] Markdown renders correctly (preview-checked).
- [x] Anchors resolve: `#examples` matches the new heading, `roadmap.md` link unchanged.

## Merge note

Targets `feat/openapi-examples-parameter-docs` (#148) so the diff shows only the docs change; will retarget to `main` once #148 and #147 land.
