### PR TITLE
fix: accept RFC 3339 lowercase 't' date-time separator

### DIFF
--- a/packages/tonik_util/lib/src/offset_date_time.dart
+++ b/packages/tonik_util/lib/src/offset_date_time.dart
@@ -79,8 +79,12 @@ class OffsetDateTime implements DateTime {
       );
     }
 
-    // Handle different separator formats (T or space)
-    final normalizedInput = input.replaceFirst(' ', 'T');
+    // DateTime.parse rejects the RFC 3339 lowercase 't' separator. Only a 't'
+    // sitting between two digits is the genuine date/time separator; matching
+    // bare 't' would clobber non-separator characters in malformed input.
+    final normalizedInput = input
+        .replaceFirst(' ', 'T')
+        .replaceFirst(RegExp(r'(?<=\d)t(?=\d)'), 'T');
 
     // Check if it has timezone offset (±HH:MM or ±HHMM)
     final timezoneRegex = RegExp(r'[+-]\d{2}:?\d{2}$');

--- a/packages/tonik_util/test/src/offset_date_time_test.dart
+++ b/packages/tonik_util/test/src/offset_date_time_test.dart
@@ -720,6 +720,33 @@ void main() {
         expect(result.microsecond, 456);
         expect(result.timeZoneName, 'UTC');
       });
+
+      test('should accept lowercase t separator with Z suffix as UTC', () {
+        final lower = OffsetDateTime.parse('2024-01-15t10:30:00Z');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00Z');
+
+        expect(lower.isUtc, isTrue);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
+
+      test('should accept lowercase t with lowercase z suffix as UTC', () {
+        final lower = OffsetDateTime.parse('2024-01-15t10:30:00z');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00Z');
+
+        expect(lower.isUtc, isTrue);
+        expect(lower.timeZoneOffset, Duration.zero);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
+
+      test('should accept uppercase T with lowercase z suffix as UTC', () {
+        final result = OffsetDateTime.parse('2024-01-15T10:30:00z');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00Z');
+
+        expect(result.isUtc, isTrue);
+        expect(result.isAtSameMomentAs(upper), isTrue);
+      });
     });
 
     group('local datetime parsing', () {
@@ -773,6 +800,22 @@ void main() {
         // Should match system timezone for milliseconds format
         final expectedLocalTime = DateTime.parse(input);
         expect(result.timeZoneOffset, expectedLocalTime.timeZoneOffset);
+      });
+
+      test('should accept lowercase t separator without timezone', () {
+        final result = OffsetDateTime.parse('2024-01-15t10:30:00');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00');
+
+        expect(result.year, 2024);
+        expect(result.month, 1);
+        expect(result.day, 15);
+        expect(result.hour, 10);
+        expect(result.minute, 30);
+        expect(result.second, 0);
+
+        final expectedLocalTime = DateTime.parse('2024-01-15T10:30:00');
+        expect(result.timeZoneOffset, expectedLocalTime.timeZoneOffset);
+        expect(result.isAtSameMomentAs(upper), isTrue);
       });
     });
 
@@ -851,6 +894,30 @@ void main() {
         expect(result.millisecond, 123);
         expect(result.microsecond, 456);
       });
+
+      test('should accept lowercase t separator with offset and colon', () {
+        final lower = OffsetDateTime.parse('2024-01-15t10:30:00+05:30');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00+05:30');
+
+        expect(lower.timeZoneName, 'UTC+05:30');
+        expect(lower.timeZoneOffset.inMinutes, 330);
+        expect(lower.hour, 10);
+        expect(lower.minute, 30);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
+
+      test('should accept lowercase t separator with offset without colon', () {
+        final lower = OffsetDateTime.parse('2024-01-15t10:30:00+0530');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00+0530');
+
+        expect(lower.timeZoneName, 'UTC+05:30');
+        expect(lower.timeZoneOffset.inMinutes, 330);
+        expect(lower.hour, 10);
+        expect(lower.minute, 30);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
     });
 
     group('error handling', () {
@@ -900,6 +967,20 @@ void main() {
           () => OffsetDateTime.parse('2023-12-25T15:30:45+05:60'),
           // Invalid minutes
           throwsA(isA<InvalidFormatException>()),
+        );
+      });
+
+      test('should not replace a non-separator lowercase t in malformed '
+          'input', () {
+        expect(
+          () => OffsetDateTime.parse('not a date'),
+          throwsA(
+            isA<InvalidFormatException>().having(
+              (e) => e.value,
+              'value',
+              'notTa date',
+            ),
+          ),
         );
       });
     });

--- a/packages/tonik_util/test/src/offset_date_time_test.dart
+++ b/packages/tonik_util/test/src/offset_date_time_test.dart
@@ -702,6 +702,25 @@ void main() {
         expect(result.timeZoneName, 'UTC');
       });
 
+      test('should parse compact basic form with lowercase t separator', () {
+        final lower = OffsetDateTime.parse('20240115t103000Z');
+        final upper = OffsetDateTime.parse('20240115T103000Z');
+
+        expect(lower.isUtc, isTrue);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
+
+      test('should accept lowercase t separator with fractional seconds', () {
+        final lower = OffsetDateTime.parse('2024-01-15t10:30:00.123Z');
+        final upper = OffsetDateTime.parse('2024-01-15T10:30:00.123Z');
+
+        expect(lower.isUtc, isTrue);
+        expect(lower.millisecond, 123);
+        expect(lower.isAtSameMomentAs(upper), isTrue);
+        expect(lower.millisecondsSinceEpoch, upper.millisecondsSinceEpoch);
+      });
+
       test('should parse UTC datetime with microseconds', () {
         // Arrange & Act
         const input = '2023-12-25T15:30:45.123456Z';


### PR DESCRIPTION
## Summary

`format: date-time` values using the RFC 3339 §5.6 lowercase `t` separator were rejected with `InvalidFormatException`, even though the standard explicitly permits it. `OffsetDateTime.parse` normalized only a space separator before delegating to Dart's `DateTime.parse`, whose grammar accepts the date/time separator solely as a space or an uppercase `T`.

RFC 3339 §5.6 states the `T` and `Z` characters may alternatively be lowercase `t` or `z`. OpenAPI defines `type: string, format: date-time` as an RFC 3339 `date-time`, so a conformant client must accept the lowercase forms.

| Input | RFC 3339 | Before | After |
|-------|----------|--------|-------|
| `2024-01-15T10:30:00Z` | valid | accepted | accepted |
| `2024-01-15t10:30:00Z` | valid (lowercase `t`) | **rejected** | accepted |
| `2024-01-15t10:30:00z` | valid (lowercase `t`+`z`) | **rejected** | accepted |

## Fix

Normalize a lowercase `t` that sits **between two digits** (the genuine date/time separator) to `T` before parsing:

```dart
final normalizedInput = input
    .replaceFirst(' ', 'T')
    .replaceFirst(RegExp(r'(?<=\d)t(?=\d)'), 'T');
```

The digit-bounded match is deliberate: matching a bare `t` would clobber non-separator characters in malformed input (e.g. the permissive default `"not a date"`). Lowercase `z` already decodes correctly via `DateTime.parse`, so this single change to the shared `parse` path fixes every generated `fromJson` / `fromSimple` / `fromForm` for date-time fields — request/response bodies, headers, path, query, and cookies.

## Tests

- Unit coverage for the lowercase `t` separator across all parse paths: `Z` suffix, lowercase `z` suffix, numeric offset (`+05:30` and `+0530`), and no-timezone local — each asserting the lowercase variant decodes to the same instant as the uppercase form.
- An adversarial case (`'not a date'`) locks in that the digit-bounded normalization does not corrupt non-separator characters in malformed input.
- All existing unit suites, the full integration suite, and 100% patch coverage pass.
