### PR TITLE
fix: recognize +json structured-syntax-suffix media types as JSON

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -115,6 +115,11 @@ jobs:
           cd integration_test/binary_models/binary_models_test
           dart test --concurrency=2
 
+      - name: Run structured syntax suffix integration tests
+        run: |
+          cd integration_test/structured_syntax_suffix/structured_syntax_suffix_test
+          dart test --concurrency=2
+
       - name: Run form urlencoded integration tests
         run: |
           cd integration_test/form_urlencoded/form_urlencoded_test

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@
 /integration_test/petstore_config/petstore_overrides_api
 /integration_test/petstore_config/petstore_deprecation_api
 /integration_test/binary_models/binary_models_api
+/integration_test/structured_syntax_suffix/structured_syntax_suffix_api
 /integration_test/form_urlencoded/form_urlencoded_api
 /integration_test/boolean_schemas/boolean_schemas_api
 /integration_test/type_arrays/type_arrays_api

--- a/integration_test/structured_syntax_suffix/openapi.yaml
+++ b/integration_test/structured_syntax_suffix/openapi.yaml
@@ -1,0 +1,54 @@
+openapi: 3.1.0
+info:
+  title: Structured Syntax Suffix API
+  description: |-
+    Test API verifying that media types using the RFC 6839 structured syntax
+    suffix `+json` (e.g. application/vnd.api+json) are treated as JSON and
+    decoded into the declared schema instead of being returned as raw bytes.
+  version: 1.0.0
+servers:
+  - url: http://localhost:8080/api/v1
+tags:
+  - name: widgets
+    description: Widget operations
+paths:
+  /widget:
+    get:
+      tags:
+        - widgets
+      summary: Get a widget
+      description: Returns a widget using the application/vnd.api+json media type.
+      operationId: getWidget
+      responses:
+        '200':
+          description: Widget retrieved successfully
+          content:
+            application/vnd.api+json:
+              schema:
+                $ref: '#/components/schemas/Widget'
+  /problem:
+    get:
+      tags:
+        - widgets
+      summary: Get a problem document
+      description: Returns a widget using the application/problem+json media type.
+      operationId: getProblem
+      responses:
+        '200':
+          description: Problem document retrieved successfully
+          content:
+            application/problem+json:
+              schema:
+                $ref: '#/components/schemas/Widget'
+components:
+  schemas:
+    Widget:
+      type: object
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: integer
+        name:
+          type: string

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/.gitignore
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/.gitignore
@@ -1,0 +1,2 @@
+.dart_tool/
+pubspec.lock

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/analysis_options.yaml
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/analysis_options.yaml
@@ -1,0 +1,5 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    avoid_print: false

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/dart_test.yaml
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/dart_test.yaml
@@ -1,0 +1,1 @@
+concurrency: 1

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/imposter-config.json
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/imposter-config.json
@@ -1,0 +1,7 @@
+{
+  "plugin": "openapi",
+  "specFile": "../../openapi.yaml",
+  "response": {
+    "scriptFile": "response.groovy"
+  }
+}

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
@@ -1,0 +1,13 @@
+def response = respond().withStatusCode(200)
+
+if (context.request.path == '/api/v1/widget' && context.request.method == 'GET') {
+    response.withHeader('Content-Type', 'application/vnd.api+json')
+            .withContent('{"id":42,"name":"sprocket"}')
+
+} else if (context.request.path == '/api/v1/problem' && context.request.method == 'GET') {
+    response.withHeader('Content-Type', 'application/problem+json')
+            .withContent('{"id":7,"name":"teapot"}')
+
+} else {
+    response.usingDefaultBehaviour()
+}

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml
@@ -1,0 +1,24 @@
+name: structured_syntax_suffix_test
+description: A test suite for the structured syntax suffix API.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=3.10.0 <4.0.0'
+
+dependencies:
+  structured_syntax_suffix_api:
+    path: ../structured_syntax_suffix_api
+  dio: ^5.8.0
+  path: ^1.9.1
+  tonik_util: ^0.1.0
+
+dev_dependencies:
+  test: ^1.25.15
+  test_helpers:
+    path: ../../test_helpers
+  very_good_analysis: ^10.2.0
+
+dependency_overrides:
+  tonik_util:
+    path: ../../../packages/tonik_util

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
@@ -1,0 +1,42 @@
+import 'package:structured_syntax_suffix_api/structured_syntax_suffix_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/api/v1';
+  });
+
+  WidgetsApi buildApi() {
+    return WidgetsApi(CustomServer(baseUrl: baseUrl));
+  }
+
+  test('application/vnd.api+json response decodes into the declared model',
+      () async {
+    final result = await buildApi().getWidget();
+
+    expect(result, isA<TonikSuccess<Widget>>());
+    final success = result as TonikSuccess<Widget>;
+
+    expect(success.response.statusCode, 200);
+    expect(success.value.id, 42);
+    expect(success.value.name, 'sprocket');
+  });
+
+  test('application/problem+json response decodes into the declared model',
+      () async {
+    final result = await buildApi().getProblem();
+
+    expect(result, isA<TonikSuccess<Widget>>());
+    final success = result as TonikSuccess<Widget>;
+
+    expect(success.response.statusCode, 200);
+    expect(success.value.id, 7);
+    expect(success.value.name, 'teapot');
+  });
+}

--- a/packages/tonik_parse/lib/src/content_type_resolver.dart
+++ b/packages/tonik_parse/lib/src/content_type_resolver.dart
@@ -31,6 +31,9 @@ core.ContentType resolveContentType(
       return core.ContentType.form;
     case 'multipart/form-data':
       return core.ContentType.multipart;
+    // RFC 6839 structured syntax suffix: any "*/*+json" media type is JSON.
+    case final type when type.endsWith('+json'):
+      return core.ContentType.json;
     default:
       log.warning(
         'Unknown content type "$mediaType", defaulting to bytes. '

--- a/packages/tonik_parse/test/content_type_resolver_test.dart
+++ b/packages/tonik_parse/test/content_type_resolver_test.dart
@@ -65,6 +65,122 @@ void main() {
       expect(result, core.ContentType.json);
     });
 
+    test('resolves +json structured syntax suffix types to json', () {
+      for (final mediaType in [
+        'application/vnd.api+json',
+        'application/ld+json',
+        'application/problem+json',
+        'application/vnd.custom+json',
+        'image/whatever+json',
+      ]) {
+        expect(
+          resolveContentType(mediaType, contentTypes: {}, log: log),
+          core.ContentType.json,
+          reason: mediaType,
+        );
+      }
+    });
+
+    test('resolves +json suffix with parameters stripped', () {
+      expect(
+        resolveContentType(
+          'application/vnd.api+json; charset=utf-8',
+          contentTypes: {},
+          log: log,
+        ),
+        core.ContentType.json,
+      );
+    });
+
+    test('resolves +json suffix case-insensitively', () {
+      expect(
+        resolveContentType(
+          'APPLICATION/VND.API+JSON',
+          contentTypes: {},
+          log: log,
+        ),
+        core.ContentType.json,
+      );
+    });
+
+    test('config override takes precedence over +json suffix rule', () {
+      expect(
+        resolveContentType(
+          'application/vnd.api+json',
+          contentTypes: {'application/vnd.api+json': core.ContentType.bytes},
+          log: log,
+        ),
+        core.ContentType.bytes,
+      );
+    });
+
+    test('exact-match types are unchanged', () {
+      expect(
+        resolveContentType('application/json', contentTypes: {}, log: log),
+        core.ContentType.json,
+      );
+      expect(
+        resolveContentType('text/plain', contentTypes: {}, log: log),
+        core.ContentType.text,
+      );
+      expect(
+        resolveContentType(
+          'application/octet-stream',
+          contentTypes: {},
+          log: log,
+        ),
+        core.ContentType.bytes,
+      );
+      expect(
+        resolveContentType(
+          'application/x-www-form-urlencoded',
+          contentTypes: {},
+          log: log,
+        ),
+        core.ContentType.form,
+      );
+      expect(
+        resolveContentType('multipart/form-data', contentTypes: {}, log: log),
+        core.ContentType.multipart,
+      );
+    });
+
+    test('suffixes other than +json default to bytes with warning', () {
+      final records = <LogRecord>[];
+      final sub = log.onRecord.listen(records.add);
+      addTearDown(sub.cancel);
+
+      for (final mediaType in [
+        'application/foo+xml',
+        'application/foo+cbor',
+      ]) {
+        expect(
+          resolveContentType(mediaType, contentTypes: {}, log: log),
+          core.ContentType.bytes,
+          reason: mediaType,
+        );
+      }
+
+      expect(records.length, 2);
+      expect(
+        records.every((r) => r.message.contains('Unknown content type')),
+        isTrue,
+      );
+    });
+
+    test('unknown non-suffixed types default to bytes with warning', () {
+      final records = <LogRecord>[];
+      final sub = log.onRecord.listen(records.add);
+      addTearDown(sub.cancel);
+
+      expect(
+        resolveContentType('application/whatever', contentTypes: {}, log: log),
+        core.ContentType.bytes,
+      );
+      expect(records.length, 1);
+      expect(records.single.message.contains('Unknown content type'), isTrue);
+    });
+
     test('resolves plain media types without parameters', () {
       expect(
         resolveContentType('application/json', contentTypes: {}, log: log),

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -156,9 +156,6 @@ void main() {
   });
 
   test('imports request body with json-like content', () {
-    // This test verifies backward compatibility: custom JSON-like content
-    // types are no longer auto-detected by 'contains(json)'. They need
-    // explicit config.
     final api = Importer().import(fileContent);
     final jsonLikeBody = api.requestBodies.firstWhereOrNull(
       (r) => r.name == 'JsonLikeBody',
@@ -169,12 +166,17 @@ void main() {
 
     final body = jsonLikeBody as RequestBodyObject?;
     expect(body?.isRequired, isTrue);
-    // Without explicit contentTypes config, unknown types default to bytes
     expect(body?.content, hasLength(2));
 
-    for (final content in body?.content ?? <RequestContent>[]) {
-      expect(content.contentType, ContentType.bytes);
-    }
+    final jsonSuffixContent = body?.content.firstWhere(
+      (c) => c.rawContentType == 'alto-endpointcost+json',
+    );
+    expect(jsonSuffixContent?.contentType, ContentType.json);
+
+    final unknownContent = body?.content.firstWhere(
+      (c) => c.rawContentType == 'application/vnd.custom+type',
+    );
+    expect(unknownContent?.contentType, ContentType.bytes);
   });
 
   test('imports custom content type with configuration', () {

--- a/packages/tonik_parse/test/response_importer_test.dart
+++ b/packages/tonik_parse/test/response_importer_test.dart
@@ -237,13 +237,18 @@ void main() {
 
     expect(jsonLikeResponse, isNotNull);
     expect(jsonLikeResponse, isA<ResponseObject>());
-    // Without explicit contentTypes config, unknown types default to bytes
     final bodies = (jsonLikeResponse as ResponseObject?)?.bodies;
     expect(bodies, hasLength(2));
 
-    for (final body in bodies!) {
-      expect(body.contentType, ContentType.bytes);
-    }
+    final jsonSuffixBody = bodies?.firstWhere(
+      (b) => b.rawContentType == 'alto-endpointcost+json',
+    );
+    expect(jsonSuffixBody?.contentType, ContentType.json);
+
+    final unknownBody = bodies?.firstWhere(
+      (b) => b.rawContentType == 'application/vnd.custom+type',
+    );
+    expect(unknownBody?.contentType, ContentType.bytes);
   });
 
   test('imports custom content type response with configuration', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -108,6 +108,11 @@ melos:
         cd integration_test/binary_models/binary_models_test
         dart test
 
+    test-integration-structured-syntax-suffix:
+      run: |
+        cd integration_test/structured_syntax_suffix/structured_syntax_suffix_test
+        dart test
+
     test-integration-form-urlencoded:
       run: |
         cd integration_test/form_urlencoded/form_urlencoded_test
@@ -248,6 +253,7 @@ melos:
         melos run test-integration-query-parameters
         melos run test-integration-path-encoding
         melos run test-integration-binary-models
+        melos run test-integration-structured-syntax-suffix
         melos run test-integration-form-urlencoded
         melos run test-integration-boolean-schemas
         melos run test-integration-type-arrays

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -107,6 +107,7 @@ rm -rf composition/composition_api
 rm -rf query_parameters/query_parameters_api
 rm -rf path_encoding/path_encoding_api
 rm -rf binary_models/binary_models_api
+rm -rf structured_syntax_suffix/structured_syntax_suffix_api
 rm -rf form_urlencoded/form_urlencoded_api
 rm -rf boolean_schemas/boolean_schemas_api
 rm -rf type_arrays/type_arrays_api
@@ -181,6 +182,9 @@ add_dependency_overrides_recursive "path_encoding/path_encoding_api"
 
 $TONIK_BINARY --config binary_models/tonik.yaml -p binary_models_api -s binary_models/openapi.yaml -o binary_models
 add_dependency_overrides_recursive "binary_models/binary_models_api"
+
+$TONIK_BINARY -p structured_syntax_suffix_api -s structured_syntax_suffix/openapi.yaml -o structured_syntax_suffix
+add_dependency_overrides_recursive "structured_syntax_suffix/structured_syntax_suffix_api"
 
 $TONIK_BINARY --config form_urlencoded/tonik_custom.yaml
 add_dependency_overrides_recursive "form_urlencoded/form_urlencoded_api"
@@ -278,6 +282,7 @@ echo "Running dart pub get for all generated packages in parallel..."
   cd query_parameters/query_parameters_api && dart pub get &
   cd path_encoding/path_encoding_api && dart pub get &
   cd binary_models/binary_models_api && dart pub get &
+  cd structured_syntax_suffix/structured_syntax_suffix_api && dart pub get &
   cd form_urlencoded/form_urlencoded_api && dart pub get &
   cd boolean_schemas/boolean_schemas_api && dart pub get &
   cd type_arrays/type_arrays_api && dart pub get &
@@ -340,6 +345,7 @@ restore_test_package_overrides "composition/composition_test/pubspec.yaml" "../.
 restore_test_package_overrides "query_parameters/query_parameters_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "path_encoding/path_encoding_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "binary_models/binary_models_test/pubspec.yaml" "../../../packages/tonik_util"
+restore_test_package_overrides "structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "form_urlencoded/form_urlencoded_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "boolean_schemas/boolean_schemas_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "type_arrays/type_arrays_test/pubspec.yaml" "../../../packages/tonik_util"
@@ -381,6 +387,7 @@ echo "Running dart pub get for all test packages in parallel..."
   cd query_parameters/query_parameters_test && dart pub get &
   cd path_encoding/path_encoding_test && dart pub get &
   cd binary_models/binary_models_test && dart pub get &
+  cd structured_syntax_suffix/structured_syntax_suffix_test && dart pub get &
   cd form_urlencoded/form_urlencoded_test && dart pub get &
   cd boolean_schemas/boolean_schemas_test && dart pub get &
   cd type_arrays/type_arrays_test && dart pub get &


### PR DESCRIPTION
## Summary

Media types using the RFC 6839 `+json` structured syntax suffix (e.g. `application/vnd.api+json`, `application/ld+json`, `application/problem+json`, SCIM/HAL/geo `+json` types) were not recognized as JSON. `resolveContentType` only matched the exact string `application/json`, so any `*/*+json` type fell through to "defaulting to bytes", the declared response schema was discarded, and the generated client returned the body as an opaque `TonikFile` instead of decoding it into the model.

Per RFC 6839 §3.1 / RFC 9110 §8.3.1 / RFC 8259, a processor that understands JSON must handle any `*/*+json` media type as JSON.

## Change

- `resolveContentType` now recognizes the `+json` structured-syntax suffix via a guarded switch case (`case final type when type.endsWith('+json')`), placed after the exact-match cases and after config overrides. Any `*/*+json` media type resolves to `ContentType.json`.
- Matching is parameter-stripped and case-insensitive (reuses the existing normalization).
- Config `contentTypes` overrides still take precedence.
- Suffixes other than `+json` (`+xml`, `+cbor`, …) still default to `bytes` with the existing warning — no new enum value, no XML handling.
- The same resolver serves request bodies and responses, so both now decode `+json` payloads into their declared models.

## Tests

- Unit tests in `tonik_parse` covering suffix recognition across media types, parameter stripping, case-insensitivity, override precedence, exact-match behavior, and non-`+json` suffixes / unknown types still defaulting to bytes with a warning.
- Two existing importer tests that previously asserted the buggy `+json` → bytes behavior were corrected to assert the right per-type outcome.
- New `structured_syntax_suffix` integration suite proving end-to-end that an `application/vnd.api+json` (and `application/problem+json`) response decodes into the declared model rather than returning a `TonikFile`.

## Verification

- `fvm dart analyze packages/`: no issues
- All unit suites pass (tonik_core, tonik_parse, tonik_generate, tonik_util, tonik)
- `structured_syntax_suffix` integration suite passes against the imposter server
- Patch coverage: 100%