### PR TITLE
fix(generate): demote runtime-default routing log from warning to fine

### DIFF
--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -365,7 +365,7 @@ class ClassGenerator {
         useImmutableCollections: useImmutableCollections,
       );
       if (runtime == null) continue;
-      _classGeneratorLog.warning(
+      _classGeneratorLog.fine(
         'Routing default to runtime fallback for '
         '$className.${prop.property.name}.',
       );

--- a/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_defaults.dart
@@ -117,7 +117,7 @@ OperationDefaultsResult resolveOperationParameterDefaults({
     );
     if (runtime == null) return;
 
-    _log.warning(
+    _log.fine(
       'Routing default to runtime fallback for $operationClassName.$specName.',
     );
     byName[normalizedName] = OperationParameterDefault.local(

--- a/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_default_value_generator_test.dart
@@ -18,6 +18,10 @@ void main() {
     ).format;
 
     setUp(() {
+      final previousRootLevel = Logger.root.level;
+      Logger.root.level = Level.ALL;
+      addTearDown(() => Logger.root.level = previousRootLevel);
+
       nameManager = NameManager(
         generator: NameGenerator(),
         stableModelSorter: StableModelSorter(),
@@ -364,13 +368,13 @@ void main() {
         );
         expect(getter.static, isTrue);
         expect(getter.type, MethodType.getter);
-        final warnings = logs
+        final routingLogs = logs
             .where(
               (r) =>
-                  r.level == Level.WARNING && r.loggerName == 'ClassGenerator',
+                  r.level == Level.FINE && r.loggerName == 'ClassGenerator',
             )
             .toList();
-        expect(warnings.map((r) => r.message), [
+        expect(routingLogs.map((r) => r.message), [
           'Routing default to runtime fallback for WithChild.child.',
         ]);
         expect(
@@ -452,13 +456,13 @@ factory WithChild.fromJson(Object? json) {
       );
       expect(getter.static, isTrue);
       expect(getter.type, MethodType.getter);
-      final warnings = logs
+      final routingLogs = logs
           .where(
             (r) =>
-                r.level == Level.WARNING && r.loggerName == 'ClassGenerator',
+                r.level == Level.FINE && r.loggerName == 'ClassGenerator',
           )
           .toList();
-      expect(warnings.map((r) => r.message), [
+      expect(routingLogs.map((r) => r.message), [
         'Routing default to runtime fallback for WithComposite.union.',
       ]);
       expect(
@@ -1076,6 +1080,10 @@ factory DefaultedSimpleRuntime.fromSimple(
     ).format;
 
     setUp(() {
+      final previousRootLevel = Logger.root.level;
+      Logger.root.level = Level.ALL;
+      addTearDown(() => Logger.root.level = previousRootLevel);
+
       nameManager = NameManager(
         generator: NameGenerator(),
         stableModelSorter: StableModelSorter(),

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_cache_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_cache_test.dart
@@ -11,6 +11,10 @@ void main() {
   late Context context;
 
   setUp(() {
+    final previousRootLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    addTearDown(() => Logger.root.level = previousRootLevel);
+
     nameManager = NameManager(
       generator: NameGenerator(),
       stableModelSorter: StableModelSorter(),
@@ -116,7 +120,7 @@ void main() {
     );
 
     test(
-      'runtime-fallback routing warning fires exactly once across two '
+      'runtime-fallback routing log fires exactly once across two '
       'forOperation calls — pre-cache behaviour would have logged twice',
       () {
         final logs = <LogRecord>[];
@@ -144,11 +148,13 @@ void main() {
             initialReservedNames: const {'_dio'},
           );
 
-        final warnings = logs
-            .where((r) => r.level == Level.WARNING)
+        final routingLogs = logs
+            .where((r) => r.level == Level.FINE)
             .map((r) => r.message)
             .toList();
-        expect(warnings, ['Routing default to runtime fallback for Op.since.']);
+        expect(routingLogs, [
+          'Routing default to runtime fallback for Op.since.',
+        ]);
       },
     );
 

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -13,6 +13,10 @@ void main() {
   late DartEmitter emitter;
 
   setUp(() {
+    final previousRootLevel = Logger.root.level;
+    Logger.root.level = Level.ALL;
+    addTearDown(() => Logger.root.level = previousRootLevel);
+
     nameManager = NameManager(
       generator: NameGenerator(),
       stableModelSorter: StableModelSorter(),
@@ -399,7 +403,7 @@ void main() {
 
     test(
       'date-time target falls through to a runtime getter — no const field, '
-      'isRuntime flag set, single routing warning emitted',
+      'isRuntime flag set, single routing log emitted',
       () {
         final logs = <LogRecord>[];
         final sub = Logger(
@@ -441,8 +445,10 @@ void main() {
         expect(result.getters, hasLength(1));
         expect(result.byName['since']?.memberName, 'sinceDefault');
         expect(result.byName['since']?.isRuntime, isTrue);
-        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
-        expect(warnings.map((r) => r.message), [
+        final routingLogs = logs
+            .where((r) => r.level == Level.FINE)
+            .toList();
+        expect(routingLogs.map((r) => r.message), [
           'Routing default to runtime fallback for Op.since.',
         ]);
       },
@@ -450,7 +456,7 @@ void main() {
 
     test(
       'ClassModel target with default falls through to a runtime getter — '
-      'no const field, isRuntime flag set, routing warning emitted',
+      'no const field, isRuntime flag set, routing log emitted',
       () {
         final logs = <LogRecord>[];
         final sub = Logger(
@@ -498,8 +504,10 @@ void main() {
         expect(result.getters, hasLength(1));
         expect(result.byName['region']?.memberName, 'regionDefault');
         expect(result.byName['region']?.isRuntime, isTrue);
-        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
-        expect(warnings.map((r) => r.message), [
+        final routingLogs = logs
+            .where((r) => r.level == Level.FINE)
+            .toList();
+        expect(routingLogs.map((r) => r.message), [
           'Routing default to runtime fallback for Op.region.',
         ]);
       },
@@ -554,14 +562,14 @@ void main() {
         expect(result.getters, hasLength(1));
         expect(result.byName['policy']?.memberName, 'policyDefault');
         expect(result.byName['policy']?.isRuntime, isTrue);
-        final warnings = logs
+        final routingLogs = logs
             .where(
               (r) =>
-                  r.level == Level.WARNING &&
+                  r.level == Level.FINE &&
                   r.loggerName == 'OperationParameterDefaults',
             )
             .toList();
-        expect(warnings.map((r) => r.message), [
+        expect(routingLogs.map((r) => r.message), [
           'Routing default to runtime fallback for Op.X-Policy.',
         ]);
         expect(
@@ -577,7 +585,7 @@ void main() {
 
     test(
       'AllOf composite target with default falls through to a runtime getter '
-      'without emitting a const field, routing warning emitted',
+      'without emitting a const field, routing log emitted',
       () {
         final logs = <LogRecord>[];
         final sub = Logger(
@@ -625,8 +633,10 @@ void main() {
         expect(result.getters, hasLength(1));
         expect(result.byName['region']?.memberName, 'regionDefault');
         expect(result.byName['region']?.isRuntime, isTrue);
-        final warnings = logs.where((r) => r.level == Level.WARNING).toList();
-        expect(warnings.map((r) => r.message), [
+        final routingLogs = logs
+            .where((r) => r.level == Level.FINE)
+            .toList();
+        expect(routingLogs.map((r) => r.message), [
           'Routing default to runtime fallback for Op.region.',
         ]);
       },


### PR DESCRIPTION
## Summary
- Routing a property/parameter's default to a runtime getter is a normal generator outcome, not a warning. The CLI defaults to `Level.WARNING`, so on real specs the user sees dozens of `[warn] Routing default to runtime fallback for …` lines that bury actual warnings.
- Drops both log sites (`operation_parameter_defaults.dart`, `class_generator.dart`) to `Level.FINE` so they only surface with `--log-level verbose`.
- Updates the three affected tests to bump `Logger.root.level` to `ALL` in `setUp` (so FINE records still reach subscribers) and assert on `Level.FINE`. Renames `warnings` locals and "routing warning" test names to "routing log" to match the new level.

## Test plan
- [x] `fvm dart analyze` on the touched files — clean
- [x] `fvm dart test` on the three affected test files — 56 passed
- [ ] Reviewer sanity-check: real CLI run with default log level shows no `Routing default to runtime fallback` lines
