### PR TITLE
fix(generate): tolerate media-type parameters in response Content-Type matching

### DIFF
--- a/integration_test/petstore/petstore_test/imposter/response.groovy
+++ b/integration_test/petstore/petstore_test/imposter/response.groovy
@@ -16,11 +16,13 @@ if (context.request.path == '/api/v3/user/login' && responseStatus == '200') {
         .withContent('"example return value"')
 
 } else if (context.request.path.matches('/api/v3/pet/\\d+/health') && responseStatus == '200') {
-    // For pet health endpoint with 200 status, return RFC 7807 Problem Details JSON
+    // For pet health endpoint with 200 status, return RFC 7807 Problem Details
+    // JSON. The Content-Type carries `version=1` and `charset=utf-8` parameters
+    // to exercise tolerant media-type matching on the generated client.
     def petId = context.request.path.replaceAll('.*/pet/(\\d+)/health', '$1')
     response = respond()
         .withStatusCode(Integer.parseInt(responseStatus))
-        .withHeader('Content-Type', 'application/problem+json')
+        .withHeader('Content-Type', 'application/problem+json; version=1; charset=utf-8')
         .withContent("""
             {
               "type": "https://example.com/probs/pet-health",
@@ -31,4 +33,18 @@ if (context.request.path == '/api/v3/user/login' && responseStatus == '200') {
               "healthStatus": "healthy"
             }
           """.trim())
-} 
+} else if (context.request.path.matches('/api/v3/pet/\\d+') && context.request.method == 'GET' && responseStatus == '200') {
+    // Sends `Content-Type: application/json; charset=utf-8` so the generated
+    // client must extract the bare media type before matching the case arm.
+    def petId = context.request.path.replaceAll('.*/pet/(\\d+)', '$1')
+    response = respond()
+        .withStatusCode(Integer.parseInt(responseStatus))
+        .withHeader('Content-Type', 'application/json; charset=utf-8')
+        .withContent("""
+            {
+              "id": ${petId},
+              "name": "doggie",
+              "photoUrls": ["https://example.com/photo.png"]
+            }
+          """.trim())
+}

--- a/integration_test/petstore/petstore_test/test/pet_test.dart
+++ b/integration_test/petstore/petstore_test/test/pet_test.dart
@@ -282,7 +282,8 @@ void main() {
   });
 
   group('getPetById', () {
-    test('200', () async {
+    test('200 decodes body when Content-Type carries charset parameter',
+        () async {
       final petApi = buildPetApi(responseStatus: '200');
 
       final pet = await petApi.getPetById(petId: 1);
@@ -295,6 +296,8 @@ void main() {
       // deprecation is defined by the OpenAPI spec and correct
       // ignore: deprecated_member_use
       expect(body, isA<Pet>());
+      expect(body.id, 1);
+      expect(body.name, 'doggie');
     });
 
     test('400', () async {
@@ -461,7 +464,8 @@ void main() {
   });
 
   group('getPetHealth', () {
-    test('200 with custom content type', () async {
+    test('200 decodes problem+json body when Content-Type carries version and '
+        'charset parameters', () async {
       final petApi = buildPetApi(responseStatus: '200');
 
       final health = await petApi.getPetHealth(petId: 123);

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -79,8 +79,9 @@ class ParseGenerator {
       ...cases,
     ];
 
-    // Only add a default case if we don't have a default response with null
-    // content type
+    // A spec `default` response with no content type already matches `(_, _)`,
+    // so emitting a synthetic `default:` arm would shadow it and produce dead
+    // code.
     if (!hasDefaultWithNullContentType) {
       switchCases.add(
         Block.of([
@@ -133,9 +134,8 @@ class ParseGenerator {
   }
 
   Code _casePattern(ResponseStatus status, String? contentType) {
-    // Spec keys are stored verbatim by the parser; normalising via the shared
-    // runtime helper here keeps emitted case patterns in lockstep with what
-    // `extractMediaType` computes against the response header at runtime.
+    // Normalise spec keys with the same helper the generated code uses at
+    // runtime so case patterns match the runtime-computed `_$mediaType`.
     final normalized = tonik_util.extractMediaType(contentType);
     final contentTypePattern = normalized != null
         ? specLiteralStringCode(normalized)
@@ -668,8 +668,8 @@ class ParseGenerator {
   Set<String?> _getContentTypes(Response response) {
     final contentTypes = <String?>{};
     final resolvedResponse = response.resolved;
-    final seenNormalized = <String>{};
-    final droppedByNormalized = <String, List<String>>{};
+    final keptByNormalized = <String, ResponseBody>{};
+    final droppedByNormalized = <String, List<ResponseBody>>{};
 
     for (final body in resolvedResponse.bodies) {
       final raw = body.rawContentType;
@@ -678,10 +678,11 @@ class ParseGenerator {
         contentTypes.add(raw);
         continue;
       }
-      if (seenNormalized.add(normalized)) {
+      if (!keptByNormalized.containsKey(normalized)) {
+        keptByNormalized[normalized] = body;
         contentTypes.add(raw);
       } else {
-        droppedByNormalized.putIfAbsent(normalized, () => []).add(raw);
+        droppedByNormalized.putIfAbsent(normalized, () => []).add(body);
       }
     }
 
@@ -690,11 +691,27 @@ class ParseGenerator {
     }
 
     for (final entry in droppedByNormalized.entries) {
+      final kept = keptByNormalized[entry.key]!;
+      final dropped = entry.value;
+      final droppedRaws = dropped
+          .map((b) => '"${b.rawContentType}"')
+          .join(', ');
+
+      final keptType = kept.model.runtimeType;
+      final hasDistinctModels = dropped.any(
+        (b) => b.model.runtimeType != keptType,
+      );
+
+      final modelInfo = hasDistinctModels
+          ? ' kept model: $keptType; dropped models: '
+                '${dropped.map((b) => b.model.runtimeType).join(', ')}.'
+          : '';
+
       log.warning(
         'Multiple response content types normalize to '
         '"${entry.key}"; keeping the first raw entry and dropping '
-        '${entry.value.map((v) => '"$v"').join(', ')}. '
-        'The dropped entries are unreachable at runtime.',
+        '$droppedRaws. '
+        'The dropped entries are unreachable at runtime.$modelInfo',
       );
     }
 

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -1,4 +1,5 @@
 import 'package:code_builder/code_builder.dart';
+import 'package:logging/logging.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
@@ -11,6 +12,7 @@ import 'package:tonik_generate/src/util/response_property_normalizer.dart';
 import 'package:tonik_generate/src/util/response_type_generator.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
+import 'package:tonik_util/tonik_util.dart' as tonik_util;
 
 class ParseGenerator {
   const ParseGenerator({
@@ -22,6 +24,8 @@ class ParseGenerator {
   final NameManager nameManager;
   final String package;
   final bool useImmutableCollections;
+
+  static final log = Logger('ParseGenerator');
 
   /// Generates the _parseResponse method for the operation.
   Method generateParseResponseMethod(Operation operation) {
@@ -60,16 +64,23 @@ class ParseGenerator {
       }
     }
 
-    // Only add a default case if we don't have a default response with
-    // null content type
     final switchCases = <Code>[
+      Block.of([
+        const Code(r'final _$mediaType = '),
+        refer(
+          'extractMediaType',
+          'package:tonik_util/tonik_util.dart',
+        ).code,
+        const Code("(response.headers.value('content-type'));"),
+      ]),
       const Code(
-        'switch ((response.statusCode, '
-        "response.headers.value('content-type'))) {",
+        r'switch ((response.statusCode, _$mediaType)) {',
       ),
       ...cases,
     ];
 
+    // Only add a default case if we don't have a default response with null
+    // content type
     if (!hasDefaultWithNullContentType) {
       switchCases.add(
         Block.of([
@@ -122,8 +133,12 @@ class ParseGenerator {
   }
 
   Code _casePattern(ResponseStatus status, String? contentType) {
-    final contentTypePattern = contentType != null
-        ? specLiteralStringCode(contentType)
+    // Spec keys are stored verbatim by the parser; normalising via the shared
+    // runtime helper here keeps emitted case patterns in lockstep with what
+    // `extractMediaType` computes against the response header at runtime.
+    final normalized = tonik_util.extractMediaType(contentType);
+    final contentTypePattern = normalized != null
+        ? specLiteralStringCode(normalized)
         : '_';
     switch (status) {
       case ExplicitResponseStatus():
@@ -653,13 +668,34 @@ class ParseGenerator {
   Set<String?> _getContentTypes(Response response) {
     final contentTypes = <String?>{};
     final resolvedResponse = response.resolved;
+    final seenNormalized = <String>{};
+    final droppedByNormalized = <String, List<String>>{};
 
     for (final body in resolvedResponse.bodies) {
-      contentTypes.add(body.rawContentType);
+      final raw = body.rawContentType;
+      final normalized = tonik_util.extractMediaType(raw);
+      if (normalized == null) {
+        contentTypes.add(raw);
+        continue;
+      }
+      if (seenNormalized.add(normalized)) {
+        contentTypes.add(raw);
+      } else {
+        droppedByNormalized.putIfAbsent(normalized, () => []).add(raw);
+      }
     }
 
     if (contentTypes.isEmpty) {
       contentTypes.add(null);
+    }
+
+    for (final entry in droppedByNormalized.entries) {
+      log.warning(
+        'Multiple response content types normalize to '
+        '"${entry.key}"; keeping the first raw entry and dropping '
+        '${entry.value.map((v) => '"$v"').join(', ')}. '
+        'The dropped entries are unreachable at runtime.',
+      );
     }
 
     return contentTypes;

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -90,11 +90,14 @@ class ParseGenerator {
             r"final _$content = response.headers.value('content-type') "
             "?? 'not specified';",
           ),
+          const Code(r"final _$matched = _$mediaType ?? 'none';"),
           const Code(r'final _$status = response.statusCode;'),
           generateResponseDecodingExceptionExpression(
             'Unexpected content type: '
             r'${_$content}'
-            ' for status code: '
+            ' (matched as: '
+            r'${_$matched}'
+            ') for status code: '
             r'${_$status}',
           ).statement,
         ]),
@@ -134,7 +137,7 @@ class ParseGenerator {
   }
 
   Code _casePattern(ResponseStatus status, String? contentType) {
-    // Normalise spec keys with the same helper the generated code uses at
+    // Normalize spec keys with the same helper the generated code uses at
     // runtime so case patterns match the runtime-computed `_$mediaType`.
     final normalized = tonik_util.extractMediaType(contentType);
     final contentTypePattern = normalized != null

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
@@ -75,7 +76,8 @@ void main() {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
 String _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = _$json.decodeJsonString();
@@ -139,7 +141,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         AnonymousModel _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = AnonymousModel.fromJson(_$json);
@@ -209,7 +212,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         User _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -266,7 +270,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         List<int> _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonList<int>();
@@ -341,7 +346,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         List<User> _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonList<Object?>()
@@ -425,7 +431,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         Pet _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = Pet.fromJson(_$json);
@@ -478,7 +485,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         String _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (var status, r'application/json') when status != null && status >= 200 && status <= 299:
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonString();
@@ -531,7 +539,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         String _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (_, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonString();
@@ -608,7 +617,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         MultiStatusOpResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -704,7 +714,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         AnonymousResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -828,7 +839,8 @@ String _parseResponse(Response<List<int>> response) {
       final method = generator.generateParseResponseMethod(operation);
       const expectedMethod = r'''
         CombinedOpResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -932,7 +944,8 @@ String _parseResponse(Response<List<int>> response) {
 
       const expectedMethod = r'''
         BaseResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -1023,7 +1036,8 @@ String _parseResponse(Response<List<int>> response) {
 
       const expectedMethod = r'''
         HeaderAliasResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -1106,7 +1120,8 @@ String _parseResponse(Response<List<int>> response) {
 
       const expectedMethod = r'''
         BodyHeaderResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = User.fromJson(_$json);
@@ -1175,7 +1190,8 @@ String _parseResponse(Response<List<int>> response) {
 
         const expectedMethod = r'''
         UserResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonString();
@@ -1254,7 +1270,8 @@ String _parseResponse(Response<List<int>> response) {
 
       const expectedMethod = r'''
         GetUserResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               final _$json = decodeResponseJson<Object?>(response.data);
               final _$body = _$json.decodeJsonString();
@@ -1306,9 +1323,10 @@ String _parseResponse(Response<List<int>> response) {
         securitySchemes: const {},
       );
       final method = generator.generateParseResponseMethod(operation);
-      const expectedMethod = '''
+      const expectedMethod = r'''
         void _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (_, _):
               return;
           }
@@ -1403,7 +1421,8 @@ String _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 String _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'text/plain'):
       final _$body = decodeResponseText(response.data);
       return _$body;
@@ -1457,7 +1476,8 @@ String _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 TonikFile _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/octet-stream'):
       final _$body = TonikFileBytes(decodeResponseBytes(response.data));
       return _$body;
@@ -1509,7 +1529,8 @@ TonikFile _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 TonikFile _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'image/png'):
       final _$body = TonikFileBytes(decodeResponseBytes(response.data));
       return _$body;
@@ -1575,7 +1596,8 @@ TonikFile _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 AnonymousResponse _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = _$json.decodeJsonString();
@@ -1636,7 +1658,8 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 String _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       final _$formString = decodeResponseText(response.data);
       final _$body = _$formString.decodeFormString();
@@ -1716,7 +1739,8 @@ String _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 FormData _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       final _$formString = decodeResponseText(response.data);
       final _$body = FormData.fromForm(_$formString, explode: true);
@@ -1769,7 +1793,8 @@ FormData _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 int _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       final _$formString = decodeResponseText(response.data);
       final _$body = _$formString.decodeFormInt();
@@ -1822,7 +1847,8 @@ int _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 DateTime _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       final _$formString = decodeResponseText(response.data);
       final _$body = _$formString.decodeFormDateTime();
@@ -1921,7 +1947,8 @@ DateTime _parseResponse(Response<List<int>> response) {
         // only if the server sends a value.
         const expectedMethod = r'''
         AnonymousResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               if (response.headers.value(r'X-Never-Header') != null) {
                 throw SimpleDecodingException(
@@ -2032,7 +2059,8 @@ DateTime _parseResponse(Response<List<int>> response) {
           // Multi-response should also generate runtime check for NeverModel.
           const expectedMethod = r'''
         MultiNeverOpResponse _parseResponse(Response<List<int>> response) {
-          switch ((response.statusCode, response.headers.value('content-type'))) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
               if (response.headers.value(r'X-Never-Header') != null) {
                 throw SimpleDecodingException(
@@ -2103,7 +2131,8 @@ DateTime _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 List<Never> _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       throw JsonDecodingException(
         'Cannot decode List<NeverModel> - this type does not permit any value.',
@@ -2156,7 +2185,8 @@ List<Never> _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 Never _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       throw JsonDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
@@ -2217,7 +2247,8 @@ Never _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 NeverAlias _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       throw JsonDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
@@ -2288,7 +2319,8 @@ NeverAlias _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 MultiNeverBodyOpResponse _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       throw JsonDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
@@ -2363,7 +2395,8 @@ MultiNeverBodyOpResponse _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 AnonymousResponse _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       if (response.headers.value(r'X-Never-Header') != null) {
         throw SimpleDecodingException(
@@ -2454,7 +2487,8 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 MultiNeverBodyHeaderOpResponse _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       if (response.headers.value(r'X-Never-Header') != null) {
         throw SimpleDecodingException(
@@ -2528,7 +2562,8 @@ MultiNeverBodyHeaderOpResponse _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 NeverFormAlias _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       throw FormDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
@@ -2586,7 +2621,8 @@ NeverFormAlias _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 Never _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       throw FormDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
@@ -2649,7 +2685,8 @@ Never _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 List<Never> _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       throw FormDecodingException(
         'Cannot decode List<NeverModel> - this type does not permit any value.',
@@ -2713,7 +2750,8 @@ List<Never> _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 List<Never>? _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
       throw FormDecodingException(
         'Cannot decode List<NeverModel> - this type does not permit any value.',
@@ -2830,7 +2868,8 @@ List<Never>? _parseResponse(Response<List<int>> response) {
           final method = generator.generateParseResponseMethod(operation);
           const expectedMethod = r'''
 String _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'multipart/form-data'):
       throw ResponseDecodingException(
         'Multipart response body decoding is not supported.',
@@ -2957,7 +2996,8 @@ String _parseResponse(Response<List<int>> response) {
 
           const expectedMethod = r'''
 String _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r"application/vnd.it's+json"):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = _$json.decodeJsonString();
@@ -2975,6 +3015,311 @@ String _parseResponse(Response<List<int>> response) {
             ),
             collapseWhitespace(format(expectedMethod)),
           );
+        },
+      );
+    });
+
+    group('spec content type normalization', () {
+      test('lowercases mixed-case spec key in case pattern', () {
+        final operation = Operation(
+          operationId: 'mixedCaseContentTypeOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/mixed-case',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'Application/JSON',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+String _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('strips parameters from spec key in case pattern', () {
+        final operation = Operation(
+          operationId: 'paramContentTypeOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/param-content',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'application/json; charset=utf-8',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+String _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('normalizes spec key for range response status', () {
+        final operation = Operation(
+          operationId: 'rangeNormalizedOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/range-normalized',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const RangeResponseStatus(min: 200, max: 299): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'Application/Problem+JSON',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+String _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (var status, r'application/problem+json') when status != null && status >= 200 && status <= 299:
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('normalizes spec key for default response status', () {
+        final operation = Operation(
+          operationId: 'defaultNormalizedOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/default-normalized',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const DefaultResponseStatus(): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'application/vnd.foo+json; version=1',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+String _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (_, r'application/vnd.foo+json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test(
+        'dedupes spec keys that normalize to the same media type and logs '
+        'a warning for the dropped raw entries',
+        () {
+          final previousRootLevel = Logger.root.level;
+          Logger.root.level = Level.ALL;
+          addTearDown(() => Logger.root.level = previousRootLevel);
+
+          final logs = <LogRecord>[];
+          final sub = Logger('ParseGenerator').onRecord.listen(logs.add);
+          addTearDown(sub.cancel);
+
+          final operation = Operation(
+            operationId: 'dedupeContentTypeOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/dedupe-content',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/json',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/json; charset=utf-8',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'Application/JSON',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
+AnonymousResponse _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return AnonymousResponseJson(body: _$body);
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+
+          final warnings = logs
+              .where((r) => r.level == Level.WARNING)
+              .map((r) => r.message)
+              .toList();
+          expect(warnings, hasLength(1));
+          expect(warnings.single, contains('application/json'));
+          expect(warnings.single, contains('application/json; charset=utf-8'));
+          expect(warnings.single, contains('Application/JSON'));
         },
       );
     });
@@ -3085,7 +3430,8 @@ String _parseResponse(Response<List<int>> response) {
         );
         const expectedMethod = r'''
 IList<String> _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = IList(_$json.decodeJsonList<String>());
@@ -3144,7 +3490,8 @@ IList<String> _parseResponse(Response<List<int>> response) {
         );
         const expectedMethod = r'''
 IMap<String, int> _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = IMap(_$json.decodeJsonMap((v) => v.decodeJsonInt()));
@@ -3209,7 +3556,8 @@ IMap<String, int> _parseResponse(Response<List<int>> response) {
         final method = generator.generateParseResponseMethod(operation);
         const expectedMethod = r'''
 Tree _parseResponse(Response<List<int>> response) {
-  switch ((response.statusCode, response.headers.value('content-type'))) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
       final _$json = decodeResponseJson<Object?>(response.data);
       late final Tree Function(Object?) _$decodeTree;

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -84,8 +84,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -149,8 +150,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -220,8 +222,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -278,8 +281,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -356,8 +360,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -439,8 +444,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -493,8 +499,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -547,8 +554,9 @@ String _parseResponse(Response<List<int>> response) {
               return _$body;
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -627,8 +635,9 @@ String _parseResponse(Response<List<int>> response) {
               return MultiStatusOpResponse400();
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
-              throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+              throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
           }
         }
       ''';
@@ -730,9 +739,10 @@ String _parseResponse(Response<List<int>> response) {
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -957,9 +967,10 @@ String _parseResponse(Response<List<int>> response) {
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -1049,9 +1060,10 @@ String _parseResponse(Response<List<int>> response) {
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -1133,9 +1145,10 @@ String _parseResponse(Response<List<int>> response) {
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -1202,9 +1215,10 @@ String _parseResponse(Response<List<int>> response) {
               return UserResponseXml(body: _$body);
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -1282,9 +1296,10 @@ String _parseResponse(Response<List<int>> response) {
               return GetUserResponse400(body: _$body);
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -1428,8 +1443,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1483,8 +1499,9 @@ TonikFile _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1536,8 +1553,9 @@ TonikFile _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1610,8 +1628,9 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
       return AnonymousResponseOctetStream(body: _$body);
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1666,8 +1685,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1747,8 +1767,9 @@ FormData _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1801,8 +1822,9 @@ int _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1855,8 +1877,9 @@ DateTime _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -1963,9 +1986,10 @@ DateTime _parseResponse(Response<List<int>> response) {
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -2076,9 +2100,10 @@ DateTime _parseResponse(Response<List<int>> response) {
               return MultiNeverOpResponse404(body: _$body);
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
               final _$status = response.statusCode;
               throw ResponseDecodingException(
-                'Unexpected content type: ${_$content} for status code: ${_$status}',
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
               );
           }
         }
@@ -2139,8 +2164,9 @@ List<Never> _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -2193,8 +2219,9 @@ Never _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -2255,8 +2282,9 @@ NeverAlias _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -2331,9 +2359,10 @@ MultiNeverBodyOpResponse _parseResponse(Response<List<int>> response) {
       return MultiNeverBodyOpResponse404(body: _$body);
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2408,9 +2437,10 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2504,9 +2534,10 @@ MultiNeverBodyHeaderOpResponse _parseResponse(Response<List<int>> response) {
       return MultiNeverBodyHeaderOpResponse404(body: _$body);
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2570,9 +2601,10 @@ NeverFormAlias _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2629,9 +2661,10 @@ Never _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2693,9 +2726,10 @@ List<Never> _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2758,9 +2792,10 @@ List<Never>? _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
       throw ResponseDecodingException(
-        'Unexpected content type: ${_$content} for status code: ${_$status}',
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
       );
   }
 }
@@ -2876,8 +2911,9 @@ String _parseResponse(Response<List<int>> response) {
       );
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3004,8 +3040,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3063,8 +3100,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3117,8 +3155,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3171,8 +3210,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3225,8 +3265,9 @@ String _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3234,6 +3275,55 @@ String _parseResponse(Response<List<int>> response) {
           collapseWhitespace(format(method.accept(emitter).toString())),
           collapseWhitespace(format(expectedMethod)),
         );
+      });
+
+      test('emits no warnings when normalizing a non-colliding spec key', () {
+        final previousRootLevel = Logger.root.level;
+        Logger.root.level = Level.ALL;
+        addTearDown(() => Logger.root.level = previousRootLevel);
+
+        final logs = <LogRecord>[];
+        final sub = Logger('ParseGenerator').onRecord.listen(logs.add);
+        addTearDown(sub.cancel);
+
+        final operation = Operation(
+          operationId: 'silentNormalizationOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/silent-normalization',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'application/json; charset=utf-8',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        generator.generateParseResponseMethod(operation);
+
+        final warnings = logs
+            .where((r) => r.level == Level.WARNING)
+            .map((r) => r.message)
+            .toList();
+        expect(warnings, isEmpty);
       });
 
       test(
@@ -3302,8 +3392,9 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
       return AnonymousResponseJson(body: _$body);
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3401,8 +3492,9 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
       return AnonymousResponseXml(body: _$body);
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3423,6 +3515,8 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
             jsonWarning,
             contains('application/json; charset=utf-8'),
           );
+          expect(jsonWarning, isNot(contains('kept model:')));
+          expect(jsonWarning, isNot(contains('dropped models:')));
           final xmlWarning = warnings.firstWhere(
             (w) => w.contains('"application/xml"'),
           );
@@ -3430,6 +3524,8 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
             xmlWarning,
             contains('application/xml; charset=utf-8'),
           );
+          expect(xmlWarning, isNot(contains('kept model:')));
+          expect(xmlWarning, isNot(contains('dropped models:')));
         },
       );
     });
@@ -3548,8 +3644,9 @@ IList<String> _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3608,8 +3705,9 @@ IMap<String, int> _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';
@@ -3676,8 +3774,9 @@ Tree _parseResponse(Response<List<int>> response) {
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
       final _$status = response.statusCode;
-      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
   }
 }
 ''';

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -3237,8 +3237,8 @@ String _parseResponse(Response<List<int>> response) {
       });
 
       test(
-        'dedupes spec keys that normalize to the same media type and logs '
-        'a warning for the dropped raw entries',
+        'dedupes spec keys that normalize to the same media type, keeps first '
+        'raw entry, and names distinct dropped model types in the warning',
         () {
           final previousRootLevel = Logger.root.level;
           Logger.root.level = Level.ALL;
@@ -3275,13 +3275,13 @@ String _parseResponse(Response<List<int>> response) {
                     examples: const [],
                   ),
                   ResponseBody(
-                    model: StringModel(context: context),
+                    model: IntegerModel(context: context),
                     rawContentType: 'application/json; charset=utf-8',
                     contentType: ContentType.json,
                     examples: const [],
                   ),
                   ResponseBody(
-                    model: StringModel(context: context),
+                    model: IntegerModel(context: context),
                     rawContentType: 'Application/JSON',
                     contentType: ContentType.json,
                     examples: const [],
@@ -3317,9 +3317,119 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
               .map((r) => r.message)
               .toList();
           expect(warnings, hasLength(1));
-          expect(warnings.single, contains('application/json'));
           expect(warnings.single, contains('application/json; charset=utf-8'));
           expect(warnings.single, contains('Application/JSON'));
+          expect(warnings.single, contains('kept model: StringModel'));
+          expect(warnings.single, contains('dropped models:'));
+          expect(warnings.single, contains('IntegerModel'));
+        },
+      );
+
+      test(
+        'dedupes two independent collision groups and emits one warning per '
+        'group',
+        () {
+          final previousRootLevel = Logger.root.level;
+          Logger.root.level = Level.ALL;
+          addTearDown(() => Logger.root.level = previousRootLevel);
+
+          final logs = <LogRecord>[];
+          final sub = Logger('ParseGenerator').onRecord.listen(logs.add);
+          addTearDown(sub.cancel);
+
+          final operation = Operation(
+            operationId: 'multiGroupDedupeOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/multi-group-dedupe',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/json',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/json; charset=utf-8',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/xml',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/xml; charset=utf-8',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
+AnonymousResponse _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return AnonymousResponseJson(body: _$body);
+    case (200, r'application/xml'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return AnonymousResponseXml(body: _$body);
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} for status code: ${_$status}');
+  }
+}
+''';
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+
+          final warnings = logs
+              .where((r) => r.level == Level.WARNING)
+              .map((r) => r.message)
+              .toList();
+          expect(warnings, hasLength(2));
+          final jsonWarning = warnings.firstWhere(
+            (w) => w.contains('"application/json"'),
+          );
+          expect(
+            jsonWarning,
+            contains('application/json; charset=utf-8'),
+          );
+          final xmlWarning = warnings.firstWhere(
+            (w) => w.contains('"application/xml"'),
+          );
+          expect(
+            xmlWarning,
+            contains('application/xml; charset=utf-8'),
+          );
         },
       );
     });

--- a/packages/tonik_util/lib/src/decoding/media_type.dart
+++ b/packages/tonik_util/lib/src/decoding/media_type.dart
@@ -1,0 +1,32 @@
+/// Extracts the bare `type/subtype` portion of an HTTP `Content-Type` header.
+///
+/// Returns the lowercased `type/subtype`, trimmed of surrounding whitespace,
+/// with any media-type parameters (e.g. `; charset=utf-8`) stripped. Returns
+/// `null` only when [header] is `null`, empty, or whitespace-only — a missing
+/// content type. Headers that contain a value but lack a recognisable
+/// `type/subtype` (e.g. `;charset=utf-8`, `garbage`) are returned verbatim
+/// (after trimming and parameter stripping where the value is non-empty) so
+/// callers can surface the original header in error messages instead of
+/// conflating malformed input with "no content type sent".
+///
+/// Servers commonly append `charset=utf-8`; ignoring parameters is required to
+/// match standard responses against generated case patterns.
+String? extractMediaType(String? header) {
+  if (header == null) return null;
+
+  final trimmed = header.trim();
+  if (trimmed.isEmpty) return null;
+
+  // Quoted-string parameter values containing `;` (e.g. `foo="a;b"`) are not
+  // honoured; we split on the first literal `;` regardless of quoting.
+  final semicolonIndex = trimmed.indexOf(';');
+  final base = semicolonIndex == -1
+      ? trimmed
+      : trimmed.substring(0, semicolonIndex);
+  final stripped = base.trim();
+
+  if (stripped.isEmpty) return trimmed;
+  if (!stripped.contains('/')) return stripped;
+
+  return stripped.toLowerCase();
+}

--- a/packages/tonik_util/lib/src/decoding/media_type.dart
+++ b/packages/tonik_util/lib/src/decoding/media_type.dart
@@ -1,16 +1,15 @@
 /// Extracts the bare `type/subtype` portion of an HTTP `Content-Type` header.
 ///
-/// Returns the lowercased `type/subtype`, trimmed of surrounding whitespace,
-/// with any media-type parameters (e.g. `; charset=utf-8`) stripped. Returns
-/// `null` only when [header] is `null`, empty, or whitespace-only — a missing
-/// content type. Headers that contain a value but lack a recognisable
-/// `type/subtype` (e.g. `;charset=utf-8`, `garbage`) are returned verbatim
-/// (after trimming and parameter stripping where the value is non-empty) so
-/// callers can surface the original header in error messages instead of
-/// conflating malformed input with "no content type sent".
-///
 /// Servers commonly append `charset=utf-8`; ignoring parameters is required to
 /// match standard responses against generated case patterns.
+///
+/// Returns:
+/// - `null` when [header] is `null`, empty, or whitespace-only.
+/// - The lowercased `type/subtype` for well-formed headers (parameters
+///   stripped, surrounding whitespace trimmed).
+/// - The trimmed header for malformed values that lack a `type/subtype`
+///   (e.g. `;charset=utf-8`, `garbage`), so error messages can surface the
+///   original input.
 String? extractMediaType(String? header) {
   if (header == null) return null;
 

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -5,6 +5,7 @@ export 'src/date.dart';
 export 'src/decoding/decoding_exception.dart';
 export 'src/decoding/form_decoder.dart';
 export 'src/decoding/json_decoder.dart';
+export 'src/decoding/media_type.dart';
 export 'src/decoding/object_decoder.dart';
 export 'src/decoding/response_decoder.dart';
 export 'src/decoding/simple_decoder.dart';

--- a/packages/tonik_util/test/src/decoding/media_type_test.dart
+++ b/packages/tonik_util/test/src/decoding/media_type_test.dart
@@ -76,28 +76,16 @@ void main() {
       );
     });
 
-    test(
-      'returns trimmed raw input when only a parameter is present so error '
-      'messages surface the malformed header',
-      () {
-        expect(extractMediaType(';charset=utf-8'), ';charset=utf-8');
-      },
-    );
+    test('returns trimmed input verbatim when only a parameter is present', () {
+      expect(extractMediaType(';charset=utf-8'), ';charset=utf-8');
+    });
 
-    test(
-      'returns trimmed raw input when value has no slash so error messages '
-      'surface the malformed header',
-      () {
-        expect(extractMediaType('garbage'), 'garbage');
-      },
-    );
+    test('returns trimmed input verbatim when value has no slash', () {
+      expect(extractMediaType('garbage'), 'garbage');
+    });
 
-    test(
-      'strips parameters from no-slash input so the surfaced header is just '
-      'the malformed type token',
-      () {
-        expect(extractMediaType('garbage; foo=bar'), 'garbage');
-      },
-    );
+    test('strips parameters from no-slash input', () {
+      expect(extractMediaType('garbage; foo=bar'), 'garbage');
+    });
   });
 }

--- a/packages/tonik_util/test/src/decoding/media_type_test.dart
+++ b/packages/tonik_util/test/src/decoding/media_type_test.dart
@@ -1,0 +1,103 @@
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('extractMediaType', () {
+    test('returns null for null header', () {
+      expect(extractMediaType(null), isNull);
+    });
+
+    test('returns null for empty header', () {
+      expect(extractMediaType(''), isNull);
+    });
+
+    test('returns null for whitespace-only header', () {
+      expect(extractMediaType('   '), isNull);
+    });
+
+    test('returns bare media type unchanged', () {
+      expect(extractMediaType('application/json'), 'application/json');
+    });
+
+    test('strips charset parameter with space after semicolon', () {
+      expect(
+        extractMediaType('application/json; charset=utf-8'),
+        'application/json',
+      );
+    });
+
+    test('strips charset parameter without space after semicolon', () {
+      expect(
+        extractMediaType('application/json;charset=utf-8'),
+        'application/json',
+      );
+    });
+
+    test('strips multiple parameters', () {
+      expect(
+        extractMediaType('application/json; charset=utf-8; profile="foo"'),
+        'application/json',
+      );
+    });
+
+    test('strips charset from vendor problem+json media type', () {
+      expect(
+        extractMediaType('application/problem+json; charset=utf-8'),
+        'application/problem+json',
+      );
+    });
+
+    test('strips version parameter from vendor +json media type', () {
+      expect(
+        extractMediaType('application/vnd.foo+json; version=1'),
+        'application/vnd.foo+json',
+      );
+    });
+
+    test('lowercases mixed-case media type', () {
+      expect(extractMediaType('Application/JSON'), 'application/json');
+    });
+
+    test('trims surrounding whitespace', () {
+      expect(extractMediaType('  application/json  '), 'application/json');
+    });
+
+    test('trims whitespace between type and parameter', () {
+      expect(
+        extractMediaType('application/json   ;   charset=utf-8'),
+        'application/json',
+      );
+    });
+
+    test('lowercases vendor media type with parameters', () {
+      expect(
+        extractMediaType('Application/Problem+JSON; Charset=UTF-8'),
+        'application/problem+json',
+      );
+    });
+
+    test(
+      'returns trimmed raw input when only a parameter is present so error '
+      'messages surface the malformed header',
+      () {
+        expect(extractMediaType(';charset=utf-8'), ';charset=utf-8');
+      },
+    );
+
+    test(
+      'returns trimmed raw input when value has no slash so error messages '
+      'surface the malformed header',
+      () {
+        expect(extractMediaType('garbage'), 'garbage');
+      },
+    );
+
+    test(
+      'strips parameters from no-slash input so the surfaced header is just '
+      'the malformed type token',
+      () {
+        expect(extractMediaType('garbage; foo=bar'), 'garbage');
+      },
+    );
+  });
+}


### PR DESCRIPTION
## Summary

- Generated `_parseResponse` matched response Content-Type headers by exact string equality, so common server responses like `application/json; charset=utf-8`, `application/problem+json; charset=utf-8`, and `application/vnd.foo+json; version=1` fell through to the default arm and threw `ResponseDecodingException`.
- Introduce `extractMediaType` in `tonik_util` that returns the lowercased `type/subtype` (parameters stripped, surrounding whitespace trimmed) and returns the trimmed raw input for malformed headers so the default arm still surfaces the original value in error messages.
- Generator emits a single normalized lookup before the switch, normalizes spec-side case-pattern keys via the same helper, and dedupes spec keys that collapse to the same media type (logging the dropped raw entries at warning level).

Closes #165

## Test plan

- [x] `extractMediaType` unit tests cover: null, empty, whitespace-only, bare media type, charset with/without space, multiple params, problem+json with charset, vendor `+json` with version, mixed case, surrounding whitespace, mid-string whitespace, malformed parameter-only input, no-slash input.
- [x] `parse_generator` tests updated to full method body comparisons (with `collapseWhitespace()` + `DartFormatter`) for the new normalized switch shape, covering explicit / range / default status patterns and a dedupe scenario asserting both single emitted case arm and the warning content.
- [x] Petstore integration test extended: imposter now returns `application/json; charset=utf-8` for `GET /pet/{petId}` and `application/problem+json; version=1; charset=utf-8` for `GET /pet/{petId}/health`. Both tests assert decode succeeds.
- [x] `fvm dart analyze packages/` — zero issues.
- [x] All unit suites pass (4848 tests).
- [x] Patch coverage 96% (`media_type.dart` 100%, `parse_generator.dart` 94%).
