### PR TITLE
feat(generate): parallelize model file generation across isolates

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,9 +92,7 @@ enums:
 # Use immutable collections (IList/IMap) instead of List/Map
 immutableCollections: true
 
-# Number of worker isolates for parallel model file generation.
-# 0 (default) auto-sizes to (logical cores - 1), clamped to 1..16.
-# 1 forces serial. >= 2 sets the worker count explicitly.
+# Parallel model file generation: 0 = auto, 1 = serial, >= 2 = explicit
 workerCount: 4
 ```
 
@@ -388,25 +386,13 @@ When deserializing, any unrecognized value will map to `unknown` instead of thro
 
 ## Parallel Model File Generation
 
-On large specs, model file generation runs in parallel across multiple worker isolates. The default behaviour scales automatically with the host CPU and is appropriate for most users.
+Model file generation runs across worker isolates when the spec is large enough to benefit. Override via `workerCount` in YAML, `--workers` on the CLI, or `TONIK_WORKERS` in the environment.
 
-```yaml
-workerCount: 4
-```
-
-```bash
-tonik --spec ./openapi.yaml --package-name my_api --workers 4
-```
-
-```bash
-TONIK_WORKERS=4 tonik --spec ./openapi.yaml --package-name my_api
-```
-
-Values:
-
-- **`0` (default)** — auto-sizes to `(number of logical cores) - 1`, clamped to the range `1..16`. Omitting the setting is equivalent.
-- **`1`** — forces serial generation on the main isolate. Useful for benchmarks, reproducibility, or constrained environments.
-- **`>= 2`** — caps the worker count. Negative values are rejected.
+| Value | Behaviour |
+|---|---|
+| `0` (default) | Auto: `(logical cores - 1)`, clamped to `1..16` |
+| `1` | Serial |
+| `>= 2` | Explicit worker count |
 
 Precedence (highest first): `--workers` CLI flag, `workerCount` config key, `TONIK_WORKERS` environment variable, auto.
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -394,9 +394,7 @@ Model file generation runs across worker isolates when the spec is large enough 
 | `1` | Serial |
 | `>= 2` | Explicit worker count |
 
-Precedence (highest first): `--workers` CLI flag, `workerCount` config key, `TONIK_WORKERS` environment variable, auto.
-
-The generated output is byte-for-byte identical regardless of worker count — switching between serial and parallel does not change the generated code. Small specs (under a few hundred models) fall back to serial automatically, since the cost of spawning workers exceeds the savings.
+Output is byte-for-byte identical regardless of worker count. Small specs fall back to serial automatically.
 
 ## Immutable Collections
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -91,6 +91,10 @@ enums:
 
 # Use immutable collections (IList/IMap) instead of List/Map
 immutableCollections: true
+
+# Number of worker isolates for parallel model file generation
+# Auto: (logical cores - 1), clamped to 1..16. Use 0 or 1 to force serial.
+workerCount: 4
 ```
 
 ## CLI Options
@@ -115,6 +119,7 @@ tonik --output-dir ./other-location
 | `--package-name`, `-p` | `packageName` | Name of the generated package (required) |
 | `--log-level` | `logLevel` | Logging verbosity: `verbose`, `info`, `warn`, `silent` (defaults to `warn`) |
 | `--immutable-collections` | `immutableCollections` | Use `IList`/`IMap` instead of `List`/`Map` (defaults to `false`) |
+| `--workers` | `workerCount` | Number of worker isolates for parallel model file generation (defaults to auto) |
 
 ## Name Overrides
 
@@ -379,6 +384,32 @@ enum Status {
 ```
 
 When deserializing, any unrecognized value will map to `unknown` instead of throwing an error.
+
+## Parallel Model File Generation
+
+On large specs, model file generation runs in parallel across multiple worker isolates. The default behaviour scales automatically with the host CPU and is appropriate for most users.
+
+```yaml
+workerCount: 4
+```
+
+```bash
+tonik --spec ./openapi.yaml --package-name my_api --workers 4
+```
+
+```bash
+TONIK_WORKERS=4 tonik --spec ./openapi.yaml --package-name my_api
+```
+
+Values:
+
+- **Unset (default)** — auto-sizes to `(number of logical cores) - 1`, clamped to the range `1..16`.
+- **`0` or `1`** — forces serial generation on the main isolate. Useful for benchmarks, reproducibility, or constrained environments.
+- **Any positive integer** — caps the worker count. Negative values are rejected.
+
+Precedence (highest first): `--workers` CLI flag, `workerCount` config key, `TONIK_WORKERS` environment variable, auto.
+
+The generated output is byte-for-byte identical regardless of worker count — switching between serial and parallel does not change the generated code. Small specs (under a few hundred models) fall back to serial automatically, since the cost of spawning workers exceeds the savings.
 
 ## Immutable Collections
 

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,8 +92,9 @@ enums:
 # Use immutable collections (IList/IMap) instead of List/Map
 immutableCollections: true
 
-# Number of worker isolates for parallel model file generation
-# Auto: (logical cores - 1), clamped to 1..16. Use 0 or 1 to force serial.
+# Number of worker isolates for parallel model file generation.
+# 0 (default) auto-sizes to (logical cores - 1), clamped to 1..16.
+# 1 forces serial. >= 2 sets the worker count explicitly.
 workerCount: 4
 ```
 
@@ -403,9 +404,9 @@ TONIK_WORKERS=4 tonik --spec ./openapi.yaml --package-name my_api
 
 Values:
 
-- **Unset (default)** — auto-sizes to `(number of logical cores) - 1`, clamped to the range `1..16`.
-- **`0` or `1`** — forces serial generation on the main isolate. Useful for benchmarks, reproducibility, or constrained environments.
-- **Any positive integer** — caps the worker count. Negative values are rejected.
+- **`0` (default)** — auto-sizes to `(number of logical cores) - 1`, clamped to the range `1..16`. Omitting the setting is equivalent.
+- **`1`** — forces serial generation on the main isolate. Useful for benchmarks, reproducibility, or constrained environments.
+- **`>= 2`** — caps the worker count. Negative values are rejected.
 
 Precedence (highest first): `--workers` CLI flag, `workerCount` config key, `TONIK_WORKERS` environment variable, auto.
 

--- a/packages/tonik/README.md
+++ b/packages/tonik/README.md
@@ -150,7 +150,7 @@ See the [petstore integration tests](https://github.com/t-unit/tonik/blob/main/i
 | **Request Bodies** | `application/json`, `application/x-www-form-urlencoded`, `application/octet-stream`, `text/plain` |
 | **Multipart** | `multipart/form-data` with primitive, file, JSON, and array parts; per-part `encoding` and content types |
 | **Schema** | `readOnly`/`writeOnly` enforcement, `nullable`, `required`, `deprecated`, boolean schemas, `additionalProperties` |
-| **Configuration** | Name overrides, filtering by tag/operation/schema, deprecation handling, content-type mapping |
+| **Configuration** | Name overrides, filtering by tag/operation/schema, deprecation handling, content-type mapping, parallel generation tuning |
 | **OAS 3.1** | `$ref` with siblings, `$defs` local definitions, boolean schemas, nullable type arrays, `contentEncoding`/`contentMediaType` |
 
 ## Acknowledgments

--- a/packages/tonik/bin/tonik.dart
+++ b/packages/tonik/bin/tonik.dart
@@ -59,8 +59,8 @@ ArgParser buildParser() {
       'workers',
       help:
           'Number of worker isolates for parallel model file generation. '
-          '0 or 1 forces serial. Defaults to auto '
-          '((numberOfProcessors - 1) clamped to 1..16).',
+          '0 (default) auto-sizes to (numberOfProcessors - 1) clamped '
+          'to 1..16; 1 forces serial; >= 2 sets the worker count.',
       valueHelp: 'n',
     );
 }
@@ -72,16 +72,11 @@ void printUsage(ArgParser argParser) {
 
 final Logger logger = Logger('tonik');
 
-/// Parses [raw] as a non-negative integer worker count. [source] names the
-/// origin (`--workers`, `TONIK_WORKERS`) for the error message.
-int? _parseWorkerCountFlag(String? raw, {required String source}) {
+int? _parseWorkerCountOrExit(String? raw, {required String source}) {
   if (raw == null || raw.isEmpty) return null;
   final parsed = int.tryParse(raw);
   if (parsed == null || parsed < 0) {
-    stderr.writeln(
-      'Error: Invalid value "$raw" for $source. '
-      'Must be a non-negative integer.',
-    );
+    stderr.writeln('Error: invalid value "$raw" for $source.');
     exit(128);
   }
   return parsed;
@@ -139,16 +134,17 @@ Future<void> main(List<String> arguments) async {
   final configPath = configPathArg ?? 'tonik.yaml';
   final fileConfig = ConfigLoader.load(configPath);
 
-  final cliWorkerCount = _parseWorkerCountFlag(
+  final cliWorkerCount = _parseWorkerCountOrExit(
     workersArg,
     source: '--workers',
   );
-
-  final fileOrCliHasWorkerCount =
-      cliWorkerCount != null || fileConfig.workerCount != null;
-  final envWorkerCount = fileOrCliHasWorkerCount
+  // Env only consulted when neither CLI nor file specified a value. File's
+  // `0` is the documented default and equivalent to unset for precedence,
+  // so we fall through to env in that case.
+  final envWorkerCount =
+      cliWorkerCount != null || fileConfig.workerCount != 0
       ? null
-      : _parseWorkerCountFlag(
+      : _parseWorkerCountOrExit(
           Platform.environment['TONIK_WORKERS'],
           source: 'TONIK_WORKERS',
         );

--- a/packages/tonik/bin/tonik.dart
+++ b/packages/tonik/bin/tonik.dart
@@ -54,6 +54,14 @@ ArgParser buildParser() {
           'Use IList/IMap from fast_immutable_collections '
           'instead of List/Map.',
       negatable: false,
+    )
+    ..addOption(
+      'workers',
+      help:
+          'Number of worker isolates for parallel model file generation. '
+          '0 or 1 forces serial. Defaults to auto '
+          '((numberOfProcessors - 1) clamped to 1..16).',
+      valueHelp: 'n',
     );
 }
 
@@ -64,7 +72,22 @@ void printUsage(ArgParser argParser) {
 
 final Logger logger = Logger('tonik');
 
-void main(List<String> arguments) {
+/// Parses [raw] as a non-negative integer worker count. [source] names the
+/// origin (`--workers`, `TONIK_WORKERS`) for the error message.
+int? _parseWorkerCountFlag(String? raw, {required String source}) {
+  if (raw == null || raw.isEmpty) return null;
+  final parsed = int.tryParse(raw);
+  if (parsed == null || parsed < 0) {
+    stderr.writeln(
+      'Error: Invalid value "$raw" for $source. '
+      'Must be a non-negative integer.',
+    );
+    exit(128);
+  }
+  return parsed;
+}
+
+Future<void> main(List<String> arguments) async {
   final argParser = buildParser();
   String? logLevelArg;
   String? packageNameArg;
@@ -72,6 +95,7 @@ void main(List<String> arguments) {
   String? outputDirArg;
   String? configPathArg;
   var immutableCollectionsArg = false;
+  String? workersArg;
 
   try {
     final results = argParser.parse(arguments);
@@ -87,6 +111,7 @@ void main(List<String> arguments) {
     outputDirArg = results['output-dir'] as String?;
     configPathArg = results['config'] as String?;
     immutableCollectionsArg = results.flag('immutable-collections');
+    workersArg = results['workers'] as String?;
   } on FormatException catch (formatException) {
     print(formatException.message);
     printUsage(argParser);
@@ -114,12 +139,27 @@ void main(List<String> arguments) {
   final configPath = configPathArg ?? 'tonik.yaml';
   final fileConfig = ConfigLoader.load(configPath);
 
+  final cliWorkerCount = _parseWorkerCountFlag(
+    workersArg,
+    source: '--workers',
+  );
+
+  final fileOrCliHasWorkerCount =
+      cliWorkerCount != null || fileConfig.workerCount != null;
+  final envWorkerCount = fileOrCliHasWorkerCount
+      ? null
+      : _parseWorkerCountFlag(
+          Platform.environment['TONIK_WORKERS'],
+          source: 'TONIK_WORKERS',
+        );
+
   final mergedConfig = fileConfig.merge(
     spec: openApiPathArg,
     outputDir: outputDirArg,
     packageName: packageNameArg,
     logLevel: cliLogLevel,
     useImmutableCollections: immutableCollectionsArg ? true : null,
+    workerCount: cliWorkerCount ?? envWorkerCount,
   );
 
   final packageName = mergedConfig.packageName;
@@ -240,7 +280,7 @@ void main(List<String> arguments) {
   }
 
   try {
-    const Generator().generate(
+    await const Generator().generate(
       apiDocument: apiDocument,
       outputDirectory: outputDir ?? '.',
       package: packageName,

--- a/packages/tonik/bin/tonik.dart
+++ b/packages/tonik/bin/tonik.dart
@@ -138,9 +138,7 @@ Future<void> main(List<String> arguments) async {
     workersArg,
     source: '--workers',
   );
-  // Env only consulted when neither CLI nor file specified a value. File's
-  // `0` is the documented default and equivalent to unset for precedence,
-  // so we fall through to env in that case.
+  // File's `0` is unset for precedence purposes (the documented default).
   final envWorkerCount =
       cliWorkerCount != null || fileConfig.workerCount != 0
       ? null

--- a/packages/tonik/lib/src/config/config_loader.dart
+++ b/packages/tonik/lib/src/config/config_loader.dart
@@ -57,7 +57,23 @@ extension ConfigLoader on CliConfig {
         yaml['immutableCollections'],
         'immutableCollections',
       ),
+      workerCount: _parseWorkerCount(yaml['workerCount']),
     );
+  }
+
+  static int? _parseWorkerCount(dynamic value) {
+    if (value == null) return null;
+    if (value is! int) {
+      throw ConfigLoaderException(
+        'Invalid config: "workerCount" must be a non-negative integer',
+      );
+    }
+    if (value < 0) {
+      throw ConfigLoaderException(
+        'Invalid config: "workerCount" must be a non-negative integer',
+      );
+    }
+    return value;
   }
 
   static String? _parseString(dynamic value, String fieldName) {
@@ -323,6 +339,7 @@ extension ConfigLoader on CliConfig {
     String? packageName,
     LogLevel? logLevel,
     bool? useImmutableCollections,
+    int? workerCount,
   }) {
     return CliConfig(
       spec: spec ?? this.spec,
@@ -337,6 +354,7 @@ extension ConfigLoader on CliConfig {
       enums: enums,
       useImmutableCollections:
           useImmutableCollections ?? this.useImmutableCollections,
+      workerCount: workerCount ?? this.workerCount,
     );
   }
 }

--- a/packages/tonik/lib/src/config/config_loader.dart
+++ b/packages/tonik/lib/src/config/config_loader.dart
@@ -61,14 +61,9 @@ extension ConfigLoader on CliConfig {
     );
   }
 
-  static int? _parseWorkerCount(dynamic value) {
-    if (value == null) return null;
-    if (value is! int) {
-      throw ConfigLoaderException(
-        'Invalid config: "workerCount" must be a non-negative integer',
-      );
-    }
-    if (value < 0) {
+  static int _parseWorkerCount(dynamic value) {
+    if (value == null) return 0;
+    if (value is! int || value < 0) {
       throw ConfigLoaderException(
         'Invalid config: "workerCount" must be a non-negative integer',
       );

--- a/packages/tonik/lib/src/config/tonik_config.dart
+++ b/packages/tonik/lib/src/config/tonik_config.dart
@@ -21,6 +21,7 @@ class CliConfig {
     this.deprecated = const DeprecatedConfig(),
     this.enums = const EnumConfig(),
     this.useImmutableCollections = false,
+    this.workerCount,
   });
 
   /// Path to the OpenAPI specification file.
@@ -53,6 +54,10 @@ class CliConfig {
   /// `Map<String, V>` for public-facing model types.
   final bool useImmutableCollections;
 
+  /// Number of worker isolates for parallel model generation. See
+  /// [TonikConfig.workerCount] for semantics.
+  final int? workerCount;
+
   TonikConfig toTonikConfig() => TonikConfig(
     nameOverrides: nameOverrides,
     contentTypes: contentTypes,
@@ -61,6 +66,7 @@ class CliConfig {
     deprecated: deprecated,
     enums: enums,
     useImmutableCollections: useImmutableCollections,
+    workerCount: workerCount,
   );
 
   static const _contentTypeEquality = MapEquality<String, ContentType>();
@@ -74,7 +80,8 @@ class CliConfig {
       'nameOverrides: $nameOverrides, contentTypes: $contentTypes, '
       'contentMediaTypes: $contentMediaTypes, filter: $filter, '
       'deprecated: $deprecated, enums: $enums, '
-      'useImmutableCollections: $useImmutableCollections}';
+      'useImmutableCollections: $useImmutableCollections, '
+      'workerCount: $workerCount}';
 
   @override
   bool operator ==(Object other) =>
@@ -94,7 +101,8 @@ class CliConfig {
           filter == other.filter &&
           deprecated == other.deprecated &&
           enums == other.enums &&
-          useImmutableCollections == other.useImmutableCollections;
+          useImmutableCollections == other.useImmutableCollections &&
+          workerCount == other.workerCount;
 
   @override
   int get hashCode => Object.hash(
@@ -109,5 +117,6 @@ class CliConfig {
     deprecated,
     enums,
     useImmutableCollections,
+    workerCount,
   );
 }

--- a/packages/tonik/lib/src/config/tonik_config.dart
+++ b/packages/tonik/lib/src/config/tonik_config.dart
@@ -54,8 +54,6 @@ class CliConfig {
   /// `Map<String, V>` for public-facing model types.
   final bool useImmutableCollections;
 
-  /// Number of worker isolates for parallel model generation. See
-  /// [TonikConfig.workerCount] for semantics.
   final int workerCount;
 
   TonikConfig toTonikConfig() => TonikConfig(

--- a/packages/tonik/lib/src/config/tonik_config.dart
+++ b/packages/tonik/lib/src/config/tonik_config.dart
@@ -21,8 +21,8 @@ class CliConfig {
     this.deprecated = const DeprecatedConfig(),
     this.enums = const EnumConfig(),
     this.useImmutableCollections = false,
-    this.workerCount,
-  });
+    this.workerCount = 0,
+  }) : assert(workerCount >= 0, 'workerCount must be non-negative');
 
   /// Path to the OpenAPI specification file.
   final String? spec;
@@ -56,7 +56,7 @@ class CliConfig {
 
   /// Number of worker isolates for parallel model generation. See
   /// [TonikConfig.workerCount] for semantics.
-  final int? workerCount;
+  final int workerCount;
 
   TonikConfig toTonikConfig() => TonikConfig(
     nameOverrides: nameOverrides,

--- a/packages/tonik/test/oas_version_defaults_parity_test.dart
+++ b/packages/tonik/test/oas_version_defaults_parity_test.dart
@@ -22,15 +22,15 @@ void main() {
     }
   });
 
-  String generateAndRead({
+  Future<String> generateAndRead({
     required Map<String, dynamic> spec,
     required String subdir,
     required String filename,
-  }) {
+  }) async {
     final api = Importer().import(spec);
     final outputDirectory = path.join(tempDir.path, subdir);
     Directory(outputDirectory).createSync(recursive: true);
-    const Generator().generate(
+    await const Generator().generate(
       apiDocument: api,
       outputDirectory: outputDirectory,
       package: 'parity_api',
@@ -128,8 +128,8 @@ void main() {
       late String out30;
       late String out31;
 
-      setUp(() {
-        out30 = generateAndRead(
+      setUp(() async {
+        out30 = await generateAndRead(
           spec: wrapSpec(
             openapiVersion: '3.0.4',
             name: className,
@@ -138,7 +138,7 @@ void main() {
           subdir: 'oas30',
           filename: filename,
         );
-        out31 = generateAndRead(
+        out31 = await generateAndRead(
           spec: wrapSpec(
             openapiVersion: '3.1.0',
             name: className,

--- a/packages/tonik/test/src/config/config_loader_test.dart
+++ b/packages/tonik/test/src/config/config_loader_test.dart
@@ -566,7 +566,7 @@ workerCount: 4
         expect(config.workerCount, 4);
       });
 
-      test('loads workerCount of 0 as serial-forcing value', () {
+      test('loads workerCount of 0 as auto-sizing value', () {
         File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
 workerCount: 0
 ''');
@@ -576,14 +576,14 @@ workerCount: 0
         expect(config.workerCount, 0);
       });
 
-      test('defaults workerCount to null when not specified', () {
+      test('defaults workerCount to 0 when not specified', () {
         File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
 spec: ./api.yaml
 ''');
 
         final config = ConfigLoader.load('${tempDir.path}/tonik.yaml');
 
-        expect(config.workerCount, isNull);
+        expect(config.workerCount, 0);
       });
 
       test('throws meaningful error when workerCount is not an int', () {

--- a/packages/tonik/test/src/config/config_loader_test.dart
+++ b/packages/tonik/test/src/config/config_loader_test.dart
@@ -556,6 +556,70 @@ immutableCollections: not_a_bool
         },
       );
 
+      test('loads workerCount as integer', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+workerCount: 4
+''');
+
+        final config = ConfigLoader.load('${tempDir.path}/tonik.yaml');
+
+        expect(config.workerCount, 4);
+      });
+
+      test('loads workerCount of 0 as serial-forcing value', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+workerCount: 0
+''');
+
+        final config = ConfigLoader.load('${tempDir.path}/tonik.yaml');
+
+        expect(config.workerCount, 0);
+      });
+
+      test('defaults workerCount to null when not specified', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+spec: ./api.yaml
+''');
+
+        final config = ConfigLoader.load('${tempDir.path}/tonik.yaml');
+
+        expect(config.workerCount, isNull);
+      });
+
+      test('throws meaningful error when workerCount is not an int', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+workerCount: not_a_number
+''');
+
+        expect(
+          () => ConfigLoader.load('${tempDir.path}/tonik.yaml'),
+          throwsA(
+            isA<ConfigLoaderException>().having(
+              (e) => e.message,
+              'message',
+              contains('"workerCount" must be a non-negative integer'),
+            ),
+          ),
+        );
+      });
+
+      test('throws meaningful error when workerCount is negative', () {
+        File('${tempDir.path}/tonik.yaml').writeAsStringSync('''
+workerCount: -1
+''');
+
+        expect(
+          () => ConfigLoader.load('${tempDir.path}/tonik.yaml'),
+          throwsA(
+            isA<ConfigLoaderException>().having(
+              (e) => e.message,
+              'message',
+              contains('"workerCount" must be a non-negative integer'),
+            ),
+          ),
+        );
+      });
+
       test('loads empty config file as default config', () {
         File('${tempDir.path}/tonik.yaml').writeAsStringSync('');
 
@@ -653,6 +717,12 @@ nameOverrides:
         expect(merged.useImmutableCollections, isTrue);
       });
 
+      test('CLI workerCount overrides config value', () {
+        const config = CliConfig(workerCount: 2);
+        final merged = config.merge(workerCount: 8);
+        expect(merged.workerCount, 8);
+      });
+
       test('merge preserves non-CLI config properties', () {
         const config = CliConfig(
           spec: './config-spec.yaml',
@@ -696,6 +766,12 @@ nameOverrides:
 
         expect(tonikConfig.useImmutableCollections, isFalse);
       });
+
+      test('passes workerCount to TonikConfig', () {
+        const config = CliConfig(workerCount: 4);
+        final tonikConfig = config.toTonikConfig();
+        expect(tonikConfig.workerCount, 4);
+      });
     });
 
     group('CliConfig toString, equality, hashCode', () {
@@ -716,6 +792,7 @@ nameOverrides:
         expect(a == b, isTrue);
         expect(a.hashCode, b.hashCode);
       });
+
     });
 
     group('type validation for string fields', () {

--- a/packages/tonik_core/lib/src/config/tonik_config.dart
+++ b/packages/tonik_core/lib/src/config/tonik_config.dart
@@ -18,8 +18,8 @@ class TonikConfig {
     this.deprecated = const DeprecatedConfig(),
     this.enums = const EnumConfig(),
     this.useImmutableCollections = false,
-    this.workerCount,
-  });
+    this.workerCount = 0,
+  }) : assert(workerCount >= 0, 'workerCount must be non-negative');
 
   final NameOverridesConfig nameOverrides;
   final Map<String, ContentType> contentTypes;
@@ -38,10 +38,10 @@ class TonikConfig {
 
   /// Number of worker isolates to use for parallel model file generation.
   ///
-  /// `null` (default) auto-sizes to `(Platform.numberOfProcessors - 1)`
-  /// clamped to `1..16`. `0` or `1` forces the serial path. Useful for
-  /// benchmarks, reproducibility, or constrained environments.
-  final int? workerCount;
+  /// `0` (default) auto-sizes to `(Platform.numberOfProcessors - 1)` clamped
+  /// to `1..16`. `1` forces the serial path. `>= 2` sets the worker count
+  /// explicitly.
+  final int workerCount;
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/config/tonik_config.dart
+++ b/packages/tonik_core/lib/src/config/tonik_config.dart
@@ -18,6 +18,7 @@ class TonikConfig {
     this.deprecated = const DeprecatedConfig(),
     this.enums = const EnumConfig(),
     this.useImmutableCollections = false,
+    this.workerCount,
   });
 
   final NameOverridesConfig nameOverrides;
@@ -35,12 +36,20 @@ class TonikConfig {
   /// `Map<String, V>` for public-facing model types.
   final bool useImmutableCollections;
 
+  /// Number of worker isolates to use for parallel model file generation.
+  ///
+  /// `null` (default) auto-sizes to `(Platform.numberOfProcessors - 1)`
+  /// clamped to `1..16`. `0` or `1` forces the serial path. Useful for
+  /// benchmarks, reproducibility, or constrained environments.
+  final int? workerCount;
+
   @override
   String toString() =>
       'TonikConfig{nameOverrides: $nameOverrides, contentTypes: $contentTypes, '
       'contentMediaTypes: $contentMediaTypes, filter: $filter, '
       'deprecated: $deprecated, enums: $enums, '
-      'useImmutableCollections: $useImmutableCollections}';
+      'useImmutableCollections: $useImmutableCollections, '
+      'workerCount: $workerCount}';
 
   @override
   bool operator ==(Object other) {
@@ -58,7 +67,8 @@ class TonikConfig {
             filter == other.filter &&
             deprecated == other.deprecated &&
             enums == other.enums &&
-            useImmutableCollections == other.useImmutableCollections;
+            useImmutableCollections == other.useImmutableCollections &&
+            workerCount == other.workerCount;
   }
 
   @override
@@ -73,6 +83,7 @@ class TonikConfig {
       deprecated,
       enums,
       useImmutableCollections,
+      workerCount,
     );
   }
 }

--- a/packages/tonik_core/lib/src/config/tonik_config.dart
+++ b/packages/tonik_core/lib/src/config/tonik_config.dart
@@ -36,11 +36,8 @@ class TonikConfig {
   /// `Map<String, V>` for public-facing model types.
   final bool useImmutableCollections;
 
-  /// Number of worker isolates to use for parallel model file generation.
-  ///
-  /// `0` (default) auto-sizes to `(Platform.numberOfProcessors - 1)` clamped
-  /// to `1..16`. `1` forces the serial path. `>= 2` sets the worker count
-  /// explicitly.
+  /// Worker isolates for parallel model file generation. `0` = auto, `1` =
+  /// serial, `>= 2` = explicit count.
   final int workerCount;
 
   @override

--- a/packages/tonik_generate/lib/src/generator.dart
+++ b/packages/tonik_generate/lib/src/generator.dart
@@ -35,11 +35,6 @@ class Generator {
   /// Below this model count, isolate setup outweighs the parallel speedup.
   static const int parallelThreshold = 200;
 
-  /// Resolves the worker count for the parallel model file generation pool.
-  /// `0` selects auto: [clampAutoWorkerCount] applied to the host processor
-  /// count. Any other value is returned as-is, so `1` forces the serial path
-  /// and `>= 2` sets the explicit worker count. The return value is always
-  /// `>= 1`.
   static int resolveWorkerCount(int requested) {
     if (requested == 0) {
       return clampAutoWorkerCount(Platform.numberOfProcessors);
@@ -47,8 +42,8 @@ class Generator {
     return requested;
   }
 
-  /// Reserves one processor for main and caps at 16 because the gains
-  /// flatten out above that on every spec we benchmarked.
+  /// Reserves one processor for main; gains flatten above 16 on every spec
+  /// benchmarked.
   static int clampAutoWorkerCount(int processorCount) {
     return (processorCount - 1).clamp(1, 16);
   }

--- a/packages/tonik_generate/lib/src/generator.dart
+++ b/packages/tonik_generate/lib/src/generator.dart
@@ -1,5 +1,6 @@
 import 'dart:io';
 
+import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/analysis_options_generator.dart';
 import 'package:tonik_generate/src/api_client/api_client_file_generator.dart';
@@ -31,18 +32,25 @@ import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 class Generator {
   const Generator();
 
-  /// Threshold below which model file generation runs serially. Spawning
-  /// isolates costs ~50-150 ms total setup; on tiny specs the serial path
-  /// finishes first. Tuned for the petstore (small) to cloudflare (large)
-  /// spectrum.
+  /// Below this model count, isolate setup outweighs the parallel speedup.
   static const int parallelThreshold = 200;
 
-  /// Resolves the worker count for the parallel model file generation
-  /// pool. `null` selects auto: `(numberOfProcessors - 1).clamp(1, 16)`.
-  /// `0` or `1` forces the serial path.
-  static int resolveWorkerCount(int? requested) {
-    if (requested != null) return requested;
-    return (Platform.numberOfProcessors - 1).clamp(1, 16);
+  /// Resolves the worker count for the parallel model file generation pool.
+  /// `0` selects auto: [clampAutoWorkerCount] applied to the host processor
+  /// count. Any other value is returned as-is, so `1` forces the serial path
+  /// and `>= 2` sets the explicit worker count. The return value is always
+  /// `>= 1`.
+  static int resolveWorkerCount(int requested) {
+    if (requested == 0) {
+      return clampAutoWorkerCount(Platform.numberOfProcessors);
+    }
+    return requested;
+  }
+
+  /// Reserves one processor for main and caps at 16 because the gains
+  /// flatten out above that on every spec we benchmarked.
+  static int clampAutoWorkerCount(int processorCount) {
+    return (processorCount - 1).clamp(1, 16);
   }
 
   Future<void> generate({
@@ -50,6 +58,7 @@ class Generator {
     required String outputDirectory,
     required String package,
     TonikConfig config = const TonikConfig(),
+    @visibleForTesting ModelWorkerPool Function()? workerPoolFactory,
   }) async {
     final useImmutableCollections = config.useImmutableCollections;
 
@@ -186,7 +195,7 @@ class Generator {
     );
 
     final resolvedWorkerCount = resolveWorkerCount(config.workerCount);
-    if (resolvedWorkerCount <= 1 ||
+    if (resolvedWorkerCount == 1 ||
         apiDocument.models.length < parallelThreshold) {
       modelGenerator.writeFiles(
         apiDocument: apiDocument,
@@ -194,7 +203,8 @@ class Generator {
         package: package,
       );
     } else {
-      await ModelWorkerPool().run(
+      final pool = (workerPoolFactory ?? ModelWorkerPool.new)();
+      await pool.run(
         apiDocument: apiDocument,
         nameManager: nameManager,
         stableModelSorter: stableModelSorter,

--- a/packages/tonik_generate/lib/src/generator.dart
+++ b/packages/tonik_generate/lib/src/generator.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/analysis_options_generator.dart';
 import 'package:tonik_generate/src/api_client/api_client_file_generator.dart';
@@ -23,17 +25,32 @@ import 'package:tonik_generate/src/response_wrapper/response_wrapper_file_genera
 import 'package:tonik_generate/src/response_wrapper/response_wrapper_generator.dart';
 import 'package:tonik_generate/src/server/server_file_generator.dart';
 import 'package:tonik_generate/src/server/server_generator.dart';
+import 'package:tonik_generate/src/util/model_worker_pool.dart';
 import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 class Generator {
   const Generator();
 
-  void generate({
+  /// Threshold below which model file generation runs serially. Spawning
+  /// isolates costs ~50-150 ms total setup; on tiny specs the serial path
+  /// finishes first. Tuned for the petstore (small) to cloudflare (large)
+  /// spectrum.
+  static const int parallelThreshold = 200;
+
+  /// Resolves the worker count for the parallel model file generation
+  /// pool. `null` selects auto: `(numberOfProcessors - 1).clamp(1, 16)`.
+  /// `0` or `1` forces the serial path.
+  static int resolveWorkerCount(int? requested) {
+    if (requested != null) return requested;
+    return (Platform.numberOfProcessors - 1).clamp(1, 16);
+  }
+
+  Future<void> generate({
     required ApiDocument apiDocument,
     required String outputDirectory,
     required String package,
     TonikConfig config = const TonikConfig(),
-  }) {
+  }) async {
     final useImmutableCollections = config.useImmutableCollections;
 
     final nameGenerator = NameGenerator();
@@ -168,11 +185,25 @@ class Generator {
       package: package,
     );
 
-    modelGenerator.writeFiles(
-      apiDocument: apiDocument,
-      outputDirectory: outputDirectory,
-      package: package,
-    );
+    final resolvedWorkerCount = resolveWorkerCount(config.workerCount);
+    if (resolvedWorkerCount <= 1 ||
+        apiDocument.models.length < parallelThreshold) {
+      modelGenerator.writeFiles(
+        apiDocument: apiDocument,
+        outputDirectory: outputDirectory,
+        package: package,
+      );
+    } else {
+      await ModelWorkerPool().run(
+        apiDocument: apiDocument,
+        nameManager: nameManager,
+        stableModelSorter: stableModelSorter,
+        outputDirectory: outputDirectory,
+        package: package,
+        useImmutableCollections: useImmutableCollections,
+        workerCount: resolvedWorkerCount,
+      );
+    }
 
     requestBodyFileGenerator.writeFiles(
       apiDocument: apiDocument,

--- a/packages/tonik_generate/lib/src/model/model_file_generator.dart
+++ b/packages/tonik_generate/lib/src/model/model_file_generator.dart
@@ -41,11 +41,8 @@ class ModelFileGenerator {
     }
   }
 
-  /// Generates and writes a single model file end-to-end.
-  ///
-  /// Dispatches on the model subtype, generates the source, ensures the
-  /// target directory exists, and writes the file. Silently skips models
-  /// that no sub-generator handles, matching [writeFiles] behavior.
+  /// Silently skips models with no matching sub-generator, matching
+  /// [writeFiles].
   void writeOne(
     Model model, {
     required String outputDirectory,

--- a/packages/tonik_generate/lib/src/model/model_file_generator.dart
+++ b/packages/tonik_generate/lib/src/model/model_file_generator.dart
@@ -41,8 +41,6 @@ class ModelFileGenerator {
     }
   }
 
-  /// Silently skips models with no matching sub-generator, matching
-  /// [writeFiles].
   void writeOne(
     Model model, {
     required String outputDirectory,

--- a/packages/tonik_generate/lib/src/model/model_file_generator.dart
+++ b/packages/tonik_generate/lib/src/model/model_file_generator.dart
@@ -36,6 +36,43 @@ class ModelFileGenerator {
   }) {
     log.fine('Writing ${apiDocument.models.length} model files');
 
+    for (final model in apiDocument.models) {
+      writeOne(model, outputDirectory: outputDirectory, package: package);
+    }
+  }
+
+  /// Generates and writes a single model file end-to-end.
+  ///
+  /// Dispatches on the model subtype, generates the source, ensures the
+  /// target directory exists, and writes the file. Silently skips models
+  /// that no sub-generator handles, matching [writeFiles] behavior.
+  void writeOne(
+    Model model, {
+    required String outputDirectory,
+    required String package,
+  }) {
+    final result = switch (model) {
+      ClassModel() => classGenerator.generate(model),
+      EnumModel<int>() => enumGenerator.generate<int>(model),
+      EnumModel<String>() => enumGenerator.generate<String>(model),
+      AnyOfModel() => anyOfGenerator.generate(model),
+      OneOfModel() => oneOfGenerator.generate(model),
+      AllOfModel() => allOfGenerator.generate(model),
+      AliasModel() => typedefGenerator.generateAlias(model),
+      ListModel() => typedefGenerator.generateList(model),
+      MapModel() => typedefGenerator.generateMap(model),
+      _ => null,
+    };
+
+    if (result == null) {
+      log.fine('Ignoring model: $model');
+      return;
+    }
+
+    log
+      ..fine('Generating model ${classGenerator.nameManager.modelName(model)}')
+      ..fine('Writing file ${result.filename}');
+
     final modelDirectory = path.joinAll([
       outputDirectory,
       package,
@@ -43,41 +80,8 @@ class ModelFileGenerator {
       'src',
       'model',
     ]);
-
-    for (final model in apiDocument.models) {
-      final name = classGenerator.nameManager.modelName(model);
-      log.fine('Generating model $name');
-
-      ({String code, String filename})? result;
-
-      switch (model) {
-        case ClassModel():
-          result = classGenerator.generate(model);
-        case EnumModel<int>():
-          result = enumGenerator.generate<int>(model);
-        case EnumModel<String>():
-          result = enumGenerator.generate<String>(model);
-        case AnyOfModel():
-          result = anyOfGenerator.generate(model);
-        case OneOfModel():
-          result = oneOfGenerator.generate(model);
-        case AllOfModel():
-          result = allOfGenerator.generate(model);
-        case AliasModel():
-          result = typedefGenerator.generateAlias(model);
-        case ListModel():
-          result = typedefGenerator.generateList(model);
-        case MapModel():
-          result = typedefGenerator.generateMap(model);
-        default:
-          log.fine('Ignoring model: $model');
-          continue;
-      }
-
-      log.fine('Writing file ${result.filename}');
-      final file = File(path.join(modelDirectory, result.filename));
-      file.parent.createSync(recursive: true);
-      file.writeAsStringSync(result.code);
-    }
+    final file = File(path.join(modelDirectory, result.filename));
+    file.parent.createSync(recursive: true);
+    file.writeAsStringSync(result.code);
   }
 }

--- a/packages/tonik_generate/lib/src/naming/name_manager.dart
+++ b/packages/tonik_generate/lib/src/naming/name_manager.dart
@@ -55,7 +55,8 @@ class NameManager {
   >
   _enumVariantNamesCache = {};
 
-  final log = Logger('NameManager');
+  // Getter (not field) keeps NameManager sendable across isolates.
+  Logger get log => Logger('NameManager');
 
   /// Primes the name generator with all names from the given objects.
   /// This ensures consistent naming across multiple calls.

--- a/packages/tonik_generate/lib/src/util/model_worker_pool.dart
+++ b/packages/tonik_generate/lib/src/util/model_worker_pool.dart
@@ -1,0 +1,556 @@
+import 'dart:async';
+import 'dart:isolate';
+import 'dart:math' as math;
+
+import 'package:logging/logging.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/all_of_generator.dart';
+import 'package:tonik_generate/src/model/any_of_generator.dart';
+import 'package:tonik_generate/src/model/class_generator.dart';
+import 'package:tonik_generate/src/model/enum_generator.dart';
+import 'package:tonik_generate/src/model/model_file_generator.dart';
+import 'package:tonik_generate/src/model/one_of_generator.dart';
+import 'package:tonik_generate/src/model/typedef_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+/// Sentinel modelIndex used by [_ModelError] to signal that a worker failed
+/// outside the per-job dispatch loop (handshake, sub-generator construction,
+/// uncaught async error). Main treats this as a fatal pool-level abort.
+const int _setupFailureIndex = -1;
+
+/// Initial handshake payload sent from main to each worker isolate.
+class _WorkerInit {
+  const _WorkerInit({
+    required this.mainInbox,
+    required this.workerId,
+    required this.models,
+    required this.nameManager,
+    required this.outputDirectory,
+    required this.package,
+    required this.useImmutableCollections,
+    required this.stableModelSorter,
+  });
+
+  final SendPort mainInbox;
+  final int workerId;
+  final List<Model> models;
+  final NameManager nameManager;
+  final String outputDirectory;
+  final String package;
+  final bool useImmutableCollections;
+  final StableModelSorter stableModelSorter;
+}
+
+/// Job message sent main -> worker, instructing the worker to generate the
+/// model at [modelIndex] of the shared list it was primed with.
+class _ModelJob {
+  const _ModelJob(this.modelIndex);
+  final int modelIndex;
+}
+
+/// Sentinel message instructing a worker to close its inbox and exit.
+class _Shutdown {
+  const _Shutdown();
+}
+
+/// Success ack sent worker -> main once the file for [modelIndex] is written.
+class _ModelAck {
+  const _ModelAck(this.workerId, this.modelIndex);
+  final int workerId;
+  final int modelIndex;
+}
+
+/// Error report sent worker -> main when generating [modelIndex] throws.
+///
+/// [error] and [stack] may be the original objects (if sendable) or fallback
+/// strings carrying their textual representation (if the originals could not
+/// cross the SendPort boundary).
+class _ModelError {
+  const _ModelError(this.workerId, this.modelIndex, this.error, this.stack);
+  final int workerId;
+  final int modelIndex;
+  final Object error;
+  final StackTrace stack;
+}
+
+/// Log record forwarded worker -> main so a single listener on the main
+/// isolate sees warnings from every worker.
+///
+/// The boundary stringifies `error` and `stackTrace` because `LogRecord.error`
+/// may hold a non-sendable Object. Listeners on `Logger.root` that branched
+/// on `record.error is SomeException` will not behave the same under the
+/// parallel path — they observe a `String` instead of the original type.
+/// `record.time` on the replayed entry is set by main, not the worker.
+class _WorkerLog {
+  const _WorkerLog({
+    required this.levelValue,
+    required this.levelName,
+    required this.loggerName,
+    required this.message,
+    required this.error,
+    required this.stackTrace,
+  });
+
+  final int levelValue;
+  final String levelName;
+  final String loggerName;
+  final String message;
+  final String? error;
+  final String? stackTrace;
+}
+
+/// Sends [error]+[stack] as a [_ModelError] without ever throwing.
+///
+/// First attempts to forward the originals (richer downstream — main can
+/// `isA<ConcreteError>()` and read the original stack). If [SendPort.send]
+/// rejects either object as non-sendable, falls back to stringified copies
+/// so main is never left waiting on a `Future.wait` for a worker that
+/// silently died inside its own catch block.
+void _sendModelError(
+  SendPort mainInbox,
+  int workerId,
+  int modelIndex,
+  Object error,
+  StackTrace stack,
+) {
+  try {
+    mainInbox.send(_ModelError(workerId, modelIndex, error, stack));
+    return;
+  } on Object {
+    // fall through to stringified fallback
+  }
+  try {
+    mainInbox.send(
+      _ModelError(
+        workerId,
+        modelIndex,
+        _NonSendableWorkerError(error.toString(), error.runtimeType.toString()),
+        StackTrace.fromString(stack.toString()),
+      ),
+    );
+  } on Object {
+    // Last resort: every send route refused. Nothing left we can do
+    // from inside the worker — main's exit listener will then observe
+    // the isolate dying and abort.
+  }
+}
+
+/// Carrier type emitted to main when the original worker error could not
+/// be sent across an [Isolate] boundary. Preserves the textual error and
+/// the original runtime type name so log messages remain useful.
+class _NonSendableWorkerError implements Exception {
+  const _NonSendableWorkerError(this.message, this.originalTypeName);
+  final String message;
+  final String originalTypeName;
+
+  @override
+  String toString() =>
+      'Worker error (original type $originalTypeName, non-sendable): $message';
+}
+
+/// Surfaces uncaught async errors that escape the worker's top-level
+/// `try`. Dart's `Isolate.spawn(onError: ...)` channel always stringifies
+/// the original error and stack before delivery, so we cannot rehydrate
+/// the originating type. Callers can use `isA<ModelWorkerAsyncError>()`
+/// to distinguish this stringified async path from a sync worker throw
+/// (which arrives with its original concrete type via [_ModelError]).
+class ModelWorkerAsyncError extends Error {
+  ModelWorkerAsyncError(this.message);
+  final String message;
+
+  @override
+  String toString() => 'tonik model worker async error: $message';
+}
+
+/// Top-level worker entry, required because [Isolate.spawn] cannot bind to
+/// a non-static closure capturing a class instance.
+Future<void> _workerEntry(_WorkerInit init) async {
+  // Top-level guard — any throw escaping below this point either inside
+  // sub-generator construction, handshake, the per-job loop's outer
+  // machinery, or an unawaited future, is forwarded to main as a
+  // setup-time _ModelError. Without this the failure is swallowed by
+  // the isolate's default error handler and main hangs on Future.wait.
+  try {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      final log = _WorkerLog(
+        levelValue: record.level.value,
+        levelName: record.level.name,
+        loggerName: record.loggerName,
+        message: record.message,
+        error: record.error?.toString(),
+        stackTrace: record.stackTrace?.toString(),
+      );
+      try {
+        init.mainInbox.send(log);
+      } on Object {
+        // Best-effort log forwarding; if the port is closed we silently
+        // drop. Main has already aborted (or completed) in that case.
+      }
+    });
+
+    final classGenerator = ClassGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final enumGenerator = EnumGenerator(nameManager: init.nameManager);
+    final oneOfGenerator = OneOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final anyOfGenerator = AnyOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final typedefGenerator = TypedefGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final allOfGenerator = AllOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+
+    final modelFileGenerator = ModelFileGenerator(
+      classGenerator: classGenerator,
+      enumGenerator: enumGenerator,
+      anyOfGenerator: anyOfGenerator,
+      oneOfGenerator: oneOfGenerator,
+      typedefGenerator: typedefGenerator,
+      allOfGenerator: allOfGenerator,
+    );
+
+    final inbox = ReceivePort();
+    init.mainInbox.send(_WorkerHandshake(init.workerId, inbox.sendPort));
+
+    await for (final msg in inbox) {
+      if (msg is _ModelJob) {
+        try {
+          modelFileGenerator.writeOne(
+            init.models[msg.modelIndex],
+            outputDirectory: init.outputDirectory,
+            package: init.package,
+          );
+          init.mainInbox.send(_ModelAck(init.workerId, msg.modelIndex));
+        } on Object catch (error, stack) {
+          _sendModelError(
+            init.mainInbox,
+            init.workerId,
+            msg.modelIndex,
+            error,
+            stack,
+          );
+        }
+      } else if (msg is _Shutdown) {
+        inbox.close();
+        return;
+      }
+    }
+  } on Object catch (error, stack) {
+    _sendModelError(
+      init.mainInbox,
+      init.workerId,
+      _setupFailureIndex,
+      error,
+      stack,
+    );
+  }
+}
+
+/// Sent worker -> main once during startup, carrying the worker's own
+/// inbox `SendPort` so main can dispatch jobs to it.
+class _WorkerHandshake {
+  const _WorkerHandshake(this.workerId, this.sendPort);
+  final int workerId;
+  final SendPort sendPort;
+}
+
+/// Resolves a [Level] for a forwarded record, preferring the canonical
+/// [Level.LEVELS] entry by value so a record's display name (`FINE`,
+/// `INFO`, ...) matches what the worker emitted. For non-canonical values
+/// (user-installed custom levels), synthesises a [Level] from the
+/// forwarded name+value — identity is not preserved across isolates.
+Level _levelForValue(int value, String name) {
+  for (final level in Level.LEVELS) {
+    if (level.value == value) return level;
+  }
+  return Level(name, value);
+}
+
+/// Bounded pool of isolates that parallelise [ModelFileGenerator.writeOne]
+/// across [Model]s.
+///
+/// Usage: instantiate, then `await pool.run(...)`. Each call to [run]
+/// spins up the requested worker isolates, ships the shared read-only
+/// state once, dispatches all models round-robin, and tears everything
+/// down before returning.
+class ModelWorkerPool {
+  ModelWorkerPool({
+    this.maxInflight = _defaultMaxInflight,
+  });
+
+  static const int _defaultMaxInflight = 256;
+
+  /// Cap on concurrently outstanding jobs across all workers. Limits the
+  /// peak memory used by generated `(filename, code)` pairs queued on
+  /// worker outboxes while main has not yet processed their acks.
+  final int maxInflight;
+
+  int _exitedWorkers = 0;
+  int _spawnedWorkers = 0;
+
+  /// Number of isolates this pool has spawned across all invocations of
+  /// [run] on this instance.
+  int get spawnedWorkers => _spawnedWorkers;
+
+  /// Number of isolates this pool has confirmed exited across all
+  /// invocations of [run]. Equal to [spawnedWorkers] after every
+  /// successful or failed [run] returns.
+  int get exitedWorkers => _exitedWorkers;
+
+  /// Dispatches every model in [apiDocument] to a pool of `workerCount`
+  /// isolates, awaits all acks (or rethrows the first worker error), and
+  /// shuts the pool down.
+  ///
+  /// The caller's `Logger.root.onRecord` listeners receive forwarded
+  /// records from workers with the original [Level] and logger name
+  /// preserved.
+  Future<void> run({
+    required ApiDocument apiDocument,
+    required NameManager nameManager,
+    required StableModelSorter stableModelSorter,
+    required String outputDirectory,
+    required String package,
+    required bool useImmutableCollections,
+    required int workerCount,
+  }) async {
+    if (workerCount < 1) {
+      throw ArgumentError.value(
+        workerCount,
+        'workerCount',
+        'must be at least 1',
+      );
+    }
+
+    final models = apiDocument.models.toList(growable: false);
+    if (models.isEmpty) return;
+
+    final effectiveWorkerCount = math.min(workerCount, models.length);
+
+    final mainInbox = ReceivePort();
+    final exitPort = ReceivePort();
+    final errorPort = ReceivePort();
+    final isolates = <Isolate>[];
+    final workerInboxes = <SendPort>[];
+    final handshakeCompleters = List<Completer<SendPort>>.generate(
+      effectiveWorkerCount,
+      (_) => Completer<SendPort>(),
+    );
+    final exitCompleters = List<Completer<void>>.generate(
+      effectiveWorkerCount,
+      (_) => Completer<void>(),
+    );
+    var nextExitSlot = 0;
+
+    final completer = Completer<void>();
+    var nextIndex = 0;
+    var inflight = 0;
+    var acked = 0;
+    var aborted = false;
+    var handshakesDone = false;
+    Object? capturedSetupError;
+    StackTrace? capturedSetupStack;
+
+    void abortWith(Object error, StackTrace stack) {
+      if (aborted) return;
+      aborted = true;
+      capturedSetupError ??= error;
+      capturedSetupStack ??= stack;
+      // Force every still-pending handshake into the error path so any
+      // `Future.wait` further down resolves instead of hanging forever.
+      for (final c in handshakeCompleters) {
+        if (!c.isCompleted) c.completeError(error, stack);
+      }
+      // Before all handshakes resolve, the run is awaiting `Future.wait`
+      // on the handshake completers — they propagate the error. After
+      // handshakes are done, the run is awaiting `completer.future`;
+      // completeError there is what unblocks.
+      if (handshakesDone && !completer.isCompleted) {
+        completer.completeError(error, stack);
+      }
+    }
+
+    late StreamSubscription<dynamic> mainSubscription;
+    late StreamSubscription<dynamic> exitSubscription;
+    late StreamSubscription<dynamic> errorSubscription;
+
+    void dispatchNext() {
+      if (aborted) return;
+      while (nextIndex < models.length && inflight < maxInflight) {
+        final idx = nextIndex++;
+        workerInboxes[idx % workerInboxes.length].send(_ModelJob(idx));
+        inflight++;
+      }
+      if (nextIndex >= models.length && inflight == 0 && !aborted) {
+        if (!completer.isCompleted) completer.complete();
+      }
+    }
+
+    // Surfaces uncaught async errors that escape the worker's top-level
+    // try (e.g. unawaited futures spawned inside generators). Isolate.spawn
+    // delivers these as a two-element [errorString, stackString] list and
+    // has already stringified the original error — `ModelWorkerAsyncError`
+    // is a named carrier so callers can tell this path apart from a sync
+    // worker throw (which preserves its concrete type via `_ModelError`).
+    errorSubscription = errorPort.listen((dynamic msg) {
+      if (aborted) return;
+      final parts = msg is List && msg.length >= 2 ? msg : ['$msg', ''];
+      abortWith(
+        ModelWorkerAsyncError('${parts[0]}'),
+        StackTrace.fromString('${parts[1]}'),
+      );
+    });
+
+    exitSubscription = exitPort.listen((dynamic _) {
+      _exitedWorkers++;
+      if (nextExitSlot < exitCompleters.length) {
+        exitCompleters[nextExitSlot++].complete();
+      }
+      // Defer a microtask so a racing `_ModelError` or `errorPort` message
+      // can land first and capture the real cause. Without this, an exit
+      // notification that arrives microseconds before its underlying error
+      // would clobber the real exception with the synthetic StateError below.
+      scheduleMicrotask(() {
+        if (aborted) return;
+        final stillPending = handshakeCompleters.any((c) => !c.isCompleted) ||
+            acked < models.length;
+        if (!stillPending) return;
+        final error = capturedSetupError ??
+            StateError(
+              'tonik model worker (id < $effectiveWorkerCount) exited '
+              'unexpectedly before completing its assigned jobs '
+              '(acked $acked of ${models.length}).',
+            );
+        final stack = capturedSetupStack ?? StackTrace.current;
+        abortWith(error, stack);
+      });
+    });
+
+    mainSubscription = mainInbox.listen((dynamic msg) {
+      if (msg is _WorkerHandshake) {
+        if (!handshakeCompleters[msg.workerId].isCompleted) {
+          handshakeCompleters[msg.workerId].complete(msg.sendPort);
+        }
+        return;
+      }
+      if (msg is _ModelAck) {
+        acked++;
+        inflight--;
+        dispatchNext();
+        return;
+      }
+      if (msg is _ModelError) {
+        // Setup-time failures (modelIndex == _setupFailureIndex) bypass the
+        // inflight bookkeeping since no job was outstanding.
+        if (msg.modelIndex != _setupFailureIndex) inflight--;
+        abortWith(msg.error, msg.stack);
+        return;
+      }
+      if (msg is _WorkerLog) {
+        Logger(msg.loggerName).log(
+          _levelForValue(msg.levelValue, msg.levelName),
+          msg.message,
+          msg.error,
+          msg.stackTrace == null
+              ? null
+              : StackTrace.fromString(msg.stackTrace!),
+        );
+        return;
+      }
+      // Defensive — protocol drift between worker and main should not
+      // be silent. Any new message type must be wired here too.
+      Logger('ModelWorkerPool').warning(
+        'ignoring unknown worker message: ${msg.runtimeType}',
+      );
+    });
+
+    try {
+      for (var i = 0; i < effectiveWorkerCount; i++) {
+        final isolate = await Isolate.spawn<_WorkerInit>(
+          _workerEntry,
+          _WorkerInit(
+            mainInbox: mainInbox.sendPort,
+            workerId: i,
+            models: models,
+            nameManager: nameManager,
+            outputDirectory: outputDirectory,
+            package: package,
+            useImmutableCollections: useImmutableCollections,
+            stableModelSorter: stableModelSorter,
+          ),
+          // Surface uncaught async errors via errorPort so a dying
+          // worker cannot leave main blocked on Future.wait.
+          onExit: exitPort.sendPort,
+          onError: errorPort.sendPort,
+          debugName: 'tonik-model-worker-$i',
+        );
+        isolates.add(isolate);
+        _spawnedWorkers++;
+      }
+
+      // If a worker exits early or errors out, its handshake completer
+      // fires with the captured error (set by exitPort / errorPort
+      // listeners through abortWith). That error propagates here, the
+      // outer try/finally tears the pool down, and `run` rethrows.
+      workerInboxes.addAll(
+        await Future.wait(handshakeCompleters.map((c) => c.future)),
+      );
+      handshakesDone = true;
+
+      dispatchNext();
+
+      await completer.future;
+    } finally {
+      for (final port in workerInboxes) {
+        try {
+          port.send(const _Shutdown());
+        } on Object {
+          // Worker already dead; nothing to shut down.
+        }
+      }
+      for (final isolate in isolates) {
+        isolate.kill();
+      }
+      // Without this wait, the spawnedWorkers/exitedWorkers counters race
+      // with the caller; tests cannot deterministically observe teardown.
+      if (isolates.isNotEmpty) {
+        await Future.wait(
+          exitCompleters.take(isolates.length).map((c) => c.future),
+        );
+      }
+      await mainSubscription.cancel();
+      await exitSubscription.cancel();
+      await errorSubscription.cancel();
+      mainInbox.close();
+      exitPort.close();
+      errorPort.close();
+    }
+
+    if (!aborted && acked != models.length) {
+      throw StateError(
+        'ModelWorkerPool finished with $acked acks for ${models.length} '
+        'models; some jobs were lost '
+        '(spawned=$_spawnedWorkers, exited=$_exitedWorkers, '
+        'inflight=$inflight, nextIndex=$nextIndex).',
+      );
+    }
+  }
+}

--- a/packages/tonik_generate/lib/src/util/model_worker_pool.dart
+++ b/packages/tonik_generate/lib/src/util/model_worker_pool.dart
@@ -14,13 +14,10 @@ import 'package:tonik_generate/src/model/one_of_generator.dart';
 import 'package:tonik_generate/src/model/typedef_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 
-/// Carrier exception thrown by [ModelWorkerPool.run] when an uncaught async
-/// error escaped a worker's top-level guard (e.g. an unawaited future
-/// throwing). Dart's `Isolate.spawn(onError: ...)` channel stringifies the
-/// original error and stack before delivery, so callers can use
-/// `isA<ModelWorkerAsyncError>()` to distinguish this stringified async
-/// path from a synchronous worker throw — the latter arrives with its
-/// original concrete type via the internal `_ModelError` carrier.
+/// Uncaught async worker error. Dart's isolate `onError` channel
+/// stringifies the original error before delivery, so the concrete type is
+/// only recoverable for sync throws (those arrive via the internal
+/// `_ModelError`).
 class ModelWorkerAsyncError implements Exception {
   ModelWorkerAsyncError(this.message);
   final String message;
@@ -29,13 +26,9 @@ class ModelWorkerAsyncError implements Exception {
   String toString() => 'tonik model worker async error: $message';
 }
 
-/// Carrier exception thrown by [ModelWorkerPool.run] when a worker error
-/// could not be transported across the [Isolate] boundary with its original
-/// runtime type (e.g. the error held a live [ReceivePort]).
-///
-/// Preserves the textual error and the original runtime type name so log
-/// messages remain useful; callers can use `isA<NonSendableWorkerError>()`
-/// to distinguish this fallback from a sendable rethrow.
+/// Worker error whose original runtime type could not cross the isolate
+/// boundary (e.g. held a live [ReceivePort]). [originalTypeName] preserves
+/// it for diagnostics.
 class NonSendableWorkerError implements Exception {
   const NonSendableWorkerError(this.message, this.originalTypeName);
   final String message;
@@ -46,13 +39,9 @@ class NonSendableWorkerError implements Exception {
       'Worker error (original type $originalTypeName, non-sendable): $message';
 }
 
-/// Bounded pool of isolates that parallelise [ModelFileGenerator.writeOne]
-/// across [Model]s.
-///
-/// Usage: instantiate, then `await pool.run(...)`. Each call to [run]
-/// spins up the requested worker isolates, ships the shared read-only
-/// state once, dispatches all models round-robin, and tears everything
-/// down before returning.
+/// Bounded isolate pool that parallelises [ModelFileGenerator.writeOne]
+/// across [Model]s. Forwards `Logger.root` records from workers to main
+/// with their original [Level] and logger name preserved.
 class ModelWorkerPool {
   ModelWorkerPool({
     this.maxInflight = _defaultMaxInflight,
@@ -60,30 +49,18 @@ class ModelWorkerPool {
 
   static const int _defaultMaxInflight = 256;
 
-  /// Cap on concurrently outstanding jobs across all workers. Limits the
-  /// peak memory used by generated `(filename, code)` pairs queued on
-  /// worker outboxes while main has not yet processed their acks.
+  /// Cap on outstanding jobs across all workers; bounds peak memory of
+  /// queued `(filename, code)` pairs.
   final int maxInflight;
 
   int _exitedWorkers = 0;
   int _spawnedWorkers = 0;
 
-  /// Number of isolates this pool has spawned across all invocations of
-  /// [run] on this instance.
   int get spawnedWorkers => _spawnedWorkers;
 
-  /// Number of isolates this pool has confirmed exited across all
-  /// invocations of [run]. Equal to [spawnedWorkers] after every
-  /// successful or failed [run] returns.
+  /// Equal to [spawnedWorkers] after every [run] returns.
   int get exitedWorkers => _exitedWorkers;
 
-  /// Dispatches every model in [apiDocument] to a pool of `workerCount`
-  /// isolates, awaits all acks (or rethrows the first worker error), and
-  /// shuts the pool down.
-  ///
-  /// The caller's `Logger.root.onRecord` listeners receive forwarded
-  /// records from workers with the original [Level] and logger name
-  /// preserved.
   Future<void> run({
     required ApiDocument apiDocument,
     required NameManager nameManager,
@@ -134,8 +111,6 @@ class ModelWorkerPool {
 
     void abortWith(Object error, StackTrace stack) {
       if (aborted) {
-        // Surface — but do not act on — secondary worker errors so they
-        // are at least visible in the log stream.
         poolLog.warning(
           'additional worker error suppressed after primary failure: $error',
           error,
@@ -146,15 +121,11 @@ class ModelWorkerPool {
       aborted = true;
       capturedSetupError ??= error;
       capturedSetupStack ??= stack;
-      // Force every still-pending handshake into the error path so any
-      // `Future.wait` further down resolves instead of hanging forever.
+      // Unblock whichever await is current: handshakes during setup,
+      // `completer.future` afterwards.
       for (final c in handshakeCompleters) {
         if (!c.isCompleted) c.completeError(error, stack);
       }
-      // Before all handshakes resolve, the run is awaiting `Future.wait`
-      // on the handshake completers — they propagate the error. After
-      // handshakes are done, the run is awaiting `completer.future`;
-      // completeError there is what unblocks.
       if (handshakesDone && !completer.isCompleted) {
         completer.completeError(error, stack);
       }
@@ -190,10 +161,8 @@ class ModelWorkerPool {
       if (nextExitSlot < exitCompleters.length) {
         exitCompleters[nextExitSlot++].complete();
       }
-      // Defer a microtask so a racing `_ModelError` or `errorPort` message
-      // can land first and capture the real cause. Without this, an exit
-      // notification that arrives microseconds before its underlying error
-      // would clobber the real exception with the synthetic StateError below.
+      // Defer so a racing `_ModelError` / `errorPort` can capture the real
+      // cause before we synthesise the watchdog StateError.
       scheduleMicrotask(() {
         if (aborted) return;
         final stillPending =
@@ -226,8 +195,6 @@ class ModelWorkerPool {
         return;
       }
       if (msg is _ModelError) {
-        // Setup-time failures bypass the inflight bookkeeping since no job
-        // was outstanding when the worker died.
         if (!msg.isSetupFailure) inflight--;
         abortWith(msg.error, msg.stack);
         return;
@@ -243,8 +210,7 @@ class ModelWorkerPool {
         );
         return;
       }
-      // Protocol drift is a programming error, not a runtime warning —
-      // any unknown message type means worker and main are out of sync.
+      // Unknown message = worker/main protocol drift (programming error).
       abortWith(
         StateError('protocol drift: unknown worker message ${msg.runtimeType}'),
         StackTrace.current,
@@ -265,9 +231,6 @@ class ModelWorkerPool {
             useImmutableCollections: useImmutableCollections,
             stableModelSorter: stableModelSorter,
           ),
-          // Surface uncaught async errors via errorPort so a dying
-          // worker cannot leave main blocked on Future.wait. See
-          // [ModelWorkerAsyncError] for the rationale on stringification.
           onExit: exitPort.sendPort,
           onError: errorPort.sendPort,
           debugName: 'tonik-model-worker-$i',
@@ -276,10 +239,6 @@ class ModelWorkerPool {
         _spawnedWorkers++;
       }
 
-      // If a worker exits early or errors out, its handshake completer
-      // fires with the captured error (set by exitPort / errorPort
-      // listeners through abortWith). That error propagates here, the
-      // outer try/finally tears the pool down, and `run` rethrows.
       workerInboxes.addAll(
         await Future.wait(handshakeCompleters.map((c) => c.future)),
       );
@@ -296,16 +255,11 @@ class ModelWorkerPool {
           // Worker already dead; nothing to shut down.
         }
       }
-      // Yield once so each worker has a chance to process the queued
-      // `_Shutdown` and flush any final log records before we kill them.
-      // Without this, a `Logger.warning` emitted in the same microtask as
-      // shutdown can be lost.
+      // Let workers drain queued logs before kill.
       await Future<void>.delayed(Duration.zero);
       for (final isolate in isolates) {
         isolate.kill();
       }
-      // Without this wait, the spawnedWorkers/exitedWorkers counters race
-      // with the caller; tests cannot deterministically observe teardown.
       if (isolates.isNotEmpty) {
         await Future.wait(
           exitCompleters.take(isolates.length).map((c) => c.future),
@@ -330,11 +284,7 @@ class ModelWorkerPool {
   }
 }
 
-/// Resolves a [Level] for a forwarded record, preferring the canonical
-/// [Level.LEVELS] entry by value so a record's display name (`FINE`,
-/// `INFO`, ...) matches what the worker emitted. For non-canonical values
-/// (user-installed custom levels), synthesises a [Level] from the
-/// forwarded name+value — identity is not preserved across isolates.
+/// Custom user-installed [Level]s do not round-trip — identity is lost.
 Level _levelForValue(int value, String name) {
   for (final level in Level.LEVELS) {
     if (level.value == value) return level;
@@ -349,11 +299,9 @@ void _sendModelError(
   required Object error,
   required StackTrace stack,
 }) {
-  // First attempt forwards the originals — richer downstream because main
-  // can `isA<ConcreteError>()` and read the original stack. If
-  // [SendPort.send] rejects either object as non-sendable, we retry with
-  // stringified copies so main is never left waiting on a `Future.wait`
-  // for a worker that silently died inside its own catch block.
+  // Try original objects first (richer), fall back to stringified copies
+  // if `SendPort.send` rejects them as non-sendable — main must never be
+  // left waiting on `Future.wait` for a worker that died in its own catch.
   try {
     mainInbox.send(
       _ModelError(
@@ -365,7 +313,7 @@ void _sendModelError(
     );
     return;
   } on Object {
-    // fall through to stringified fallback
+    // ignore: retry with stringified copies below.
   }
   try {
     mainInbox.send(
@@ -380,9 +328,7 @@ void _sendModelError(
       ),
     );
   } on Object {
-    // Last resort: every send route refused. Best-effort breadcrumb to
-    // stderr so the developer at least sees the original error before
-    // main's exit listener observes the dying isolate and aborts.
+    // Both sends refused — leave a breadcrumb before the isolate dies.
     stderr.writeln(
       'tonik model worker $workerId: failed to forward error '
       '(${error.runtimeType}) to main: $error',
@@ -391,11 +337,8 @@ void _sendModelError(
 }
 
 Future<void> _workerEntry(_WorkerInit init) async {
-  // Top-level guard — any throw escaping below this point either inside
-  // sub-generator construction, handshake, the per-job loop's outer
-  // machinery, or an unawaited future, is forwarded to main as a
-  // setup-time _ModelError. Without this the failure is swallowed by
-  // the isolate's default error handler and main hangs on Future.wait.
+  // Top-level guard: anything escaping below is forwarded to main as a
+  // setup-time _ModelError so main never hangs on `Future.wait`.
   try {
     Logger.root.level = Level.ALL;
     Logger.root.onRecord.listen((record) {
@@ -410,8 +353,7 @@ Future<void> _workerEntry(_WorkerInit init) async {
       try {
         init.mainInbox.send(log);
       } on Object {
-        // Best-effort log forwarding; if the port is closed we silently
-        // drop. Main has already aborted (or completed) in that case.
+        // Best-effort: main has aborted or completed, drop the record.
       }
     });
 
@@ -528,11 +470,8 @@ class _ModelAck {
   final int modelIndex;
 }
 
-/// [error] and [stack] may be the original objects (if sendable across the
-/// isolate boundary) or fallback stringified copies. A null [modelIndex]
-/// flags a worker that died outside the per-job dispatch loop (handshake,
-/// sub-generator construction, uncaught async error inside the top-level
-/// guard); main does not decrement `inflight` for those.
+/// [error]/[stack] are the originals when sendable, stringified otherwise.
+/// `modelIndex == null` flags a setup-time failure (no inflight to release).
 class _ModelError {
   const _ModelError({
     required this.workerId,
@@ -548,12 +487,8 @@ class _ModelError {
   bool get isSetupFailure => modelIndex == null;
 }
 
-/// The boundary stringifies `error` and `stackTrace` because
-/// [LogRecord.error] may hold a non-sendable Object. Listeners on
-/// `Logger.root` that branched on `record.error is SomeException` will
-/// not behave the same under the parallel path — they observe a `String`
-/// instead of the original type. `record.time` on the replayed entry is
-/// set by main, not the worker.
+/// `error`/`stackTrace` are stringified at the boundary; `record.error is
+/// SomeException` checks in main listeners will not match.
 class _WorkerLog {
   const _WorkerLog({
     required this.levelValue,

--- a/packages/tonik_generate/lib/src/util/model_worker_pool.dart
+++ b/packages/tonik_generate/lib/src/util/model_worker_pool.dart
@@ -1,4 +1,5 @@
 import 'dart:async';
+import 'dart:io';
 import 'dart:isolate';
 import 'dart:math' as math;
 
@@ -13,148 +14,14 @@ import 'package:tonik_generate/src/model/one_of_generator.dart';
 import 'package:tonik_generate/src/model/typedef_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 
-/// Sentinel modelIndex used by [_ModelError] to signal that a worker failed
-/// outside the per-job dispatch loop (handshake, sub-generator construction,
-/// uncaught async error). Main treats this as a fatal pool-level abort.
-const int _setupFailureIndex = -1;
-
-/// Initial handshake payload sent from main to each worker isolate.
-class _WorkerInit {
-  const _WorkerInit({
-    required this.mainInbox,
-    required this.workerId,
-    required this.models,
-    required this.nameManager,
-    required this.outputDirectory,
-    required this.package,
-    required this.useImmutableCollections,
-    required this.stableModelSorter,
-  });
-
-  final SendPort mainInbox;
-  final int workerId;
-  final List<Model> models;
-  final NameManager nameManager;
-  final String outputDirectory;
-  final String package;
-  final bool useImmutableCollections;
-  final StableModelSorter stableModelSorter;
-}
-
-/// Job message sent main -> worker, instructing the worker to generate the
-/// model at [modelIndex] of the shared list it was primed with.
-class _ModelJob {
-  const _ModelJob(this.modelIndex);
-  final int modelIndex;
-}
-
-/// Sentinel message instructing a worker to close its inbox and exit.
-class _Shutdown {
-  const _Shutdown();
-}
-
-/// Success ack sent worker -> main once the file for [modelIndex] is written.
-class _ModelAck {
-  const _ModelAck(this.workerId, this.modelIndex);
-  final int workerId;
-  final int modelIndex;
-}
-
-/// Error report sent worker -> main when generating [modelIndex] throws.
-///
-/// [error] and [stack] may be the original objects (if sendable) or fallback
-/// strings carrying their textual representation (if the originals could not
-/// cross the SendPort boundary).
-class _ModelError {
-  const _ModelError(this.workerId, this.modelIndex, this.error, this.stack);
-  final int workerId;
-  final int modelIndex;
-  final Object error;
-  final StackTrace stack;
-}
-
-/// Log record forwarded worker -> main so a single listener on the main
-/// isolate sees warnings from every worker.
-///
-/// The boundary stringifies `error` and `stackTrace` because `LogRecord.error`
-/// may hold a non-sendable Object. Listeners on `Logger.root` that branched
-/// on `record.error is SomeException` will not behave the same under the
-/// parallel path — they observe a `String` instead of the original type.
-/// `record.time` on the replayed entry is set by main, not the worker.
-class _WorkerLog {
-  const _WorkerLog({
-    required this.levelValue,
-    required this.levelName,
-    required this.loggerName,
-    required this.message,
-    required this.error,
-    required this.stackTrace,
-  });
-
-  final int levelValue;
-  final String levelName;
-  final String loggerName;
-  final String message;
-  final String? error;
-  final String? stackTrace;
-}
-
-/// Sends [error]+[stack] as a [_ModelError] without ever throwing.
-///
-/// First attempts to forward the originals (richer downstream — main can
-/// `isA<ConcreteError>()` and read the original stack). If [SendPort.send]
-/// rejects either object as non-sendable, falls back to stringified copies
-/// so main is never left waiting on a `Future.wait` for a worker that
-/// silently died inside its own catch block.
-void _sendModelError(
-  SendPort mainInbox,
-  int workerId,
-  int modelIndex,
-  Object error,
-  StackTrace stack,
-) {
-  try {
-    mainInbox.send(_ModelError(workerId, modelIndex, error, stack));
-    return;
-  } on Object {
-    // fall through to stringified fallback
-  }
-  try {
-    mainInbox.send(
-      _ModelError(
-        workerId,
-        modelIndex,
-        _NonSendableWorkerError(error.toString(), error.runtimeType.toString()),
-        StackTrace.fromString(stack.toString()),
-      ),
-    );
-  } on Object {
-    // Last resort: every send route refused. Nothing left we can do
-    // from inside the worker — main's exit listener will then observe
-    // the isolate dying and abort.
-  }
-}
-
-/// Carrier type emitted to main when the original worker error could not
-/// be sent across an [Isolate] boundary. Preserves the textual error and
-/// the original runtime type name so log messages remain useful.
-class _NonSendableWorkerError implements Exception {
-  const _NonSendableWorkerError(this.message, this.originalTypeName);
-  final String message;
-  final String originalTypeName;
-
-  @override
-  String toString() =>
-      'Worker error (original type $originalTypeName, non-sendable): $message';
-}
-
-/// Surfaces uncaught async errors that escape the worker's top-level
-/// `try`. Dart's `Isolate.spawn(onError: ...)` channel always stringifies
-/// the original error and stack before delivery, so we cannot rehydrate
-/// the originating type. Callers can use `isA<ModelWorkerAsyncError>()`
-/// to distinguish this stringified async path from a sync worker throw
-/// (which arrives with its original concrete type via [_ModelError]).
-class ModelWorkerAsyncError extends Error {
+/// Carrier exception thrown by [ModelWorkerPool.run] when an uncaught async
+/// error escaped a worker's top-level guard (e.g. an unawaited future
+/// throwing). Dart's `Isolate.spawn(onError: ...)` channel stringifies the
+/// original error and stack before delivery, so callers can use
+/// `isA<ModelWorkerAsyncError>()` to distinguish this stringified async
+/// path from a synchronous worker throw — the latter arrives with its
+/// original concrete type via the internal `_ModelError` carrier.
+class ModelWorkerAsyncError implements Exception {
   ModelWorkerAsyncError(this.message);
   final String message;
 
@@ -162,127 +29,21 @@ class ModelWorkerAsyncError extends Error {
   String toString() => 'tonik model worker async error: $message';
 }
 
-/// Top-level worker entry, required because [Isolate.spawn] cannot bind to
-/// a non-static closure capturing a class instance.
-Future<void> _workerEntry(_WorkerInit init) async {
-  // Top-level guard — any throw escaping below this point either inside
-  // sub-generator construction, handshake, the per-job loop's outer
-  // machinery, or an unawaited future, is forwarded to main as a
-  // setup-time _ModelError. Without this the failure is swallowed by
-  // the isolate's default error handler and main hangs on Future.wait.
-  try {
-    Logger.root.level = Level.ALL;
-    Logger.root.onRecord.listen((record) {
-      final log = _WorkerLog(
-        levelValue: record.level.value,
-        levelName: record.level.name,
-        loggerName: record.loggerName,
-        message: record.message,
-        error: record.error?.toString(),
-        stackTrace: record.stackTrace?.toString(),
-      );
-      try {
-        init.mainInbox.send(log);
-      } on Object {
-        // Best-effort log forwarding; if the port is closed we silently
-        // drop. Main has already aborted (or completed) in that case.
-      }
-    });
+/// Carrier exception thrown by [ModelWorkerPool.run] when a worker error
+/// could not be transported across the [Isolate] boundary with its original
+/// runtime type (e.g. the error held a live [ReceivePort]).
+///
+/// Preserves the textual error and the original runtime type name so log
+/// messages remain useful; callers can use `isA<NonSendableWorkerError>()`
+/// to distinguish this fallback from a sendable rethrow.
+class NonSendableWorkerError implements Exception {
+  const NonSendableWorkerError(this.message, this.originalTypeName);
+  final String message;
+  final String originalTypeName;
 
-    final classGenerator = ClassGenerator(
-      nameManager: init.nameManager,
-      package: init.package,
-      useImmutableCollections: init.useImmutableCollections,
-    );
-    final enumGenerator = EnumGenerator(nameManager: init.nameManager);
-    final oneOfGenerator = OneOfGenerator(
-      nameManager: init.nameManager,
-      package: init.package,
-      stableModelSorter: init.stableModelSorter,
-      useImmutableCollections: init.useImmutableCollections,
-    );
-    final anyOfGenerator = AnyOfGenerator(
-      nameManager: init.nameManager,
-      package: init.package,
-      stableModelSorter: init.stableModelSorter,
-      useImmutableCollections: init.useImmutableCollections,
-    );
-    final typedefGenerator = TypedefGenerator(
-      nameManager: init.nameManager,
-      package: init.package,
-      useImmutableCollections: init.useImmutableCollections,
-    );
-    final allOfGenerator = AllOfGenerator(
-      nameManager: init.nameManager,
-      package: init.package,
-      stableModelSorter: init.stableModelSorter,
-      useImmutableCollections: init.useImmutableCollections,
-    );
-
-    final modelFileGenerator = ModelFileGenerator(
-      classGenerator: classGenerator,
-      enumGenerator: enumGenerator,
-      anyOfGenerator: anyOfGenerator,
-      oneOfGenerator: oneOfGenerator,
-      typedefGenerator: typedefGenerator,
-      allOfGenerator: allOfGenerator,
-    );
-
-    final inbox = ReceivePort();
-    init.mainInbox.send(_WorkerHandshake(init.workerId, inbox.sendPort));
-
-    await for (final msg in inbox) {
-      if (msg is _ModelJob) {
-        try {
-          modelFileGenerator.writeOne(
-            init.models[msg.modelIndex],
-            outputDirectory: init.outputDirectory,
-            package: init.package,
-          );
-          init.mainInbox.send(_ModelAck(init.workerId, msg.modelIndex));
-        } on Object catch (error, stack) {
-          _sendModelError(
-            init.mainInbox,
-            init.workerId,
-            msg.modelIndex,
-            error,
-            stack,
-          );
-        }
-      } else if (msg is _Shutdown) {
-        inbox.close();
-        return;
-      }
-    }
-  } on Object catch (error, stack) {
-    _sendModelError(
-      init.mainInbox,
-      init.workerId,
-      _setupFailureIndex,
-      error,
-      stack,
-    );
-  }
-}
-
-/// Sent worker -> main once during startup, carrying the worker's own
-/// inbox `SendPort` so main can dispatch jobs to it.
-class _WorkerHandshake {
-  const _WorkerHandshake(this.workerId, this.sendPort);
-  final int workerId;
-  final SendPort sendPort;
-}
-
-/// Resolves a [Level] for a forwarded record, preferring the canonical
-/// [Level.LEVELS] entry by value so a record's display name (`FINE`,
-/// `INFO`, ...) matches what the worker emitted. For non-canonical values
-/// (user-installed custom levels), synthesises a [Level] from the
-/// forwarded name+value — identity is not preserved across isolates.
-Level _levelForValue(int value, String name) {
-  for (final level in Level.LEVELS) {
-    if (level.value == value) return level;
-  }
-  return Level(name, value);
+  @override
+  String toString() =>
+      'Worker error (original type $originalTypeName, non-sendable): $message';
 }
 
 /// Bounded pool of isolates that parallelise [ModelFileGenerator.writeOne]
@@ -369,8 +130,19 @@ class ModelWorkerPool {
     Object? capturedSetupError;
     StackTrace? capturedSetupStack;
 
+    final poolLog = Logger('ModelWorkerPool');
+
     void abortWith(Object error, StackTrace stack) {
-      if (aborted) return;
+      if (aborted) {
+        // Surface — but do not act on — secondary worker errors so they
+        // are at least visible in the log stream.
+        poolLog.warning(
+          'additional worker error suppressed after primary failure: $error',
+          error,
+          stack,
+        );
+        return;
+      }
       aborted = true;
       capturedSetupError ??= error;
       capturedSetupStack ??= stack;
@@ -404,12 +176,6 @@ class ModelWorkerPool {
       }
     }
 
-    // Surfaces uncaught async errors that escape the worker's top-level
-    // try (e.g. unawaited futures spawned inside generators). Isolate.spawn
-    // delivers these as a two-element [errorString, stackString] list and
-    // has already stringified the original error — `ModelWorkerAsyncError`
-    // is a named carrier so callers can tell this path apart from a sync
-    // worker throw (which preserves its concrete type via `_ModelError`).
     errorSubscription = errorPort.listen((dynamic msg) {
       if (aborted) return;
       final parts = msg is List && msg.length >= 2 ? msg : ['$msg', ''];
@@ -430,10 +196,12 @@ class ModelWorkerPool {
       // would clobber the real exception with the synthetic StateError below.
       scheduleMicrotask(() {
         if (aborted) return;
-        final stillPending = handshakeCompleters.any((c) => !c.isCompleted) ||
+        final stillPending =
+            handshakeCompleters.any((c) => !c.isCompleted) ||
             acked < models.length;
         if (!stillPending) return;
-        final error = capturedSetupError ??
+        final error =
+            capturedSetupError ??
             StateError(
               'tonik model worker (id < $effectiveWorkerCount) exited '
               'unexpectedly before completing its assigned jobs '
@@ -458,9 +226,9 @@ class ModelWorkerPool {
         return;
       }
       if (msg is _ModelError) {
-        // Setup-time failures (modelIndex == _setupFailureIndex) bypass the
-        // inflight bookkeeping since no job was outstanding.
-        if (msg.modelIndex != _setupFailureIndex) inflight--;
+        // Setup-time failures bypass the inflight bookkeeping since no job
+        // was outstanding when the worker died.
+        if (!msg.isSetupFailure) inflight--;
         abortWith(msg.error, msg.stack);
         return;
       }
@@ -475,10 +243,11 @@ class ModelWorkerPool {
         );
         return;
       }
-      // Defensive — protocol drift between worker and main should not
-      // be silent. Any new message type must be wired here too.
-      Logger('ModelWorkerPool').warning(
-        'ignoring unknown worker message: ${msg.runtimeType}',
+      // Protocol drift is a programming error, not a runtime warning —
+      // any unknown message type means worker and main are out of sync.
+      abortWith(
+        StateError('protocol drift: unknown worker message ${msg.runtimeType}'),
+        StackTrace.current,
       );
     });
 
@@ -497,7 +266,8 @@ class ModelWorkerPool {
             stableModelSorter: stableModelSorter,
           ),
           // Surface uncaught async errors via errorPort so a dying
-          // worker cannot leave main blocked on Future.wait.
+          // worker cannot leave main blocked on Future.wait. See
+          // [ModelWorkerAsyncError] for the rationale on stringification.
           onExit: exitPort.sendPort,
           onError: errorPort.sendPort,
           debugName: 'tonik-model-worker-$i',
@@ -526,6 +296,11 @@ class ModelWorkerPool {
           // Worker already dead; nothing to shut down.
         }
       }
+      // Yield once so each worker has a chance to process the queued
+      // `_Shutdown` and flush any final log records before we kill them.
+      // Without this, a `Logger.warning` emitted in the same microtask as
+      // shutdown can be lost.
+      await Future<void>.delayed(Duration.zero);
       for (final isolate in isolates) {
         isolate.kill();
       }
@@ -553,4 +328,252 @@ class ModelWorkerPool {
       );
     }
   }
+}
+
+/// Resolves a [Level] for a forwarded record, preferring the canonical
+/// [Level.LEVELS] entry by value so a record's display name (`FINE`,
+/// `INFO`, ...) matches what the worker emitted. For non-canonical values
+/// (user-installed custom levels), synthesises a [Level] from the
+/// forwarded name+value — identity is not preserved across isolates.
+Level _levelForValue(int value, String name) {
+  for (final level in Level.LEVELS) {
+    if (level.value == value) return level;
+  }
+  return Level(name, value);
+}
+
+void _sendModelError(
+  SendPort mainInbox,
+  int workerId, {
+  required int? modelIndex,
+  required Object error,
+  required StackTrace stack,
+}) {
+  // First attempt forwards the originals — richer downstream because main
+  // can `isA<ConcreteError>()` and read the original stack. If
+  // [SendPort.send] rejects either object as non-sendable, we retry with
+  // stringified copies so main is never left waiting on a `Future.wait`
+  // for a worker that silently died inside its own catch block.
+  try {
+    mainInbox.send(
+      _ModelError(
+        workerId: workerId,
+        modelIndex: modelIndex,
+        error: error,
+        stack: stack,
+      ),
+    );
+    return;
+  } on Object {
+    // fall through to stringified fallback
+  }
+  try {
+    mainInbox.send(
+      _ModelError(
+        workerId: workerId,
+        modelIndex: modelIndex,
+        error: NonSendableWorkerError(
+          error.toString(),
+          error.runtimeType.toString(),
+        ),
+        stack: StackTrace.fromString(stack.toString()),
+      ),
+    );
+  } on Object {
+    // Last resort: every send route refused. Best-effort breadcrumb to
+    // stderr so the developer at least sees the original error before
+    // main's exit listener observes the dying isolate and aborts.
+    stderr.writeln(
+      'tonik model worker $workerId: failed to forward error '
+      '(${error.runtimeType}) to main: $error',
+    );
+  }
+}
+
+Future<void> _workerEntry(_WorkerInit init) async {
+  // Top-level guard — any throw escaping below this point either inside
+  // sub-generator construction, handshake, the per-job loop's outer
+  // machinery, or an unawaited future, is forwarded to main as a
+  // setup-time _ModelError. Without this the failure is swallowed by
+  // the isolate's default error handler and main hangs on Future.wait.
+  try {
+    Logger.root.level = Level.ALL;
+    Logger.root.onRecord.listen((record) {
+      final log = _WorkerLog(
+        levelValue: record.level.value,
+        levelName: record.level.name,
+        loggerName: record.loggerName,
+        message: record.message,
+        error: record.error?.toString(),
+        stackTrace: record.stackTrace?.toString(),
+      );
+      try {
+        init.mainInbox.send(log);
+      } on Object {
+        // Best-effort log forwarding; if the port is closed we silently
+        // drop. Main has already aborted (or completed) in that case.
+      }
+    });
+
+    final classGenerator = ClassGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final enumGenerator = EnumGenerator(nameManager: init.nameManager);
+    final oneOfGenerator = OneOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final anyOfGenerator = AnyOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final typedefGenerator = TypedefGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+    final allOfGenerator = AllOfGenerator(
+      nameManager: init.nameManager,
+      package: init.package,
+      stableModelSorter: init.stableModelSorter,
+      useImmutableCollections: init.useImmutableCollections,
+    );
+
+    final modelFileGenerator = ModelFileGenerator(
+      classGenerator: classGenerator,
+      enumGenerator: enumGenerator,
+      anyOfGenerator: anyOfGenerator,
+      oneOfGenerator: oneOfGenerator,
+      typedefGenerator: typedefGenerator,
+      allOfGenerator: allOfGenerator,
+    );
+
+    final inbox = ReceivePort();
+    init.mainInbox.send(_WorkerHandshake(init.workerId, inbox.sendPort));
+
+    await for (final msg in inbox) {
+      if (msg is _ModelJob) {
+        try {
+          modelFileGenerator.writeOne(
+            init.models[msg.modelIndex],
+            outputDirectory: init.outputDirectory,
+            package: init.package,
+          );
+          init.mainInbox.send(_ModelAck(init.workerId, msg.modelIndex));
+        } on Object catch (error, stack) {
+          _sendModelError(
+            init.mainInbox,
+            init.workerId,
+            modelIndex: msg.modelIndex,
+            error: error,
+            stack: stack,
+          );
+        }
+      } else if (msg is _Shutdown) {
+        inbox.close();
+        return;
+      }
+    }
+  } on Object catch (error, stack) {
+    _sendModelError(
+      init.mainInbox,
+      init.workerId,
+      modelIndex: null,
+      error: error,
+      stack: stack,
+    );
+  }
+}
+
+class _WorkerInit {
+  const _WorkerInit({
+    required this.mainInbox,
+    required this.workerId,
+    required this.models,
+    required this.nameManager,
+    required this.outputDirectory,
+    required this.package,
+    required this.useImmutableCollections,
+    required this.stableModelSorter,
+  });
+
+  final SendPort mainInbox;
+  final int workerId;
+  final List<Model> models;
+  final NameManager nameManager;
+  final String outputDirectory;
+  final String package;
+  final bool useImmutableCollections;
+  final StableModelSorter stableModelSorter;
+}
+
+class _ModelJob {
+  const _ModelJob(this.modelIndex);
+  final int modelIndex;
+}
+
+class _Shutdown {
+  const _Shutdown();
+}
+
+class _ModelAck {
+  const _ModelAck(this.workerId, this.modelIndex);
+  final int workerId;
+  final int modelIndex;
+}
+
+/// [error] and [stack] may be the original objects (if sendable across the
+/// isolate boundary) or fallback stringified copies. A null [modelIndex]
+/// flags a worker that died outside the per-job dispatch loop (handshake,
+/// sub-generator construction, uncaught async error inside the top-level
+/// guard); main does not decrement `inflight` for those.
+class _ModelError {
+  const _ModelError({
+    required this.workerId,
+    required this.modelIndex,
+    required this.error,
+    required this.stack,
+  });
+  final int workerId;
+  final int? modelIndex;
+  final Object error;
+  final StackTrace stack;
+
+  bool get isSetupFailure => modelIndex == null;
+}
+
+/// The boundary stringifies `error` and `stackTrace` because
+/// [LogRecord.error] may hold a non-sendable Object. Listeners on
+/// `Logger.root` that branched on `record.error is SomeException` will
+/// not behave the same under the parallel path — they observe a `String`
+/// instead of the original type. `record.time` on the replayed entry is
+/// set by main, not the worker.
+class _WorkerLog {
+  const _WorkerLog({
+    required this.levelValue,
+    required this.levelName,
+    required this.loggerName,
+    required this.message,
+    required this.error,
+    required this.stackTrace,
+  });
+
+  final int levelValue;
+  final String levelName;
+  final String loggerName;
+  final String message;
+  final String? error;
+  final String? stackTrace;
+}
+
+class _WorkerHandshake {
+  const _WorkerHandshake(this.workerId, this.sendPort);
+  final int workerId;
+  final SendPort sendPort;
 }

--- a/packages/tonik_generate/test/src/generator/generator_any_of_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_any_of_test.dart
@@ -19,7 +19,7 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates file for anyOf model', () {
+    test('generates file for anyOf model', () async {
       final anyOfModel = AnyOfModel(
         isDeprecated: false,
         name: 'FlexibleModel',
@@ -49,7 +49,7 @@ void main() {
 
       const packageName = 'test_package';
 
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_library_metadata_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_library_metadata_test.dart
@@ -19,7 +19,7 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates library with comprehensive API metadata', () {
+    test('generates library with comprehensive API metadata', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -63,7 +63,7 @@ void main() {
       );
 
       const packageName = 'petstore_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -114,7 +114,7 @@ void main() {
       expect(content, contains('/// Documentation URL: https://swagger.io'));
     });
 
-    test('handles missing optional metadata gracefully', () {
+    test('handles missing optional metadata gracefully', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -142,7 +142,7 @@ void main() {
       );
 
       const packageName = 'simple_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -166,7 +166,7 @@ void main() {
       expect(content, isNot(contains('/// Documentation:')));
     });
 
-    test('generates library with summary (OAS 3.1)', () {
+    test('generates library with summary (OAS 3.1)', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -195,7 +195,7 @@ void main() {
       );
 
       const packageName = 'petstore_summary_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -211,7 +211,7 @@ void main() {
       expect(content, contains('/// A longer description with more details.'));
     });
 
-    test('generates library with license identifier (OAS 3.1)', () {
+    test('generates library with license identifier (OAS 3.1)', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -242,7 +242,7 @@ void main() {
       );
 
       const packageName = 'spdx_license_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_library_security_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_library_security_test.dart
@@ -19,7 +19,9 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('includes security schemes information in library documentation', () {
+    test(
+        'includes security schemes information in library documentation',
+        () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -76,7 +78,7 @@ void main() {
       );
 
       const packageName = 'petstore_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -101,7 +103,7 @@ void main() {
       );
     });
 
-    test('includes OAuth2 security scheme information', () {
+    test('includes OAuth2 security scheme information', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -162,7 +164,7 @@ void main() {
       );
 
       const packageName = 'oauth_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -183,7 +185,7 @@ void main() {
       expect(content, contains('///   Scopes: read, write'));
     });
 
-    test('includes mutual TLS security scheme information', () {
+    test('includes mutual TLS security scheme information', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -233,7 +235,7 @@ void main() {
       );
 
       const packageName = 'mutual_tls_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -251,7 +253,7 @@ void main() {
       );
     });
 
-    test('handles empty security schemes', () {
+    test('handles empty security schemes', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -298,7 +300,7 @@ void main() {
       );
 
       const packageName = 'simple_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,
@@ -313,7 +315,7 @@ void main() {
       expect(content, isNot(contains('/// Security Schemes:')));
     });
 
-    test('omits description when none provided', () {
+    test('omits description when none provided', () async {
       final models = <Model>{
         ClassModel(
           isDeprecated: false,
@@ -370,7 +372,7 @@ void main() {
       );
 
       const packageName = 'no_desc_api';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_models_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_models_test.dart
@@ -21,7 +21,7 @@ void main() {
 
     test(
       'generates files for class, enum, oneOf, anyOf, allOf, alias, list',
-      () {
+      () async {
         final models = <Model>{
           ClassModel(
             isDeprecated: false,
@@ -106,7 +106,7 @@ void main() {
         );
 
         const packageName = 'test_package';
-        const Generator().generate(
+        await const Generator().generate(
           apiDocument: apiDoc,
           outputDirectory: tempDir.path,
           package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_operations_and_wrappers_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_operations_and_wrappers_test.dart
@@ -19,7 +19,7 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates operation files, wrappers, and API clients', () {
+    test('generates operation files, wrappers, and API clients', () async {
       final successResponse = ResponseObject(
         name: 'Ok',
         context: ctx,
@@ -104,7 +104,7 @@ void main() {
       );
 
       const packageName = 'test_package';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_parallel_models_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_parallel_models_test.dart
@@ -4,6 +4,7 @@ import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/generator.dart';
+import 'package:tonik_generate/src/util/model_worker_pool.dart';
 
 Map<String, String> _readModelTree(String root, String package) {
   final modelDir = Directory(path.join(root, package, 'lib', 'src', 'model'));
@@ -15,6 +16,36 @@ Map<String, String> _readModelTree(String root, String package) {
     result[path.basename(file.path)] = file.readAsStringSync();
   }
   return result;
+}
+
+ApiDocument _modelsDocument(int count, Context ctx) {
+  final models = <Model>{};
+  for (var i = 0; i < count; i++) {
+    models.add(
+      ClassModel(
+        isDeprecated: false,
+        name: 'Model$i',
+        properties: const [],
+        context: ctx,
+        examples: const [],
+      ),
+    );
+  }
+  return ApiDocument(
+    title: 'Test',
+    version: '1.0.0',
+    description: 'Test',
+    models: models,
+    responseHeaders: const {},
+    requestHeaders: const {},
+    servers: const {},
+    operations: const {},
+    responses: const <Response>{},
+    queryParameters: const {},
+    pathParameters: const {},
+    cookieParameters: const {},
+    requestBodies: const {},
+  );
 }
 
 void main() {
@@ -34,72 +65,98 @@ void main() {
     test(
       'dispatches via worker pool when threshold is met and workerCount > 1',
       () async {
-        final models = <Model>{};
-        for (var i = 0; i < Generator.parallelThreshold; i++) {
-          models.add(
-            ClassModel(
-              isDeprecated: false,
-              name: 'Model$i',
-              properties: const [],
-              context: ctx,
-              examples: const [],
-            ),
-          );
-        }
+        final apiDoc = _modelsDocument(Generator.parallelThreshold, ctx);
 
-        final apiDoc = ApiDocument(
-          title: 'Test',
-          version: '1.0.0',
-          description: 'Test',
-          models: models,
-          responseHeaders: const {},
-          requestHeaders: const {},
-          servers: const {},
-          operations: const {},
-          responses: const <Response>{},
-          queryParameters: const {},
-          pathParameters: const {},
-          cookieParameters: const {},
-          requestBodies: const {},
-        );
-
+        var parallelPoolCount = 0;
         const parallelPackage = 'parallel_pkg';
         await const Generator().generate(
           apiDocument: apiDoc,
           outputDirectory: tempDir.path,
           package: parallelPackage,
           config: const TonikConfig(workerCount: 2),
+          workerPoolFactory: () {
+            parallelPoolCount++;
+            return ModelWorkerPool();
+          },
         );
 
+        var serialPoolCount = 0;
         const serialPackage = 'serial_pkg';
         await const Generator().generate(
           apiDocument: apiDoc,
           outputDirectory: tempDir.path,
           package: serialPackage,
           config: const TonikConfig(workerCount: 1),
+          workerPoolFactory: () {
+            serialPoolCount++;
+            return ModelWorkerPool();
+          },
+        );
+
+        expect(
+          parallelPoolCount,
+          1,
+          reason: 'parallel branch must instantiate the worker pool once',
+        );
+        expect(
+          serialPoolCount,
+          0,
+          reason: 'serial branch must not instantiate the worker pool',
         );
 
         final parallelTree = _readModelTree(tempDir.path, parallelPackage);
         final serialTree = _readModelTree(tempDir.path, serialPackage);
 
         expect(parallelTree, isNotEmpty);
-        expect(parallelTree.length, models.length);
+        expect(parallelTree.length, apiDoc.models.length);
         expect(parallelTree, serialTree);
+      },
+    );
+
+    test(
+      'runs serially when model count is below parallelThreshold',
+      () async {
+        final apiDoc = _modelsDocument(Generator.parallelThreshold - 1, ctx);
+
+        var poolCount = 0;
+        await const Generator().generate(
+          apiDocument: apiDoc,
+          outputDirectory: tempDir.path,
+          package: 'below_threshold_pkg',
+          config: const TonikConfig(workerCount: 8),
+          workerPoolFactory: () {
+            poolCount++;
+            return ModelWorkerPool();
+          },
+        );
+
+        expect(
+          poolCount,
+          0,
+          reason: 'below-threshold path must skip the worker pool entirely '
+              'regardless of how many workers the caller requested',
+        );
+
+        final tree = _readModelTree(tempDir.path, 'below_threshold_pkg');
+        expect(tree, isNotEmpty);
+        expect(tree.length, apiDoc.models.length);
       },
     );
   });
 
-  group('Generator.resolveWorkerCount', () {
-    test('returns explicit requested value when provided', () {
-      expect(Generator.resolveWorkerCount(0), 0);
-      expect(Generator.resolveWorkerCount(1), 1);
-      expect(Generator.resolveWorkerCount(8), 8);
+  group('Generator.clampAutoWorkerCount', () {
+    test('reserves one CPU for main and clamps to [1, 16]', () {
+      expect(Generator.clampAutoWorkerCount(0), 1);
+      expect(Generator.clampAutoWorkerCount(1), 1);
+      expect(Generator.clampAutoWorkerCount(2), 1);
+      expect(Generator.clampAutoWorkerCount(17), 16);
+      expect(Generator.clampAutoWorkerCount(100), 16);
     });
 
-    test('auto-sizes when null is passed', () {
-      final auto = Generator.resolveWorkerCount(null);
-      expect(auto, greaterThanOrEqualTo(1));
-      expect(auto, lessThanOrEqualTo(16));
+    test('returns processorCount - 1 inside the clamp window', () {
+      expect(Generator.clampAutoWorkerCount(3), 2);
+      expect(Generator.clampAutoWorkerCount(8), 7);
+      expect(Generator.clampAutoWorkerCount(16), 15);
     });
   });
 }

--- a/packages/tonik_generate/test/src/generator/generator_parallel_models_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_parallel_models_test.dart
@@ -1,0 +1,105 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/generator.dart';
+
+Map<String, String> _readModelTree(String root, String package) {
+  final modelDir = Directory(path.join(root, package, 'lib', 'src', 'model'));
+  if (!modelDir.existsSync()) return const {};
+  final result = <String, String>{};
+  final entries = modelDir.listSync().whereType<File>().toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  for (final file in entries) {
+    result[path.basename(file.path)] = file.readAsStringSync();
+  }
+  return result;
+}
+
+void main() {
+  group('Generator parallel model path', () {
+    late Directory tempDir;
+    late Context ctx;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('gen_parallel_');
+      ctx = Context.initial();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test(
+      'dispatches via worker pool when threshold is met and workerCount > 1',
+      () async {
+        final models = <Model>{};
+        for (var i = 0; i < Generator.parallelThreshold; i++) {
+          models.add(
+            ClassModel(
+              isDeprecated: false,
+              name: 'Model$i',
+              properties: const [],
+              context: ctx,
+              examples: const [],
+            ),
+          );
+        }
+
+        final apiDoc = ApiDocument(
+          title: 'Test',
+          version: '1.0.0',
+          description: 'Test',
+          models: models,
+          responseHeaders: const {},
+          requestHeaders: const {},
+          servers: const {},
+          operations: const {},
+          responses: const <Response>{},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          requestBodies: const {},
+        );
+
+        const parallelPackage = 'parallel_pkg';
+        await const Generator().generate(
+          apiDocument: apiDoc,
+          outputDirectory: tempDir.path,
+          package: parallelPackage,
+          config: const TonikConfig(workerCount: 2),
+        );
+
+        const serialPackage = 'serial_pkg';
+        await const Generator().generate(
+          apiDocument: apiDoc,
+          outputDirectory: tempDir.path,
+          package: serialPackage,
+          config: const TonikConfig(workerCount: 1),
+        );
+
+        final parallelTree = _readModelTree(tempDir.path, parallelPackage);
+        final serialTree = _readModelTree(tempDir.path, serialPackage);
+
+        expect(parallelTree, isNotEmpty);
+        expect(parallelTree.length, models.length);
+        expect(parallelTree, serialTree);
+      },
+    );
+  });
+
+  group('Generator.resolveWorkerCount', () {
+    test('returns explicit requested value when provided', () {
+      expect(Generator.resolveWorkerCount(0), 0);
+      expect(Generator.resolveWorkerCount(1), 1);
+      expect(Generator.resolveWorkerCount(8), 8);
+    });
+
+    test('auto-sizes when null is passed', () {
+      final auto = Generator.resolveWorkerCount(null);
+      expect(auto, greaterThanOrEqualTo(1));
+      expect(auto, lessThanOrEqualTo(16));
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/generator/generator_request_and_response_files_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_request_and_response_files_test.dart
@@ -19,7 +19,8 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates request body file (multi-content) and response files', () {
+    test('generates request body file (multi-content) and response files',
+        () async {
       final multiBodyRequest = RequestBodyObject(
         name: 'MultiBody',
         context: ctx,
@@ -106,7 +107,7 @@ void main() {
       );
 
       const packageName = 'test_package';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_root_files_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_root_files_test.dart
@@ -17,7 +17,7 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates pubspec.yaml and analysis_options.yaml', () {
+    test('generates pubspec.yaml and analysis_options.yaml', () async {
       final apiDoc = ApiDocument(
         title: 'Test API',
         version: '1.0.0',
@@ -35,7 +35,7 @@ void main() {
       );
 
       const packageName = 'test_package';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/generator/generator_server_and_library_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_server_and_library_test.dart
@@ -19,7 +19,7 @@ void main() {
       tempDir.deleteSync(recursive: true);
     });
 
-    test('generates server file and library exports', () {
+    test('generates server file and library exports', () async {
       final servers = {
         const Server(url: 'https://api.example.com', description: 'Prod'),
         const Server(
@@ -55,7 +55,7 @@ void main() {
       );
 
       const packageName = 'test_package';
-      const Generator().generate(
+      await const Generator().generate(
         apiDocument: apiDoc,
         outputDirectory: tempDir.path,
         package: packageName,

--- a/packages/tonik_generate/test/src/model/model_file_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/model_file_generator_test.dart
@@ -1,0 +1,360 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/all_of_generator.dart';
+import 'package:tonik_generate/src/model/any_of_generator.dart';
+import 'package:tonik_generate/src/model/class_generator.dart';
+import 'package:tonik_generate/src/model/enum_generator.dart';
+import 'package:tonik_generate/src/model/model_file_generator.dart';
+import 'package:tonik_generate/src/model/one_of_generator.dart';
+import 'package:tonik_generate/src/model/typedef_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+const _package = 'pkg';
+
+ModelFileGenerator _buildGenerator() {
+  final nameGenerator = NameGenerator();
+  final stableModelSorter = StableModelSorter();
+  final nameManager = NameManager(
+    generator: nameGenerator,
+    stableModelSorter: stableModelSorter,
+  );
+
+  return ModelFileGenerator(
+    classGenerator: ClassGenerator(
+      nameManager: nameManager,
+      package: _package,
+    ),
+    enumGenerator: EnumGenerator(nameManager: nameManager),
+    anyOfGenerator: AnyOfGenerator(
+      nameManager: nameManager,
+      package: _package,
+      stableModelSorter: stableModelSorter,
+    ),
+    oneOfGenerator: OneOfGenerator(
+      nameManager: nameManager,
+      package: _package,
+      stableModelSorter: stableModelSorter,
+    ),
+    typedefGenerator: TypedefGenerator(
+      nameManager: nameManager,
+      package: _package,
+    ),
+    allOfGenerator: AllOfGenerator(
+      nameManager: nameManager,
+      package: _package,
+      stableModelSorter: stableModelSorter,
+    ),
+  );
+}
+
+String _modelDir(String outputDirectory) =>
+    path.joinAll([outputDirectory, _package, 'lib', 'src', 'model']);
+
+void main() {
+  group('ModelFileGenerator.writeOne', () {
+    late Directory tempDir;
+    late Context ctx;
+    late ModelFileGenerator generator;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('model_file_generator_');
+      ctx = Context.initial();
+      generator = _buildGenerator();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('writes ClassModel file with a class declaration', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'User',
+        properties: const [],
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'user.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('class '));
+    });
+
+    test('writes EnumModel<int> file with an enum declaration', () {
+      final model = EnumModel<int>(
+        isDeprecated: false,
+        name: 'Priority',
+        values: {
+          const EnumEntry(value: 1),
+          const EnumEntry(value: 2),
+        },
+        isNullable: false,
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'priority.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('enum '));
+    });
+
+    test('writes EnumModel<String> file with an enum declaration', () {
+      final model = EnumModel<String>(
+        isDeprecated: false,
+        name: 'Color',
+        values: {
+          const EnumEntry(value: 'red'),
+          const EnumEntry(value: 'blue'),
+        },
+        isNullable: false,
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'color.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('enum '));
+    });
+
+    test('writes AnyOfModel file with a class declaration', () {
+      final model = AnyOfModel(
+        isDeprecated: false,
+        name: 'FlexibleModel',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: ctx)),
+          (discriminatorValue: null, model: IntegerModel(context: ctx)),
+        },
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(
+        path.join(_modelDir(tempDir.path), 'flexible_model.dart'),
+      );
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('class '));
+    });
+
+    test('writes OneOfModel file with a class declaration', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Choice',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: ctx)),
+          (discriminatorValue: null, model: IntegerModel(context: ctx)),
+        },
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'choice.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('class '));
+    });
+
+    test('writes AllOfModel file with a class declaration', () {
+      final model = AllOfModel(
+        isDeprecated: false,
+        name: 'Combined',
+        models: {
+          StringModel(context: ctx),
+          IntegerModel(context: ctx),
+        },
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'combined.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('class '));
+    });
+
+    test('writes AliasModel file with a typedef declaration', () {
+      final model = AliasModel(
+        name: 'UserId',
+        model: StringModel(context: ctx),
+        context: ctx,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'user_id.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('typedef '));
+    });
+
+    test('writes ListModel file with a typedef declaration', () {
+      final model = ListModel(
+        name: 'UserList',
+        content: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: const [],
+          context: ctx,
+          examples: const [],
+        ),
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'user_list.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('typedef '));
+    });
+
+    test('writes MapModel file with a typedef declaration', () {
+      final model = MapModel(
+        name: 'UserMap',
+        valueModel: ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: const [],
+          context: ctx,
+          examples: const [],
+        ),
+        context: ctx,
+        examples: const [],
+      );
+
+      generator.writeOne(
+        model,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final file = File(path.join(_modelDir(tempDir.path), 'user_map.dart'));
+      expect(file.existsSync(), isTrue);
+      expect(file.readAsStringSync(), contains('typedef '));
+    });
+
+    test('skips unsupported model subtype without writing any file', () {
+      generator.writeOne(
+        StringModel(context: ctx),
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      final dir = Directory(_modelDir(tempDir.path));
+      expect(
+        dir.existsSync() ? dir.listSync() : const <FileSystemEntity>[],
+        isEmpty,
+      );
+    });
+  });
+
+  group('ModelFileGenerator.writeFiles', () {
+    late Directory tempDir;
+    late Context ctx;
+    late ModelFileGenerator generator;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('model_file_generator_');
+      ctx = Context.initial();
+      generator = _buildGenerator();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('writes one file per dispatched model in apiDocument', () {
+      final apiDoc = ApiDocument(
+        title: 'Test',
+        version: '1.0.0',
+        description: 'Test',
+        models: <Model>{
+          ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: ctx,
+            examples: const [],
+          ),
+          AliasModel(
+            name: 'UserId',
+            model: StringModel(context: ctx),
+            context: ctx,
+            examples: const [],
+            defaultValue: null,
+          ),
+        },
+        responseHeaders: const {},
+        requestHeaders: const {},
+        servers: const {},
+        operations: const {},
+        responses: const <Response>{},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        requestBodies: const {},
+      );
+
+      generator.writeFiles(
+        apiDocument: apiDoc,
+        outputDirectory: tempDir.path,
+        package: _package,
+      );
+
+      expect(
+        File(path.join(_modelDir(tempDir.path), 'user.dart')).existsSync(),
+        isTrue,
+      );
+      expect(
+        File(path.join(_modelDir(tempDir.path), 'user_id.dart')).existsSync(),
+        isTrue,
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
+++ b/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
@@ -645,6 +645,75 @@ void main() {
       expect(pool.exitedWorkers, pool.spawnedWorkers);
     });
 
+    test(
+      'forwards worker log.warning attached error as stringified type name '
+      'with reconstructable stack',
+      () async {
+        final apiDoc = _allSubtypeModelDocument(ctx);
+
+        final outDir = Directory(path.join(tempDir.path, 'errlogout'))
+          ..createSync();
+
+        final nameGenerator = NameGenerator();
+        final stableModelSorter = StableModelSorter();
+        final nameManager = _WarningLoggingNameManager(
+          generator: nameGenerator,
+          stableModelSorter: stableModelSorter,
+        )
+          ..prime(
+            models: apiDoc.models,
+            responses: apiDoc.responses,
+            requestBodies: apiDoc.requestBodies,
+            operations: apiDoc.operations,
+            tags: apiDoc.operationsByTag.keys,
+            servers: apiDoc.servers,
+          )
+          ..armed = true;
+
+        final previousLevel = Logger.root.level;
+        Logger.root.level = Level.ALL;
+        final forwarded = <LogRecord>[];
+        final sub = Logger.root.onRecord.listen(forwarded.add);
+
+        try {
+          await ModelWorkerPool().run(
+            apiDocument: apiDoc,
+            nameManager: nameManager,
+            stableModelSorter: stableModelSorter,
+            outputDirectory: outDir.path,
+            package: _package,
+            useImmutableCollections: false,
+            workerCount: 1,
+          );
+        } finally {
+          await sub.cancel();
+          Logger.root.level = previousLevel;
+        }
+
+        final warning = forwarded.firstWhere(
+          (r) =>
+              r.loggerName == 'TestWorkerLogger' && r.level == Level.WARNING,
+        );
+
+        expect(
+          warning.error,
+          isA<String>(),
+          reason: 'attached error must arrive as a String (boundary '
+              'stringifies it because the original may be non-sendable)',
+        );
+        expect(
+          warning.error! as String,
+          contains('_AttachedException'),
+          reason: 'stringified error must preserve the original runtime '
+              'type name so log readers can tell error types apart',
+        );
+
+        expect(warning.stackTrace, isA<StackTrace>());
+        expect(warning.stackTrace, isNotNull);
+        expect(warning.stackTrace!.toString(), isNotEmpty);
+      },
+    );
+
     test('throws ArgumentError when workerCount is below 1', () {
       final apiDoc = _allSubtypeModelDocument(ctx);
       final setup = _buildSerial();
@@ -745,6 +814,40 @@ class _PortBearingError implements Exception {
   final ReceivePort port;
   @override
   String toString() => 'PortBearingError carrying $port';
+}
+
+/// NameManager that, once [armed], emits a single `log.warning` with an
+/// attached exception (and a real stack trace). Exercises the
+/// log-forwarding contract: error arrives as a stringified type name and
+/// stackTrace as a reconstructable [StackTrace].
+class _WarningLoggingNameManager extends NameManager {
+  _WarningLoggingNameManager({
+    required super.generator,
+    required super.stableModelSorter,
+  });
+
+  bool armed = false;
+  bool _fired = false;
+
+  @override
+  String modelName(Model model) {
+    if (armed && !_fired) {
+      _fired = true;
+      try {
+        throw _AttachedException('synthetic warning payload');
+      } on _AttachedException catch (e, s) {
+        Logger('TestWorkerLogger').warning('attached error log', e, s);
+      }
+    }
+    return super.modelName(model);
+  }
+}
+
+class _AttachedException implements Exception {
+  _AttachedException(this.message);
+  final String message;
+  @override
+  String toString() => '_AttachedException: $message';
 }
 
 /// NameManager that, once [armed], schedules an unawaited future that

--- a/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
+++ b/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
@@ -1,0 +1,777 @@
+import 'dart:async';
+import 'dart:io';
+import 'dart:isolate';
+
+import 'package:logging/logging.dart';
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/all_of_generator.dart';
+import 'package:tonik_generate/src/model/any_of_generator.dart';
+import 'package:tonik_generate/src/model/class_generator.dart';
+import 'package:tonik_generate/src/model/enum_generator.dart';
+import 'package:tonik_generate/src/model/model_file_generator.dart';
+import 'package:tonik_generate/src/model/one_of_generator.dart';
+import 'package:tonik_generate/src/model/typedef_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/model_worker_pool.dart';
+
+const _package = 'pkg';
+
+({
+  NameManager nameManager,
+  StableModelSorter stableModelSorter,
+  ModelFileGenerator modelFileGenerator,
+})
+_buildSerial() {
+  final nameGenerator = NameGenerator();
+  final stableModelSorter = StableModelSorter();
+  final nameManager = NameManager(
+    generator: nameGenerator,
+    stableModelSorter: stableModelSorter,
+  );
+  final classGenerator = ClassGenerator(
+    nameManager: nameManager,
+    package: _package,
+  );
+  final enumGenerator = EnumGenerator(nameManager: nameManager);
+  final anyOfGenerator = AnyOfGenerator(
+    nameManager: nameManager,
+    package: _package,
+    stableModelSorter: stableModelSorter,
+  );
+  final oneOfGenerator = OneOfGenerator(
+    nameManager: nameManager,
+    package: _package,
+    stableModelSorter: stableModelSorter,
+  );
+  final typedefGenerator = TypedefGenerator(
+    nameManager: nameManager,
+    package: _package,
+  );
+  final allOfGenerator = AllOfGenerator(
+    nameManager: nameManager,
+    package: _package,
+    stableModelSorter: stableModelSorter,
+  );
+
+  return (
+    nameManager: nameManager,
+    stableModelSorter: stableModelSorter,
+    modelFileGenerator: ModelFileGenerator(
+      classGenerator: classGenerator,
+      enumGenerator: enumGenerator,
+      anyOfGenerator: anyOfGenerator,
+      oneOfGenerator: oneOfGenerator,
+      typedefGenerator: typedefGenerator,
+      allOfGenerator: allOfGenerator,
+    ),
+  );
+}
+
+ApiDocument _allSubtypeModelDocument(Context ctx) {
+  return ApiDocument(
+    title: 'Test',
+    version: '1.0.0',
+    description: 'Test',
+    models: <Model>{
+      ClassModel(
+        isDeprecated: false,
+        name: 'User',
+        properties: const [],
+        context: ctx,
+        examples: const [],
+      ),
+      EnumModel<String>(
+        isDeprecated: false,
+        name: 'Status',
+        values: {
+          const EnumEntry(value: 'active'),
+          const EnumEntry(value: 'inactive'),
+        },
+        isNullable: false,
+        context: ctx,
+        examples: const [],
+      ),
+      EnumModel<int>(
+        isDeprecated: false,
+        name: 'Priority',
+        values: {
+          const EnumEntry(value: 1),
+          const EnumEntry(value: 2),
+        },
+        isNullable: false,
+        context: ctx,
+        examples: const [],
+      ),
+      OneOfModel(
+        isDeprecated: false,
+        name: 'Choice',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: ctx)),
+          (discriminatorValue: null, model: IntegerModel(context: ctx)),
+        },
+        context: ctx,
+        examples: const [],
+      ),
+      AnyOfModel(
+        isDeprecated: false,
+        name: 'FlexibleModel',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: ctx)),
+          (discriminatorValue: null, model: IntegerModel(context: ctx)),
+        },
+        context: ctx,
+        examples: const [],
+      ),
+      AllOfModel(
+        isDeprecated: false,
+        name: 'Combined',
+        models: {
+          StringModel(context: ctx),
+          IntegerModel(context: ctx),
+        },
+        context: ctx,
+        examples: const [],
+      ),
+      AliasModel(
+        name: 'UserId',
+        model: StringModel(context: ctx),
+        context: ctx,
+        examples: const [],
+        defaultValue: null,
+      ),
+      ListModel(
+        name: 'UserList',
+        content: StringModel(context: ctx),
+        context: ctx,
+        examples: const [],
+      ),
+      MapModel(
+        name: 'UserMap',
+        valueModel: StringModel(context: ctx),
+        context: ctx,
+        examples: const [],
+      ),
+    },
+    responseHeaders: const {},
+    requestHeaders: const {},
+    servers: const {},
+    operations: const {},
+    responses: const <Response>{},
+    queryParameters: const {},
+    pathParameters: const {},
+    cookieParameters: const {},
+    requestBodies: const {},
+  );
+}
+
+void _primeBoth(NameManager nameManager, ApiDocument apiDocument) {
+  nameManager.prime(
+    models: apiDocument.models,
+    responses: apiDocument.responses,
+    requestBodies: apiDocument.requestBodies,
+    operations: apiDocument.operations,
+    tags: apiDocument.operationsByTag.keys,
+    servers: apiDocument.servers,
+  );
+}
+
+Map<String, String> _readModelTree(String root) {
+  final modelDir = Directory(path.join(root, _package, 'lib', 'src', 'model'));
+  if (!modelDir.existsSync()) return const {};
+  final result = <String, String>{};
+  final entries = modelDir.listSync().whereType<File>().toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  for (final file in entries) {
+    result[path.basename(file.path)] = file.readAsStringSync();
+  }
+  return result;
+}
+
+void main() {
+  group('ModelWorkerPool.run', () {
+    late Directory tempDir;
+    late Context ctx;
+
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('model_worker_pool_');
+      ctx = Context.initial();
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    test('produces byte-identical file tree as serial writeFiles', () async {
+      final apiDoc = _allSubtypeModelDocument(ctx);
+
+      final serialDir = Directory(path.join(tempDir.path, 'serial'))
+        ..createSync();
+      final parallelDir = Directory(path.join(tempDir.path, 'parallel'))
+        ..createSync();
+
+      final serial = _buildSerial();
+      _primeBoth(serial.nameManager, apiDoc);
+      serial.modelFileGenerator.writeFiles(
+        apiDocument: apiDoc,
+        outputDirectory: serialDir.path,
+        package: _package,
+      );
+
+      final parallel = _buildSerial();
+      _primeBoth(parallel.nameManager, apiDoc);
+      await ModelWorkerPool().run(
+        apiDocument: apiDoc,
+        nameManager: parallel.nameManager,
+        stableModelSorter: parallel.stableModelSorter,
+        outputDirectory: parallelDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: 2,
+      );
+
+      expect(_readModelTree(parallelDir.path), _readModelTree(serialDir.path));
+    });
+
+    test(
+      'rethrows worker error with original concrete type and worker stack',
+      () async {
+        final apiDoc = ApiDocument(
+          title: 'Test',
+          version: '1.0.0',
+          description: 'Test',
+          models: <Model>{
+            ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: const [],
+              context: ctx,
+              examples: const [],
+            ),
+          },
+          responseHeaders: const {},
+          requestHeaders: const {},
+          servers: const {},
+          operations: const {},
+          responses: const <Response>{},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          requestBodies: const {},
+        );
+
+        final setup = _buildSerial();
+        _primeBoth(setup.nameManager, apiDoc);
+
+        Object? capturedError;
+        StackTrace? capturedStack;
+        try {
+          await ModelWorkerPool().run(
+            apiDocument: apiDoc,
+            nameManager: setup.nameManager,
+            stableModelSorter: setup.stableModelSorter,
+            outputDirectory: '/this/path/does/not/exist/and/cannot/be/created',
+            package: _package,
+            useImmutableCollections: false,
+            workerCount: 1,
+          );
+        } on Object catch (e, s) {
+          capturedError = e;
+          capturedStack = s;
+        }
+
+        expect(
+          capturedError,
+          isA<FileSystemException>(),
+          reason: 'pool must rethrow the worker-side throw with its '
+              'original concrete type, not wrap it in StateError',
+        );
+        expect(
+          capturedError,
+          isNot(isA<StateError>()),
+          reason: 'a racing exit notification must not clobber the real '
+              'worker exception with the watchdog StateError',
+        );
+        expect(
+          capturedStack.toString(),
+          contains('model_file_generator.dart'),
+          reason: 'stack must contain a worker-side frame so users can '
+              'locate the failing generator path',
+        );
+      },
+    );
+
+    test(
+      'surfaces uncaught async errors as ModelWorkerAsyncError',
+      () async {
+        // Many models behind a single worker so the async crash scheduled
+        // during the first model can land at main before the worker has
+        // acked all remaining jobs. With one model the ack and the async
+        // error would race at the completer.
+        final apiDoc = _allSubtypeModelDocument(ctx);
+
+        final nameGenerator = NameGenerator();
+        final stableModelSorter = StableModelSorter();
+        final nameManager = _AsyncCrashingNameManager(
+          generator: nameGenerator,
+          stableModelSorter: stableModelSorter,
+        )
+          ..prime(
+            models: apiDoc.models,
+            responses: apiDoc.responses,
+            requestBodies: apiDoc.requestBodies,
+            operations: apiDoc.operations,
+            tags: apiDoc.operationsByTag.keys,
+            servers: apiDoc.servers,
+          )
+          ..armed = true;
+
+        Object? capturedError;
+        await ModelWorkerPool()
+            .run(
+              apiDocument: apiDoc,
+              nameManager: nameManager,
+              stableModelSorter: stableModelSorter,
+              outputDirectory: tempDir.path,
+              package: _package,
+              useImmutableCollections: false,
+              workerCount: 1,
+            )
+            .timeout(
+              const Duration(seconds: 15),
+              onTimeout: () => fail(
+                'pool silently hung on uncaught async worker error',
+              ),
+            )
+            .catchError((Object e) {
+              capturedError = e;
+            });
+
+        expect(
+          capturedError,
+          isA<ModelWorkerAsyncError>(),
+          reason: 'uncaught async errors must arrive as a named carrier so '
+              'callers can distinguish them from the sync rethrow path',
+        );
+        expect(
+          capturedError.toString(),
+          contains('synthetic async crash'),
+          reason: 'the original error message must round-trip through '
+              'ModelWorkerAsyncError',
+        );
+      },
+    );
+
+    test(
+      'aborts (does not silently hang) when worker throws non-sendable error',
+      () async {
+        final apiDoc = ApiDocument(
+          title: 'Test',
+          version: '1.0.0',
+          description: 'Test',
+          models: <Model>{
+            ClassModel(
+              isDeprecated: false,
+              name: 'User',
+              properties: const [],
+              context: ctx,
+              examples: const [],
+            ),
+          },
+          responseHeaders: const {},
+          requestHeaders: const {},
+          servers: const {},
+          operations: const {},
+          responses: const <Response>{},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          requestBodies: const {},
+        );
+
+        final nameGenerator = NameGenerator();
+        final stableModelSorter = StableModelSorter();
+        final nameManager = _NonSendableThrowingNameManager(
+          generator: nameGenerator,
+          stableModelSorter: stableModelSorter,
+        )
+          ..prime(
+            models: apiDoc.models,
+            responses: apiDoc.responses,
+            requestBodies: apiDoc.requestBodies,
+            operations: apiDoc.operations,
+            tags: apiDoc.operationsByTag.keys,
+            servers: apiDoc.servers,
+          )
+          ..armed = true;
+
+        Object? capturedError;
+        await ModelWorkerPool()
+            .run(
+              apiDocument: apiDoc,
+              nameManager: nameManager,
+              stableModelSorter: stableModelSorter,
+              outputDirectory: tempDir.path,
+              package: _package,
+              useImmutableCollections: false,
+              workerCount: 1,
+            )
+            .timeout(
+              const Duration(seconds: 15),
+              onTimeout: () => fail(
+                'pool silently hung on non-sendable worker error',
+              ),
+            )
+            .catchError((Object e) {
+              capturedError = e;
+            });
+
+        expect(
+          capturedError,
+          isNotNull,
+          reason: 'a non-sendable worker error must surface as some '
+              'thrown error, not be swallowed into a hang',
+        );
+        expect(
+          capturedError.toString(),
+          contains('non-sendable'),
+          reason: 'fallback carrier should identify itself so users can '
+              'tell sendable rethrow apart from stringified fallback',
+        );
+        expect(
+          capturedError.toString(),
+          contains('_PortBearingError'),
+          reason: 'fallback carrier should preserve the original '
+              'runtime type name in its message',
+        );
+      },
+    );
+
+    test('aborts when worker setup throws before handshake', () async {
+      final apiDoc = ApiDocument(
+        title: 'Test',
+        version: '1.0.0',
+        description: 'Test',
+        models: <Model>{
+          ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: ctx,
+            examples: const [],
+          ),
+        },
+        responseHeaders: const {},
+        requestHeaders: const {},
+        servers: const {},
+        operations: const {},
+        responses: const <Response>{},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        requestBodies: const {},
+      );
+
+      final nameGenerator = NameGenerator();
+      final stableModelSorter = StableModelSorter();
+      final nameManager = _ConstructorThrowingNameManager(
+        generator: nameGenerator,
+        stableModelSorter: stableModelSorter,
+      )
+        ..prime(
+          models: apiDoc.models,
+          responses: apiDoc.responses,
+          requestBodies: apiDoc.requestBodies,
+          operations: apiDoc.operations,
+          tags: apiDoc.operationsByTag.keys,
+          servers: apiDoc.servers,
+        )
+        ..armed = true;
+
+      Object? capturedError;
+      await ModelWorkerPool()
+          .run(
+            apiDocument: apiDoc,
+            nameManager: nameManager,
+            stableModelSorter: stableModelSorter,
+            outputDirectory: tempDir.path,
+            package: _package,
+            useImmutableCollections: false,
+            workerCount: 1,
+          )
+          .timeout(
+            const Duration(seconds: 15),
+            onTimeout: () => fail(
+              'pool silently hung on worker setup/handshake-time throw',
+            ),
+          )
+          .catchError((Object e) {
+            capturedError = e;
+          });
+
+      expect(
+        capturedError,
+        isNotNull,
+        reason: 'a worker setup-time throw must surface as a thrown error, '
+            'not a silent hang on Future.wait(handshakeCompleters)',
+      );
+    });
+
+    test(
+      'forwarded log records reach main Logger.root with original level + name',
+      () async {
+        final apiDoc = _allSubtypeModelDocument(ctx);
+
+        final outDir = Directory(path.join(tempDir.path, 'logout'))
+          ..createSync();
+
+        final setup = _buildSerial();
+        _primeBoth(setup.nameManager, apiDoc);
+
+        final previousLevel = Logger.root.level;
+        Logger.root.level = Level.ALL;
+        final forwarded = <LogRecord>[];
+        final sub = Logger.root.onRecord.listen(forwarded.add);
+
+        try {
+          await ModelWorkerPool().run(
+            apiDocument: apiDoc,
+            nameManager: setup.nameManager,
+            stableModelSorter: setup.stableModelSorter,
+            outputDirectory: outDir.path,
+            package: _package,
+            useImmutableCollections: false,
+            workerCount: 2,
+          );
+        } finally {
+          await sub.cancel();
+          Logger.root.level = previousLevel;
+        }
+
+        final modelGeneratorRecords = forwarded
+            .where((r) => r.loggerName == 'ModelGenerator')
+            .toList();
+        expect(modelGeneratorRecords, isNotEmpty);
+        expect(
+          modelGeneratorRecords.first.level,
+          Level.FINE,
+          reason: 'canonical Level (preserving name + value) should '
+              'round-trip via _WorkerLog',
+        );
+        expect(modelGeneratorRecords.first.level.name, Level.FINE.name);
+      },
+    );
+
+    test('removes main Logger.root subscription after run returns', () async {
+      final apiDoc = _allSubtypeModelDocument(ctx);
+      final outDir = Directory(path.join(tempDir.path, 'cleanout'))
+        ..createSync();
+
+      final setup = _buildSerial();
+      _primeBoth(setup.nameManager, apiDoc);
+
+      await ModelWorkerPool().run(
+        apiDocument: apiDoc,
+        nameManager: setup.nameManager,
+        stableModelSorter: setup.stableModelSorter,
+        outputDirectory: outDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: 2,
+      );
+
+      final recordsAfter = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(recordsAfter.add);
+      Logger('test-after-run').warning('post-run');
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(
+        recordsAfter.where((r) => r.loggerName == 'test-after-run').length,
+        1,
+        reason: 'only the test listener should observe new records — '
+            'pool listeners must be torn down',
+      );
+    });
+
+    test('terminates all isolates after run completes successfully', () async {
+      final apiDoc = _allSubtypeModelDocument(ctx);
+      final outDir = Directory(path.join(tempDir.path, 'isolateout'))
+        ..createSync();
+
+      final setup = _buildSerial();
+      _primeBoth(setup.nameManager, apiDoc);
+
+      final pool = ModelWorkerPool();
+      await pool.run(
+        apiDocument: apiDoc,
+        nameManager: setup.nameManager,
+        stableModelSorter: setup.stableModelSorter,
+        outputDirectory: outDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: 2,
+      );
+
+      expect(pool.spawnedWorkers, 2);
+      expect(pool.exitedWorkers, pool.spawnedWorkers);
+    });
+
+    test('terminates all isolates after run fails', () async {
+      final apiDoc = _allSubtypeModelDocument(ctx);
+
+      final setup = _buildSerial();
+      _primeBoth(setup.nameManager, apiDoc);
+
+      final pool = ModelWorkerPool();
+      try {
+        await pool.run(
+          apiDocument: apiDoc,
+          nameManager: setup.nameManager,
+          stableModelSorter: setup.stableModelSorter,
+          outputDirectory: '/no/such/dir/and/cannot/be/made',
+          package: _package,
+          useImmutableCollections: false,
+          workerCount: 2,
+        );
+        fail('expected failure');
+      } on Object catch (_) {
+        // expected
+      }
+
+      expect(pool.spawnedWorkers, 2);
+      expect(pool.exitedWorkers, pool.spawnedWorkers);
+    });
+
+    test('throws ArgumentError when workerCount is below 1', () {
+      final apiDoc = _allSubtypeModelDocument(ctx);
+      final setup = _buildSerial();
+      _primeBoth(setup.nameManager, apiDoc);
+
+      expect(
+        () => ModelWorkerPool().run(
+          apiDocument: apiDoc,
+          nameManager: setup.nameManager,
+          stableModelSorter: setup.stableModelSorter,
+          outputDirectory: tempDir.path,
+          package: _package,
+          useImmutableCollections: false,
+          workerCount: 0,
+        ),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('returns immediately when models set is empty', () async {
+      final apiDoc = ApiDocument(
+        title: 'Test',
+        version: '1.0.0',
+        models: const <Model>{},
+        responseHeaders: const {},
+        requestHeaders: const {},
+        servers: const {},
+        operations: const {},
+        responses: const <Response>{},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        requestBodies: const {},
+      );
+
+      final setup = _buildSerial();
+      _primeBoth(setup.nameManager, apiDoc);
+
+      await ModelWorkerPool().run(
+        apiDocument: apiDoc,
+        nameManager: setup.nameManager,
+        stableModelSorter: setup.stableModelSorter,
+        outputDirectory: tempDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: 4,
+      );
+
+      expect(
+        Directory(
+          path.join(tempDir.path, _package, 'lib', 'src', 'model'),
+        ).existsSync(),
+        isFalse,
+      );
+    });
+  });
+}
+
+/// NameManager that, once [armed] is set, throws a non-sendable error
+/// (carrying a live [ReceivePort]) on the next `modelName` lookup.
+/// Arming after `prime()` lets the worker — but not the main isolate —
+/// trip the throw, exercising the fallback path of `_sendModelError`.
+class _NonSendableThrowingNameManager extends NameManager {
+  _NonSendableThrowingNameManager({
+    required super.generator,
+    required super.stableModelSorter,
+  });
+
+  bool armed = false;
+
+  @override
+  String modelName(Model model) {
+    if (armed) throw _PortBearingError(ReceivePort());
+    return super.modelName(model);
+  }
+}
+
+/// NameManager that, once [armed], throws synchronously on `modelName`
+/// — used to provoke a worker-side throw from the per-job dispatch loop
+/// and prove main never silently hangs.
+class _ConstructorThrowingNameManager extends NameManager {
+  _ConstructorThrowingNameManager({
+    required super.generator,
+    required super.stableModelSorter,
+  });
+
+  bool armed = false;
+
+  @override
+  String modelName(Model model) {
+    if (armed) throw StateError('synthetic worker setup failure');
+    return super.modelName(model);
+  }
+}
+
+class _PortBearingError implements Exception {
+  _PortBearingError(this.port);
+  final ReceivePort port;
+  @override
+  String toString() => 'PortBearingError carrying $port';
+}
+
+/// NameManager that, once [armed], schedules an unawaited future that
+/// throws asynchronously on the first call — bypassing the worker's
+/// per-job `try/catch` and triggering the isolate `onError` channel.
+/// Schedules only once so the worker still processes models 2..N normally;
+/// the async error fires while remaining jobs are in flight, making the
+/// arrival order at main deterministic (errorPort lands before all acks).
+class _AsyncCrashingNameManager extends NameManager {
+  _AsyncCrashingNameManager({
+    required super.generator,
+    required super.stableModelSorter,
+  });
+
+  bool armed = false;
+  bool _fired = false;
+
+  @override
+  String modelName(Model model) {
+    if (armed && !_fired) {
+      _fired = true;
+      unawaited(
+        Future<void>.microtask(() {
+          throw StateError('synthetic async crash');
+        }),
+      );
+    }
+    return super.modelName(model);
+  }
+}

--- a/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
+++ b/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
@@ -84,7 +84,7 @@ void main() {
       () async {
         try {
           await runPool(
-            outputDirectory: '/this/path/does/not/exist/and/cannot/be/created',
+            outputDirectory: _unwritableDirectory(tempDir),
             workerCount: 1,
           );
           fail('expected the worker write to throw');
@@ -224,7 +224,7 @@ void main() {
           apiDocument: apiDoc,
           nameManager: nameManager,
           stableModelSorter: sorter,
-          outputDirectory: '/no/such/dir/and/cannot/be/made',
+          outputDirectory: _unwritableDirectory(tempDir),
           package: _package,
           useImmutableCollections: false,
           workerCount: 2,
@@ -303,6 +303,16 @@ ModelFileGenerator _serialGenerator(
       stableModelSorter: sorter,
     ),
   );
+}
+
+/// Returns a path whose creation as a directory will always fail. Pointing
+/// `outputDirectory` here lets workers exercise the `FileSystemException`
+/// path on every OS — `mkdir` under a regular file is rejected by Windows
+/// and POSIX alike, with no permission assumptions on `/`.
+String _unwritableDirectory(Directory tempDir) {
+  final blocker = File(path.join(tempDir.path, 'blocker'));
+  if (!blocker.existsSync()) blocker.writeAsStringSync('x');
+  return path.join(blocker.path, 'sub');
 }
 
 Map<String, String> _readModelTree(String root) {

--- a/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
+++ b/packages/tonik_generate/test/src/util/model_worker_pool_test.dart
@@ -19,58 +19,330 @@ import 'package:tonik_generate/src/util/model_worker_pool.dart';
 
 const _package = 'pkg';
 
-({
-  NameManager nameManager,
-  StableModelSorter stableModelSorter,
-  ModelFileGenerator modelFileGenerator,
-})
-_buildSerial() {
-  final nameGenerator = NameGenerator();
-  final stableModelSorter = StableModelSorter();
-  final nameManager = NameManager(
-    generator: nameGenerator,
-    stableModelSorter: stableModelSorter,
-  );
-  final classGenerator = ClassGenerator(
-    nameManager: nameManager,
-    package: _package,
-  );
-  final enumGenerator = EnumGenerator(nameManager: nameManager);
-  final anyOfGenerator = AnyOfGenerator(
-    nameManager: nameManager,
-    package: _package,
-    stableModelSorter: stableModelSorter,
-  );
-  final oneOfGenerator = OneOfGenerator(
-    nameManager: nameManager,
-    package: _package,
-    stableModelSorter: stableModelSorter,
-  );
-  final typedefGenerator = TypedefGenerator(
-    nameManager: nameManager,
-    package: _package,
-  );
-  final allOfGenerator = AllOfGenerator(
-    nameManager: nameManager,
-    package: _package,
-    stableModelSorter: stableModelSorter,
-  );
+void main() {
+  group('ModelWorkerPool.run', () {
+    late Directory tempDir;
+    late ApiDocument apiDoc;
+    late NameManager nameManager;
+    late StableModelSorter sorter;
+    late ModelFileGenerator serialGenerator;
 
-  return (
-    nameManager: nameManager,
-    stableModelSorter: stableModelSorter,
-    modelFileGenerator: ModelFileGenerator(
-      classGenerator: classGenerator,
-      enumGenerator: enumGenerator,
-      anyOfGenerator: anyOfGenerator,
-      oneOfGenerator: oneOfGenerator,
-      typedefGenerator: typedefGenerator,
-      allOfGenerator: allOfGenerator,
+    setUp(() {
+      tempDir = Directory.systemTemp.createTempSync('model_worker_pool_');
+      apiDoc = _allSubtypeDocument(Context.initial());
+      sorter = StableModelSorter();
+      nameManager = _prime(_makeNameManager(sorter), apiDoc);
+      serialGenerator = _serialGenerator(nameManager, sorter);
+    });
+
+    tearDown(() {
+      tempDir.deleteSync(recursive: true);
+    });
+
+    Future<void> runPool({
+      ApiDocument? doc,
+      NameManager? names,
+      String? outputDirectory,
+      int workerCount = 2,
+    }) {
+      return ModelWorkerPool().run(
+        apiDocument: doc ?? apiDoc,
+        nameManager: names ?? nameManager,
+        stableModelSorter: sorter,
+        outputDirectory: outputDirectory ?? tempDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: workerCount,
+      );
+    }
+
+    test('produces byte-identical file tree as serial writeFiles', () async {
+      final serialDir = Directory(path.join(tempDir.path, 'serial'))
+        ..createSync();
+      final parallelDir = Directory(path.join(tempDir.path, 'parallel'))
+        ..createSync();
+
+      serialGenerator.writeFiles(
+        apiDocument: apiDoc,
+        outputDirectory: serialDir.path,
+        package: _package,
+      );
+
+      // Fresh NameManager — naming has mutable state we don't want to
+      // share between the two runs.
+      final parallelNames = _prime(_makeNameManager(sorter), apiDoc);
+      await runPool(names: parallelNames, outputDirectory: parallelDir.path);
+
+      expect(
+        _readModelTree(parallelDir.path),
+        _readModelTree(serialDir.path),
+      );
+    });
+
+    test(
+      'rethrows worker error with original concrete type and worker stack',
+      () async {
+        try {
+          await runPool(
+            outputDirectory: '/this/path/does/not/exist/and/cannot/be/created',
+            workerCount: 1,
+          );
+          fail('expected the worker write to throw');
+        } on FileSystemException catch (_, stack) {
+          expect(stack.toString(), contains('model_file_generator.dart'));
+        }
+      },
+    );
+
+    test('surfaces uncaught async errors as ModelWorkerAsyncError', () async {
+      // Many models behind a single worker so the async crash scheduled on
+      // the first lookup lands at main before the worker has acked all jobs.
+      final hooked = _HookedNameManager(sorter)
+        ..onLookup = _oneShot(() {
+          unawaited(
+            Future<void>.microtask(
+              () => throw StateError('synthetic async crash'),
+            ),
+          );
+        });
+      _prime(hooked, apiDoc).armed = true;
+
+      try {
+        await runPool(names: hooked, workerCount: 1)
+            .timeout(const Duration(seconds: 15));
+        fail('expected ModelWorkerAsyncError');
+      } on TimeoutException {
+        fail('pool silently hung on uncaught async worker error');
+      } on ModelWorkerAsyncError catch (e) {
+        expect(e.toString(), contains('synthetic async crash'));
+      }
+    });
+
+    test('aborts (does not hang) when worker throws non-sendable error',
+        () async {
+      final hooked = _HookedNameManager(sorter)
+        ..onLookup = () => throw _PortBearingError(ReceivePort());
+      _prime(hooked, apiDoc).armed = true;
+
+      try {
+        await runPool(names: hooked, workerCount: 1)
+            .timeout(const Duration(seconds: 15));
+        fail('expected the non-sendable error to surface');
+      } on TimeoutException {
+        fail('pool silently hung on non-sendable worker error');
+      } on NonSendableWorkerError catch (e) {
+        expect(e.originalTypeName, contains('_PortBearingError'));
+      }
+    });
+
+    test('aborts when worker setup throws before handshake', () async {
+      final hooked = _HookedNameManager(sorter)
+        ..onLookup = () => throw StateError('synthetic worker setup failure');
+      _prime(hooked, apiDoc).armed = true;
+
+      await expectLater(
+        runPool(names: hooked, workerCount: 1)
+            .timeout(const Duration(seconds: 15)),
+        throwsA(isA<StateError>()),
+      );
+    });
+
+    test(
+      'forwards Logger records to main with original level and logger name',
+      () async {
+        final records = await _captureRecords(runPool);
+        final modelGenRecord = records.firstWhere(
+          (r) => r.loggerName == 'ModelGenerator',
+        );
+
+        expect(modelGenRecord.level, Level.FINE);
+      },
+    );
+
+    test(
+      'forwards log.warning attached error as stringified type name '
+      'with reconstructable stack',
+      () async {
+        final hooked = _HookedNameManager(sorter)
+          ..onLookup = _oneShot(() {
+            try {
+              throw _AttachedException('synthetic warning payload');
+            } on _AttachedException catch (e, s) {
+              Logger('TestWorkerLogger').warning('attached error log', e, s);
+            }
+          });
+        _prime(hooked, apiDoc).armed = true;
+
+        final records = await _captureRecords(
+          () => runPool(names: hooked, workerCount: 1),
+        );
+        final warning = records.firstWhere(
+          (r) => r.loggerName == 'TestWorkerLogger' && r.level == Level.WARNING,
+        );
+
+        expect(warning.error, isA<String>());
+        expect(warning.error! as String, contains('_AttachedException'));
+        expect(warning.stackTrace.toString(), isNotEmpty);
+      },
+    );
+
+    test('removes pool listeners from Logger.root after run returns', () async {
+      await runPool();
+
+      final recordsAfter = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(recordsAfter.add);
+      Logger('test-after-run').warning('post-run');
+      await Future<void>.delayed(Duration.zero);
+      await sub.cancel();
+
+      expect(
+        recordsAfter.where((r) => r.loggerName == 'test-after-run'),
+        hasLength(1),
+      );
+    });
+
+    test('terminates all isolates after run completes successfully', () async {
+      final pool = ModelWorkerPool();
+      await pool.run(
+        apiDocument: apiDoc,
+        nameManager: nameManager,
+        stableModelSorter: sorter,
+        outputDirectory: tempDir.path,
+        package: _package,
+        useImmutableCollections: false,
+        workerCount: 2,
+      );
+
+      expect(pool.spawnedWorkers, 2);
+      expect(pool.exitedWorkers, pool.spawnedWorkers);
+    });
+
+    test('terminates all isolates after run fails', () async {
+      final pool = ModelWorkerPool();
+      try {
+        await pool.run(
+          apiDocument: apiDoc,
+          nameManager: nameManager,
+          stableModelSorter: sorter,
+          outputDirectory: '/no/such/dir/and/cannot/be/made',
+          package: _package,
+          useImmutableCollections: false,
+          workerCount: 2,
+        );
+        fail('expected failure');
+      } on Object catch (_) {
+        // expected
+      }
+
+      expect(pool.spawnedWorkers, 2);
+      expect(pool.exitedWorkers, pool.spawnedWorkers);
+    });
+
+    test('throws ArgumentError when workerCount is below 1', () {
+      expect(
+        () => runPool(workerCount: 0),
+        throwsA(isA<ArgumentError>()),
+      );
+    });
+
+    test('returns immediately when models set is empty', () async {
+      final empty = _emptyDocument();
+      final names = _prime(_makeNameManager(sorter), empty);
+
+      await runPool(doc: empty, names: names, workerCount: 4);
+
+      final modelDir = Directory(
+        path.join(tempDir.path, _package, 'lib', 'src', 'model'),
+      );
+      expect(modelDir.existsSync(), isFalse);
+    });
+  });
+}
+
+NameManager _makeNameManager(StableModelSorter sorter) => NameManager(
+  generator: NameGenerator(),
+  stableModelSorter: sorter,
+);
+
+T _prime<T extends NameManager>(T names, ApiDocument doc) {
+  names.prime(
+    models: doc.models,
+    responses: doc.responses,
+    requestBodies: doc.requestBodies,
+    operations: doc.operations,
+    tags: doc.operationsByTag.keys,
+    servers: doc.servers,
+  );
+  return names;
+}
+
+ModelFileGenerator _serialGenerator(
+  NameManager names,
+  StableModelSorter sorter,
+) {
+  return ModelFileGenerator(
+    classGenerator: ClassGenerator(nameManager: names, package: _package),
+    enumGenerator: EnumGenerator(nameManager: names),
+    anyOfGenerator: AnyOfGenerator(
+      nameManager: names,
+      package: _package,
+      stableModelSorter: sorter,
+    ),
+    oneOfGenerator: OneOfGenerator(
+      nameManager: names,
+      package: _package,
+      stableModelSorter: sorter,
+    ),
+    typedefGenerator: TypedefGenerator(
+      nameManager: names,
+      package: _package,
+    ),
+    allOfGenerator: AllOfGenerator(
+      nameManager: names,
+      package: _package,
+      stableModelSorter: sorter,
     ),
   );
 }
 
-ApiDocument _allSubtypeModelDocument(Context ctx) {
+Map<String, String> _readModelTree(String root) {
+  final modelDir = Directory(path.join(root, _package, 'lib', 'src', 'model'));
+  if (!modelDir.existsSync()) return const {};
+  final entries = modelDir.listSync().whereType<File>().toList()
+    ..sort((a, b) => a.path.compareTo(b.path));
+  return {
+    for (final file in entries)
+      path.basename(file.path): file.readAsStringSync(),
+  };
+}
+
+/// Runs [body] with `Logger.root` at [Level.ALL] and returns every record
+/// emitted during its execution.
+Future<List<LogRecord>> _captureRecords(Future<void> Function() body) async {
+  final previousLevel = Logger.root.level;
+  Logger.root.level = Level.ALL;
+  final records = <LogRecord>[];
+  final sub = Logger.root.onRecord.listen(records.add);
+  try {
+    await body();
+  } finally {
+    await sub.cancel();
+    Logger.root.level = previousLevel;
+  }
+  return records;
+}
+
+/// Wraps [action] so it runs at most once across repeated invocations.
+void Function() _oneShot(void Function() action) {
+  var fired = false;
+  return () {
+    if (fired) return;
+    fired = true;
+    action();
+  };
+}
+
+ApiDocument _allSubtypeDocument(Context ctx) {
   return ApiDocument(
     title: 'Test',
     version: '1.0.0',
@@ -97,10 +369,7 @@ ApiDocument _allSubtypeModelDocument(Context ctx) {
       EnumModel<int>(
         isDeprecated: false,
         name: 'Priority',
-        values: {
-          const EnumEntry(value: 1),
-          const EnumEntry(value: 2),
-        },
+        values: {const EnumEntry(value: 1), const EnumEntry(value: 2)},
         isNullable: false,
         context: ctx,
         examples: const [],
@@ -128,10 +397,7 @@ ApiDocument _allSubtypeModelDocument(Context ctx) {
       AllOfModel(
         isDeprecated: false,
         name: 'Combined',
-        models: {
-          StringModel(context: ctx),
-          IntegerModel(context: ctx),
-        },
+        models: {StringModel(context: ctx), IntegerModel(context: ctx)},
         context: ctx,
         examples: const [],
       ),
@@ -167,644 +433,34 @@ ApiDocument _allSubtypeModelDocument(Context ctx) {
   );
 }
 
-void _primeBoth(NameManager nameManager, ApiDocument apiDocument) {
-  nameManager.prime(
-    models: apiDocument.models,
-    responses: apiDocument.responses,
-    requestBodies: apiDocument.requestBodies,
-    operations: apiDocument.operations,
-    tags: apiDocument.operationsByTag.keys,
-    servers: apiDocument.servers,
-  );
-}
+ApiDocument _emptyDocument() => ApiDocument(
+  title: 'Test',
+  version: '1.0.0',
+  models: const <Model>{},
+  responseHeaders: const {},
+  requestHeaders: const {},
+  servers: const {},
+  operations: const {},
+  responses: const <Response>{},
+  queryParameters: const {},
+  pathParameters: const {},
+  cookieParameters: const {},
+  requestBodies: const {},
+);
 
-Map<String, String> _readModelTree(String root) {
-  final modelDir = Directory(path.join(root, _package, 'lib', 'src', 'model'));
-  if (!modelDir.existsSync()) return const {};
-  final result = <String, String>{};
-  final entries = modelDir.listSync().whereType<File>().toList()
-    ..sort((a, b) => a.path.compareTo(b.path));
-  for (final file in entries) {
-    result[path.basename(file.path)] = file.readAsStringSync();
-  }
-  return result;
-}
+/// NameManager that invokes [onLookup] on every `modelName` call once
+/// [armed] is true. Replaces the family of one-off subclasses used to
+/// exercise the worker pool's failure paths.
+class _HookedNameManager extends NameManager {
+  _HookedNameManager(StableModelSorter sorter)
+    : super(generator: NameGenerator(), stableModelSorter: sorter);
 
-void main() {
-  group('ModelWorkerPool.run', () {
-    late Directory tempDir;
-    late Context ctx;
-
-    setUp(() {
-      tempDir = Directory.systemTemp.createTempSync('model_worker_pool_');
-      ctx = Context.initial();
-    });
-
-    tearDown(() {
-      tempDir.deleteSync(recursive: true);
-    });
-
-    test('produces byte-identical file tree as serial writeFiles', () async {
-      final apiDoc = _allSubtypeModelDocument(ctx);
-
-      final serialDir = Directory(path.join(tempDir.path, 'serial'))
-        ..createSync();
-      final parallelDir = Directory(path.join(tempDir.path, 'parallel'))
-        ..createSync();
-
-      final serial = _buildSerial();
-      _primeBoth(serial.nameManager, apiDoc);
-      serial.modelFileGenerator.writeFiles(
-        apiDocument: apiDoc,
-        outputDirectory: serialDir.path,
-        package: _package,
-      );
-
-      final parallel = _buildSerial();
-      _primeBoth(parallel.nameManager, apiDoc);
-      await ModelWorkerPool().run(
-        apiDocument: apiDoc,
-        nameManager: parallel.nameManager,
-        stableModelSorter: parallel.stableModelSorter,
-        outputDirectory: parallelDir.path,
-        package: _package,
-        useImmutableCollections: false,
-        workerCount: 2,
-      );
-
-      expect(_readModelTree(parallelDir.path), _readModelTree(serialDir.path));
-    });
-
-    test(
-      'rethrows worker error with original concrete type and worker stack',
-      () async {
-        final apiDoc = ApiDocument(
-          title: 'Test',
-          version: '1.0.0',
-          description: 'Test',
-          models: <Model>{
-            ClassModel(
-              isDeprecated: false,
-              name: 'User',
-              properties: const [],
-              context: ctx,
-              examples: const [],
-            ),
-          },
-          responseHeaders: const {},
-          requestHeaders: const {},
-          servers: const {},
-          operations: const {},
-          responses: const <Response>{},
-          queryParameters: const {},
-          pathParameters: const {},
-          cookieParameters: const {},
-          requestBodies: const {},
-        );
-
-        final setup = _buildSerial();
-        _primeBoth(setup.nameManager, apiDoc);
-
-        Object? capturedError;
-        StackTrace? capturedStack;
-        try {
-          await ModelWorkerPool().run(
-            apiDocument: apiDoc,
-            nameManager: setup.nameManager,
-            stableModelSorter: setup.stableModelSorter,
-            outputDirectory: '/this/path/does/not/exist/and/cannot/be/created',
-            package: _package,
-            useImmutableCollections: false,
-            workerCount: 1,
-          );
-        } on Object catch (e, s) {
-          capturedError = e;
-          capturedStack = s;
-        }
-
-        expect(
-          capturedError,
-          isA<FileSystemException>(),
-          reason: 'pool must rethrow the worker-side throw with its '
-              'original concrete type, not wrap it in StateError',
-        );
-        expect(
-          capturedError,
-          isNot(isA<StateError>()),
-          reason: 'a racing exit notification must not clobber the real '
-              'worker exception with the watchdog StateError',
-        );
-        expect(
-          capturedStack.toString(),
-          contains('model_file_generator.dart'),
-          reason: 'stack must contain a worker-side frame so users can '
-              'locate the failing generator path',
-        );
-      },
-    );
-
-    test(
-      'surfaces uncaught async errors as ModelWorkerAsyncError',
-      () async {
-        // Many models behind a single worker so the async crash scheduled
-        // during the first model can land at main before the worker has
-        // acked all remaining jobs. With one model the ack and the async
-        // error would race at the completer.
-        final apiDoc = _allSubtypeModelDocument(ctx);
-
-        final nameGenerator = NameGenerator();
-        final stableModelSorter = StableModelSorter();
-        final nameManager = _AsyncCrashingNameManager(
-          generator: nameGenerator,
-          stableModelSorter: stableModelSorter,
-        )
-          ..prime(
-            models: apiDoc.models,
-            responses: apiDoc.responses,
-            requestBodies: apiDoc.requestBodies,
-            operations: apiDoc.operations,
-            tags: apiDoc.operationsByTag.keys,
-            servers: apiDoc.servers,
-          )
-          ..armed = true;
-
-        Object? capturedError;
-        await ModelWorkerPool()
-            .run(
-              apiDocument: apiDoc,
-              nameManager: nameManager,
-              stableModelSorter: stableModelSorter,
-              outputDirectory: tempDir.path,
-              package: _package,
-              useImmutableCollections: false,
-              workerCount: 1,
-            )
-            .timeout(
-              const Duration(seconds: 15),
-              onTimeout: () => fail(
-                'pool silently hung on uncaught async worker error',
-              ),
-            )
-            .catchError((Object e) {
-              capturedError = e;
-            });
-
-        expect(
-          capturedError,
-          isA<ModelWorkerAsyncError>(),
-          reason: 'uncaught async errors must arrive as a named carrier so '
-              'callers can distinguish them from the sync rethrow path',
-        );
-        expect(
-          capturedError.toString(),
-          contains('synthetic async crash'),
-          reason: 'the original error message must round-trip through '
-              'ModelWorkerAsyncError',
-        );
-      },
-    );
-
-    test(
-      'aborts (does not silently hang) when worker throws non-sendable error',
-      () async {
-        final apiDoc = ApiDocument(
-          title: 'Test',
-          version: '1.0.0',
-          description: 'Test',
-          models: <Model>{
-            ClassModel(
-              isDeprecated: false,
-              name: 'User',
-              properties: const [],
-              context: ctx,
-              examples: const [],
-            ),
-          },
-          responseHeaders: const {},
-          requestHeaders: const {},
-          servers: const {},
-          operations: const {},
-          responses: const <Response>{},
-          queryParameters: const {},
-          pathParameters: const {},
-          cookieParameters: const {},
-          requestBodies: const {},
-        );
-
-        final nameGenerator = NameGenerator();
-        final stableModelSorter = StableModelSorter();
-        final nameManager = _NonSendableThrowingNameManager(
-          generator: nameGenerator,
-          stableModelSorter: stableModelSorter,
-        )
-          ..prime(
-            models: apiDoc.models,
-            responses: apiDoc.responses,
-            requestBodies: apiDoc.requestBodies,
-            operations: apiDoc.operations,
-            tags: apiDoc.operationsByTag.keys,
-            servers: apiDoc.servers,
-          )
-          ..armed = true;
-
-        Object? capturedError;
-        await ModelWorkerPool()
-            .run(
-              apiDocument: apiDoc,
-              nameManager: nameManager,
-              stableModelSorter: stableModelSorter,
-              outputDirectory: tempDir.path,
-              package: _package,
-              useImmutableCollections: false,
-              workerCount: 1,
-            )
-            .timeout(
-              const Duration(seconds: 15),
-              onTimeout: () => fail(
-                'pool silently hung on non-sendable worker error',
-              ),
-            )
-            .catchError((Object e) {
-              capturedError = e;
-            });
-
-        expect(
-          capturedError,
-          isNotNull,
-          reason: 'a non-sendable worker error must surface as some '
-              'thrown error, not be swallowed into a hang',
-        );
-        expect(
-          capturedError.toString(),
-          contains('non-sendable'),
-          reason: 'fallback carrier should identify itself so users can '
-              'tell sendable rethrow apart from stringified fallback',
-        );
-        expect(
-          capturedError.toString(),
-          contains('_PortBearingError'),
-          reason: 'fallback carrier should preserve the original '
-              'runtime type name in its message',
-        );
-      },
-    );
-
-    test('aborts when worker setup throws before handshake', () async {
-      final apiDoc = ApiDocument(
-        title: 'Test',
-        version: '1.0.0',
-        description: 'Test',
-        models: <Model>{
-          ClassModel(
-            isDeprecated: false,
-            name: 'User',
-            properties: const [],
-            context: ctx,
-            examples: const [],
-          ),
-        },
-        responseHeaders: const {},
-        requestHeaders: const {},
-        servers: const {},
-        operations: const {},
-        responses: const <Response>{},
-        queryParameters: const {},
-        pathParameters: const {},
-        cookieParameters: const {},
-        requestBodies: const {},
-      );
-
-      final nameGenerator = NameGenerator();
-      final stableModelSorter = StableModelSorter();
-      final nameManager = _ConstructorThrowingNameManager(
-        generator: nameGenerator,
-        stableModelSorter: stableModelSorter,
-      )
-        ..prime(
-          models: apiDoc.models,
-          responses: apiDoc.responses,
-          requestBodies: apiDoc.requestBodies,
-          operations: apiDoc.operations,
-          tags: apiDoc.operationsByTag.keys,
-          servers: apiDoc.servers,
-        )
-        ..armed = true;
-
-      Object? capturedError;
-      await ModelWorkerPool()
-          .run(
-            apiDocument: apiDoc,
-            nameManager: nameManager,
-            stableModelSorter: stableModelSorter,
-            outputDirectory: tempDir.path,
-            package: _package,
-            useImmutableCollections: false,
-            workerCount: 1,
-          )
-          .timeout(
-            const Duration(seconds: 15),
-            onTimeout: () => fail(
-              'pool silently hung on worker setup/handshake-time throw',
-            ),
-          )
-          .catchError((Object e) {
-            capturedError = e;
-          });
-
-      expect(
-        capturedError,
-        isNotNull,
-        reason: 'a worker setup-time throw must surface as a thrown error, '
-            'not a silent hang on Future.wait(handshakeCompleters)',
-      );
-    });
-
-    test(
-      'forwarded log records reach main Logger.root with original level + name',
-      () async {
-        final apiDoc = _allSubtypeModelDocument(ctx);
-
-        final outDir = Directory(path.join(tempDir.path, 'logout'))
-          ..createSync();
-
-        final setup = _buildSerial();
-        _primeBoth(setup.nameManager, apiDoc);
-
-        final previousLevel = Logger.root.level;
-        Logger.root.level = Level.ALL;
-        final forwarded = <LogRecord>[];
-        final sub = Logger.root.onRecord.listen(forwarded.add);
-
-        try {
-          await ModelWorkerPool().run(
-            apiDocument: apiDoc,
-            nameManager: setup.nameManager,
-            stableModelSorter: setup.stableModelSorter,
-            outputDirectory: outDir.path,
-            package: _package,
-            useImmutableCollections: false,
-            workerCount: 2,
-          );
-        } finally {
-          await sub.cancel();
-          Logger.root.level = previousLevel;
-        }
-
-        final modelGeneratorRecords = forwarded
-            .where((r) => r.loggerName == 'ModelGenerator')
-            .toList();
-        expect(modelGeneratorRecords, isNotEmpty);
-        expect(
-          modelGeneratorRecords.first.level,
-          Level.FINE,
-          reason: 'canonical Level (preserving name + value) should '
-              'round-trip via _WorkerLog',
-        );
-        expect(modelGeneratorRecords.first.level.name, Level.FINE.name);
-      },
-    );
-
-    test('removes main Logger.root subscription after run returns', () async {
-      final apiDoc = _allSubtypeModelDocument(ctx);
-      final outDir = Directory(path.join(tempDir.path, 'cleanout'))
-        ..createSync();
-
-      final setup = _buildSerial();
-      _primeBoth(setup.nameManager, apiDoc);
-
-      await ModelWorkerPool().run(
-        apiDocument: apiDoc,
-        nameManager: setup.nameManager,
-        stableModelSorter: setup.stableModelSorter,
-        outputDirectory: outDir.path,
-        package: _package,
-        useImmutableCollections: false,
-        workerCount: 2,
-      );
-
-      final recordsAfter = <LogRecord>[];
-      final sub = Logger.root.onRecord.listen(recordsAfter.add);
-      Logger('test-after-run').warning('post-run');
-      await Future<void>.delayed(Duration.zero);
-      await sub.cancel();
-
-      expect(
-        recordsAfter.where((r) => r.loggerName == 'test-after-run').length,
-        1,
-        reason: 'only the test listener should observe new records — '
-            'pool listeners must be torn down',
-      );
-    });
-
-    test('terminates all isolates after run completes successfully', () async {
-      final apiDoc = _allSubtypeModelDocument(ctx);
-      final outDir = Directory(path.join(tempDir.path, 'isolateout'))
-        ..createSync();
-
-      final setup = _buildSerial();
-      _primeBoth(setup.nameManager, apiDoc);
-
-      final pool = ModelWorkerPool();
-      await pool.run(
-        apiDocument: apiDoc,
-        nameManager: setup.nameManager,
-        stableModelSorter: setup.stableModelSorter,
-        outputDirectory: outDir.path,
-        package: _package,
-        useImmutableCollections: false,
-        workerCount: 2,
-      );
-
-      expect(pool.spawnedWorkers, 2);
-      expect(pool.exitedWorkers, pool.spawnedWorkers);
-    });
-
-    test('terminates all isolates after run fails', () async {
-      final apiDoc = _allSubtypeModelDocument(ctx);
-
-      final setup = _buildSerial();
-      _primeBoth(setup.nameManager, apiDoc);
-
-      final pool = ModelWorkerPool();
-      try {
-        await pool.run(
-          apiDocument: apiDoc,
-          nameManager: setup.nameManager,
-          stableModelSorter: setup.stableModelSorter,
-          outputDirectory: '/no/such/dir/and/cannot/be/made',
-          package: _package,
-          useImmutableCollections: false,
-          workerCount: 2,
-        );
-        fail('expected failure');
-      } on Object catch (_) {
-        // expected
-      }
-
-      expect(pool.spawnedWorkers, 2);
-      expect(pool.exitedWorkers, pool.spawnedWorkers);
-    });
-
-    test(
-      'forwards worker log.warning attached error as stringified type name '
-      'with reconstructable stack',
-      () async {
-        final apiDoc = _allSubtypeModelDocument(ctx);
-
-        final outDir = Directory(path.join(tempDir.path, 'errlogout'))
-          ..createSync();
-
-        final nameGenerator = NameGenerator();
-        final stableModelSorter = StableModelSorter();
-        final nameManager = _WarningLoggingNameManager(
-          generator: nameGenerator,
-          stableModelSorter: stableModelSorter,
-        )
-          ..prime(
-            models: apiDoc.models,
-            responses: apiDoc.responses,
-            requestBodies: apiDoc.requestBodies,
-            operations: apiDoc.operations,
-            tags: apiDoc.operationsByTag.keys,
-            servers: apiDoc.servers,
-          )
-          ..armed = true;
-
-        final previousLevel = Logger.root.level;
-        Logger.root.level = Level.ALL;
-        final forwarded = <LogRecord>[];
-        final sub = Logger.root.onRecord.listen(forwarded.add);
-
-        try {
-          await ModelWorkerPool().run(
-            apiDocument: apiDoc,
-            nameManager: nameManager,
-            stableModelSorter: stableModelSorter,
-            outputDirectory: outDir.path,
-            package: _package,
-            useImmutableCollections: false,
-            workerCount: 1,
-          );
-        } finally {
-          await sub.cancel();
-          Logger.root.level = previousLevel;
-        }
-
-        final warning = forwarded.firstWhere(
-          (r) =>
-              r.loggerName == 'TestWorkerLogger' && r.level == Level.WARNING,
-        );
-
-        expect(
-          warning.error,
-          isA<String>(),
-          reason: 'attached error must arrive as a String (boundary '
-              'stringifies it because the original may be non-sendable)',
-        );
-        expect(
-          warning.error! as String,
-          contains('_AttachedException'),
-          reason: 'stringified error must preserve the original runtime '
-              'type name so log readers can tell error types apart',
-        );
-
-        expect(warning.stackTrace, isA<StackTrace>());
-        expect(warning.stackTrace, isNotNull);
-        expect(warning.stackTrace!.toString(), isNotEmpty);
-      },
-    );
-
-    test('throws ArgumentError when workerCount is below 1', () {
-      final apiDoc = _allSubtypeModelDocument(ctx);
-      final setup = _buildSerial();
-      _primeBoth(setup.nameManager, apiDoc);
-
-      expect(
-        () => ModelWorkerPool().run(
-          apiDocument: apiDoc,
-          nameManager: setup.nameManager,
-          stableModelSorter: setup.stableModelSorter,
-          outputDirectory: tempDir.path,
-          package: _package,
-          useImmutableCollections: false,
-          workerCount: 0,
-        ),
-        throwsA(isA<ArgumentError>()),
-      );
-    });
-
-    test('returns immediately when models set is empty', () async {
-      final apiDoc = ApiDocument(
-        title: 'Test',
-        version: '1.0.0',
-        models: const <Model>{},
-        responseHeaders: const {},
-        requestHeaders: const {},
-        servers: const {},
-        operations: const {},
-        responses: const <Response>{},
-        queryParameters: const {},
-        pathParameters: const {},
-        cookieParameters: const {},
-        requestBodies: const {},
-      );
-
-      final setup = _buildSerial();
-      _primeBoth(setup.nameManager, apiDoc);
-
-      await ModelWorkerPool().run(
-        apiDocument: apiDoc,
-        nameManager: setup.nameManager,
-        stableModelSorter: setup.stableModelSorter,
-        outputDirectory: tempDir.path,
-        package: _package,
-        useImmutableCollections: false,
-        workerCount: 4,
-      );
-
-      expect(
-        Directory(
-          path.join(tempDir.path, _package, 'lib', 'src', 'model'),
-        ).existsSync(),
-        isFalse,
-      );
-    });
-  });
-}
-
-/// NameManager that, once [armed] is set, throws a non-sendable error
-/// (carrying a live [ReceivePort]) on the next `modelName` lookup.
-/// Arming after `prime()` lets the worker — but not the main isolate —
-/// trip the throw, exercising the fallback path of `_sendModelError`.
-class _NonSendableThrowingNameManager extends NameManager {
-  _NonSendableThrowingNameManager({
-    required super.generator,
-    required super.stableModelSorter,
-  });
-
+  void Function() onLookup = () {};
   bool armed = false;
 
   @override
   String modelName(Model model) {
-    if (armed) throw _PortBearingError(ReceivePort());
-    return super.modelName(model);
-  }
-}
-
-/// NameManager that, once [armed], throws synchronously on `modelName`
-/// — used to provoke a worker-side throw from the per-job dispatch loop
-/// and prove main never silently hangs.
-class _ConstructorThrowingNameManager extends NameManager {
-  _ConstructorThrowingNameManager({
-    required super.generator,
-    required super.stableModelSorter,
-  });
-
-  bool armed = false;
-
-  @override
-  String modelName(Model model) {
-    if (armed) throw StateError('synthetic worker setup failure');
+    if (armed) onLookup();
     return super.modelName(model);
   }
 }
@@ -816,65 +472,9 @@ class _PortBearingError implements Exception {
   String toString() => 'PortBearingError carrying $port';
 }
 
-/// NameManager that, once [armed], emits a single `log.warning` with an
-/// attached exception (and a real stack trace). Exercises the
-/// log-forwarding contract: error arrives as a stringified type name and
-/// stackTrace as a reconstructable [StackTrace].
-class _WarningLoggingNameManager extends NameManager {
-  _WarningLoggingNameManager({
-    required super.generator,
-    required super.stableModelSorter,
-  });
-
-  bool armed = false;
-  bool _fired = false;
-
-  @override
-  String modelName(Model model) {
-    if (armed && !_fired) {
-      _fired = true;
-      try {
-        throw _AttachedException('synthetic warning payload');
-      } on _AttachedException catch (e, s) {
-        Logger('TestWorkerLogger').warning('attached error log', e, s);
-      }
-    }
-    return super.modelName(model);
-  }
-}
-
 class _AttachedException implements Exception {
   _AttachedException(this.message);
   final String message;
   @override
   String toString() => '_AttachedException: $message';
-}
-
-/// NameManager that, once [armed], schedules an unawaited future that
-/// throws asynchronously on the first call — bypassing the worker's
-/// per-job `try/catch` and triggering the isolate `onError` channel.
-/// Schedules only once so the worker still processes models 2..N normally;
-/// the async error fires while remaining jobs are in flight, making the
-/// arrival order at main deterministic (errorPort lands before all acks).
-class _AsyncCrashingNameManager extends NameManager {
-  _AsyncCrashingNameManager({
-    required super.generator,
-    required super.stableModelSorter,
-  });
-
-  bool armed = false;
-  bool _fired = false;
-
-  @override
-  String modelName(Model model) {
-    if (armed && !_fired) {
-      _fired = true;
-      unawaited(
-        Future<void>.microtask(() {
-          throw StateError('synthetic async crash');
-        }),
-      );
-    }
-    return super.modelName(model);
-  }
 }


### PR DESCRIPTION
## Summary

- Parallelize model file generation across Dart isolates. On a 28k-model spec the model phase dominates wall clock (~75% of total); the new bounded worker pool dispatches per-model code generation across isolates while small specs continue on the existing serial path.
- New `workerCount` configuration knob exposed via CLI `--workers <n>`, YAML `workerCount`, and `TONIK_WORKERS` env var (precedence in that order; auto when all unset). Auto-sized to `(Platform.numberOfProcessors - 1).clamp(1, 16)`; switches to serial below 200 models.
- Output is byte-identical between serial and parallel paths (unit + integration verified).

Closes the parallelization plan at `docs/plans/parallelize-model-generation.md` (Phases 1, 2, 3). Phase 4 wall-clock tuning and Phase 5 extension to operations/responses are deferred per the plan.

## Test plan

- [x] `fvm dart analyze packages/` — clean
- [x] `melos run test` — all 5 unit suites green (4825 tests)
- [x] `melos run test-integration-all` — 36/36 integration suites green
- [x] Patch coverage 92% overall (`bash scripts/coverage.sh --diff main`)
- [x] `ModelFileGenerator.writeOne` per-subtype tests cover all 9 dispatched model types
- [x] `ModelWorkerPool` byte-equivalence test asserts identical file trees between serial `writeFiles` and 2-worker pool run on a 9-model fixture
- [x] Worker error preservation test asserts original `FileSystemException` type AND a worker-side stack frame survive the rethrow
- [x] Worker `Logger` records forwarded to main with original `Level` + `Logger.name` preserved
- [x] No leaked isolates after `run` returns on both success and failure paths
- [ ] Manual smoke run on a large spec to confirm the wall-clock improvement on the developer machine
