### PR TITLE
fix: accept whole-number double JSON values for integer fields

### DIFF
--- a/packages/tonik_util/lib/src/decoding/json_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/json_decoder.dart
@@ -132,41 +132,37 @@ extension JsonDecoder on Object? {
 
   /// Decodes a JSON value to an int.
   ///
+  /// `jsonDecode` yields a [double] for numbers written in fractional or
+  /// exponent form (e.g. `10.0`, `1e1`); such whole-number doubles denote an
+  /// integer and are accepted, matching JSON Schema's `integer` definition.
   /// Throws [InvalidTypeException] if the value is not a valid int or is null.
   int decodeJsonInt({String? context}) {
-    if (this == null) {
-      throw InvalidTypeException(
-        value: 'null',
-        targetType: int,
-        context: context,
-      );
+    final value = this;
+    if (value is int) {
+      return value;
     }
-    if (this is! int) {
-      throw InvalidTypeException(
-        value: toString(),
-        targetType: int,
-        context: context,
-      );
+    if (value is double &&
+        value.isFinite &&
+        value == value.truncateToDouble()) {
+      return value.toInt();
     }
-    return this! as int;
+    throw InvalidTypeException(
+      value: value == null ? 'null' : toString(),
+      targetType: int,
+      context: context,
+    );
   }
 
   /// Decodes a JSON value to a nullable int.
   ///
-  /// Returns null if the value is null or an empty string.
+  /// Returns null if the value is null.
+  /// Accepts whole-number doubles like [decodeJsonInt].
   /// Throws [InvalidTypeException] if the value is not a valid int.
   int? decodeJsonNullableInt({String? context}) {
     if (this == null) {
       return null;
     }
-    if (this is! int) {
-      throw InvalidTypeException(
-        value: toString(),
-        targetType: int,
-        context: context,
-      );
-    }
-    return this! as int;
+    return decodeJsonInt(context: context);
   }
 
   /// Decodes a JSON value to a num.

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -163,6 +163,70 @@ void main() {
           throwsA(isA<InvalidTypeException>()),
         );
       });
+
+      test('decodes whole-number double JSON values as int', () {
+        expect((10.0 as Object?).decodeJsonInt(), 10);
+        expect((1e1 as Object?).decodeJsonInt(), 10);
+        expect((-3.0 as Object?).decodeJsonInt(), -3);
+        expect((0.0 as Object?).decodeJsonInt(), 0);
+      });
+
+      test('decodes nullable whole-number double JSON values as int', () {
+        expect((10.0 as Object?).decodeJsonNullableInt(), 10);
+        expect((1e1 as Object?).decodeJsonNullableInt(), 10);
+        expect((-3.0 as Object?).decodeJsonNullableInt(), -3);
+        expect((0.0 as Object?).decodeJsonNullableInt(), 0);
+        expect(null.decodeJsonNullableInt(), isNull);
+      });
+
+      test('throws on fractional double', () {
+        expect(
+          () => (1.5 as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (1.5 as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws on non-finite double', () {
+        expect(
+          () => (double.nan as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (double.infinity as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (-double.infinity as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (double.nan as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (double.infinity as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (-double.infinity as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws on non-numeric types', () {
+        expect(
+          () => true.decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => true.decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
     });
 
     group('num', () {

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -150,7 +150,13 @@ void main() {
         );
         expect(
           () => null.decodeJsonInt(),
-          throwsA(isA<InvalidTypeException>()),
+          throwsA(
+            isA<InvalidTypeException>().having(
+              (e) => e.value,
+              'value',
+              'null',
+            ),
+          ),
         );
       });
 
@@ -179,14 +185,18 @@ void main() {
         expect(null.decodeJsonNullableInt(), isNull);
       });
 
-      test('throws on fractional double', () {
+      test('throws on fractional double carrying the source value', () {
         expect(
           () => (1.5 as Object?).decodeJsonInt(),
-          throwsA(isA<InvalidTypeException>()),
+          throwsA(
+            isA<InvalidTypeException>().having((e) => e.value, 'value', '1.5'),
+          ),
         );
         expect(
           () => (1.5 as Object?).decodeJsonNullableInt(),
-          throwsA(isA<InvalidTypeException>()),
+          throwsA(
+            isA<InvalidTypeException>().having((e) => e.value, 'value', '1.5'),
+          ),
         );
       });
 


### PR DESCRIPTION
## Summary

An `integer`-typed field rejected JSON numbers written in fractional or exponent form (`10.0`, `1e1`). `dart:convert`'s `jsonDecode` parses those tokens as Dart `double`, and `decodeJsonInt` gated strictly on `is int`, so a standard-conformant response carrying an integer value as `10.0` threw `InvalidTypeException`.

RFC 8259 has a single JSON `number` type, and JSON Schema (draft-06 through 2020-12, the dialect OAS 3.0/3.1 use) defines `integer` as any number with a zero fractional part — so `10.0` and `1e1` denote the integer `10` and must be accepted. Every `type: integer` property emits `decodeJsonInt`/`decodeJsonNullableInt`, so this affected all integer fields.

## Change

`decodeJsonInt` (and `decodeJsonNullableInt`, which now delegates to it) accept a finite `double` with a zero fractional part and convert it to `int`, mirroring how `decodeJsonNum`/`decodeJsonDouble` already tolerate any `num`. Genuinely fractional doubles (`1.5`), non-finite values (`NaN`, `±Infinity`), non-numeric types, and `null` (non-nullable) still throw `InvalidTypeException`.

The fix is confined to these two runtime methods in `tonik_util`; the generated call site is unchanged.

## Tests

Added unit tests in `json_decoder_test.dart` covering whole-number-double acceptance (`10.0`, `1e1`, `-3.0`, `0.0`) for both variants, `null` handling, and rejection of fractional, non-finite, and non-numeric inputs. Patch coverage 100%.
