### PR TITLE
ci: restrict GITHUB_TOKEN to contents:read in workflows

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   analyze:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [ main ]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## Summary
- Adds a top-level `permissions: { contents: read }` block to `lint.yml`, `test.yml`, and `integration_tests.yml`.
- Closes the three CodeQL `actions/missing-workflow-permissions` alerts (#1, #2, #3).

## Why
Without an explicit `permissions:` block, `GITHUB_TOKEN` falls back to the repo/org default — historically read-write across the board, which is broader than these workflows need. None of the three workflows write to issues, PRs, packages, releases, or pages; the test workflow's Codecov upload uses its own `CODECOV_TOKEN`. `contents: read` is the least-privilege minimum that still lets `actions/checkout` clone the repo.

## Test plan
- [ ] Lint workflow runs green on this PR
- [ ] Unit test workflow runs green on this PR
- [ ] Integration test workflow runs green on this PR
- [ ] CodeQL alerts 1, 2, 3 auto-close after merge to main
