### PR TITLE
refactor(tonik_generate): cache operation default resolution per operation

### DIFF
--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -19,11 +19,13 @@ class ApiClientGenerator {
   ApiClientGenerator({
     required this.nameManager,
     required this.package,
+    required this.defaultsCache,
     this.useImmutableCollections = false,
   });
 
   final NameManager nameManager;
   final String package;
+  final OperationDefaultsCache defaultsCache;
   final bool useImmutableCollections;
 
   ({String code, String filename}) generate(
@@ -137,11 +139,10 @@ class ApiClientGenerator {
     );
 
     final operationClassName = nameManager.operationName(operation);
-    final defaults = resolveOperationParameterDefaults(
+    final defaults = defaultsCache.forOperation(
+      operation,
       normalizedParams: normalizedParams,
       operationClassName: operationClassName,
-      nameManager: nameManager,
-      package: package,
       initialReservedNames: initialOperationDefaultReservedNames(
         normalizedParams: normalizedParams,
         hasRequestBody: hasRequestBody,

--- a/packages/tonik_generate/lib/src/generator.dart
+++ b/packages/tonik_generate/lib/src/generator.dart
@@ -23,6 +23,7 @@ import 'package:tonik_generate/src/response_wrapper/response_wrapper_file_genera
 import 'package:tonik_generate/src/response_wrapper/response_wrapper_generator.dart';
 import 'package:tonik_generate/src/server/server_file_generator.dart';
 import 'package:tonik_generate/src/server/server_generator.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 class Generator {
   const Generator();
@@ -81,9 +82,15 @@ class Generator {
       allOfGenerator: allOfGenerator,
     );
 
+    final defaultsCache = OperationDefaultsCache(
+      nameManager: nameManager,
+      package: package,
+    );
+
     final operationGenerator = OperationGenerator(
       nameManager: nameManager,
       package: package,
+      defaultsCache: defaultsCache,
       useImmutableCollections: useImmutableCollections,
     );
 
@@ -124,6 +131,7 @@ class Generator {
     final apiClientGenerator = ApiClientGenerator(
       nameManager: nameManager,
       package: package,
+      defaultsCache: defaultsCache,
       useImmutableCollections: useImmutableCollections,
     );
 

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -23,6 +23,7 @@ class OperationGenerator {
   OperationGenerator({
     required this.nameManager,
     required this.package,
+    required this.defaultsCache,
     this.useImmutableCollections = false,
   }) : _optionsGenerator = OptionsGenerator(
          nameManager: nameManager,
@@ -52,6 +53,7 @@ class OperationGenerator {
 
   final NameManager nameManager;
   final String package;
+  final OperationDefaultsCache defaultsCache;
   final bool useImmutableCollections;
 
   final OptionsGenerator _optionsGenerator;
@@ -111,11 +113,10 @@ class OperationGenerator {
       ),
     );
 
-    final defaults = resolveOperationParameterDefaults(
+    final defaults = defaultsCache.forOperation(
+      operation,
       normalizedParams: normalizedParams,
       operationClassName: className,
-      nameManager: nameManager,
-      package: package,
       initialReservedNames: initialOperationDefaultReservedNames(
         normalizedParams: normalizedParams,
         hasRequestBody: hasRequestBody,

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -55,12 +55,13 @@ class OperationParameterDefault {
   }
 }
 
-({
+typedef OperationDefaultsResult = ({
   Map<String, OperationParameterDefault> byName,
   List<Field> fields,
   List<Method> getters,
-})
-resolveOperationParameterDefaults({
+});
+
+OperationDefaultsResult resolveOperationParameterDefaults({
   required NormalizedRequestParameters normalizedParams,
   required String operationClassName,
   required NameManager nameManager,
@@ -178,3 +179,35 @@ Set<String> initialOperationDefaultReservedNames({
   for (final p in normalizedParams.headers) p.normalizedName,
   for (final p in normalizedParams.cookieParameters) p.normalizedName,
 };
+
+/// Memoizes [resolveOperationParameterDefaults] per [Operation] so the
+/// side-effecting parts (warning logs, [NameManager] reservations) fire
+/// exactly once per operation per generator run, regardless of which
+/// consumer (operation class, api-client forwarder) asks first.
+class OperationDefaultsCache {
+  OperationDefaultsCache({
+    required NameManager nameManager,
+    required String package,
+  }) : _nameManager = nameManager,
+       _package = package;
+
+  final NameManager _nameManager;
+  final String _package;
+  final Map<Operation, OperationDefaultsResult> _byOperation = {};
+
+  OperationDefaultsResult forOperation(
+    Operation operation, {
+    required NormalizedRequestParameters normalizedParams,
+    required String operationClassName,
+    required Set<String> initialReservedNames,
+  }) => _byOperation.putIfAbsent(
+    operation,
+    () => resolveOperationParameterDefaults(
+      normalizedParams: normalizedParams,
+      operationClassName: operationClassName,
+      nameManager: _nameManager,
+      package: _package,
+      initialReservedNames: initialReservedNames,
+    ),
+  );
+}

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -180,10 +180,10 @@ Set<String> initialOperationDefaultReservedNames({
   for (final p in normalizedParams.cookieParameters) p.normalizedName,
 };
 
-/// Memoizes [resolveOperationParameterDefaults] per [Operation] so the
-/// side-effecting parts (warning logs, [NameManager] reservations) fire
-/// exactly once per operation per generator run, regardless of which
-/// consumer (operation class, api-client forwarder) asks first.
+/// Memoizes [resolveOperationParameterDefaults] per [Operation] so warning
+/// logs and default-member name allocations fire exactly once per operation
+/// per generator run. Keys on [Operation] identity — callers must share the
+/// same instance from the parsed [ApiDocument].
 class OperationDefaultsCache {
   OperationDefaultsCache({
     required NameManager nameManager,

--- a/packages/tonik_generate/test/src/api_client/api_client_file_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_file_generator_test.dart
@@ -7,6 +7,7 @@ import 'package:tonik_generate/src/api_client/api_client_file_generator.dart';
 import 'package:tonik_generate/src/api_client/api_client_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   group('ApiClientFileGenerator', () {
@@ -24,6 +25,10 @@ void main() {
       final apiClientGenerator = ApiClientGenerator(
         nameManager: nameManager,
         package: 'test_package',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'test_package',
+        ),
       );
       generator = ApiClientFileGenerator(
         apiClientGenerator: apiClientGenerator,

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_security_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_security_test.dart
@@ -3,6 +3,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/api_client/api_client_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   late ApiClientGenerator generator;
@@ -18,6 +19,10 @@ void main() {
     generator = ApiClientGenerator(
       nameManager: nameManager,
       package: 'test_package',
+      defaultsCache: OperationDefaultsCache(
+        nameManager: nameManager,
+        package: 'test_package',
+      ),
     );
     testContext = Context.initial();
 

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -5,6 +5,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/api_client/api_client_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   late ApiClientGenerator generator;
@@ -25,6 +26,10 @@ void main() {
     generator = ApiClientGenerator(
       nameManager: nameManager,
       package: 'test_package',
+      defaultsCache: OperationDefaultsCache(
+        nameManager: nameManager,
+        package: 'test_package',
+      ),
     );
     testContext = Context.initial();
     emitter = DartEmitter(useNullSafetySyntax: true);

--- a/packages/tonik_generate/test/src/operation/operation_deprecation_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_deprecation_test.dart
@@ -5,6 +5,7 @@ import 'package:tonik_generate/src/api_client/api_client_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/operation/operation_generator.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   late NameManager nameManager;
@@ -35,6 +36,10 @@ void main() {
       generator = ApiClientGenerator(
         nameManager: nameManager,
         package: 'test_package',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'test_package',
+        ),
       );
     });
 
@@ -123,6 +128,10 @@ void main() {
       generator = OperationGenerator(
         nameManager: nameManager,
         package: 'test_package',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'test_package',
+        ),
       );
     });
 
@@ -203,6 +212,10 @@ void main() {
       generator = ApiClientGenerator(
         nameManager: nameManager,
         package: 'test_package',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'test_package',
+        ),
       );
       emitter = DartEmitter(useNullSafetySyntax: true);
     });

--- a/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
@@ -6,6 +6,7 @@ import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
 import 'package:tonik_generate/src/operation/operation_generator.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   group('OperationGenerator call method return type', () {
@@ -24,6 +25,10 @@ void main() {
       generator = OperationGenerator(
         nameManager: nameManager,
         package: 'api',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'api',
+        ),
       );
       context = Context.initial();
       emitter = DartEmitter(useNullSafetySyntax: true);

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -7,6 +7,7 @@ import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
 import 'package:tonik_generate/src/operation/operation_generator.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
   group('OperationGenerator', () {
@@ -29,6 +30,10 @@ void main() {
       generator = OperationGenerator(
         nameManager: nameManager,
         package: 'api',
+        defaultsCache: OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'api',
+        ),
       );
       context = Context.initial();
       emitter = DartEmitter(useNullSafetySyntax: true);

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_cache_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_cache_test.dart
@@ -1,0 +1,192 @@
+import 'package:logging/logging.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
+import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
+
+void main() {
+  late NameManager nameManager;
+  late Context context;
+
+  setUp(() {
+    nameManager = NameManager(
+      generator: NameGenerator(),
+      stableModelSorter: StableModelSorter(),
+    );
+    context = Context.initial();
+  });
+
+  Operation makeOperation({required String id, required String path}) =>
+      Operation(
+        operationId: id,
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: path,
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+  QueryParameterObject queryString({
+    required String name,
+    Object? defaultValue,
+  }) => QueryParameterObject(
+    name: name,
+    rawName: name,
+    description: null,
+    isRequired: false,
+    isDeprecated: false,
+    allowEmptyValue: false,
+    allowReserved: false,
+    explode: false,
+    model: StringModel(context: context),
+    encoding: QueryParameterEncoding.form,
+    context: context,
+    examples: const [],
+    defaultValue: defaultValue,
+  );
+
+  QueryParameterObject queryDateTime({
+    required String name,
+    required String defaultValue,
+  }) => QueryParameterObject(
+    name: name,
+    rawName: name,
+    description: null,
+    isRequired: false,
+    isDeprecated: false,
+    allowEmptyValue: false,
+    allowReserved: false,
+    explode: false,
+    model: DateTimeModel(context: context),
+    encoding: QueryParameterEncoding.form,
+    context: context,
+    examples: const [],
+    defaultValue: defaultValue,
+  );
+
+  NormalizedRequestParameters normalizeQuery(
+    Set<QueryParameterObject> queryParameters,
+  ) => normalizeRequestParameters(
+    pathParameters: const {},
+    queryParameters: queryParameters,
+    headers: const {},
+  );
+
+  group('OperationDefaultsCache', () {
+    test(
+      'memoizes per operation — second forOperation(op) returns the same '
+      'record instance the first call produced',
+      () {
+        final op = makeOperation(id: 'getRegion', path: '/region');
+        final normalized = normalizeQuery({
+          queryString(name: 'region', defaultValue: 'eu'),
+        });
+
+        final cache = OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final r1 = cache.forOperation(
+          op,
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          initialReservedNames: const {'_dio'},
+        );
+        final r2 = cache.forOperation(
+          op,
+          normalizedParams: normalized,
+          operationClassName: 'Op',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(identical(r1.byName, r2.byName), isTrue);
+        expect(identical(r1.fields, r2.fields), isTrue);
+        expect(identical(r1.getters, r2.getters), isTrue);
+        expect(r1.byName['region']?.memberName, 'regionDefault');
+      },
+    );
+
+    test(
+      'runtime-fallback routing warning fires exactly once across two '
+      'forOperation calls — pre-cache behaviour would have logged twice',
+      () {
+        final logs = <LogRecord>[];
+        final sub = Logger(
+          'OperationParameterDefaults',
+        ).onRecord.listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final op = makeOperation(id: 'listSince', path: '/list');
+        final normalized = normalizeQuery({
+          queryDateTime(name: 'since', defaultValue: '2024-01-01T00:00:00Z'),
+        });
+
+        OperationDefaultsCache(nameManager: nameManager, package: 'api')
+          ..forOperation(
+            op,
+            normalizedParams: normalized,
+            operationClassName: 'Op',
+            initialReservedNames: const {'_dio'},
+          )
+          ..forOperation(
+            op,
+            normalizedParams: normalized,
+            operationClassName: 'Op',
+            initialReservedNames: const {'_dio'},
+          );
+
+        final warnings = logs
+            .where((r) => r.level == Level.WARNING)
+            .map((r) => r.message)
+            .toList();
+        expect(warnings, ['Routing default to runtime fallback for Op.since.']);
+      },
+    );
+
+    test(
+      'distinct Operation instances get independent results — '
+      "one operation's defaults do not leak into the other's byName map",
+      () {
+        final opA = makeOperation(id: 'getA', path: '/a');
+        final opB = makeOperation(id: 'getB', path: '/b');
+        final normalizedA = normalizeQuery({
+          queryString(name: 'alpha', defaultValue: 'a'),
+        });
+        final normalizedB = normalizeQuery({
+          queryString(name: 'beta', defaultValue: 'b'),
+        });
+
+        final cache = OperationDefaultsCache(
+          nameManager: nameManager,
+          package: 'api',
+        );
+
+        final resultA = cache.forOperation(
+          opA,
+          normalizedParams: normalizedA,
+          operationClassName: 'OpA',
+          initialReservedNames: const {'_dio'},
+        );
+        final resultB = cache.forOperation(
+          opB,
+          normalizedParams: normalizedB,
+          operationClassName: 'OpB',
+          initialReservedNames: const {'_dio'},
+        );
+
+        expect(resultA.byName.keys, ['alpha']);
+        expect(resultB.byName.keys, ['beta']);
+        expect(identical(resultA.byName, resultB.byName), isFalse);
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- `resolveOperationParameterDefaults` ran twice per operation — once inside `OperationGenerator`, once inside `ApiClientGenerator`. Both calls produced identical records, but the side effects (drop warnings, runtime-fallback routing warnings, `NameManager` reservation picks) fired twice.
- Introduce `OperationDefaultsCache` that wraps the function and memoizes per `Operation` instance. Both generators take the cache through their constructor; `Generator` builds one per run and threads it into both.
- The api-client side keeps its `withOwner(...)` qualification — the cache stores the unqualified record.

Generated code is byte-identical: regenerating `integration_test/` produces no diff. Each spec-author-facing default warning now fires exactly once per affected default per tonik run.

## Test plan

- [x] `fvm dart analyze packages` — 0 issues.
- [x] `fvm dart test packages/tonik_generate` — 2,745 tests pass.
- [x] New `operation_parameter_defaults_cache_test.dart` covers identity memoization, single-warning emission, and per-operation isolation.
- [x] `./scripts/setup_integration_tests.sh` — `git status integration_test/` clean afterwards (byte-identical fixture).
