### PR TITLE
feat: apply primitive defaults to operation parameters

### DIFF
--- a/integration_test/defaulted_primitives/defaulted_primitives_test/test/defaulted_parameters_test.dart
+++ b/integration_test/defaulted_primitives/defaulted_primitives_test/test/defaulted_parameters_test.dart
@@ -1,0 +1,112 @@
+import 'package:defaulted_primitives_api/defaulted_primitives_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+
+Dio _newDio({required void Function(RequestOptions) onRequest}) {
+  final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+  dio.interceptors.add(
+    InterceptorsWrapper(
+      onRequest: (options, handler) {
+        onRequest(options);
+        handler.reject(
+          DioException(
+            requestOptions: options,
+            type: DioExceptionType.cancel,
+          ),
+        );
+      },
+    ),
+  );
+  return dio;
+}
+
+void main() {
+  group('operation parameter defaults — public static const accessors', () {
+    test('query string default is reachable', () {
+      expect(ListThings.regionDefault, 'us');
+    });
+
+    test('required-with-default query integer default is reachable', () {
+      expect(ListThings.pageDefault, 1);
+    });
+
+    test('header integer default is reachable', () {
+      expect(ListThings.retriesDefault, 5);
+    });
+
+    test('cookie boolean default is reachable', () {
+      expect(ListThings.trackingDefault, isFalse);
+    });
+
+    test('path string default is reachable', () {
+      expect(GetThing.idDefault, 'x');
+    });
+  });
+
+  group('operation call() with no arguments uses defaults', () {
+    test(
+      'omitted query/header/cookie parameters serialise the default values',
+      () async {
+        RequestOptions? captured;
+        final dio = _newDio(onRequest: (o) => captured = o);
+
+        await ListThings(dio).call();
+
+        final options = captured!;
+        final uri = options.uri;
+
+        expect(uri.queryParameters['region'], 'us');
+        expect(uri.queryParameters['page'], '1');
+
+        final headers = options.headers;
+        expect(headers['X-Retries'], '5');
+
+        final cookie = headers['Cookie']! as String;
+        expect(cookie, contains('tracking=false'));
+      },
+    );
+
+    test(
+      'omitted path parameter substitutes the default into the URL template',
+      () async {
+        RequestOptions? captured;
+        final dio = _newDio(onRequest: (o) => captured = o);
+
+        await GetThing(dio).call();
+
+        expect(captured!.uri.path, endsWith('/things/x'));
+      },
+    );
+  });
+
+  group('operation call() with explicit args overrides defaults', () {
+    test('explicit query/header/cookie values replace the defaults', () async {
+      RequestOptions? captured;
+      final dio = _newDio(onRequest: (o) => captured = o);
+
+      await ListThings(dio).call(
+        region: 'eu',
+        page: 7,
+        retries: 9,
+        tracking: true,
+      );
+
+      final options = captured!;
+      final uri = options.uri;
+
+      expect(uri.queryParameters['region'], 'eu');
+      expect(uri.queryParameters['page'], '7');
+      expect(options.headers['X-Retries'], '9');
+      expect(options.headers['Cookie']! as String, contains('tracking=true'));
+    });
+
+    test('explicit path value replaces the default in the URL', () async {
+      RequestOptions? captured;
+      final dio = _newDio(onRequest: (o) => captured = o);
+
+      await GetThing(dio).call(id: 'custom');
+
+      expect(captured!.uri.path, endsWith('/things/custom'));
+    });
+  });
+}

--- a/integration_test/defaulted_primitives/openapi.yaml
+++ b/integration_test/defaulted_primitives/openapi.yaml
@@ -27,6 +27,63 @@ paths:
                 properties:
                   status:
                     type: string
+  /things:
+    get:
+      operationId: listThings
+      summary: List things with defaulted parameters
+      parameters:
+        - name: region
+          in: query
+          schema:
+            type: string
+            default: "us"
+        - name: page
+          in: query
+          required: true
+          schema:
+            type: integer
+            default: 1
+        - name: X-Retries
+          in: header
+          schema:
+            type: integer
+            default: 5
+        - name: tracking
+          in: cookie
+          schema:
+            type: boolean
+            default: false
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  ok:
+                    type: boolean
+  /things/{id}:
+    get:
+      operationId: getThing
+      summary: Get a single thing with defaulted path parameter
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+            default: "x"
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id:
+                    type: string
 
 components:
   schemas:

--- a/integration_test/medama/medama_test/test/stats_api_test.dart
+++ b/integration_test/medama/medama_test/test/stats_api_test.dart
@@ -38,8 +38,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdSummaryResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/summary',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/summary',
         );
       });
 
@@ -141,7 +141,8 @@ void main() {
         expect(uri.queryParameters['end'], isNotNull);
       });
 
-      test('omits optional parameters when not provided', () async {
+      test('omits non-defaulted optional parameters when not provided '
+          'and applies the schema default for previous', () async {
         final api = buildStatsApi(responseStatus: '200');
 
         final response = await api.getWebsiteIdSummary(
@@ -151,7 +152,7 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdSummaryResponse>;
         final uri = success.response.requestOptions.uri;
-        expect(uri.queryParameters.containsKey('previous'), isFalse);
+        expect(uri.queryParameters['previous'], 'false');
         expect(uri.queryParameters.containsKey('interval'), isFalse);
         expect(uri.queryParameters.containsKey('start'), isFalse);
         expect(uri.queryParameters.containsKey('end'), isFalse);
@@ -318,8 +319,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdPagesResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/pages',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/pages',
         );
       });
 
@@ -505,8 +506,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdTimeResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/time',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/time',
         );
       });
 
@@ -648,8 +649,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdReferrersResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/referrers',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/referrers',
         );
       });
 
@@ -685,12 +686,12 @@ void main() {
         final response = await api.getWebsiteIdReferrers(
           meSess: 'test_session',
           hostname: 'example.com',
-          grouped: true,
+          grouped: false,
         );
 
         final success = response as TonikSuccess<GetWebsiteIdReferrersResponse>;
         final uri = success.response.requestOptions.uri;
-        expect(uri.queryParameters['grouped'], 'true');
+        expect(uri.queryParameters['grouped'], 'false');
       });
     });
 
@@ -845,8 +846,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdSourcesResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/sources',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/sources',
         );
       });
 
@@ -1020,8 +1021,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdMediumsResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/mediums',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/mediums',
         );
       });
 
@@ -1195,8 +1196,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdCampaignsResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/campaigns',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/campaigns',
         );
       });
 
@@ -1376,8 +1377,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdBrowsersResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/browsers',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/browsers',
         );
       });
 
@@ -1557,8 +1558,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdOsResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/os',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/os',
         );
       });
 
@@ -1714,8 +1715,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdDeviceResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/devices',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/devices',
         );
       });
 
@@ -1889,8 +1890,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdCountryResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/countries',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/countries',
         );
       });
 
@@ -2064,8 +2065,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsiteIdLanguageResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/website/example.com/languages',
+          success.response.requestOptions.uri.path,
+          '/website/example.com/languages',
         );
       });
 

--- a/integration_test/medama/medama_test/test/website_api_test.dart
+++ b/integration_test/medama/medama_test/test/website_api_test.dart
@@ -35,8 +35,8 @@ void main() {
 
         final success = response as TonikSuccess<GetWebsitesResponse>;
         expect(
-          success.response.requestOptions.path,
-          '$baseUrl/websites',
+          success.response.requestOptions.uri.path,
+          '/websites',
         );
       });
 
@@ -86,14 +86,14 @@ void main() {
         expect(uri.queryParameters['summary'], 'false');
       });
 
-      test('summary is omitted when not provided', () async {
+      test('summary defaults to false when not provided', () async {
         final api = buildWebsiteApi(responseStatus: '200');
 
         final response = await api.getWebsites(meSess: 'test_session');
 
         final success = response as TonikSuccess<GetWebsitesResponse>;
         final uri = success.response.requestOptions.uri;
-        expect(uri.queryParameters.containsKey('summary'), isFalse);
+        expect(uri.queryParameters['summary'], 'false');
       });
     });
 

--- a/integration_test/openai/openai_test/test/openai_test.dart
+++ b/integration_test/openai/openai_test/test/openai_test.dart
@@ -196,7 +196,7 @@ void main() {
       expect(uri.queryParameters['limit'], '10');
     });
 
-    test('list_files 200 no params', () async {
+    test('list_files 200 applies schema default for limit', () async {
       final op = ListFiles(buildDio(responseStatus: '200'));
 
       final result = await op();
@@ -207,7 +207,10 @@ void main() {
 
       final uri = success.response.requestOptions.uri;
       expect(uri.path, '/v1/files');
-      expect(uri.queryParameters, isEmpty);
+      expect(uri.queryParameters['limit'], '10000');
+      expect(uri.queryParameters.containsKey('purpose'), isFalse);
+      expect(uri.queryParameters.containsKey('order'), isFalse);
+      expect(uri.queryParameters.containsKey('after'), isFalse);
     });
   });
 
@@ -258,27 +261,31 @@ void main() {
       expect(uri.queryParameters['limit'], '5');
     });
 
-    test('list_fine_tuning_events 200 no query params', () async {
-      final op = ListFineTuningEvents(
-        buildDio(responseStatus: '200'),
-      );
+    test(
+      'list_fine_tuning_events 200 applies schema default for limit',
+      () async {
+        final op = ListFineTuningEvents(
+          buildDio(responseStatus: '200'),
+        );
 
-      final result = await op(fineTuningJobId: 'ftjob-abc123');
+        final result = await op(fineTuningJobId: 'ftjob-abc123');
 
-      expect(
-        result,
-        isA<TonikSuccess<ListFineTuningJobEventsResponse>>(),
-      );
-      final success = result as TonikSuccess<ListFineTuningJobEventsResponse>;
-      expect(success.response.statusCode, 200);
+        expect(
+          result,
+          isA<TonikSuccess<ListFineTuningJobEventsResponse>>(),
+        );
+        final success = result as TonikSuccess<ListFineTuningJobEventsResponse>;
+        expect(success.response.statusCode, 200);
 
-      final uri = success.response.requestOptions.uri;
-      expect(
-        uri.path,
-        '/v1/fine_tuning/jobs/ftjob-abc123/events',
-      );
-      expect(uri.queryParameters, isEmpty);
-    });
+        final uri = success.response.requestOptions.uri;
+        expect(
+          uri.path,
+          '/v1/fine_tuning/jobs/ftjob-abc123/events',
+        );
+        expect(uri.queryParameters['limit'], '20');
+        expect(uri.queryParameters.containsKey('after'), isFalse);
+      },
+    );
   });
 
   // ── POST /fine_tuning/jobs/{id}/cancel (CancelFineTuningJob) ─────────

--- a/packages/tonik_core/lib/src/model/cookie_parameter.dart
+++ b/packages/tonik_core/lib/src/model/cookie_parameter.dart
@@ -111,8 +111,6 @@ class CookieParameterObject extends CookieParameter {
 
   Object? defaultValue;
 
-  /// The parameter's own [defaultValue] when set, otherwise the default
-  /// carried by its [model] when that model is an [AliasModel] chain.
   Object? get effectiveDefaultValue {
     if (defaultValue != null) return defaultValue;
     final m = model;

--- a/packages/tonik_core/lib/src/model/cookie_parameter.dart
+++ b/packages/tonik_core/lib/src/model/cookie_parameter.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 /// Encoding styles supported for cookie parameters.

--- a/packages/tonik_core/lib/src/model/cookie_parameter.dart
+++ b/packages/tonik_core/lib/src/model/cookie_parameter.dart
@@ -111,6 +111,14 @@ class CookieParameterObject extends CookieParameter {
 
   Object? defaultValue;
 
+  /// The parameter's own [defaultValue] when set, otherwise the default
+  /// carried by its [model] when that model is an [AliasModel] chain.
+  Object? get effectiveDefaultValue {
+    if (defaultValue != null) return defaultValue;
+    final m = model;
+    return m is AliasModel ? m.defaultValue : null;
+  }
+
   @override
   String toString() =>
       'CookieParameter{name: $name, nameOverride: $nameOverride, '

--- a/packages/tonik_core/lib/src/model/cookie_parameter.dart
+++ b/packages/tonik_core/lib/src/model/cookie_parameter.dart
@@ -111,11 +111,7 @@ class CookieParameterObject extends CookieParameter {
 
   Object? defaultValue;
 
-  Object? get effectiveDefaultValue {
-    if (defaultValue != null) return defaultValue;
-    final m = model;
-    return m is AliasModel ? m.defaultValue : null;
-  }
+  Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/model/effective_default.dart
+++ b/packages/tonik_core/lib/src/model/effective_default.dart
@@ -1,7 +1,9 @@
 import 'package:tonik_core/src/model/model.dart';
 
-/// Walks one step through an [AliasModel] only when [localDefault] is null;
-/// the alias default never overrides a property/parameter's own default.
+/// Returns [localDefault] when set; otherwise falls back to [model]'s
+/// default if [model] is an [AliasModel] (which itself walks the alias
+/// chain with cycle protection). The alias default never overrides a
+/// property/parameter's own local default.
 Object? effectiveDefault(Object? localDefault, Model model) {
   if (localDefault != null) return localDefault;
   return model is AliasModel ? model.defaultValue : null;

--- a/packages/tonik_core/lib/src/model/effective_default.dart
+++ b/packages/tonik_core/lib/src/model/effective_default.dart
@@ -1,0 +1,8 @@
+import 'package:tonik_core/src/model/model.dart';
+
+/// Walks one step through an [AliasModel] only when [localDefault] is null;
+/// the alias default never overrides a property/parameter's own default.
+Object? effectiveDefault(Object? localDefault, Model model) {
+  if (localDefault != null) return localDefault;
+  return model is AliasModel ? model.defaultValue : null;
+}

--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -1,5 +1,6 @@
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/src/model/example.dart';
 import 'package:tonik_core/src/util/context.dart';
 import 'package:tonik_util/tonik_util.dart';
@@ -632,11 +633,7 @@ class Property {
 
   /// The property's own [defaultValue] when set, otherwise the default
   /// carried by its [model] when that model is an [AliasModel] chain.
-  Object? get effectiveDefaultValue {
-    if (defaultValue != null) return defaultValue;
-    final m = model;
-    return m is AliasModel ? m.defaultValue : null;
-  }
+  Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/model/path_parameter.dart
+++ b/packages/tonik_core/lib/src/model/path_parameter.dart
@@ -120,11 +120,7 @@ class PathParameterObject extends PathParameter {
 
   Object? defaultValue;
 
-  Object? get effectiveDefaultValue {
-    if (defaultValue != null) return defaultValue;
-    final m = model;
-    return m is AliasModel ? m.defaultValue : null;
-  }
+  Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/model/path_parameter.dart
+++ b/packages/tonik_core/lib/src/model/path_parameter.dart
@@ -120,8 +120,6 @@ class PathParameterObject extends PathParameter {
 
   Object? defaultValue;
 
-  /// The parameter's own [defaultValue] when set, otherwise the default
-  /// carried by its [model] when that model is an [AliasModel] chain.
   Object? get effectiveDefaultValue {
     if (defaultValue != null) return defaultValue;
     final m = model;

--- a/packages/tonik_core/lib/src/model/path_parameter.dart
+++ b/packages/tonik_core/lib/src/model/path_parameter.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 /// Encoding styles supported for path parameters.

--- a/packages/tonik_core/lib/src/model/path_parameter.dart
+++ b/packages/tonik_core/lib/src/model/path_parameter.dart
@@ -120,6 +120,14 @@ class PathParameterObject extends PathParameter {
 
   Object? defaultValue;
 
+  /// The parameter's own [defaultValue] when set, otherwise the default
+  /// carried by its [model] when that model is an [AliasModel] chain.
+  Object? get effectiveDefaultValue {
+    if (defaultValue != null) return defaultValue;
+    final m = model;
+    return m is AliasModel ? m.defaultValue : null;
+  }
+
   @override
   String toString() =>
       'PathParameterObject{name: $name, nameOverride: $nameOverride, '

--- a/packages/tonik_core/lib/src/model/query_parameter.dart
+++ b/packages/tonik_core/lib/src/model/query_parameter.dart
@@ -128,6 +128,14 @@ class QueryParameterObject extends QueryParameter {
 
   Object? defaultValue;
 
+  /// The parameter's own [defaultValue] when set, otherwise the default
+  /// carried by its [model] when that model is an [AliasModel] chain.
+  Object? get effectiveDefaultValue {
+    if (defaultValue != null) return defaultValue;
+    final m = model;
+    return m is AliasModel ? m.defaultValue : null;
+  }
+
   @override
   String toString() =>
       'QueryParameter{name: $name, nameOverride: $nameOverride, '

--- a/packages/tonik_core/lib/src/model/query_parameter.dart
+++ b/packages/tonik_core/lib/src/model/query_parameter.dart
@@ -128,11 +128,7 @@ class QueryParameterObject extends QueryParameter {
 
   Object? defaultValue;
 
-  Object? get effectiveDefaultValue {
-    if (defaultValue != null) return defaultValue;
-    final m = model;
-    return m is AliasModel ? m.defaultValue : null;
-  }
+  Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/model/query_parameter.dart
+++ b/packages/tonik_core/lib/src/model/query_parameter.dart
@@ -128,8 +128,6 @@ class QueryParameterObject extends QueryParameter {
 
   Object? defaultValue;
 
-  /// The parameter's own [defaultValue] when set, otherwise the default
-  /// carried by its [model] when that model is an [AliasModel] chain.
   Object? get effectiveDefaultValue {
     if (defaultValue != null) return defaultValue;
     final m = model;

--- a/packages/tonik_core/lib/src/model/query_parameter.dart
+++ b/packages/tonik_core/lib/src/model/query_parameter.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 /// Encoding styles supported for query parameters.

--- a/packages/tonik_core/lib/src/model/request_header.dart
+++ b/packages/tonik_core/lib/src/model/request_header.dart
@@ -114,6 +114,14 @@ class RequestHeaderObject extends RequestHeader {
 
   Object? defaultValue;
 
+  /// The header's own [defaultValue] when set, otherwise the default
+  /// carried by its [model] when that model is an [AliasModel] chain.
+  Object? get effectiveDefaultValue {
+    if (defaultValue != null) return defaultValue;
+    final m = model;
+    return m is AliasModel ? m.defaultValue : null;
+  }
+
   @override
   String toString() =>
       'RequestHeader{name: $name, nameOverride: $nameOverride, '

--- a/packages/tonik_core/lib/src/model/request_header.dart
+++ b/packages/tonik_core/lib/src/model/request_header.dart
@@ -1,4 +1,5 @@
 import 'package:meta/meta.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 /// Encoding style supported for header parameters.

--- a/packages/tonik_core/lib/src/model/request_header.dart
+++ b/packages/tonik_core/lib/src/model/request_header.dart
@@ -114,8 +114,6 @@ class RequestHeaderObject extends RequestHeader {
 
   Object? defaultValue;
 
-  /// The header's own [defaultValue] when set, otherwise the default
-  /// carried by its [model] when that model is an [AliasModel] chain.
   Object? get effectiveDefaultValue {
     if (defaultValue != null) return defaultValue;
     final m = model;

--- a/packages/tonik_core/lib/src/model/request_header.dart
+++ b/packages/tonik_core/lib/src/model/request_header.dart
@@ -114,11 +114,7 @@ class RequestHeaderObject extends RequestHeader {
 
   Object? defaultValue;
 
-  Object? get effectiveDefaultValue {
-    if (defaultValue != null) return defaultValue;
-    final m = model;
-    return m is AliasModel ? m.defaultValue : null;
-  }
+  Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/tonik_core.dart
+++ b/packages/tonik_core/lib/tonik_core.dart
@@ -11,6 +11,7 @@ export 'src/model/api_document.dart';
 export 'src/model/contact.dart';
 export 'src/model/content_type.dart';
 export 'src/model/cookie_parameter.dart';
+export 'src/model/effective_default.dart';
 export 'src/model/example.dart';
 export 'src/model/external_documentation.dart';
 export 'src/model/license.dart';

--- a/packages/tonik_core/lib/tonik_core.dart
+++ b/packages/tonik_core/lib/tonik_core.dart
@@ -11,7 +11,6 @@ export 'src/model/api_document.dart';
 export 'src/model/contact.dart';
 export 'src/model/content_type.dart';
 export 'src/model/cookie_parameter.dart';
-export 'src/model/effective_default.dart';
 export 'src/model/example.dart';
 export 'src/model/external_documentation.dart';
 export 'src/model/license.dart';

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -1,0 +1,55 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+
+void main() {
+  late Context context;
+
+  setUp(() {
+    context = Context.initial();
+  });
+
+  AliasModel aliasWith(Object? defaultValue) => AliasModel(
+    name: 'A',
+    model: StringModel(context: context),
+    context: context,
+    examples: const [],
+    defaultValue: defaultValue,
+  );
+
+  group('effectiveDefault', () {
+    test('returns the local default when set, regardless of model type', () {
+      expect(effectiveDefault('local', StringModel(context: context)), 'local');
+    });
+
+    test('returns the alias-carried default when local is null', () {
+      expect(effectiveDefault(null, aliasWith('from-alias')), 'from-alias');
+    });
+
+    test('local default takes precedence over alias-carried default', () {
+      expect(effectiveDefault('local', aliasWith('from-alias')), 'local');
+    });
+
+    test('returns null when neither local nor alias carry a default', () {
+      expect(effectiveDefault(null, aliasWith(null)), isNull);
+    });
+
+    test('non-alias model with null local default returns null', () {
+      expect(effectiveDefault(null, StringModel(context: context)), isNull);
+    });
+
+    test(
+      'local default is preserved verbatim — booleans, numbers, maps',
+      () {
+        expect(
+          effectiveDefault(false, BooleanModel(context: context)),
+          isFalse,
+        );
+        expect(effectiveDefault(0, IntegerModel(context: context)), 0);
+        expect(
+          effectiveDefault(<String, Object?>{'k': 'v'}, aliasWith(null)),
+          {'k': 'v'},
+        );
+      },
+    );
+  });
+}

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -1,4 +1,5 @@
 import 'package:test/test.dart';
+import 'package:tonik_core/src/model/effective_default.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 void main() {

--- a/packages/tonik_core/test/src/model/parameter_effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/parameter_effective_default_test.dart
@@ -1,0 +1,178 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+
+void main() {
+  late Context context;
+
+  setUp(() {
+    context = Context.initial();
+  });
+
+  AliasModel aliasWith(Object? defaultValue) => AliasModel(
+    name: 'A',
+    model: StringModel(context: context),
+    context: context,
+    examples: const [],
+    defaultValue: defaultValue,
+  );
+
+  group('QueryParameterObject.effectiveDefaultValue', () {
+    QueryParameterObject with$({
+      required Object? defaultValue,
+      required Model model,
+    }) => QueryParameterObject(
+      name: 'q',
+      rawName: 'q',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      allowReserved: false,
+      explode: false,
+      model: model,
+      encoding: QueryParameterEncoding.form,
+      context: context,
+      examples: const [],
+      defaultValue: defaultValue,
+    );
+
+    test('returns local default when set', () {
+      final p = with$(
+        defaultValue: 'local',
+        model: StringModel(context: context),
+      );
+      expect(p.effectiveDefaultValue, 'local');
+    });
+
+    test('falls back to alias default when local is null', () {
+      final p = with$(defaultValue: null, model: aliasWith('from-alias'));
+      expect(p.effectiveDefaultValue, 'from-alias');
+    });
+
+    test('local default overrides alias default', () {
+      final p = with$(defaultValue: 'local', model: aliasWith('from-alias'));
+      expect(p.effectiveDefaultValue, 'local');
+    });
+
+    test('returns null when neither side carries a default', () {
+      final p = with$(
+        defaultValue: null,
+        model: StringModel(context: context),
+      );
+      expect(p.effectiveDefaultValue, isNull);
+    });
+  });
+
+  group('PathParameterObject.effectiveDefaultValue', () {
+    PathParameterObject with$({
+      required Object? defaultValue,
+      required Model model,
+    }) => PathParameterObject(
+      name: 'p',
+      rawName: 'p',
+      description: null,
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: model,
+      encoding: PathParameterEncoding.simple,
+      context: context,
+      examples: const [],
+      defaultValue: defaultValue,
+    );
+
+    test('returns local default when set', () {
+      final p = with$(
+        defaultValue: 'x',
+        model: StringModel(context: context),
+      );
+      expect(p.effectiveDefaultValue, 'x');
+    });
+
+    test('falls back to alias default when local is null', () {
+      final p = with$(defaultValue: null, model: aliasWith('y'));
+      expect(p.effectiveDefaultValue, 'y');
+    });
+
+    test('local default overrides alias default', () {
+      final p = with$(defaultValue: 'z', model: aliasWith('y'));
+      expect(p.effectiveDefaultValue, 'z');
+    });
+  });
+
+  group('RequestHeaderObject.effectiveDefaultValue', () {
+    RequestHeaderObject with$({
+      required Object? defaultValue,
+      required Model model,
+    }) => RequestHeaderObject(
+      name: 'h',
+      rawName: 'h',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: model,
+      encoding: HeaderParameterEncoding.simple,
+      context: context,
+      examples: const [],
+      defaultValue: defaultValue,
+    );
+
+    test('returns local default when set', () {
+      final p = with$(
+        defaultValue: 5,
+        model: IntegerModel(context: context),
+      );
+      expect(p.effectiveDefaultValue, 5);
+    });
+
+    test('falls back to alias default when local is null', () {
+      final p = with$(defaultValue: null, model: aliasWith('alias'));
+      expect(p.effectiveDefaultValue, 'alias');
+    });
+
+    test('local default overrides alias default', () {
+      final p = with$(defaultValue: 'local', model: aliasWith('alias'));
+      expect(p.effectiveDefaultValue, 'local');
+    });
+  });
+
+  group('CookieParameterObject.effectiveDefaultValue', () {
+    CookieParameterObject with$({
+      required Object? defaultValue,
+      required Model model,
+    }) => CookieParameterObject(
+      name: 'c',
+      rawName: 'c',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      explode: false,
+      model: model,
+      encoding: CookieParameterEncoding.form,
+      context: context,
+      examples: const [],
+      defaultValue: defaultValue,
+    );
+
+    test('returns local default when set', () {
+      final p = with$(
+        defaultValue: true,
+        model: BooleanModel(context: context),
+      );
+      expect(p.effectiveDefaultValue, isTrue);
+    });
+
+    test('falls back to alias default when local is null', () {
+      final p = with$(defaultValue: null, model: aliasWith('a'));
+      expect(p.effectiveDefaultValue, 'a');
+    });
+
+    test('local default overrides alias default', () {
+      final p = with$(defaultValue: 'local', model: aliasWith('alias'));
+      expect(p.effectiveDefaultValue, 'local');
+    });
+  });
+}

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -9,6 +9,7 @@ import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/operation_parameter_generator.dart';
 import 'package:tonik_generate/src/util/response_type_generator.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
@@ -118,10 +119,59 @@ class ApiClientGenerator {
 
   /// Generates a method for an operation
   Method _generateMethod(Operation operation) {
+    final hasRequestBody =
+        operation.requestBody?.resolvedContent.isNotEmpty ?? false;
+
+    final normalizedParams = normalizeRequestParameters(
+      pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
+      queryParameters: operation.queryParameters
+          .map((p) => p.resolve())
+          .toSet(),
+      headers: operation.headers.map((p) => p.resolve()).toSet(),
+      cookieParameters: operation.cookieParameters
+          .map((p) => p.resolve())
+          .toSet(),
+      reservedNames: operationReservedParameterNames(
+        hasRequestBody: hasRequestBody,
+      ),
+    );
+
+    final operationClassName = nameManager.operationName(operation);
+    final defaults = resolveOperationParameterDefaults(
+      normalizedParams: normalizedParams,
+      operationClassName: operationClassName,
+      nameManager: nameManager,
+      package: package,
+      initialReservedNames: initialOperationDefaultReservedNames(
+        normalizedParams: normalizedParams,
+        hasRequestBody: hasRequestBody,
+        hasResponses: operation.responses.isNotEmpty,
+        hasQueryParameters: operation.queryParameters.isNotEmpty,
+      ),
+      emitWarnings: false,
+    );
+
+    final operationUrl = sourceFileUrl(
+      package,
+      'operation',
+      operationClassName,
+    );
+    final qualifiedDefaults = {
+      for (final entry in defaults.byName.entries)
+        entry.key: OperationParameterDefault(
+          memberName: entry.value.memberName,
+          value: entry.value.value,
+          type: entry.value.type,
+          ownerClassName: operationClassName,
+          ownerUrl: operationUrl,
+        ),
+    };
+
     final parameters = generateParameters(
       operation: operation,
       nameManager: nameManager,
       package: package,
+      defaultsByName: qualifiedDefaults,
     );
 
     final resultType = resultTypeForOperation(

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -158,10 +158,7 @@ class ApiClientGenerator {
     );
     final qualifiedDefaults = {
       for (final entry in defaults.byName.entries)
-        entry.key: OperationParameterDefault.qualified(
-          memberName: entry.value.memberName,
-          value: entry.value.value,
-          type: entry.value.type,
+        entry.key: entry.value.withOwner(
           className: operationClassName,
           url: operationUrl,
         ),

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -145,8 +145,6 @@ class ApiClientGenerator {
       initialReservedNames: initialOperationDefaultReservedNames(
         normalizedParams: normalizedParams,
         hasRequestBody: hasRequestBody,
-        hasResponses: operation.responses.isNotEmpty,
-        hasQueryParameters: operation.queryParameters.isNotEmpty,
       ),
       emitWarnings: false,
     );

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -158,12 +158,12 @@ class ApiClientGenerator {
     );
     final qualifiedDefaults = {
       for (final entry in defaults.byName.entries)
-        entry.key: OperationParameterDefault(
+        entry.key: OperationParameterDefault.qualified(
           memberName: entry.value.memberName,
           value: entry.value.value,
           type: entry.value.type,
-          ownerClassName: operationClassName,
-          ownerUrl: operationUrl,
+          className: operationClassName,
+          url: operationUrl,
         ),
     };
 

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -10,7 +10,7 @@ import 'package:tonik_generate/src/util/additional_properties_helpers.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
-import 'package:tonik_generate/src/util/default_value_materialiser.dart';
+import 'package:tonik_generate/src/util/default_resolution.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
 import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
@@ -273,16 +273,7 @@ class ClassGenerator {
         for (final prop in normalizedProperties) {
           final defaulted = defaultsByName[prop.normalizedName];
           if (defaulted == null) continue;
-          b.fields.add(
-            Field(
-              (fb) => fb
-                ..static = true
-                ..modifier = FieldModifier.constant
-                ..name = defaulted.memberName
-                ..type = defaulted.type
-                ..assignment = defaulted.value.code,
-            ),
-          );
+          b.fields.add(defaultField(defaulted));
         }
 
         b.fields.addAll(
@@ -314,7 +305,7 @@ class ClassGenerator {
     );
   }
 
-  Map<String, _DefaultedProperty> _resolveDefaults(
+  Map<String, ResolvedDefault> _resolveDefaults(
     List<({String normalizedName, Property property})> normalizedProperties,
     String className, {
     String? apFieldName,
@@ -324,44 +315,24 @@ class ClassGenerator {
       ?apFieldName,
     };
 
-    final result = <String, _DefaultedProperty>{};
+    final result = <String, ResolvedDefault>{};
     for (final prop in normalizedProperties) {
-      final raw = prop.property.effectiveDefaultValue;
-      // Null carrier collapses "no default" and "default: null" — emit nothing.
-      if (raw == null) continue;
-
-      final materialised = materialiseConstDefault(
-        jsonValue: raw,
-        targetModel: prop.property.model,
-      );
-
-      if (materialised == null) {
-        if (prop.property.model.resolved is PrimitiveModel) {
-          _classGeneratorLog.warning(
-            'Dropping default for $className.${prop.property.name}: '
-            'value does not match the property type.',
-          );
-        }
-        continue;
-      }
-
-      final memberName = nameManager.defaultMemberName(
-        propertyName: prop.normalizedName,
+      final resolved = resolveSingleDefault(
+        normalizedName: prop.normalizedName,
+        specName: prop.property.name,
+        model: prop.property.model,
+        rawDefault: prop.property.effectiveDefaultValue,
+        containerName: className,
+        location: 'property',
         reservedNames: reservedNames,
+        nameManager: nameManager,
+        package: package,
+        onDroppedDefault: _classGeneratorLog.warning,
+        isNullableOverride: prop.property.isNullable,
+        useImmutableCollections: useImmutableCollections,
       );
-      reservedNames.add(memberName);
-
-      result[prop.normalizedName] = _DefaultedProperty(
-        memberName: memberName,
-        value: materialised,
-        type: typeReference(
-          prop.property.model,
-          nameManager,
-          package,
-          isNullableOverride: prop.property.isNullable,
-          useImmutableCollections: useImmutableCollections,
-        ),
-      );
+      if (resolved == null) continue;
+      result[prop.normalizedName] = resolved;
     }
     return result;
   }
@@ -369,7 +340,7 @@ class ClassGenerator {
   Expression _defaultIfAbsent({
     required Expression decoded,
     required String key,
-    required _DefaultedProperty defaulted,
+    required ResolvedDefault defaulted,
   }) => refer(r'_$values')
       .property('containsKey')
       .call([specLiteralString(key)])
@@ -417,7 +388,7 @@ class ClassGenerator {
   Constructor _buildFromSimpleConstructor(
     String className,
     ClassModel model,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     // Schema-level writeOnly: decoding is never valid.
     if (model.isWriteOnly) {
@@ -502,7 +473,7 @@ class ClassGenerator {
     List<({String normalizedName, Property property})> allProperties,
     List<String> writeOnlyRequiredNames,
     ClassModel classModel,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     if (properties.isEmpty) {
       if (hasAnyProperties) {
@@ -680,7 +651,7 @@ class ClassGenerator {
   Constructor _buildFromJsonConstructor(
     String className,
     ClassModel model,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     // Schema-level writeOnly: decoding is never valid.
     if (model.isWriteOnly) {
@@ -721,7 +692,7 @@ class ClassGenerator {
   Code _buildFromJsonBody(
     String className,
     ClassModel model,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     final normalizedProperties = normalizeProperties(
       model.properties.where((p) => !p.isWriteOnly).toList(),
@@ -1725,7 +1696,7 @@ if ($name != null) {
   Constructor _buildFromFormConstructor(
     String className,
     ClassModel model,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     // Schema-level writeOnly: decoding is never valid.
     if (model.isWriteOnly) {
@@ -1810,7 +1781,7 @@ if ($name != null) {
     List<({String normalizedName, Property property})> allProperties,
     List<String> writeOnlyRequiredNames,
     ClassModel classModel,
-    Map<String, _DefaultedProperty> defaultsByName,
+    Map<String, ResolvedDefault> defaultsByName,
   ) {
     if (properties.isEmpty) {
       if (hasAnyProperties) {
@@ -2142,22 +2113,4 @@ if ($name != null) {
     }
     return false;
   }
-}
-
-/// A defaulted property's resolved member metadata.
-///
-/// Built once per class generation and threaded through the constructor /
-/// `fromJson` / `fromSimple` / `fromForm` emitters so all references stay
-/// in lock-step on naming and shape.
-@immutable
-class _DefaultedProperty {
-  const _DefaultedProperty({
-    required this.memberName,
-    required this.value,
-    required this.type,
-  });
-
-  final String memberName;
-  final Expression value;
-  final TypeReference type;
 }

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -12,6 +12,7 @@ import 'package:tonik_generate/src/operation/path_generator.dart';
 import 'package:tonik_generate/src/operation/query_generator.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/operation_parameter_generator.dart';
 import 'package:tonik_generate/src/util/response_type_generator.dart';
 import 'package:tonik_generate/src/util/to_multipart_expression_generator.dart';
@@ -110,6 +111,19 @@ class OperationGenerator {
       ),
     );
 
+    final defaults = resolveOperationParameterDefaults(
+      normalizedParams: normalizedParams,
+      operationClassName: className,
+      nameManager: nameManager,
+      package: package,
+      initialReservedNames: initialOperationDefaultReservedNames(
+        normalizedParams: normalizedParams,
+        hasRequestBody: hasRequestBody,
+        hasResponses: operation.responses.isNotEmpty,
+        hasQueryParameters: operation.queryParameters.isNotEmpty,
+      ),
+    );
+
     return Class(
       (b) {
         b
@@ -121,7 +135,8 @@ class OperationGenerator {
                 ..modifier = FieldModifier.final$
                 ..type = refer('Dio', 'package:dio/dio.dart'),
             ),
-          );
+          )
+          ..fields.addAll(defaults.fields);
 
         if (operation.isDeprecated) {
           b.annotations.add(
@@ -145,7 +160,11 @@ class OperationGenerator {
             ),
           )
           ..methods.addAll([
-            generateCallMethod(operation, normalizedParams),
+            generateCallMethod(
+              operation,
+              normalizedParams,
+              defaultsByName: defaults.byName,
+            ),
             _pathGenerator.generatePathMethod(
               operation,
               normalizedParams.pathParameters,
@@ -172,14 +191,16 @@ class OperationGenerator {
   @visibleForTesting
   Method generateCallMethod(
     Operation operation,
-    NormalizedRequestParameters normalizedParams,
-  ) {
+    NormalizedRequestParameters normalizedParams, {
+    Map<String, OperationParameterDefault> defaultsByName = const {},
+  }) {
     final hasRequestBody =
         operation.requestBody?.resolvedContent.isNotEmpty ?? false;
     final parameters = generateParameters(
       operation: operation,
       nameManager: nameManager,
       package: package,
+      defaultsByName: defaultsByName,
     );
 
     final pathArgs = <String, Expression>{};

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -119,8 +119,6 @@ class OperationGenerator {
       initialReservedNames: initialOperationDefaultReservedNames(
         normalizedParams: normalizedParams,
         hasRequestBody: hasRequestBody,
-        hasResponses: operation.responses.isNotEmpty,
-        hasQueryParameters: operation.queryParameters.isNotEmpty,
       ),
     );
 

--- a/packages/tonik_generate/lib/src/util/default_resolution.dart
+++ b/packages/tonik_generate/lib/src/util/default_resolution.dart
@@ -1,0 +1,115 @@
+import 'dart:convert';
+
+import 'package:code_builder/code_builder.dart';
+import 'package:meta/meta.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/default_value_materialiser.dart';
+import 'package:tonik_generate/src/util/type_reference_generator.dart';
+
+@immutable
+class ResolvedDefault {
+  const ResolvedDefault({
+    required this.memberName,
+    required this.value,
+    required this.type,
+  });
+
+  final String memberName;
+  final Expression value;
+  final TypeReference type;
+}
+
+/// Composite-target defaults drop silently — they cannot carry a const
+/// default anyway, so emitting a warning would be noise.
+ResolvedDefault? resolveSingleDefault({
+  required String normalizedName,
+  required String specName,
+  required Model model,
+  required Object? rawDefault,
+  required String containerName,
+  required String location,
+  required Set<String> reservedNames,
+  required NameManager nameManager,
+  required String package,
+  required void Function(String message)? onDroppedDefault,
+  bool isNullableOverride = false,
+  bool useImmutableCollections = false,
+}) {
+  if (rawDefault == null) return null;
+
+  final materialised = materialiseConstDefault(
+    jsonValue: rawDefault,
+    targetModel: model,
+  );
+
+  if (materialised == null) {
+    if (onDroppedDefault != null) {
+      final resolved = model.resolved;
+      if (resolved is PrimitiveModel) {
+        final reason = _isMaterialiserSupportedPrimitive(model)
+            ? 'value does not match the parameter type'
+            : 'default value cannot be expressed as a const Dart expression '
+                  'for this type';
+        onDroppedDefault(
+          'Dropping default for $containerName.$specName '
+          '($location, expected ${resolved.runtimeType}, '
+          'value: ${_describeDefault(rawDefault)}): $reason.',
+        );
+      }
+    }
+    return null;
+  }
+
+  final memberName = nameManager.defaultMemberName(
+    propertyName: normalizedName,
+    reservedNames: reservedNames,
+  );
+  reservedNames.add(memberName);
+
+  return ResolvedDefault(
+    memberName: memberName,
+    value: materialised,
+    type: typeReference(
+      model,
+      nameManager,
+      package,
+      isNullableOverride: isNullableOverride,
+      useImmutableCollections: useImmutableCollections,
+    ),
+  );
+}
+
+Field defaultField(ResolvedDefault resolved) => Field(
+  (b) => b
+    ..static = true
+    ..modifier = FieldModifier.constant
+    ..name = resolved.memberName
+    ..type = resolved.type
+    ..assignment = resolved.value.code,
+);
+
+// YAML's timestamp inference can hand us a `DateTime` (or any non-JSON
+// scalar) — fall back to `toString` so a logging path never throws.
+String _describeDefault(Object? raw) =>
+    _isJsonEncodable(raw) ? jsonEncode(raw) : raw.toString();
+
+bool _isJsonEncodable(Object? value) => switch (value) {
+  null || bool() || num() || String() => true,
+  final List<Object?> list => list.every(_isJsonEncodable),
+  final Map<Object?, Object?> map =>
+    map.keys.every((k) => k is String) && map.values.every(_isJsonEncodable),
+  _ => false,
+};
+
+// Mirrors the supported-types switch in default_value_materialiser.dart;
+// kept duplicated so a primitive added there without a parallel update here
+// shows up immediately as a wrong-reason warning.
+bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
+  StringModel() ||
+  IntegerModel() ||
+  DoubleModel() ||
+  NumberModel() ||
+  BooleanModel() => true,
+  _ => false,
+};

--- a/packages/tonik_generate/lib/src/util/default_resolution.dart
+++ b/packages/tonik_generate/lib/src/util/default_resolution.dart
@@ -53,7 +53,7 @@ ResolvedDefault? resolveSingleDefault({
                   'for this type';
         onDroppedDefault(
           'Dropping default for $containerName.$specName '
-          '($location, expected ${_specTypeName(resolved)}, '
+          '($location, expected ${resolved.runtimeType}, '
           'value: ${_describeDefault(rawDefault)}): $reason.',
         );
       }
@@ -112,20 +112,4 @@ bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
   NumberModel() ||
   BooleanModel() => true,
   _ => false,
-};
-
-// Spec authors edit YAML in OpenAPI keywords, not the generator's Dart class
-// names — surface the keyword so the warning is directly actionable.
-String _specTypeName(PrimitiveModel resolved) => switch (resolved) {
-  StringModel() => 'string',
-  IntegerModel() => 'integer',
-  DoubleModel() => 'number (double)',
-  NumberModel() => 'number',
-  BooleanModel() => 'boolean',
-  DateTimeModel() => 'string (date-time)',
-  DateModel() => 'string (date)',
-  UriModel() => 'string (uri)',
-  DecimalModel() => 'string (decimal)',
-  BinaryModel() => 'string (binary)',
-  Base64Model() => 'string (byte)',
 };

--- a/packages/tonik_generate/lib/src/util/default_resolution.dart
+++ b/packages/tonik_generate/lib/src/util/default_resolution.dart
@@ -48,12 +48,12 @@ ResolvedDefault? resolveSingleDefault({
       final resolved = model.resolved;
       if (resolved is PrimitiveModel) {
         final reason = _isMaterialiserSupportedPrimitive(model)
-            ? 'value does not match the parameter type'
+            ? 'value does not match the expected type'
             : 'default value cannot be expressed as a const Dart expression '
                   'for this type';
         onDroppedDefault(
           'Dropping default for $containerName.$specName '
-          '($location, expected ${resolved.runtimeType}, '
+          '($location, expected ${_specTypeName(resolved)}, '
           'value: ${_describeDefault(rawDefault)}): $reason.',
         );
       }
@@ -112,4 +112,20 @@ bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
   NumberModel() ||
   BooleanModel() => true,
   _ => false,
+};
+
+// Spec authors edit YAML in OpenAPI keywords, not the generator's Dart class
+// names — surface the keyword so the warning is directly actionable.
+String _specTypeName(PrimitiveModel resolved) => switch (resolved) {
+  StringModel() => 'string',
+  IntegerModel() => 'integer',
+  DoubleModel() => 'number (double)',
+  NumberModel() => 'number',
+  BooleanModel() => 'boolean',
+  DateTimeModel() => 'string (date-time)',
+  DateModel() => 'string (date)',
+  UriModel() => 'string (uri)',
+  DecimalModel() => 'string (decimal)',
+  BinaryModel() => 'string (binary)',
+  Base64Model() => 'string (byte)',
 };

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -28,11 +28,18 @@ class OperationParameterDefault {
   OperationParameterDefault withOwner({
     required String className,
     required String url,
-  }) => OperationParameterDefault.qualified(
-    memberName: memberName,
-    className: className,
-    url: url,
-  );
+  }) {
+    assert(
+      _owner == null,
+      'withOwner called on an already-qualified OperationParameterDefault — '
+      'qualifying twice would silently overwrite the existing owner.',
+    );
+    return OperationParameterDefault.qualified(
+      memberName: memberName,
+      className: className,
+      url: url,
+    );
+  }
 
   Code defaultToCode() {
     final owner = _owner;

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -1,13 +1,10 @@
-import 'dart:convert';
-
 import 'package:code_builder/code_builder.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
-import 'package:tonik_generate/src/util/default_value_materialiser.dart';
-import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_generate/src/util/default_resolution.dart';
 
 final Logger _log = Logger('OperationParameterDefaults');
 
@@ -68,6 +65,7 @@ resolveOperationParameterDefaults({
   final reserved = {...initialReservedNames};
   final byName = <String, OperationParameterDefault>{};
   final fields = <Field>[];
+  final onDropped = emitWarnings ? _log.warning : null;
 
   void process({
     required String normalizedName,
@@ -76,57 +74,24 @@ resolveOperationParameterDefaults({
     required String specName,
     required String location,
   }) {
-    if (rawDefault == null) return;
-
-    final materialised = materialiseConstDefault(
-      jsonValue: rawDefault,
-      targetModel: model,
-    );
-
-    if (materialised == null) {
-      if (emitWarnings) {
-        final resolved = model.resolved;
-        if (resolved is PrimitiveModel) {
-          final reason = _isMaterialiserSupportedPrimitive(model)
-              ? 'value does not match the parameter type'
-              : 'default value cannot be expressed as a const Dart '
-                    'expression for this type';
-          _log.warning(
-            'Dropping default for $operationClassName.$specName '
-            '($location, expected ${resolved.runtimeType}, '
-            'value: ${_describeDefault(rawDefault)}): $reason.',
-          );
-        }
-      }
-      return;
-    }
-
-    final memberName = nameManager.defaultMemberName(
-      propertyName: normalizedName,
+    final resolved = resolveSingleDefault(
+      normalizedName: normalizedName,
+      specName: specName,
+      model: model,
+      rawDefault: rawDefault,
+      containerName: operationClassName,
+      location: location,
       reservedNames: reserved,
+      nameManager: nameManager,
+      package: package,
+      onDroppedDefault: onDropped,
     );
-    reserved.add(memberName);
-
-    final type = typeReference(
-      model,
-      nameManager,
-      package,
-    );
+    if (resolved == null) return;
 
     byName[normalizedName] = OperationParameterDefault.local(
-      memberName: memberName,
+      memberName: resolved.memberName,
     );
-
-    fields.add(
-      Field(
-        (b) => b
-          ..static = true
-          ..modifier = FieldModifier.constant
-          ..name = memberName
-          ..type = type
-          ..assignment = materialised.code,
-      ),
-    );
+    fields.add(defaultField(resolved));
   }
 
   for (final p in normalizedParams.pathParameters) {
@@ -188,29 +153,4 @@ Set<String> initialOperationDefaultReservedNames({
   for (final p in normalizedParams.queryParameters) p.normalizedName,
   for (final p in normalizedParams.headers) p.normalizedName,
   for (final p in normalizedParams.cookieParameters) p.normalizedName,
-};
-
-// YAML's timestamp inference can hand us a `DateTime` (or any non-JSON
-// scalar) — fall back to `toString` so a logging path never throws.
-String _describeDefault(Object? raw) =>
-    _isJsonEncodable(raw) ? jsonEncode(raw) : raw.toString();
-
-bool _isJsonEncodable(Object? value) => switch (value) {
-  null || bool() || num() || String() => true,
-  final List<Object?> list => list.every(_isJsonEncodable),
-  final Map<Object?, Object?> map =>
-    map.keys.every((k) => k is String) && map.values.every(_isJsonEncodable),
-  _ => false,
-};
-
-// Mirrors the supported-types switch in default_value_materialiser.dart;
-// kept duplicated so a primitive added there without a parallel update here
-// shows up immediately as a wrong-reason warning.
-bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
-  StringModel() ||
-  IntegerModel() ||
-  DoubleModel() ||
-  NumberModel() ||
-  BooleanModel() => true,
-  _ => false,
 };

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -11,33 +11,28 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 final Logger _log = Logger('OperationParameterDefaults');
 
-/// A materialised default for a single operation parameter, plus the
-/// metadata needed to reference it from a generated call site.
-///
-/// Two construction modes guarantee owner metadata is set as a pair:
-/// `.local` for references inside the owning operation class, `.qualified`
-/// for references from a different file (e.g. an API-client wrapper) that
-/// needs both the class name and its source URL to compile.
 @immutable
 class OperationParameterDefault {
-  const OperationParameterDefault.local({
-    required this.memberName,
-    required this.value,
-    required this.type,
-  }) : _owner = null;
+  const OperationParameterDefault.local({required this.memberName})
+    : _owner = null;
 
   const OperationParameterDefault.qualified({
     required this.memberName,
-    required this.value,
-    required this.type,
     required String className,
     required String url,
   }) : _owner = (className: className, url: url);
 
   final String memberName;
-  final Expression value;
-  final TypeReference type;
   final ({String className, String url})? _owner;
+
+  OperationParameterDefault withOwner({
+    required String className,
+    required String url,
+  }) => OperationParameterDefault.qualified(
+    memberName: memberName,
+    className: className,
+    url: url,
+  );
 
   Code defaultToCode() {
     final owner = _owner;
@@ -48,9 +43,6 @@ class OperationParameterDefault {
   }
 }
 
-/// Resolves operation-parameter defaults into materialised const
-/// expressions and the static fields that hold them.
-///
 /// Pass [emitWarnings] `false` on secondary call sites (e.g. the
 /// API-client forwarder) — the primary site already logs once per
 /// dropped default.
@@ -94,7 +86,8 @@ resolveOperationParameterDefaults({
                     'expression for this type';
           _log.warning(
             'Dropping default for $operationClassName.$specName '
-            '($location, value: ${_describeDefault(rawDefault)}): $reason.',
+            '($location, expected ${resolved.runtimeType}, '
+            'value: ${_describeDefault(rawDefault)}): $reason.',
           );
         }
       }
@@ -115,8 +108,6 @@ resolveOperationParameterDefaults({
 
     byName[normalizedName] = OperationParameterDefault.local(
       memberName: memberName,
-      value: materialised,
-      type: type,
     );
 
     fields.add(

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:code_builder/code_builder.dart';
 import 'package:logging/logging.dart';
 import 'package:meta/meta.dart';
@@ -9,35 +11,49 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 final Logger _log = Logger('OperationParameterDefaults');
 
-/// Qualified with [ownerClassName] when emitted outside the owning operation
-/// class (API-client wrapper); otherwise a bare reference suffices.
+/// A materialised default for a single operation parameter, plus the
+/// metadata needed to reference it from a generated call site.
+///
+/// Two construction modes guarantee owner metadata is set as a pair:
+/// `.local` for references inside the owning operation class, `.qualified`
+/// for references from a different file (e.g. an API-client wrapper) that
+/// needs both the class name and its source URL to compile.
 @immutable
 class OperationParameterDefault {
-  const OperationParameterDefault({
+  const OperationParameterDefault.local({
     required this.memberName,
     required this.value,
     required this.type,
-    this.ownerClassName,
-    this.ownerUrl,
-  });
+  }) : _owner = null;
+
+  const OperationParameterDefault.qualified({
+    required this.memberName,
+    required this.value,
+    required this.type,
+    required String className,
+    required String url,
+  }) : _owner = (className: className, url: url);
 
   final String memberName;
   final Expression value;
   final TypeReference type;
-  final String? ownerClassName;
-  final String? ownerUrl;
+  final ({String className, String url})? _owner;
 
   Code defaultToCode() {
-    final owner = ownerClassName;
+    final owner = _owner;
     if (owner == null) {
       return refer(memberName).code;
     }
-    return refer(owner, ownerUrl).property(memberName).code;
+    return refer(owner.className, owner.url).property(memberName).code;
   }
 }
 
-/// Primary emission site for warnings; API-client forwarding suppresses to
-/// avoid duplicates.
+/// Resolves operation-parameter defaults into materialised const
+/// expressions and the static fields that hold them.
+///
+/// Pass [emitWarnings] `false` on secondary call sites (e.g. the
+/// API-client forwarder) — the primary site already logs once per
+/// dropped default.
 ({
   Map<String, OperationParameterDefault> byName,
   List<Field> fields,
@@ -59,6 +75,7 @@ resolveOperationParameterDefaults({
     required Model model,
     required Object? rawDefault,
     required String specName,
+    required String location,
   }) {
     if (rawDefault == null) return;
 
@@ -68,11 +85,18 @@ resolveOperationParameterDefaults({
     );
 
     if (materialised == null) {
-      if (emitWarnings && _isMaterialiserSupportedPrimitive(model)) {
-        _log.warning(
-          'Dropping default for $operationClassName.$specName: '
-          'value does not match the parameter type.',
-        );
+      if (emitWarnings) {
+        final resolved = model.resolved;
+        if (resolved is PrimitiveModel) {
+          final reason = _isMaterialiserSupportedPrimitive(model)
+              ? 'value does not match the parameter type'
+              : 'default value cannot be expressed as a const Dart '
+                    'expression for this type';
+          _log.warning(
+            'Dropping default for $operationClassName.$specName '
+            '($location, value: ${_describeDefault(rawDefault)}): $reason.',
+          );
+        }
       }
       return;
     }
@@ -89,7 +113,7 @@ resolveOperationParameterDefaults({
       package,
     );
 
-    byName[normalizedName] = OperationParameterDefault(
+    byName[normalizedName] = OperationParameterDefault.local(
       memberName: memberName,
       value: materialised,
       type: type,
@@ -113,6 +137,7 @@ resolveOperationParameterDefaults({
       model: p.parameter.model,
       rawDefault: p.parameter.effectiveDefaultValue,
       specName: p.parameter.rawName,
+      location: 'path',
     );
   }
   for (final p in normalizedParams.queryParameters) {
@@ -121,6 +146,7 @@ resolveOperationParameterDefaults({
       model: p.parameter.model,
       rawDefault: p.parameter.effectiveDefaultValue,
       specName: p.parameter.rawName,
+      location: 'query',
     );
   }
   for (final p in normalizedParams.headers) {
@@ -129,6 +155,7 @@ resolveOperationParameterDefaults({
       model: p.parameter.model,
       rawDefault: p.parameter.effectiveDefaultValue,
       specName: p.parameter.rawName,
+      location: 'header',
     );
   }
   for (final p in normalizedParams.cookieParameters) {
@@ -137,6 +164,7 @@ resolveOperationParameterDefaults({
       model: p.parameter.model,
       rawDefault: p.parameter.effectiveDefaultValue,
       specName: p.parameter.rawName,
+      location: 'cookie',
     );
   }
 
@@ -164,10 +192,22 @@ Set<String> initialOperationDefaultReservedNames({
   for (final p in normalizedParams.cookieParameters) p.normalizedName,
 };
 
-// Must duplicate (not introspect) the set in default_value_materialiser.dart —
-// the coupling is intentional: a `PrimitiveModel` outside this set (DateTime,
-// Date, Decimal, Uri, Binary, Base64) is parseable but not const-materialisable
-// in Dart, so its default is silently dropped without warning.
+// YAML's timestamp inference can hand us a `DateTime` (or any non-JSON
+// scalar) — fall back to `toString` so a logging path never throws.
+String _describeDefault(Object? raw) =>
+    _isJsonEncodable(raw) ? jsonEncode(raw) : raw.toString();
+
+bool _isJsonEncodable(Object? value) => switch (value) {
+  null || bool() || num() || String() => true,
+  final List<Object?> list => list.every(_isJsonEncodable),
+  final Map<Object?, Object?> map =>
+    map.keys.every((k) => k is String) && map.values.every(_isJsonEncodable),
+  _ => false,
+};
+
+// Mirrors the supported-types switch in default_value_materialiser.dart;
+// kept duplicated so a primitive added there without a parallel update here
+// shows up immediately as a wrong-reason warning.
 bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
   StringModel() ||
   IntegerModel() ||

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -134,19 +134,15 @@ resolveOperationParameterDefaults({
   return (byName: byName, fields: fields);
 }
 
+// Normalised parameter names cannot start with `_` (see `normalizeSingle` in
+// name_utils.dart), and the default-member candidate is `<paramName>Default`
+// — so private operation members like `_dio` / `_path` / `_queryParameters`
+// can never collide with a default and don't need to be reserved here.
 Set<String> initialOperationDefaultReservedNames({
   required NormalizedRequestParameters normalizedParams,
   required bool hasRequestBody,
-  required bool hasResponses,
-  required bool hasQueryParameters,
 }) => <String>{
-  '_dio',
   'call',
-  '_path',
-  '_data',
-  '_options',
-  if (hasQueryParameters) '_queryParameters',
-  if (hasResponses) '_parseResponse',
   if (hasRequestBody) 'body',
   'cancelToken',
   for (final p in normalizedParams.pathParameters) p.normalizedName,

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -1,0 +1,178 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:logging/logging.dart';
+import 'package:meta/meta.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
+import 'package:tonik_generate/src/util/default_value_materialiser.dart';
+import 'package:tonik_generate/src/util/type_reference_generator.dart';
+
+final Logger _log = Logger('OperationParameterDefaults');
+
+/// Qualified with [ownerClassName] when emitted outside the owning operation
+/// class (API-client wrapper); otherwise a bare reference suffices.
+@immutable
+class OperationParameterDefault {
+  const OperationParameterDefault({
+    required this.memberName,
+    required this.value,
+    required this.type,
+    this.ownerClassName,
+    this.ownerUrl,
+  });
+
+  final String memberName;
+  final Expression value;
+  final TypeReference type;
+  final String? ownerClassName;
+  final String? ownerUrl;
+
+  Code defaultToCode() {
+    final owner = ownerClassName;
+    if (owner == null) {
+      return refer(memberName).code;
+    }
+    return refer(owner, ownerUrl).property(memberName).code;
+  }
+}
+
+/// Primary emission site for warnings; API-client forwarding suppresses to
+/// avoid duplicates.
+({
+  Map<String, OperationParameterDefault> byName,
+  List<Field> fields,
+})
+resolveOperationParameterDefaults({
+  required NormalizedRequestParameters normalizedParams,
+  required String operationClassName,
+  required NameManager nameManager,
+  required String package,
+  required Set<String> initialReservedNames,
+  bool emitWarnings = true,
+}) {
+  final reserved = {...initialReservedNames};
+  final byName = <String, OperationParameterDefault>{};
+  final fields = <Field>[];
+
+  void process({
+    required String normalizedName,
+    required Model model,
+    required Object? rawDefault,
+    required String specName,
+  }) {
+    if (rawDefault == null) return;
+
+    final materialised = materialiseConstDefault(
+      jsonValue: rawDefault,
+      targetModel: model,
+    );
+
+    if (materialised == null) {
+      if (emitWarnings && _isMaterialiserSupportedPrimitive(model)) {
+        _log.warning(
+          'Dropping default for $operationClassName.$specName: '
+          'value does not match the parameter type.',
+        );
+      }
+      return;
+    }
+
+    final memberName = nameManager.defaultMemberName(
+      propertyName: normalizedName,
+      reservedNames: reserved,
+    );
+    reserved.add(memberName);
+
+    final type = typeReference(
+      model,
+      nameManager,
+      package,
+    );
+
+    byName[normalizedName] = OperationParameterDefault(
+      memberName: memberName,
+      value: materialised,
+      type: type,
+    );
+
+    fields.add(
+      Field(
+        (b) => b
+          ..static = true
+          ..modifier = FieldModifier.constant
+          ..name = memberName
+          ..type = type
+          ..assignment = materialised.code,
+      ),
+    );
+  }
+
+  for (final p in normalizedParams.pathParameters) {
+    process(
+      normalizedName: p.normalizedName,
+      model: p.parameter.model,
+      rawDefault: p.parameter.effectiveDefaultValue,
+      specName: p.parameter.rawName,
+    );
+  }
+  for (final p in normalizedParams.queryParameters) {
+    process(
+      normalizedName: p.normalizedName,
+      model: p.parameter.model,
+      rawDefault: p.parameter.effectiveDefaultValue,
+      specName: p.parameter.rawName,
+    );
+  }
+  for (final p in normalizedParams.headers) {
+    process(
+      normalizedName: p.normalizedName,
+      model: p.parameter.model,
+      rawDefault: p.parameter.effectiveDefaultValue,
+      specName: p.parameter.rawName,
+    );
+  }
+  for (final p in normalizedParams.cookieParameters) {
+    process(
+      normalizedName: p.normalizedName,
+      model: p.parameter.model,
+      rawDefault: p.parameter.effectiveDefaultValue,
+      specName: p.parameter.rawName,
+    );
+  }
+
+  return (byName: byName, fields: fields);
+}
+
+Set<String> initialOperationDefaultReservedNames({
+  required NormalizedRequestParameters normalizedParams,
+  required bool hasRequestBody,
+  required bool hasResponses,
+  required bool hasQueryParameters,
+}) => <String>{
+  '_dio',
+  'call',
+  '_path',
+  '_data',
+  '_options',
+  if (hasQueryParameters) '_queryParameters',
+  if (hasResponses) '_parseResponse',
+  if (hasRequestBody) 'body',
+  'cancelToken',
+  for (final p in normalizedParams.pathParameters) p.normalizedName,
+  for (final p in normalizedParams.queryParameters) p.normalizedName,
+  for (final p in normalizedParams.headers) p.normalizedName,
+  for (final p in normalizedParams.cookieParameters) p.normalizedName,
+};
+
+// Must duplicate (not introspect) the set in default_value_materialiser.dart —
+// the coupling is intentional: a `PrimitiveModel` outside this set (DateTime,
+// Date, Decimal, Uri, Binary, Base64) is parseable but not const-materialisable
+// in Dart, so its default is silently dropped without warning.
+bool _isMaterialiserSupportedPrimitive(Model model) => switch (model.resolved) {
+  StringModel() ||
+  IntegerModel() ||
+  DoubleModel() ||
+  NumberModel() ||
+  BooleanModel() => true,
+  _ => false,
+};

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -7,12 +7,12 @@ import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
-/// Generates parameters for an operation.
+/// Generates the `call()` parameters for an operation.
 ///
-/// When [defaultsByName] is provided, parameters keyed by their normalised
-/// name receive `..required = false ..defaultTo = refer(<memberName>).code`.
-/// Callers (operation_generator) supply the map alongside the static-const
-/// field list so the two stay in lock-step.
+/// Parameters whose normalized name appears in [defaultsByName] are emitted
+/// as optional, with a `defaultTo` referencing the corresponding static
+/// const on the owning class (qualified when the call site lives outside
+/// that class, e.g. an API-client wrapper).
 List<Parameter> generateParameters({
   required Operation operation,
   required NameManager nameManager,

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -9,10 +9,9 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 /// Generates the `call()` parameters for an operation.
 ///
-/// Parameters whose normalized name appears in [defaultsByName] are emitted
-/// as optional, with a `defaultTo` referencing the corresponding static
-/// const on the owning class (qualified when the call site lives outside
-/// that class, e.g. an API-client wrapper).
+/// When [defaultsByName] is supplied, named parameters become optional and
+/// receive `defaultTo` references — qualified for call sites outside the
+/// owning class so the import allocator resolves them.
 List<Parameter> generateParameters({
   required Operation operation,
   required NameManager nameManager,

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -3,14 +3,21 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
 import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
-/// Generates parameters for an operation
+/// Generates parameters for an operation.
+///
+/// When [defaultsByName] is provided, parameters keyed by their normalised
+/// name receive `..required = false ..defaultTo = refer(<memberName>).code`.
+/// Callers (operation_generator) supply the map alongside the static-const
+/// field list so the two stay in lock-step.
 List<Parameter> generateParameters({
   required Operation operation,
   required NameManager nameManager,
   required String package,
+  Map<String, OperationParameterDefault> defaultsByName = const {},
 }) {
   final hasRequestBody =
       operation.requestBody?.resolvedContent.isNotEmpty ?? false;
@@ -62,11 +69,13 @@ List<Parameter> generateParameters({
 
   // Add path parameters
   for (final pathParam in normalizedParams.pathParameters) {
+    final defaulted = defaultsByName[pathParam.normalizedName];
     final parameterType = typeReference(
       pathParam.parameter.model,
       nameManager,
       package,
-      isNullableOverride: !pathParam.parameter.isRequired,
+      isNullableOverride:
+          !pathParam.parameter.isRequired && defaulted == null,
     );
 
     parameters.add(
@@ -76,7 +85,8 @@ List<Parameter> generateParameters({
             ..name = pathParam.normalizedName
             ..type = parameterType
             ..named = true
-            ..required = pathParam.parameter.isRequired;
+            ..required = defaulted == null && pathParam.parameter.isRequired
+            ..defaultTo = defaulted?.defaultToCode();
 
           if (pathParam.parameter.isDeprecated) {
             b.annotations.add(
@@ -92,11 +102,13 @@ List<Parameter> generateParameters({
 
   // Add query parameters
   for (final queryParam in normalizedParams.queryParameters) {
+    final defaulted = defaultsByName[queryParam.normalizedName];
     final parameterType = typeReference(
       queryParam.parameter.model,
       nameManager,
       package,
-      isNullableOverride: !queryParam.parameter.isRequired,
+      isNullableOverride:
+          !queryParam.parameter.isRequired && defaulted == null,
     );
 
     parameters.add(
@@ -106,7 +118,8 @@ List<Parameter> generateParameters({
             ..name = queryParam.normalizedName
             ..type = parameterType
             ..named = true
-            ..required = queryParam.parameter.isRequired;
+            ..required = defaulted == null && queryParam.parameter.isRequired
+            ..defaultTo = defaulted?.defaultToCode();
 
           if (queryParam.parameter.isDeprecated) {
             b.annotations.add(
@@ -122,11 +135,13 @@ List<Parameter> generateParameters({
 
   // Add header parameters
   for (final headerParam in normalizedParams.headers) {
+    final defaulted = defaultsByName[headerParam.normalizedName];
     final parameterType = typeReference(
       headerParam.parameter.model,
       nameManager,
       package,
-      isNullableOverride: !headerParam.parameter.isRequired,
+      isNullableOverride:
+          !headerParam.parameter.isRequired && defaulted == null,
     );
 
     parameters.add(
@@ -136,7 +151,8 @@ List<Parameter> generateParameters({
             ..name = headerParam.normalizedName
             ..type = parameterType
             ..named = true
-            ..required = headerParam.parameter.isRequired;
+            ..required = defaulted == null && headerParam.parameter.isRequired
+            ..defaultTo = defaulted?.defaultToCode();
 
           if (headerParam.parameter.isDeprecated) {
             b.annotations.add(
@@ -152,11 +168,13 @@ List<Parameter> generateParameters({
 
   // Add cookie parameters
   for (final cookieParam in normalizedParams.cookieParameters) {
+    final defaulted = defaultsByName[cookieParam.normalizedName];
     final parameterType = typeReference(
       cookieParam.parameter.model,
       nameManager,
       package,
-      isNullableOverride: !cookieParam.parameter.isRequired,
+      isNullableOverride:
+          !cookieParam.parameter.isRequired && defaulted == null,
     );
 
     parameters.add(
@@ -166,7 +184,8 @@ List<Parameter> generateParameters({
             ..name = cookieParam.normalizedName
             ..type = parameterType
             ..named = true
-            ..required = cookieParam.parameter.isRequired;
+            ..required = defaulted == null && cookieParam.parameter.isRequired
+            ..defaultTo = defaulted?.defaultToCode();
 
           if (cookieParam.parameter.isDeprecated) {
             b.annotations.add(

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -2007,5 +2007,63 @@ void main() {
         expect(method.name, r'$class');
       });
     });
+
+    group('parameter defaults', () {
+      test(
+        'forwards defaulted parameters with class-qualified defaultTo so the '
+        'reference resolves outside the operation class',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'region',
+            rawName: 'region',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: testContext),
+            encoding: QueryParameterEncoding.form,
+            context: testContext,
+            examples: const [],
+            defaultValue: 'us',
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: testContext,
+            tags: {Tag(name: 'things')},
+            isDeprecated: false,
+            path: '/things',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final generatedClass = generator.generateClass(
+            {operation},
+            Tag(name: 'things'),
+            testServers,
+          );
+
+          final method = generatedClass.methods.firstWhere(
+            (m) => m.name == 'listThings',
+          );
+
+          final regionParam = method.optionalParameters
+              .firstWhere((p) => p.name == 'region');
+          expect(regionParam.required, isFalse);
+          expect(regionParam.type?.accept(emitter).toString(), 'String');
+          expect(
+            regionParam.defaultTo?.accept(emitter).toString(),
+            'ListThings.regionDefault',
+          );
+        },
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/api_client/api_client_generator.dart';
@@ -2061,6 +2062,60 @@ void main() {
           expect(
             regionParam.defaultTo?.accept(emitter).toString(),
             'ListThings.regionDefault',
+          );
+        },
+      );
+
+      test(
+        'suppresses dropped-default warnings — the operation class is the '
+        'sole logging site',
+        () {
+          final logs = <LogRecord>[];
+          final sub = Logger('OperationParameterDefaults')
+              .onRecord
+              .listen(logs.add);
+          addTearDown(sub.cancel);
+
+          final queryParam = QueryParameterObject(
+            name: 'enabled',
+            rawName: 'enabled',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: BooleanModel(context: testContext),
+            encoding: QueryParameterEncoding.form,
+            context: testContext,
+            examples: const [],
+            defaultValue: 'true',
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: testContext,
+            tags: {Tag(name: 'things')},
+            isDeprecated: false,
+            path: '/things',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          generator.generateClass(
+            {operation},
+            Tag(name: 'things'),
+            testServers,
+          );
+
+          expect(
+            logs.where((r) => r.level == Level.WARNING),
+            isEmpty,
           );
         },
       );

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -2067,6 +2067,64 @@ void main() {
       );
 
       test(
+        'forwarder body invokes the operation with the parameter name, not '
+        'the qualified default reference',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'region',
+            rawName: 'region',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: testContext),
+            encoding: QueryParameterEncoding.form,
+            context: testContext,
+            examples: const [],
+            defaultValue: 'us',
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: testContext,
+            tags: {Tag(name: 'things')},
+            isDeprecated: false,
+            path: '/things',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final generatedClass = generator.generateClass(
+            {operation},
+            Tag(name: 'things'),
+            testServers,
+          );
+
+          final generatedCode = format(
+            generatedClass.accept(emitter).toString(),
+          );
+
+          const expectedMethod = '''
+Future<TonikResult<void>> listThings({
+  String region = ListThings.regionDefault,
+}) async => _listThings(region: region);
+''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedMethod)),
+          );
+        },
+      );
+
+      test(
         'suppresses dropped-default warnings — the operation class is the '
         'sole logging site',
         () {

--- a/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
@@ -276,8 +276,9 @@ void main() {
       expect(warnings, hasLength(1));
       expect(
         warnings.single.message,
-        'Dropping default for Mismatched.tier (property, expected integer, '
-        'value: "no"): value does not match the expected type.',
+        'Dropping default for Mismatched.tier '
+        '(property, expected IntegerModel, value: "no"): '
+        'value does not match the expected type.',
       );
     });
 
@@ -318,7 +319,7 @@ void main() {
       expect(
         warnings.single.message,
         'Dropping default for WithAliasedBadDefault.count '
-        '(property, expected integer, value: "bad"): '
+        '(property, expected IntegerModel, value: "bad"): '
         'value does not match the expected type.',
       );
     });

--- a/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
@@ -274,7 +274,11 @@ void main() {
       final warnings =
           logs.where((r) => r.level == Level.WARNING).toList();
       expect(warnings, hasLength(1));
-      expect(warnings.single.message, contains('Mismatched.tier'));
+      expect(
+        warnings.single.message,
+        'Dropping default for Mismatched.tier (property, expected IntegerModel, '
+        'value: "no"): value does not match the parameter type.',
+      );
     });
 
     test('alias-carried mismatched default still drops + logs once', () {
@@ -313,7 +317,9 @@ void main() {
       expect(warnings, hasLength(1));
       expect(
         warnings.single.message,
-        contains('WithAliasedBadDefault.count'),
+        'Dropping default for WithAliasedBadDefault.count '
+        '(property, expected IntegerModel, value: "bad"): '
+        'value does not match the parameter type.',
       );
     });
 

--- a/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
@@ -276,8 +276,8 @@ void main() {
       expect(warnings, hasLength(1));
       expect(
         warnings.single.message,
-        'Dropping default for Mismatched.tier (property, expected IntegerModel, '
-        'value: "no"): value does not match the parameter type.',
+        'Dropping default for Mismatched.tier (property, expected integer, '
+        'value: "no"): value does not match the expected type.',
       );
     });
 
@@ -318,8 +318,8 @@ void main() {
       expect(
         warnings.single.message,
         'Dropping default for WithAliasedBadDefault.count '
-        '(property, expected IntegerModel, value: "bad"): '
-        'value does not match the parameter type.',
+        '(property, expected integer, value: "bad"): '
+        'value does not match the expected type.',
       );
     });
 

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -3103,6 +3103,91 @@ Future<TonikResult<void>> call({
           );
         },
       );
+
+      test(
+        'multipart per-part header with an aliased default does not emit a '
+        'static const field on the operation class',
+        () {
+          final aliasedModel = AliasModel(
+            name: 'TraceIdHeader',
+            model: StringModel(context: context),
+            context: context,
+            examples: const [],
+            defaultValue: 'static-trace-id',
+          );
+
+          final requestBody = RequestBodyObject(
+            name: 'uploadBody',
+            context: context,
+            description: null,
+            isRequired: true,
+            content: {
+              RequestContent(
+                model: ClassModel(
+                  name: 'UploadForm',
+                  properties: [
+                    Property(
+                      name: 'file',
+                      model: BinaryModel(context: context),
+                      isRequired: true,
+                      isNullable: false,
+                      isDeprecated: false,
+                      examples: const [],
+                      defaultValue: null,
+                    ),
+                  ],
+                  context: context,
+                  isDeprecated: false,
+                  examples: const [],
+                ),
+                contentType: ContentType.multipart,
+                rawContentType: 'multipart/form-data',
+                encoding: {
+                  'file': MultipartPropertyEncoding(
+                    contentType: ContentType.bytes,
+                    rawContentType: 'application/octet-stream',
+                    headers: {
+                      'X-Trace-Id': ResponseHeaderObject(
+                        name: 'X-Trace-Id',
+                        context: context,
+                        description: null,
+                        explode: false,
+                        model: aliasedModel,
+                        isRequired: true,
+                        isDeprecated: false,
+                        encoding: ResponseHeaderEncoding.simple,
+                        examples: const [],
+                      ),
+                    },
+                  ),
+                },
+                examples: const [],
+              ),
+            },
+          );
+
+          final operation = Operation(
+            operationId: 'upload',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/upload',
+            method: HttpMethod.post,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            requestBody: requestBody,
+            securitySchemes: const {},
+          );
+
+          final result = generator.generateClass(operation, 'Upload');
+
+          final fieldNames = result.fields.map((f) => f.name).toList();
+          expect(fieldNames, ['_dio']);
+        },
+      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -3301,7 +3301,7 @@ Future<TonikResult<void>> call({
 
       test(
         'emits exactly one warning when a primitive default value does not '
-        'match the parameter type',
+        'match the expected type',
         () {
           final logs = <LogRecord>[];
           final sub = Logger('OperationParameterDefaults')

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -2848,5 +2848,261 @@ Future<TonikResult<void>> call({
         );
       });
     });
+
+    group('generateClass — parameter defaults', () {
+      test(
+        'mixed-location defaults emit static const fields ordered '
+        'path → query → header → cookie immediately after _dio',
+        () {
+          final pathParam = PathParameterObject(
+            name: 'id',
+            rawName: 'id',
+            description: null,
+            isRequired: true,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: PathParameterEncoding.simple,
+            context: context,
+            examples: const [],
+            defaultValue: 'x',
+          );
+          final queryParam = QueryParameterObject(
+            name: 'region',
+            rawName: 'region',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: 'us',
+          );
+          final header = RequestHeaderObject(
+            name: 'retries',
+            rawName: 'X-Retries',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            explode: false,
+            model: IntegerModel(context: context),
+            encoding: HeaderParameterEncoding.simple,
+            context: context,
+            examples: const [],
+            defaultValue: 5,
+          );
+          final cookie = CookieParameterObject(
+            name: 'tracking',
+            rawName: 'tracking',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            explode: false,
+            model: BooleanModel(context: context),
+            encoding: CookieParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: false,
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/things/{id}',
+            method: HttpMethod.get,
+            headers: {header},
+            queryParameters: {queryParam},
+            pathParameters: {pathParam},
+            cookieParameters: {cookie},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final result = generator.generateClass(operation, 'ListThings');
+
+          final fieldNames = result.fields.map((f) => f.name).toList();
+          expect(fieldNames, [
+            '_dio',
+            'idDefault',
+            'regionDefault',
+            'retriesDefault',
+            'trackingDefault',
+          ]);
+
+          final regionField =
+              result.fields.firstWhere((f) => f.name == 'regionDefault');
+          expect(regionField.static, isTrue);
+          expect(regionField.modifier, FieldModifier.constant);
+          expect(regionField.type?.symbol, 'String');
+
+          final callMethod =
+              result.methods.firstWhere((m) => m.name == 'call');
+          final regionParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'region');
+          expect(regionParam.required, isFalse);
+          expect(
+            regionParam.defaultTo?.accept(emitter).toString(),
+            'regionDefault',
+          );
+          expect(regionParam.type?.accept(emitter).toString(), 'String');
+
+          final idParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'id');
+          expect(idParam.required, isFalse);
+          expect(
+            idParam.defaultTo?.accept(emitter).toString(),
+            'idDefault',
+          );
+          expect(idParam.type?.accept(emitter).toString(), 'String');
+
+          final retriesParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'retries');
+          expect(retriesParam.required, isFalse);
+          expect(
+            retriesParam.defaultTo?.accept(emitter).toString(),
+            'retriesDefault',
+          );
+          expect(retriesParam.type?.accept(emitter).toString(), 'int');
+
+          final trackingParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'tracking');
+          expect(trackingParam.required, isFalse);
+          expect(
+            trackingParam.defaultTo?.accept(emitter).toString(),
+            'trackingDefault',
+          );
+          expect(trackingParam.type?.accept(emitter).toString(), 'bool');
+        },
+      );
+
+      test(
+        'parameter with no default keeps required+nullable rules and gets '
+        'no static const field',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'filter',
+            rawName: 'filter',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          );
+
+          final operation = Operation(
+            operationId: 'noDefaults',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/pets',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final result = generator.generateClass(operation, 'NoDefaults');
+
+          expect(
+            result.fields.where((f) => f.name == 'filterDefault'),
+            isEmpty,
+          );
+
+          final callMethod =
+              result.methods.firstWhere((m) => m.name == 'call');
+          final filterParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'filter');
+          expect(filterParam.required, isFalse);
+          expect(filterParam.defaultTo, isNull);
+          expect(filterParam.type?.accept(emitter).toString(), 'String?');
+        },
+      );
+
+      test(
+        'collision: query parameter named regionDefault forces suffix on '
+        'region default',
+        () {
+          final region = QueryParameterObject(
+            name: 'region',
+            rawName: 'region',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: 'us',
+          );
+          final preExisting = QueryParameterObject(
+            name: 'regionDefault',
+            rawName: 'regionDefault',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          );
+
+          final operation = Operation(
+            operationId: 'collide',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/x',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {region, preExisting},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          final result = generator.generateClass(operation, 'Collide');
+
+          final defaultField = result.fields.firstWhere(
+            (f) => f.name == 'regionDefault2',
+            orElse: () => Field((b) => b..name = 'MISSING'),
+          );
+          expect(defaultField.name, 'regionDefault2');
+
+          final callMethod =
+              result.methods.firstWhere((m) => m.name == 'call');
+          final regionParam = callMethod.optionalParameters
+              .firstWhere((p) => p.name == 'region');
+          expect(
+            regionParam.defaultTo?.accept(emitter).toString(),
+            'regionDefault2',
+          );
+        },
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
@@ -3186,6 +3187,166 @@ Future<TonikResult<void>> call({
 
           final fieldNames = result.fields.map((f) => f.name).toList();
           expect(fieldNames, ['_dio']);
+        },
+      );
+
+      test(
+        'call() body delegates to _path/_queryParameters with the parameter '
+        'name, not the qualified default reference',
+        () {
+          final queryParam = QueryParameterObject(
+            name: 'region',
+            rawName: 'region',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: StringModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: 'us',
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/things',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  String region = regionDefault,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(
+      path: _$newPath,
+      query: _queryParameters(region: region),
+    );
+    _$data = _data();
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final cls = generator.generateClass(operation, 'ListThings');
+          final method = cls.methods.firstWhere((m) => m.name == 'call');
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(expectedMethod),
+          );
+        },
+      );
+
+      test(
+        'emits exactly one warning when a primitive default value does not '
+        'match the parameter type',
+        () {
+          final logs = <LogRecord>[];
+          final sub = Logger('OperationParameterDefaults')
+              .onRecord
+              .listen(logs.add);
+          addTearDown(sub.cancel);
+
+          final queryParam = QueryParameterObject(
+            name: 'enabled',
+            rawName: 'enabled',
+            description: null,
+            isRequired: false,
+            isDeprecated: false,
+            allowEmptyValue: false,
+            allowReserved: false,
+            explode: false,
+            model: BooleanModel(context: context),
+            encoding: QueryParameterEncoding.form,
+            context: context,
+            examples: const [],
+            defaultValue: 'true',
+          );
+
+          final operation = Operation(
+            operationId: 'listThings',
+            context: context,
+            tags: const {},
+            isDeprecated: false,
+            path: '/things',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: {queryParam},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            securitySchemes: const {},
+          );
+
+          generator.generateClass(operation, 'ListThings');
+
+          final warnings =
+              logs.where((r) => r.level == Level.WARNING).toList();
+          expect(warnings, hasLength(1));
+          expect(warnings.single.message, contains('ListThings'));
+          expect(warnings.single.message, contains('enabled'));
         },
       );
     });

--- a/packages/tonik_generate/test/src/util/default_resolution_test.dart
+++ b/packages/tonik_generate/test/src/util/default_resolution_test.dart
@@ -68,7 +68,7 @@ void main() {
         expect(messages, hasLength(1));
         expect(
           messages.single,
-          'Dropping default for BadOp.name (query, expected integer, '
+          'Dropping default for BadOp.name (query, expected IntegerModel, '
           'value: "not-a-number"): '
           'value does not match the expected type.',
         );
@@ -98,7 +98,7 @@ void main() {
         expect(messages, hasLength(1));
         expect(
           messages.single,
-          'Dropping default for Op.since (query, expected string (date-time), '
+          'Dropping default for Op.since (query, expected DateTimeModel, '
           'value: "2024-01-01T00:00:00Z"): '
           'default value cannot be expressed as a const Dart expression '
           'for this type.',

--- a/packages/tonik_generate/test/src/util/default_resolution_test.dart
+++ b/packages/tonik_generate/test/src/util/default_resolution_test.dart
@@ -1,0 +1,304 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/default_resolution.dart';
+
+void main() {
+  late NameManager nameManager;
+  late Context context;
+  late DartEmitter emitter;
+
+  setUp(() {
+    nameManager = NameManager(
+      generator: NameGenerator(),
+      stableModelSorter: StableModelSorter(),
+    );
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  String renderAssignment(Code? assignment) =>
+      assignment == null ? '' : assignment.accept(emitter).toString();
+
+  group('resolveSingleDefault', () {
+    test(
+      'absent raw default returns null without touching reserved names',
+      () {
+        final reserved = <String>{'region'};
+        final result = resolveSingleDefault(
+          normalizedName: 'region',
+          specName: 'region',
+          model: StringModel(context: context),
+          rawDefault: null,
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: (_) {},
+        );
+        expect(result, isNull);
+        expect(reserved, {'region'});
+      },
+    );
+
+    test(
+      'primitive type mismatch returns null and emits a unified warning '
+      'with container, spec name, location, expected type, value, and reason',
+      () {
+        final messages = <String>[];
+        final reserved = <String>{'name'};
+        final result = resolveSingleDefault(
+          normalizedName: 'name',
+          specName: 'name',
+          model: IntegerModel(context: context),
+          rawDefault: 'not-a-number',
+          containerName: 'BadOp',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+
+        expect(result, isNull);
+        expect(reserved, {'name'});
+        expect(messages, hasLength(1));
+        expect(
+          messages.single,
+          'Dropping default for BadOp.name (query, expected IntegerModel, '
+          'value: "not-a-number"): '
+          'value does not match the parameter type.',
+        );
+      },
+    );
+
+    test(
+      'non-const-materialisable primitive (DateTime) returns null and emits '
+      'the const-expression reason',
+      () {
+        final messages = <String>[];
+        final reserved = <String>{'since'};
+        final result = resolveSingleDefault(
+          normalizedName: 'since',
+          specName: 'since',
+          model: DateTimeModel(context: context),
+          rawDefault: '2024-01-01T00:00:00Z',
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+
+        expect(result, isNull);
+        expect(messages, hasLength(1));
+        expect(
+          messages.single,
+          'Dropping default for Op.since (query, expected DateTimeModel, '
+          'value: "2024-01-01T00:00:00Z"): '
+          'default value cannot be expressed as a const Dart expression '
+          'for this type.',
+        );
+      },
+    );
+
+    test(
+      'composite target (ClassModel) drops the default silently — no result, '
+      'no warning, reserved names untouched',
+      () {
+        final messages = <String>[];
+        final reserved = <String>{'region'};
+        final result = resolveSingleDefault(
+          normalizedName: 'region',
+          specName: 'region',
+          model: ClassModel(
+            isDeprecated: false,
+            name: 'Region',
+            properties: const [],
+            context: context,
+            examples: const [],
+          ),
+          rawDefault: const <String, Object?>{},
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+
+        expect(result, isNull);
+        expect(messages, isEmpty);
+        expect(reserved, {'region'});
+      },
+    );
+
+    test(
+      'success path returns memberName, materialised value, and type; '
+      'mutates reserved names',
+      () {
+        final reserved = <String>{'region'};
+        final result = resolveSingleDefault(
+          normalizedName: 'region',
+          specName: 'region',
+          model: StringModel(context: context),
+          rawDefault: 'us',
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: (_) {},
+        );
+
+        expect(result, isNotNull);
+        expect(result!.memberName, 'regionDefault');
+        expect(result.type.symbol, 'String');
+        expect(reserved, {'region', 'regionDefault'});
+
+        final field = defaultField(result);
+        expect(field.static, isTrue);
+        expect(field.modifier, FieldModifier.constant);
+        expect(field.name, 'regionDefault');
+        expect(field.type?.symbol, 'String');
+        expect(renderAssignment(field.assignment), "r'us'");
+      },
+    );
+
+    test(
+      'name collision against existing reserved name appends suffix',
+      () {
+        final reserved = <String>{'region', 'regionDefault'};
+        final result = resolveSingleDefault(
+          normalizedName: 'region',
+          specName: 'region',
+          model: StringModel(context: context),
+          rawDefault: 'us',
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: (_) {},
+        );
+
+        expect(result, isNotNull);
+        expect(result!.memberName, 'regionDefault2');
+        expect(reserved.contains('regionDefault2'), isTrue);
+      },
+    );
+
+    test(
+      'null onDroppedDefault suppresses the warning while still returning null',
+      () {
+        final reserved = <String>{'page'};
+        final result = resolveSingleDefault(
+          normalizedName: 'page',
+          specName: 'page',
+          model: IntegerModel(context: context),
+          rawDefault: 'not-a-number',
+          containerName: 'BadOp',
+          location: 'query',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: null,
+        );
+        expect(result, isNull);
+        expect(reserved, {'page'});
+      },
+    );
+
+    test(
+      'isNullableOverride forces a nullable type reference on success',
+      () {
+        final reserved = <String>{'nickname'};
+        final result = resolveSingleDefault(
+          normalizedName: 'nickname',
+          specName: 'nickname',
+          model: StringModel(context: context),
+          rawDefault: 'fallback',
+          containerName: 'Holder',
+          location: 'property',
+          reservedNames: reserved,
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: (_) {},
+          isNullableOverride: true,
+        );
+
+        expect(result, isNotNull);
+        expect(result!.type.isNullable, isTrue);
+        expect(result.type.accept(emitter).toString(), 'String?');
+      },
+    );
+
+    test(
+      'warning describes a non-JSON-encodable raw default via toString',
+      () {
+        final messages = <String>[];
+        final yamlDateTime = DateTime.utc(2024, 6, 15);
+        resolveSingleDefault(
+          normalizedName: 'since',
+          specName: 'since',
+          model: DateTimeModel(context: context),
+          rawDefault: yamlDateTime,
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: <String>{'since'},
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+        expect(messages, hasLength(1));
+        expect(messages.single, contains(yamlDateTime.toString()));
+      },
+    );
+
+    test(
+      'warning JSON-encodes a Map<String,Object?> raw default with valid keys',
+      () {
+        final messages = <String>[];
+        resolveSingleDefault(
+          normalizedName: 'value',
+          specName: 'value',
+          model: DateTimeModel(context: context),
+          rawDefault: const <String, Object?>{'a': 1, 'b': null},
+          containerName: 'Op',
+          location: 'query',
+          reservedNames: <String>{'value'},
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+        expect(messages, hasLength(1));
+        expect(messages.single, contains('{"a":1,"b":null}'));
+      },
+    );
+
+    test(
+      'property location label is preserved verbatim in the warning',
+      () {
+        final messages = <String>[];
+        resolveSingleDefault(
+          normalizedName: 'tier',
+          specName: 'tier',
+          model: IntegerModel(context: context),
+          rawDefault: 'no',
+          containerName: 'Mismatched',
+          location: 'property',
+          reservedNames: <String>{'tier'},
+          nameManager: nameManager,
+          package: 'api',
+          onDroppedDefault: messages.add,
+        );
+        expect(messages, hasLength(1));
+        expect(messages.single, contains('Mismatched.tier (property,'));
+      },
+    );
+  });
+}

--- a/packages/tonik_generate/test/src/util/default_resolution_test.dart
+++ b/packages/tonik_generate/test/src/util/default_resolution_test.dart
@@ -68,9 +68,9 @@ void main() {
         expect(messages, hasLength(1));
         expect(
           messages.single,
-          'Dropping default for BadOp.name (query, expected IntegerModel, '
+          'Dropping default for BadOp.name (query, expected integer, '
           'value: "not-a-number"): '
-          'value does not match the parameter type.',
+          'value does not match the expected type.',
         );
       },
     );
@@ -98,7 +98,7 @@ void main() {
         expect(messages, hasLength(1));
         expect(
           messages.single,
-          'Dropping default for Op.since (query, expected DateTimeModel, '
+          'Dropping default for Op.since (query, expected string (date-time), '
           'value: "2024-01-01T00:00:00Z"): '
           'default value cannot be expressed as a const Dart expression '
           'for this type.',

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -939,4 +939,38 @@ void main() {
       },
     );
   });
+
+  group('OperationParameterDefault.withOwner', () {
+    test('qualifies a local default with the supplied owner', () {
+      const local = OperationParameterDefault.local(
+        memberName: 'regionDefault',
+      );
+
+      final qualified = local.withOwner(
+        className: 'ListThings',
+        url: 'package:api/src/operation/list_things.dart',
+      );
+
+      expect(
+        qualified.defaultToCode().accept(emitter).toString(),
+        'ListThings.regionDefault',
+      );
+    });
+
+    test('asserts when called on an already-qualified default', () {
+      const qualified = OperationParameterDefault.qualified(
+        memberName: 'regionDefault',
+        className: 'ListThings',
+        url: 'package:api/src/operation/list_things.dart',
+      );
+
+      expect(
+        () => qualified.withOwner(
+          className: 'OtherClass',
+          url: 'package:api/src/operation/other_class.dart',
+        ),
+        throwsA(isA<AssertionError>()),
+      );
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -255,7 +255,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BadOp.page'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected integer'));
+        expect(message, contains('expected IntegerModel'));
         expect(message, contains('"not-a-number"'));
         expect(message, contains('value does not match the expected type'));
       },
@@ -308,7 +308,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BoolOp.enabled'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected boolean'));
+        expect(message, contains('expected BooleanModel'));
         expect(message, contains('"true"'));
         expect(message, contains('value does not match the expected type'));
       },
@@ -361,7 +361,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('StrOp.name'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected string'));
+        expect(message, contains('expected StringModel'));
         expect(message, contains('value: 42'));
         expect(message, contains('value does not match the expected type'));
       },
@@ -560,7 +560,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('Op.since'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected string (date-time)'));
+        expect(message, contains('expected DateTimeModel'));
         expect(message, contains('"2024-01-01T00:00:00Z"'));
         expect(
           message,

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -897,47 +897,32 @@ void main() {
       final names = initialOperationDefaultReservedNames(
         normalizedParams: normalized,
         hasRequestBody: true,
-        hasResponses: true,
-        hasQueryParameters: true,
       );
 
       expect(names, containsAll(<String>[
-        '_dio',
         'call',
-        '_path',
-        '_data',
-        '_options',
-        '_queryParameters',
-        '_parseResponse',
         'body',
         'cancelToken',
         'region',
       ]));
     });
 
-    test(
-      'omits body, query, response method names when not applicable',
-      () {
-        const normalized = NormalizedRequestParameters(
-          pathParameters: [],
-          queryParameters: [],
-          headers: [],
-          cookieParameters: [],
-        );
+    test('omits body when no request body is present', () {
+      const normalized = NormalizedRequestParameters(
+        pathParameters: [],
+        queryParameters: [],
+        headers: [],
+        cookieParameters: [],
+      );
 
-        final names = initialOperationDefaultReservedNames(
-          normalizedParams: normalized,
-          hasRequestBody: false,
-          hasResponses: false,
-          hasQueryParameters: false,
-        );
+      final names = initialOperationDefaultReservedNames(
+        normalizedParams: normalized,
+        hasRequestBody: false,
+      );
 
-        expect(names.contains('body'), isFalse);
-        expect(names.contains('_queryParameters'), isFalse);
-        expect(names.contains('_parseResponse'), isFalse);
-        expect(names, containsAll(<String>['_dio', 'cancelToken', 'call']));
-      },
-    );
+      expect(names.contains('body'), isFalse);
+      expect(names, containsAll(<String>['cancelToken', 'call']));
+    });
   });
 
   group('OperationParameterDefault.withOwner', () {

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -64,6 +64,52 @@ void main() {
       },
     );
 
+    test(
+      'explicit defaultValue: null is treated as no default — no field, '
+      'no warning, no byName entry',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {region},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+      },
+    );
+
     test('materialises primitive defaults across all four locations '
         'in path → query → header → cookie field order', () {
       final pathId = PathParameterObject(
@@ -209,6 +255,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BadOp.page'));
         expect(message, contains('(query,'));
+        expect(message, contains('expected IntegerModel'));
         expect(message, contains('"not-a-number"'));
         expect(message, contains('value does not match the parameter type'));
       },
@@ -261,6 +308,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BoolOp.enabled'));
         expect(message, contains('(query,'));
+        expect(message, contains('expected BooleanModel'));
         expect(message, contains('"true"'));
         expect(message, contains('value does not match the parameter type'));
       },
@@ -313,6 +361,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('StrOp.name'));
         expect(message, contains('(query,'));
+        expect(message, contains('expected StringModel'));
         expect(message, contains('value: 42'));
         expect(message, contains('value does not match the parameter type'));
       },
@@ -511,6 +560,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('Op.since'));
         expect(message, contains('(query,'));
+        expect(message, contains('expected DateTimeModel'));
         expect(message, contains('"2024-01-01T00:00:00Z"'));
         expect(
           message,

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -1,3 +1,5 @@
+import 'dart:async';
+
 import 'package:code_builder/code_builder.dart';
 import 'package:logging/logging.dart';
 import 'package:test/test.dart';
@@ -204,7 +206,115 @@ void main() {
         expect(result.fields, isEmpty);
         final warnings = logs.where((r) => r.level == Level.WARNING).toList();
         expect(warnings, hasLength(1));
-        expect(warnings.single.message, contains('BadOp.page'));
+        final message = warnings.single.message;
+        expect(message, contains('BadOp.page'));
+        expect(message, contains('(query,'));
+        expect(message, contains('"not-a-number"'));
+        expect(message, contains('value does not match the parameter type'));
+      },
+    );
+
+    test(
+      'type mismatch on a boolean parameter emits a warning with the '
+      'location, value, and reason',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final bad = QueryParameterObject(
+          name: 'enabled',
+          rawName: 'enabled',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: BooleanModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'true',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {bad},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'BoolOp',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        final message = warnings.single.message;
+        expect(message, contains('BoolOp.enabled'));
+        expect(message, contains('(query,'));
+        expect(message, contains('"true"'));
+        expect(message, contains('value does not match the parameter type'));
+      },
+    );
+
+    test(
+      'type mismatch on a string parameter (int value) emits a warning with '
+      'the JSON-encoded numeric value',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final bad = QueryParameterObject(
+          name: 'name',
+          rawName: 'name',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 42,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {bad},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'StrOp',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        final message = warnings.single.message;
+        expect(message, contains('StrOp.name'));
+        expect(message, contains('(query,'));
+        expect(message, contains('value: 42'));
+        expect(message, contains('value does not match the parameter type'));
       },
     );
 
@@ -355,8 +465,8 @@ void main() {
     );
 
     test(
-      'date-time target with a valid date-time literal emits no field '
-      'and no warning',
+      'date-time target emits no field but warns that the value is not '
+      'const-materialisable',
       () {
         final logs = <LogRecord>[];
         final sub = Logger('OperationParameterDefaults')
@@ -396,7 +506,16 @@ void main() {
 
         expect(result.byName.containsKey('since'), isFalse);
         expect(result.fields, isEmpty);
-        expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        final message = warnings.single.message;
+        expect(message, contains('Op.since'));
+        expect(message, contains('(query,'));
+        expect(message, contains('"2024-01-01T00:00:00Z"'));
+        expect(
+          message,
+          contains('cannot be expressed as a const Dart expression'),
+        );
       },
     );
 
@@ -448,6 +567,255 @@ void main() {
         expect(result.byName, isEmpty);
         expect(result.fields, isEmpty);
         expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+      },
+    );
+
+    test(
+      'double parameter with numeric default materialises a double-typed '
+      'const field',
+      () {
+        final ratio = QueryParameterObject(
+          name: 'ratio',
+          rawName: 'ratio',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: DoubleModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 1.5,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {ratio},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName['ratio']?.memberName, 'ratioDefault');
+        expect(result.fields, hasLength(1));
+        expect(result.fields.single.type?.symbol, 'double');
+        expect(renderAssignment(result.fields.single.assignment), '1.5');
+      },
+    );
+
+    test(
+      'number parameter with int default materialises a num-typed '
+      'const field',
+      () {
+        final ratio = QueryParameterObject(
+          name: 'ratio',
+          rawName: 'ratio',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: NumberModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 2,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {ratio},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName['ratio']?.memberName, 'ratioDefault');
+        expect(result.fields, hasLength(1));
+        expect(result.fields.single.type?.symbol, 'num');
+        expect(renderAssignment(result.fields.single.assignment), '2');
+      },
+    );
+
+    test(
+      'enum parameter with a defaulted variant emits no field and no '
+      'warning (composite/non-PrimitiveModel — silent by design)',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final order = QueryParameterObject(
+          name: 'order',
+          rawName: 'order',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: EnumModel<String>(
+            name: 'Order',
+            values: {
+              const EnumEntry(value: 'asc'),
+              const EnumEntry(value: 'desc'),
+            },
+            isNullable: false,
+            isDeprecated: false,
+            context: context,
+            examples: const [],
+          ),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'desc',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {order},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+      },
+    );
+
+    test(
+      'warning formatter falls back to toString when the raw default is '
+      'not JSON-encodable (e.g. a YAML-parsed DateTime)',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final yamlDateTime = DateTime.utc(2024, 6, 15);
+        final bad = QueryParameterObject(
+          name: 'since',
+          rawName: 'since',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: DateTimeModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: yamlDateTime,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {bad},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        expect(warnings.single.message, contains(yamlDateTime.toString()));
+      },
+    );
+
+    test(
+      'emitWarnings: false suppresses the dropped-default warning while '
+      'the default emitWarnings: true logs exactly once',
+      () {
+        final bad = QueryParameterObject(
+          name: 'page',
+          rawName: 'page',
+          description: null,
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: IntegerModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'not-a-number',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {bad},
+          headers: const {},
+        );
+
+        final suppressedLogs = <LogRecord>[];
+        final suppressedSub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(suppressedLogs.add);
+        resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'BadOp',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+          emitWarnings: false,
+        );
+        unawaited(suppressedSub.cancel());
+        expect(
+          suppressedLogs.where((r) => r.level == Level.WARNING),
+          isEmpty,
+        );
+
+        final emittedLogs = <LogRecord>[];
+        final emittedSub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(emittedLogs.add);
+        addTearDown(emittedSub.cancel);
+        resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'BadOp',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+        expect(
+          emittedLogs.where((r) => r.level == Level.WARNING),
+          hasLength(1),
+        );
       },
     );
   });

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -1,0 +1,524 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
+
+void main() {
+  late NameManager nameManager;
+  late Context context;
+  late DartEmitter emitter;
+
+  setUp(() {
+    nameManager = NameManager(
+      generator: NameGenerator(),
+      stableModelSorter: StableModelSorter(),
+    );
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  String renderAssignment(Code? assignment) =>
+      assignment == null ? '' : assignment.accept(emitter).toString();
+
+  group('resolveOperationParameterDefaults', () {
+    test(
+      'returns empty result when no parameter carries a default',
+      () {
+        final normalized = normalizeRequestParameters(
+          pathParameters: {
+            PathParameterObject(
+              name: 'id',
+              rawName: 'id',
+              description: null,
+              isRequired: true,
+              isDeprecated: false,
+              allowEmptyValue: false,
+              explode: false,
+              model: StringModel(context: context),
+              encoding: PathParameterEncoding.simple,
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+          },
+          queryParameters: const {},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+      },
+    );
+
+    test('materialises primitive defaults across all four locations '
+        'in path → query → header → cookie field order', () {
+      final pathId = PathParameterObject(
+        name: 'id',
+        rawName: 'id',
+        description: null,
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: PathParameterEncoding.simple,
+        context: context,
+        examples: const [],
+        defaultValue: 'x',
+      );
+      final qRegion = QueryParameterObject(
+        name: 'region',
+        rawName: 'region',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        allowReserved: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: QueryParameterEncoding.form,
+        context: context,
+        examples: const [],
+        defaultValue: 'us',
+      );
+      final hRetries = RequestHeaderObject(
+        name: 'retries',
+        rawName: 'X-Retries',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        model: IntegerModel(context: context),
+        encoding: HeaderParameterEncoding.simple,
+        context: context,
+        examples: const [],
+        defaultValue: 5,
+      );
+      final cTracking = CookieParameterObject(
+        name: 'tracking',
+        rawName: 'tracking',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        explode: false,
+        model: BooleanModel(context: context),
+        encoding: CookieParameterEncoding.form,
+        context: context,
+        examples: const [],
+        defaultValue: false,
+      );
+
+      final normalized = normalizeRequestParameters(
+        pathParameters: {pathId},
+        queryParameters: {qRegion},
+        headers: {hRetries},
+        cookieParameters: {cTracking},
+      );
+
+      final result = resolveOperationParameterDefaults(
+        normalizedParams: normalized,
+        operationClassName: 'ListThings',
+        nameManager: nameManager,
+        package: 'api',
+        initialReservedNames: const {'_dio'},
+      );
+
+      expect(
+        result.byName.keys.toList(),
+        ['id', 'region', 'retries', 'tracking'],
+      );
+      expect(
+        result.fields.map((f) => f.name).toList(),
+        ['idDefault', 'regionDefault', 'retriesDefault', 'trackingDefault'],
+      );
+
+      expect(result.fields[0].type?.symbol, 'String');
+      expect(result.fields[0].static, isTrue);
+      expect(result.fields[0].modifier, FieldModifier.constant);
+      expect(renderAssignment(result.fields[0].assignment), "r'x'");
+
+      expect(result.fields[1].type?.symbol, 'String');
+      expect(renderAssignment(result.fields[1].assignment), "r'us'");
+
+      expect(result.fields[2].type?.symbol, 'int');
+      expect(renderAssignment(result.fields[2].assignment), '5');
+
+      expect(result.fields[3].type?.symbol, 'bool');
+      expect(renderAssignment(result.fields[3].assignment), 'false');
+    });
+
+    test(
+      'drops type-mismatched default with a single warning, no field, '
+      'no map entry',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final bad = QueryParameterObject(
+          name: 'page',
+          rawName: 'page',
+          description: null,
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: IntegerModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'not-a-number',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {bad},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'BadOp',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
+        expect(warnings, hasLength(1));
+        expect(warnings.single.message, contains('BadOp.page'));
+      },
+    );
+
+    test(
+      'alias-carried default surfaces via effectiveDefaultValue',
+      () {
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: AliasModel(
+            name: 'Region',
+            model: StringModel(context: context),
+            context: context,
+            examples: const [],
+            defaultValue: 'us',
+          ),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {region},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName['region']?.memberName, 'regionDefault');
+        expect(result.fields, hasLength(1));
+        expect(renderAssignment(result.fields.single.assignment), "r'us'");
+      },
+    );
+
+    test(
+      'parameter-local default takes precedence over alias default',
+      () {
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: AliasModel(
+            name: 'Region',
+            model: StringModel(context: context),
+            context: context,
+            examples: const [],
+            defaultValue: 'us',
+          ),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'eu',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {region},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(renderAssignment(result.fields.single.assignment), "r'eu'");
+      },
+    );
+
+    test(
+      'collision: parameter normalized name matches the candidate default '
+      'name — suffix is appended',
+      () {
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'us',
+        );
+        final preExisting = QueryParameterObject(
+          name: 'regionDefault',
+          rawName: 'regionDefault',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {region, preExisting},
+          headers: const {},
+        );
+
+        final reserved = <String>{
+          '_dio',
+          for (final p in normalized.queryParameters) p.normalizedName,
+        };
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: reserved,
+        );
+
+        expect(result.byName['region']?.memberName, 'regionDefault2');
+      },
+    );
+
+    test(
+      'date-time target with a valid date-time literal emits no field '
+      'and no warning',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final since = QueryParameterObject(
+          name: 'since',
+          rawName: 'since',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: DateTimeModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: '2024-01-01T00:00:00Z',
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {since},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName.containsKey('since'), isFalse);
+        expect(result.fields, isEmpty);
+        expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+      },
+    );
+
+    test(
+      'composite target with default emits no field and no warning',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger('OperationParameterDefaults')
+            .onRecord
+            .listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: ClassModel(
+            isDeprecated: false,
+            name: 'Region',
+            properties: const [],
+            context: context,
+            examples: const [],
+          ),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: const <String, Object?>{},
+        );
+
+        final normalized = normalizeRequestParameters(
+          pathParameters: const {},
+          queryParameters: {region},
+          headers: const {},
+        );
+
+        final result = resolveOperationParameterDefaults(
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          nameManager: nameManager,
+          package: 'api',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(result.byName, isEmpty);
+        expect(result.fields, isEmpty);
+        expect(logs.where((r) => r.level == Level.WARNING), isEmpty);
+      },
+    );
+  });
+
+  group('initialOperationDefaultReservedNames', () {
+    test('reserves the standard operation class member names', () {
+      final region = QueryParameterObject(
+        name: 'region',
+        rawName: 'region',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        allowReserved: false,
+        explode: false,
+        model: StringModel(context: context),
+        encoding: QueryParameterEncoding.form,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final normalized = normalizeRequestParameters(
+        pathParameters: const {},
+        queryParameters: {region},
+        headers: const {},
+      );
+
+      final names = initialOperationDefaultReservedNames(
+        normalizedParams: normalized,
+        hasRequestBody: true,
+        hasResponses: true,
+        hasQueryParameters: true,
+      );
+
+      expect(names, containsAll(<String>[
+        '_dio',
+        'call',
+        '_path',
+        '_data',
+        '_options',
+        '_queryParameters',
+        '_parseResponse',
+        'body',
+        'cancelToken',
+        'region',
+      ]));
+    });
+
+    test(
+      'omits body, query, response method names when not applicable',
+      () {
+        const normalized = NormalizedRequestParameters(
+          pathParameters: [],
+          queryParameters: [],
+          headers: [],
+          cookieParameters: [],
+        );
+
+        final names = initialOperationDefaultReservedNames(
+          normalizedParams: normalized,
+          hasRequestBody: false,
+          hasResponses: false,
+          hasQueryParameters: false,
+        );
+
+        expect(names.contains('body'), isFalse);
+        expect(names.contains('_queryParameters'), isFalse);
+        expect(names.contains('_parseResponse'), isFalse);
+        expect(names, containsAll(<String>['_dio', 'cancelToken', 'call']));
+      },
+    );
+  });
+}

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -255,9 +255,9 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BadOp.page'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected IntegerModel'));
+        expect(message, contains('expected integer'));
         expect(message, contains('"not-a-number"'));
-        expect(message, contains('value does not match the parameter type'));
+        expect(message, contains('value does not match the expected type'));
       },
     );
 
@@ -308,9 +308,9 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('BoolOp.enabled'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected BooleanModel'));
+        expect(message, contains('expected boolean'));
         expect(message, contains('"true"'));
-        expect(message, contains('value does not match the parameter type'));
+        expect(message, contains('value does not match the expected type'));
       },
     );
 
@@ -361,9 +361,9 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('StrOp.name'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected StringModel'));
+        expect(message, contains('expected string'));
         expect(message, contains('value: 42'));
-        expect(message, contains('value does not match the parameter type'));
+        expect(message, contains('value does not match the expected type'));
       },
     );
 
@@ -560,7 +560,7 @@ void main() {
         final message = warnings.single.message;
         expect(message, contains('Op.since'));
         expect(message, contains('(query,'));
-        expect(message, contains('expected DateTimeModel'));
+        expect(message, contains('expected string (date-time)'));
         expect(message, contains('"2024-01-01T00:00:00Z"'));
         expect(
           message,

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -1145,6 +1145,99 @@ void main() {
       final typeCode = headerParam.type?.accept(emitter).toString();
       expect(typeCode, contains('String'));
     });
+
+    test(
+      'per-part header backed by an alias with a default does not receive a '
+      'defaultTo or static const field (defaults pipeline is operation '
+      'parameters only)',
+      () {
+        final aliasedModel = AliasModel(
+          name: 'TraceIdHeader',
+          model: StringModel(context: context),
+          context: context,
+          examples: const [],
+          defaultValue: 'static-trace-id',
+        );
+
+        final requestBody = RequestBodyObject(
+          name: 'uploadBody',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'UploadForm',
+                properties: [
+                  Property(
+                    name: 'file',
+                    model: BinaryModel(context: context),
+                    isRequired: true,
+                    isNullable: false,
+                    isDeprecated: false,
+                    examples: const [],
+                    defaultValue: null,
+                  ),
+                ],
+                context: context,
+                isDeprecated: false,
+                examples: const [],
+              ),
+              contentType: ContentType.multipart,
+              rawContentType: 'multipart/form-data',
+              encoding: {
+                'file': MultipartPropertyEncoding(
+                  contentType: ContentType.bytes,
+                  rawContentType: 'application/octet-stream',
+                  headers: {
+                    'X-Trace-Id': ResponseHeaderObject(
+                      name: 'X-Trace-Id',
+                      context: context,
+                      description: null,
+                      explode: false,
+                      model: aliasedModel,
+                      isRequired: true,
+                      isDeprecated: false,
+                      encoding: ResponseHeaderEncoding.simple,
+                      examples: const [],
+                    ),
+                  },
+                ),
+              },
+              examples: const [],
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'upload',
+          context: context,
+          tags: const {},
+          isDeprecated: false,
+          path: '/upload',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final headerParam = parameters.firstWhere(
+          (p) => p.name == 'fileTraceId',
+        );
+        expect(headerParam.defaultTo, isNull);
+        expect(headerParam.required, isTrue);
+      },
+    );
   });
 
   group('body parameter name collision', () {
@@ -1772,7 +1865,7 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'region': OperationParameterDefault(
+            'region': OperationParameterDefault.local(
               memberName: 'regionDefault',
               value: const CodeExpression(Code("r'us'")),
               type: _dummyType,
@@ -1816,7 +1909,7 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'page': OperationParameterDefault(
+            'page': OperationParameterDefault.local(
               memberName: 'pageDefault',
               value: const CodeExpression(Code('1')),
               type: _dummyType,
@@ -1856,7 +1949,7 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'retries': OperationParameterDefault(
+            'retries': OperationParameterDefault.local(
               memberName: 'retriesDefault',
               value: const CodeExpression(Code('5')),
               type: _dummyType,
@@ -1896,7 +1989,7 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'tracking': OperationParameterDefault(
+            'tracking': OperationParameterDefault.local(
               memberName: 'trackingDefault',
               value: const CodeExpression(Code('false')),
               type: _dummyType,
@@ -1943,7 +2036,7 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'id': OperationParameterDefault(
+            'id': OperationParameterDefault.local(
               memberName: 'idDefault',
               value: const CodeExpression(Code("r'x'")),
               type: _dummyType,

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -1865,10 +1865,8 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'region': OperationParameterDefault.local(
+            'region': const OperationParameterDefault.local(
               memberName: 'regionDefault',
-              value: const CodeExpression(Code("r'us'")),
-              type: _dummyType,
             ),
           },
         );
@@ -1909,10 +1907,8 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'page': OperationParameterDefault.local(
+            'page': const OperationParameterDefault.local(
               memberName: 'pageDefault',
-              value: const CodeExpression(Code('1')),
-              type: _dummyType,
             ),
           },
         );
@@ -1949,10 +1945,8 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'retries': OperationParameterDefault.local(
+            'retries': const OperationParameterDefault.local(
               memberName: 'retriesDefault',
-              value: const CodeExpression(Code('5')),
-              type: _dummyType,
             ),
           },
         );
@@ -1989,10 +1983,8 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'tracking': OperationParameterDefault.local(
+            'tracking': const OperationParameterDefault.local(
               memberName: 'trackingDefault',
-              value: const CodeExpression(Code('false')),
-              type: _dummyType,
             ),
           },
         );
@@ -2036,10 +2028,8 @@ void main() {
           nameManager: nameManager,
           package: 'api',
           defaultsByName: {
-            'id': OperationParameterDefault.local(
+            'id': const OperationParameterDefault.local(
               memberName: 'idDefault',
-              value: const CodeExpression(Code("r'x'")),
-              type: _dummyType,
             ),
           },
         );
@@ -2086,9 +2076,3 @@ void main() {
     );
   });
 }
-
-final _dummyType = TypeReference(
-  (b) => b
-    ..symbol = 'String'
-    ..url = 'dart:core',
-);

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -3,6 +3,7 @@ import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/operation_parameter_generator.dart';
 
 void main() {
@@ -1722,4 +1723,279 @@ void main() {
       },
     );
   });
+
+  group('generateParameters — defaultsByName', () {
+    Operation operationWith({
+      Set<QueryParameterObject> queryParameters = const {},
+      Set<PathParameterObject> pathParameters = const {},
+      Set<RequestHeaderObject> headers = const {},
+      Set<CookieParameterObject> cookieParameters = const {},
+      String path = '/things',
+    }) => Operation(
+      operationId: 'op',
+      context: context,
+      tags: const {},
+      isDeprecated: false,
+      path: path,
+      method: HttpMethod.get,
+      headers: headers,
+      queryParameters: queryParameters,
+      pathParameters: pathParameters,
+      cookieParameters: cookieParameters,
+      responses: const {},
+      securitySchemes: const {},
+    );
+
+    test(
+      'optional query string with materialised default becomes non-required '
+      'with defaultTo and non-nullable type',
+      () {
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 'us',
+        );
+
+        final operation = operationWith(queryParameters: {region});
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+          defaultsByName: {
+            'region': OperationParameterDefault(
+              memberName: 'regionDefault',
+              value: const CodeExpression(Code("r'us'")),
+              type: _dummyType,
+            ),
+          },
+        );
+
+        expect(parameters.length, 1);
+        final param = parameters.single;
+        expect(param.name, 'region');
+        expect(param.required, isFalse);
+        expect(param.named, isTrue);
+        expect(param.defaultTo?.accept(emitter).toString(), 'regionDefault');
+        expect(param.type?.accept(emitter).toString(), 'String');
+      },
+    );
+
+    test(
+      'required query int with materialised default becomes non-required '
+      'with defaultTo',
+      () {
+        final page = QueryParameterObject(
+          name: 'page',
+          rawName: 'page',
+          description: null,
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: IntegerModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: 1,
+        );
+
+        final operation = operationWith(queryParameters: {page});
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+          defaultsByName: {
+            'page': OperationParameterDefault(
+              memberName: 'pageDefault',
+              value: const CodeExpression(Code('1')),
+              type: _dummyType,
+            ),
+          },
+        );
+
+        final param = parameters.single;
+        expect(param.required, isFalse);
+        expect(param.defaultTo?.accept(emitter).toString(), 'pageDefault');
+        expect(param.type?.accept(emitter).toString(), 'int');
+      },
+    );
+
+    test(
+      'header integer with materialised default exposes defaultTo + '
+      'non-nullable int type',
+      () {
+        final retries = RequestHeaderObject(
+          name: 'retries',
+          rawName: 'X-Retries',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          model: IntegerModel(context: context),
+          encoding: HeaderParameterEncoding.simple,
+          context: context,
+          examples: const [],
+          defaultValue: 5,
+        );
+
+        final operation = operationWith(headers: {retries});
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+          defaultsByName: {
+            'retries': OperationParameterDefault(
+              memberName: 'retriesDefault',
+              value: const CodeExpression(Code('5')),
+              type: _dummyType,
+            ),
+          },
+        );
+
+        final param = parameters.single;
+        expect(param.name, 'retries');
+        expect(param.required, isFalse);
+        expect(param.defaultTo?.accept(emitter).toString(), 'retriesDefault');
+        expect(param.type?.accept(emitter).toString(), 'int');
+      },
+    );
+
+    test(
+      'cookie boolean with materialised default exposes defaultTo + '
+      'non-nullable bool type',
+      () {
+        final tracking = CookieParameterObject(
+          name: 'tracking',
+          rawName: 'tracking',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          explode: false,
+          model: BooleanModel(context: context),
+          encoding: CookieParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: false,
+        );
+
+        final operation = operationWith(cookieParameters: {tracking});
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+          defaultsByName: {
+            'tracking': OperationParameterDefault(
+              memberName: 'trackingDefault',
+              value: const CodeExpression(Code('false')),
+              type: _dummyType,
+            ),
+          },
+        );
+
+        final param = parameters.single;
+        expect(param.name, 'tracking');
+        expect(param.required, isFalse);
+        expect(
+          param.defaultTo?.accept(emitter).toString(),
+          'trackingDefault',
+        );
+        expect(param.type?.accept(emitter).toString(), 'bool');
+      },
+    );
+
+    test(
+      'path string with materialised default becomes non-required + '
+      'defaultTo, no warning',
+      () {
+        final id = PathParameterObject(
+          name: 'id',
+          rawName: 'id',
+          description: null,
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: PathParameterEncoding.simple,
+          context: context,
+          examples: const [],
+          defaultValue: 'x',
+        );
+
+        final operation = operationWith(
+          pathParameters: {id},
+          path: '/things/{id}',
+        );
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+          defaultsByName: {
+            'id': OperationParameterDefault(
+              memberName: 'idDefault',
+              value: const CodeExpression(Code("r'x'")),
+              type: _dummyType,
+            ),
+          },
+        );
+
+        final param = parameters.single;
+        expect(param.required, isFalse);
+        expect(param.defaultTo?.accept(emitter).toString(), 'idDefault');
+        expect(param.type?.accept(emitter).toString(), 'String');
+      },
+    );
+
+    test(
+      'parameter without a defaults entry retains normal required/optional '
+      'rules — defaultTo stays null',
+      () {
+        final region = QueryParameterObject(
+          name: 'region',
+          rawName: 'region',
+          description: null,
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: context),
+          encoding: QueryParameterEncoding.form,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final operation = operationWith(queryParameters: {region});
+        final parameters = generateParameters(
+          operation: operation,
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final param = parameters.single;
+        expect(param.required, isTrue);
+        expect(param.defaultTo, isNull);
+        expect(param.type?.accept(emitter).toString(), 'String');
+      },
+    );
+  });
 }
+
+final _dummyType = TypeReference(
+  (b) => b
+    ..symbol = 'String'
+    ..url = 'dart:core',
+);


### PR DESCRIPTION
## Summary

Operation parameters (query, path, header, cookie) now honour primitive `default` values declared in the OpenAPI schema, mirroring the const-default infrastructure that already exists for class properties.

For each defaulted parameter whose target is a materialiser-supported primitive (`string`, `integer`, `number`, `boolean`):

- The operation class gets `static const T <paramName>Default = <literal>;` (e.g. `ListThings.regionDefault`).
- The `call()` parameter becomes optional and uses `defaultTo` referencing that const.
- A `required: true` parameter with a materialisable default becomes Dart-optional. Parse/core `isRequired` is preserved (spec faithfulness).
- A path parameter with a default still substitutes into the URL when the caller omits it.
- Alias-chain defaults are followed via a new `effectiveDefaultValue` getter on each parameter object type.

For non-materialisable targets (`DateTimeModel`, `DateModel`, `DecimalModel`, `UriModel`, `BinaryModel`, `Base64Model`, composites) the default is silently dropped — those are not const-expressible in Dart and a future iteration may handle them via a runtime getter.

Type mismatches on a materialiser-supported primitive log one warning and drop the default, matching the existing class-property behaviour.

Multipart per-part header parameters are intentionally not given operation-class defaults in this PR.

## Test plan

- [x] Unit tests in `packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart`, `operation_parameter_generator_test.dart`, and `packages/tonik_generate/test/src/operation/operation_generator_test.dart` — full method/class body comparison via `collapseWhitespace()` + `DartFormatter` and object introspection on `Field`/`Parameter`/`Method` shape
- [x] Alias-chain coverage in `packages/tonik_core/test/src/model/parameter_effective_default_test.dart`
- [x] Integration tests in `integration_test/defaulted_primitives/defaulted_primitives_test/test/defaulted_parameters_test.dart` covering: (a) static const exposure, (b) `call()` with no args produces defaulted URL/headers/cookies, (c) explicit override works, (d) path default substitutes into the URL
- [x] `fvm dart analyze packages/` clean
- [x] All 4673 unit tests pass (tonik, tonik_core, tonik_parse, tonik_generate, tonik_util)
- [x] Affected integration suites pass (`defaulted_primitives`, `medama`, `openai`)
- [x] Patch coverage 100% on the new code
