### PR TITLE
ci: analyze generated code and fix all analyzer warnings

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -26,4 +26,26 @@ jobs:
           melos bootstrap
 
       - name: Analyze code
-        run: melos exec dart analyze
+        run: melos exec -- dart analyze --fatal-infos
+
+  analyze-generated:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+      - name: Install dependencies
+        run: |
+          dart pub global activate melos
+          melos bootstrap
+
+      - name: Generate integration test code
+        run: ./scripts/setup_integration_tests.sh
+        shell: bash
+
+      - name: Analyze generated code
+        run: dart analyze --fatal-infos integration_test

--- a/integration_test/composition/composition_test/test/all_of_test.dart
+++ b/integration_test/composition/composition_test/test/all_of_test.dart
@@ -26,21 +26,33 @@ void main() {
     });
 
     test('toForm - explode true', () {
-      expect(formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'count=1&id=1');
+      expect(
+        formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        'count=1&id=1',
+      );
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfPrimitive.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
 
     test('toForm - explode false', () {
-      expect(formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'count,1,id,1');
+      expect(
+        formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+        'count,1,id,1',
+      );
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfPrimitive.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -120,7 +132,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfPrimitive.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -133,7 +148,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfPrimitive.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -218,21 +236,33 @@ void main() {
     });
 
     test('toForm - explode true', () {
-      expect(formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=1&number=1');
+      expect(
+        formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        'name=1&number=1',
+      );
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfComplex.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
 
     test('toForm - explode false', () {
-      expect(formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,1,number,1');
+      expect(
+        formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+        'name,1,number,1',
+      );
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfComplex.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -324,7 +354,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfComplex.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -337,7 +370,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfComplex.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -429,7 +465,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfEnum.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -442,7 +481,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfEnum.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -522,7 +564,8 @@ void main() {
 
     test('toForm throws EncodingException', () {
       expect(
-        () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        () =>
+            formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
         throwsA(isA<EncodingException>()),
       );
     });
@@ -591,7 +634,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = NestedAllOfInAllOf.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -604,7 +650,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = NestedAllOfInAllOf.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -691,7 +740,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -745,7 +797,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -801,7 +856,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = TwoLevelAllOf.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -814,7 +872,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = TwoLevelAllOf.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -923,7 +984,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = ThreeLevelAllOf.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -936,7 +1000,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = ThreeLevelAllOf.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });
@@ -1019,7 +1086,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1077,7 +1147,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1118,7 +1191,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1166,7 +1242,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1282,7 +1361,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1333,7 +1415,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1394,7 +1479,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1450,7 +1538,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix.fromForm(form, explode: true);
         expect(reconstructed, allOf);
       });
@@ -1463,7 +1554,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix.fromForm(form, explode: false);
         expect(reconstructed, allOf);
       });
@@ -1621,7 +1715,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = MultiLevelNesting.fromForm(form, explode: true);
         expect(reconstructed, allOf);
       });
@@ -1634,7 +1731,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = MultiLevelNesting.fromForm(form, explode: false);
         expect(reconstructed, allOf);
       });
@@ -1729,7 +1829,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1778,7 +1881,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1836,7 +1942,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfWithSimpleList.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -1849,7 +1958,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       expect(
         () => AllOfWithSimpleList.fromForm(form, explode: false),
         throwsA(isA<DecodingException>()),
@@ -1961,7 +2073,8 @@ void main() {
 
     test('toForm throws EncodingException', () {
       expect(
-        () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        () =>
+            formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
         throwsA(isA<EncodingException>()),
       );
     });
@@ -2034,7 +2147,10 @@ void main() {
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfWithEnumList.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
@@ -2047,7 +2163,10 @@ void main() {
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       expect(
         () => AllOfWithEnumList.fromForm(form, explode: false),
         throwsA(isA<DecodingException>()),
@@ -2158,7 +2277,8 @@ void main() {
 
     test('toForm throws EncodingException', () {
       expect(
-        () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        () =>
+            formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
         throwsA(isA<EncodingException>()),
       );
     });
@@ -2235,7 +2355,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexListComposition.fromForm(
           form,
           explode: true,
@@ -2251,7 +2374,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          allOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         expect(
           () => ComplexListComposition.fromForm(form, explode: false),
           throwsA(isA<DecodingException>()),
@@ -2372,7 +2498,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -2439,7 +2568,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -2503,7 +2635,8 @@ void main() {
 
     test('toForm throws EncodingException', () {
       expect(
-        () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        () =>
+            formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
         throwsA(isA<EncodingException>()),
       );
     });
@@ -2804,7 +2937,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            allOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -2854,21 +2990,33 @@ void main() {
     });
 
     test('toForm - explode true', () {
-      expect(formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+      expect(
+        formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+        '1',
+      );
     });
 
     test('form roundtrip - explode true', () {
-      final form = formValue(allOf.toForm('p', explode: true, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: true, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfDirectPrimitive.fromForm(form, explode: true);
       expect(reconstructed, allOf);
     });
 
     test('toForm - explode false', () {
-      expect(formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+      expect(
+        formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+        '1',
+      );
     });
 
     test('form roundtrip - explode false', () {
-      final form = formValue(allOf.toForm('p', explode: false, allowEmpty: true), 'p');
+      final form = formValue(
+        allOf.toForm('p', explode: false, allowEmpty: true),
+        'p',
+      );
       final reconstructed = AllOfDirectPrimitive.fromForm(form, explode: false);
       expect(reconstructed, allOf);
     });

--- a/integration_test/composition/composition_test/test/any_of_test.dart
+++ b/integration_test/composition/composition_test/test/any_of_test.dart
@@ -24,21 +24,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'hello');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'hello',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'hello');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'hello',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -115,7 +127,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -128,7 +143,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -210,31 +228,55 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '42');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '42',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: true);
         // After form roundtrip, both int and string fields are set because
         // "42" can be decoded as both an integer and a string.
         expect(reconstructed.int, 42);
         expect(reconstructed.string, '42');
-        expect(formValue(reconstructed.toForm('p', explode: true, allowEmpty: true), 'p'), form);
+        expect(
+          formValue(
+            reconstructed.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
+          form,
+        );
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '42');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '42',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: false);
         // After form roundtrip, both int and string fields are set because
         // "42" can be decoded as both an integer and a string.
         expect(reconstructed.int, 42);
         expect(reconstructed.string, '42');
-        expect(formValue(reconstructed.toForm('p', explode: false, allowEmpty: true), 'p'), form);
+        expect(
+          formValue(
+            reconstructed.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          ),
+          form,
+        );
       });
 
       test('toSimple - explode true', () {
@@ -313,31 +355,55 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'true');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'true',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: true);
         // After form roundtrip, both bool and string fields are set because
         // "true" can be decoded as both a boolean and a string.
         expect(reconstructed.bool, true);
         expect(reconstructed.string, 'true');
-        expect(formValue(reconstructed.toForm('p', explode: true, allowEmpty: true), 'p'), form);
+        expect(
+          formValue(
+            reconstructed.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
+          form,
+        );
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'true');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'true',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfPrimitive.fromForm(form, explode: false);
         // After form roundtrip, both bool and string fields are set because
         // "true" can be decoded as both a boolean and a string.
         expect(reconstructed.bool, true);
         expect(reconstructed.string, 'true');
-        expect(formValue(reconstructed.toForm('p', explode: false, allowEmpty: true), 'p'), form);
+        expect(
+          formValue(
+            reconstructed.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          ),
+          form,
+        );
       });
 
       test('toSimple - explode true', () {
@@ -469,21 +535,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Alice');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=Alice',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Alice');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,Alice',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -553,21 +631,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=123');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'number=123',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,123');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'number,123',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -647,7 +737,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -660,7 +753,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfComplex.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -744,21 +840,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfEnum.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfEnum.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -828,21 +936,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '2');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '2',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfEnum.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '2');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '2',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfEnum.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -965,21 +1085,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '42');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '42',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '42');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '42',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1049,21 +1181,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=123');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'number=123',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,123');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'number,123',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1135,21 +1279,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfMixed.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1214,7 +1370,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1282,7 +1441,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAnyOfInAllOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -1295,7 +1457,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAnyOfInAllOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1393,7 +1558,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAnyOfInAllOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -1406,7 +1574,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAnyOfInAllOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1497,7 +1668,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -1553,11 +1727,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Charlie');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=Charlie',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAllOfInAnyOf.fromForm(form, explode: true);
         // Both class1 and allOfMixed are set because AllOfMixed contains
         // a String field.
@@ -1576,11 +1756,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Charlie');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,Charlie',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedAllOfInAnyOf.fromForm(form, explode: false);
         // Both class1 and allOfMixed are set because AllOfMixed contains
         // a String field.
@@ -1705,21 +1891,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedOneOfInAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedOneOfInAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1795,21 +1993,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '3.14');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '3.14',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedOneOfInAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '3.14');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '3.14',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedOneOfInAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1941,21 +2151,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'test');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'test',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'test');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'test',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -2027,11 +2249,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=test');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=test',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: true);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2047,11 +2275,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,test');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,test',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: false);
         // Both twoLevelAnyOfModel and string are set because any string can
         // be decoded to String.
@@ -2153,11 +2387,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=42');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'number=42',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: true);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2171,11 +2411,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,42');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'number,42',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelAnyOf.fromForm(form, explode: false);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2271,21 +2517,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'deep');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'deep',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'deep');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'deep',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -2368,11 +2626,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: true);
         // Both threeLevelAnyOfModel and string are set because any
         // string can be decoded to String.
@@ -2386,11 +2650,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: false);
         // Both threeLevelAnyOfModel and string are set because any
         // string can be decoded to String.
@@ -2493,11 +2763,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=test');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=test',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: true);
         // Both threeLevelAnyOfModel and string are set because any
         // string can be decoded to String.
@@ -2515,11 +2791,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,test');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,test',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ThreeLevelAnyOf.fromForm(form, explode: false);
         // Both threeLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2642,11 +2924,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = DeepNestedAnyOf.fromForm(form, explode: true);
         // Both nestedAnyOfInAnyOf and enum1 are set because
         // NestedAnyOfInAnyOf.anyOfPrimitive contains a String variant.
@@ -2664,11 +2952,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = DeepNestedAnyOf.fromForm(form, explode: false);
         // Both nestedAnyOfInAnyOf and enum1 are set because
         // NestedAnyOfInAnyOf.anyOfPrimitive contains a String variant.
@@ -2781,21 +3075,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'test');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'test',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = DeepNestedAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'test');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'test',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = DeepNestedAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -2874,11 +3180,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromForm(
           form,
           explode: true,
@@ -2887,11 +3199,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromForm(
           form,
           explode: false,
@@ -2974,11 +3292,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), '2');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '2',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromForm(
           form,
           explode: true,
@@ -2987,11 +3311,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), '2');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '2',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromForm(
           form,
           explode: false,
@@ -3316,7 +3646,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -3383,7 +3716,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -3452,7 +3788,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -3515,11 +3854,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'asdf%20asdf');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'asdf%20asdf',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithComplexList.fromForm(
           form,
           explode: true,
@@ -3528,11 +3873,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'asdf%20asdf');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'asdf%20asdf',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithComplexList.fromForm(
           form,
           explode: false,
@@ -3610,7 +3961,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -3773,7 +4127,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -3836,21 +4193,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'true');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'true',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithMixedLists.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'true');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'true',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithMixedLists.fromForm(
           form,
           explode: false,
@@ -4227,7 +4596,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4281,7 +4653,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4346,7 +4721,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4423,7 +4801,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedListInAnyOf.fromForm(form, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -4436,7 +4817,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = NestedListInAnyOf.fromForm(form, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -4524,7 +4908,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4593,7 +4980,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4656,11 +5046,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'test%20string');
+        expect(
+          formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'test%20string',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithListOfComposites.fromForm(
           form,
           explode: true,
@@ -4669,11 +5065,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'test%20string');
+        expect(
+          formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'test%20string',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(anyOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          anyOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = AnyOfWithListOfComposites.fromForm(
           form,
           explode: false,
@@ -4768,7 +5170,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });
@@ -4882,7 +5287,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyVariant.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyVariant.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });

--- a/integration_test/composition/composition_test/test/inherited_discriminator_test.dart
+++ b/integration_test/composition/composition_test/test/inherited_discriminator_test.dart
@@ -50,7 +50,10 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        final form = formValue(petChoice.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          petChoice.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         expect(form, contains('petType=cat'));
         expect(form, contains('name=Whiskers'));
         expect(form, contains('meow=purr'));
@@ -112,7 +115,10 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        final form = formValue(petChoice.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          petChoice.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         expect(form, contains('petType=dog'));
         expect(form, contains('name=Buddy'));
         expect(form, contains('bark=woof'));

--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -24,21 +24,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'string',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'string',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -115,7 +127,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -128,7 +143,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -210,21 +228,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfPrimitive.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -296,21 +326,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Kate');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=Kate',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfComplex.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Kate');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,Kate',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfComplex.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -380,21 +422,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=1');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'number=1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfComplex.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,1');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'number,1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfComplex.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -466,21 +520,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfEnum.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value1');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfEnum.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -550,21 +616,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfEnum.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          '1',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfEnum.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -636,21 +714,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'my%20value');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'my%20value',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'my%20value');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'my%20value',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -720,21 +810,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Kate');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'name=Kate',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Kate');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'name,Kate',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -818,11 +920,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: true);
         // Ambiguous: Enum1.value2 encodes to 'value2', which is
         // indistinguishable from a plain string. Without discriminators, any
@@ -841,11 +949,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = OneOfMixed.fromForm(form, explode: false);
         // Ambiguous: Enum1.value2 encodes to 'value2', which is
         // indistinguishable from a plain string. Without discriminators,
@@ -959,11 +1073,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: true,
@@ -972,11 +1092,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1055,11 +1181,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1068,11 +1200,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1155,11 +1293,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'name=Mark',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1168,11 +1312,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'name,Mark',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1253,11 +1403,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=2');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'number=2',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1266,11 +1422,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,2');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'number,2',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedOneOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1365,7 +1527,10 @@ void main() {
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAllOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1381,7 +1546,10 @@ void main() {
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAllOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1474,11 +1642,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'Peter');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'Peter',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAllOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1487,11 +1661,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'Peter');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'Peter',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAllOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1581,11 +1761,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1601,11 +1787,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1707,11 +1899,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=2');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'number=2',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1720,11 +1918,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,2');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'number,2',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1812,11 +2016,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '2');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '2',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: true,
@@ -1832,11 +2042,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '2');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '2',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = NestedAnyOfInOneOf.fromForm(
             form,
             explode: false,
@@ -1933,7 +2149,10 @@ void main() {
 
         test('toForm throws EncodingException', () {
           expect(
-            () => formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            () => formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            ),
             throwsA(isA<EncodingException>()),
           );
         });
@@ -1985,11 +2204,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'false');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'false',
+          );
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'false');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'false',
+          );
         });
 
         test('toSimple - explode true', () {
@@ -2052,21 +2277,39 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              'string',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(form, explode: true);
             expect(reconstructed, oneOf);
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              'string',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(
               form,
               explode: false,
@@ -2147,21 +2390,39 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              '1',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(form, explode: true);
             expect(reconstructed, oneOf);
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              '1',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(
               form,
               explode: false,
@@ -2252,11 +2513,20 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Mark');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              'name=Mark',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(form, explode: true);
             // Ambiguous oneOf: Class1 appears both as a direct variant
             // and nested in NestedOneOfInOneOf. The decoder tries variants
@@ -2268,11 +2538,20 @@ void main() {
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Mark');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              'name,Mark',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(
               form,
               explode: false,
@@ -2387,21 +2666,39 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'number=2');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              'number=2',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(form, explode: true);
             expect(reconstructed, oneOf);
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'number,2');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              'number,2',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = DeepNestedOneOf.fromForm(
               form,
               explode: false,
@@ -2489,21 +2786,33 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'name=Mark',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = DeepNestedOneOf.fromForm(form, explode: true);
           expect(reconstructed, oneOf);
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'name,Mark',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = DeepNestedOneOf.fromForm(form, explode: false);
           expect(reconstructed, oneOf);
         });
@@ -2583,21 +2892,33 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'Mark',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: true);
           expect(reconstructed, oneOf);
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'Mark',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: false);
           expect(reconstructed, oneOf);
         });
@@ -2670,21 +2991,33 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: true);
           expect(reconstructed, oneOf);
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: false);
           expect(reconstructed, oneOf);
         });
@@ -2759,21 +3092,33 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'false');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'false',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: true);
           expect(reconstructed, oneOf);
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'false');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'false',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelOneOf.fromForm(form, explode: false);
           expect(reconstructed, oneOf);
         });
@@ -2863,7 +3208,10 @@ void main() {
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelMixedOneOfAllOf.fromForm(
             form,
             explode: true,
@@ -2889,7 +3237,10 @@ void main() {
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = TwoLevelMixedOneOfAllOf.fromForm(
             form,
             explode: false,
@@ -3011,11 +3362,17 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'Mark');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'Mark',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedOneOfAllOf.fromForm(
           form,
           explode: true,
@@ -3024,11 +3381,17 @@ void main() {
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'Mark');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'Mark',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = TwoLevelMixedOneOfAllOf.fromForm(
           form,
           explode: false,
@@ -3115,21 +3478,39 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              'string',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(form, explode: true);
             expect(reconstructed, oneOf);
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              'string',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(
               form,
               explode: false,
@@ -3213,11 +3594,20 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              '1',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(form, explode: true);
             // Ambiguous oneOf: integer (nested) and number (direct) both
             // match numeric values. The decoder tries to decode as double
@@ -3226,11 +3616,20 @@ void main() {
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              '1',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(
               form,
               explode: false,
@@ -3322,21 +3721,39 @@ void main() {
           });
 
           test('toForm - explode true', () {
-            expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'true');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: true, allowEmpty: true),
+                'p',
+              ),
+              'true',
+            );
           });
 
           test('form roundtrip - explode true', () {
-            final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(form, explode: true);
             expect(reconstructed, oneOf);
           });
 
           test('toForm - explode false', () {
-            expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'true');
+            expect(
+              formValue(
+                oneOf.toForm('p', explode: false, allowEmpty: true),
+                'p',
+              ),
+              'true',
+            );
           });
 
           test('form roundtrip - explode false', () {
-            final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+            final form = formValue(
+              oneOf.toForm('p', explode: false, allowEmpty: true),
+              'p',
+            );
             final reconstructed = ThreeLevelOneOf.fromForm(
               form,
               explode: false,
@@ -3418,21 +3835,33 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '-991');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '-991',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelOneOf.fromForm(form, explode: true);
           expect(reconstructed, oneOf);
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '-991');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '-991',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelOneOf.fromForm(form, explode: false);
           expect(reconstructed, oneOf);
         });
@@ -3516,7 +3945,10 @@ void main() {
 
         test('toForm throws EncodingException', () {
           expect(
-            () => formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            () => formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            ),
             throwsA(isA<EncodingException>()),
           );
         });
@@ -3575,7 +4007,10 @@ void main() {
 
         test('toForm throws EncodingException', () {
           expect(
-            () => formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            () => formValue(
+              oneOf.toForm('p', explode: true, allowEmpty: true),
+              'p',
+            ),
             throwsA(isA<EncodingException>()),
           );
         });
@@ -3635,11 +4070,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'name=Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'name=Mark',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelMixedOneOfAllOfAnyOf.fromForm(
             form,
             explode: true,
@@ -3648,11 +4089,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'name,Mark');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'name,Mark',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelMixedOneOfAllOfAnyOf.fromForm(
             form,
             explode: false,
@@ -3744,11 +4191,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: true,
@@ -3757,11 +4210,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: false,
@@ -3842,11 +4301,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: true,
@@ -3855,11 +4320,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), '1');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            '1',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: false,
@@ -3940,11 +4411,17 @@ void main() {
         });
 
         test('toForm - explode true', () {
-          expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode true', () {
-          final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: true,
@@ -3965,11 +4442,17 @@ void main() {
         });
 
         test('toForm - explode false', () {
-          expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'string');
+          expect(
+            formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+            'string',
+          );
         });
 
         test('form roundtrip - explode false', () {
-          final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+          final form = formValue(
+            oneOf.toForm('p', explode: false, allowEmpty: true),
+            'p',
+          );
           final reconstructed = ThreeLevelWithRefs.fromForm(
             form,
             explode: false,
@@ -4099,7 +4582,10 @@ void main() {
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix2.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -4112,7 +4598,10 @@ void main() {
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix2.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -4200,21 +4689,33 @@ void main() {
       });
 
       test('toForm - explode true', () {
-        expect(formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode true', () {
-        final form = formValue(oneOf.toForm('p', explode: true, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: true, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix2.fromForm(form, explode: true);
         expect(reconstructed, oneOf);
       });
 
       test('toForm - explode false', () {
-        expect(formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'), 'value2');
+        expect(
+          formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p'),
+          'value2',
+        );
       });
 
       test('form roundtrip - explode false', () {
-        final form = formValue(oneOf.toForm('p', explode: false, allowEmpty: true), 'p');
+        final form = formValue(
+          oneOf.toForm('p', explode: false, allowEmpty: true),
+          'p',
+        );
         final reconstructed = ComplexNestedMix2.fromForm(form, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -4356,7 +4857,10 @@ void main() {
 
       test('toForm throws EncodingException', () {
         expect(
-          () => formValue(anyVariant.toForm('p', explode: true, allowEmpty: true), 'p'),
+          () => formValue(
+            anyVariant.toForm('p', explode: true, allowEmpty: true),
+            'p',
+          ),
           throwsA(isA<EncodingException>()),
         );
       });

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml
@@ -7,10 +7,10 @@ environment:
   sdk: '>=3.10.0 <4.0.0'
 
 dependencies:
-  structured_syntax_suffix_api:
-    path: ../structured_syntax_suffix_api
   dio: ^5.8.0
   path: ^1.9.1
+  structured_syntax_suffix_api:
+    path: ../structured_syntax_suffix_api
   tonik_util: ^0.1.0
 
 dev_dependencies:

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -280,11 +280,15 @@ class DataGenerator {
           'body',
           model,
           useQueryComponent: true,
-          isNullable: !isRequired,
         );
         bodyCode
-          ..add(formExpr.code)
-          ..add(const Code(';'));
+          ..clear()
+          ..addAll([
+            if (!isRequired) const Code('if (body == null) return null;\n'),
+            const Code('return '),
+            formExpr.code,
+            const Code(';'),
+          ]);
       case ContentType.multipart:
         bodyCode
           ..clear()

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -10,7 +10,6 @@ BuiltExpression buildToFormValueExpression(
   required bool useQueryComponent,
   bool explodeLiteral = true,
   bool allowEmptyLiteral = true,
-  bool isNullable = false,
 }) {
   final receiver = refer(valueExpression);
   final resolved = model.resolved;
@@ -44,7 +43,7 @@ BuiltExpression buildToFormValueExpression(
   }
 
   final entries = buildFormEntriesValueExpression(
-    isNullable ? receiver.nullChecked : receiver,
+    receiver,
     model,
     paramName: literalString(''),
     explode: literalBool(explodeLiteral),
@@ -60,13 +59,7 @@ BuiltExpression buildToFormValueExpression(
     );
   }
 
-  // A nullable body must collapse to null rather than throw.
-  final body = _entriesToBody(entries);
-  return BuiltExpression.simple(
-    isNullable
-        ? receiver.equalTo(literalNull).conditional(literalNull, body)
-        : body,
-  );
+  return BuiltExpression.simple(_entriesToBody(entries));
 }
 
 Expression _entriesToBody(Expression entries) {

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1101,12 +1101,11 @@ void main() {
 
         const expectedMethod = r'''
           Object? _data({Pet? body}) {
-            return body == null
-                ? null
-                : body!
-                    .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
-                    .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
-                    .join('&');
+            if (body == null) return null;
+            return body
+                .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+                .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                .join('&');
           }
         ''';
 

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -336,7 +336,8 @@ void main() {
       return !body.contains('EncodingException') && !body.contains('.map(');
     }
 
-    // Enumerates every concrete Model subtype so the two switch statements cannot drift apart.
+    // Enumerates every concrete Model subtype so the two switch statements
+    // cannot drift apart.
     List<Model> allConcreteModels() => <Model>[
       StringModel(context: context),
       BooleanModel(context: context),
@@ -421,7 +422,8 @@ void main() {
     test(
       'every scalar arm of buildUriEncodeExpression is element-encodable',
       () {
-        // Collections and BinaryModel single-value encode but are deliberately not element-encodable.
+        // Collections and BinaryModel single-value encode but are deliberately
+        // not element-encodable.
         const nonElementTypes = [MapModel, ListModel, BinaryModel];
         for (final model in allConcreteModels()) {
           if (nonElementTypes.contains(model.runtimeType)) continue;

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -59,36 +59,6 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('nullable ClassModel body null-checks before encoding', () {
-      final model = ClassModel(
-        name: 'Form',
-        isDeprecated: false,
-        properties: const [],
-        context: context,
-        examples: const [],
-      );
-
-      final result = buildToFormValueExpression(
-        'body',
-        model,
-        useQueryComponent: true,
-        isNullable: true,
-      );
-
-      final expected = format(r'''
-        test() {
-          body == null
-              ? null
-              : body!
-                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
-                  .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
-                  .join('&');
-        }
-      ''');
-
-      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
-    });
-
     test('AnyModel body renders directly via encodeAnyToForm', () {
       final result = buildToFormValueExpression(
         'body',


### PR DESCRIPTION
## Why

CI never caught analyzer issues in the generated code, for two compounding reasons:

1. `lint.yml` only ran `melos exec dart analyze` over the workspace packages. The generated `_api` code is gitignored (regenerated in CI) and was never analyzed.
2. `dart analyze` exits 0 on info-level issues by default, so even the workspace analysis wasn't gating infos.

A full `dart analyze integration_test` reported **1445 info-level issues**.

## What

**CI**
- `analyze` job now runs `melos exec -- dart analyze --fatal-infos`.
- New `analyze-generated` job regenerates the integration code and runs `dart analyze --fatal-infos integration_test`.

**Fixes for everything that surfaced**
- **Form bodies (1104 issues):** the `_data` method for nullable form-urlencoded bodies generated `body == null ? null : body!.toForm(...)`, tripping `prefer_null_aware_operators` and `unnecessary_non_null_assertion` in every spec. It now emits a readable early-return guard, matching how multipart bodies already generate:
  ```dart
  Object? _data({Pet? body}) {
    if (body == null) return null;
    return body
        .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
        .join('&');
  }
  ```
  The unused `isNullable` parameter was removed from `buildToFormValueExpression`.
- **Line length (340):** `dart format` on the composition integration tests.
- **Pubspec (1):** sorted `structured_syntax_suffix_test` dependencies.
- **Comments (2):** wrapped two over-long comments in `tonik_generate` tests.

## Verification
- `melos exec -- dart analyze --fatal-infos` → SUCCESS
- `dart analyze --fatal-infos integration_test` → No issues found
- `tonik_generate` unit suite → 2741 passing
- `form_urlencoded` integration tests → 26 passing (regenerated guard-style code is functionally correct)
