### PR TITLE
fix: accept integer-valued JSON numbers in double and int lists

### DIFF
--- a/packages/tonik_util/lib/src/decoding/json_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/json_decoder.dart
@@ -246,7 +246,11 @@ extension JsonDecoder on Object? {
 
   /// Decodes a JSON value to a List of type [T].
   ///
-  /// Throws [InvalidTypeException] if the value is not a list or is null.
+  /// For `double` and `int` elements, JSON numbers are coerced the same way as
+  /// the scalar [decodeJsonDouble]/[decodeJsonInt] decoders: integer JSON
+  /// numbers satisfy a `double` list, and whole-number doubles satisfy an `int`
+  /// list. Throws [InvalidTypeException] if the value is not a list, is null,
+  /// or contains an element that cannot be coerced to [T].
   List<T> decodeJsonList<T>({String? context}) {
     if (this == null) {
       throw InvalidTypeException(
@@ -264,6 +268,21 @@ extension JsonDecoder on Object? {
     }
 
     final list = this! as List;
+
+    if (T == double) {
+      return [
+        for (final Object? element in list)
+          element.decodeJsonDouble(context: context) as T,
+      ];
+    }
+
+    if (T == int) {
+      return [
+        for (final Object? element in list)
+          element.decodeJsonInt(context: context) as T,
+      ];
+    }
+
     final mapped = list.whereType<T>();
 
     if (mapped.length != list.length) {

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -504,6 +504,86 @@ void main() {
       final json = jsonDecode('null') as Object?;
       expect(json.decodeJsonNullableList<int>(), isNull);
     });
+
+    test('decodes double list from integer-valued JSON numbers', () {
+      final json = jsonDecode('[1,2,3]') as Object?;
+      expect(json.decodeJsonList<double>(), [1.0, 2.0, 3.0]);
+    });
+
+    test('decodes double list mixing fractional and integer numbers', () {
+      final json = jsonDecode('[1.5,2]') as Object?;
+      expect(json.decodeJsonList<double>(), [1.5, 2.0]);
+    });
+
+    test('decodes double list of fractional numbers', () {
+      final json = jsonDecode('[1.0,2.0]') as Object?;
+      expect(json.decodeJsonList<double>(), [1.0, 2.0]);
+    });
+
+    test('throws for double list with a string element', () {
+      final json = jsonDecode('["x"]') as Object?;
+      expect(
+        () => json.decodeJsonList<double>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('throws for double list with a bool element', () {
+      final json = jsonDecode('[true]') as Object?;
+      expect(
+        () => json.decodeJsonList<double>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('throws for double list with a null element', () {
+      final json = jsonDecode('[null]') as Object?;
+      expect(
+        () => json.decodeJsonList<double>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('decodes int list from whole-number doubles', () {
+      final json = jsonDecode('[1,2.0]') as Object?;
+      expect(json.decodeJsonList<int>(), [1, 2]);
+    });
+
+    test('throws for int list with a fractional double', () {
+      final json = jsonDecode('[1.5]') as Object?;
+      expect(
+        () => json.decodeJsonList<int>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('throws for int list with a non-numeric element', () {
+      final json = jsonDecode('["x"]') as Object?;
+      expect(
+        () => json.decodeJsonList<int>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('decodes int list of integer-valued JSON numbers', () {
+      final json = jsonDecode('[1,2,3]') as Object?;
+      expect(json.decodeJsonList<int>(), [1, 2, 3]);
+    });
+
+    test('decodes nullable double list from integer-valued JSON numbers', () {
+      final json = jsonDecode('[1,2]') as Object?;
+      expect(json.decodeJsonNullableList<double>(), [1.0, 2.0]);
+    });
+
+    test('returns null for nullable double list of null', () {
+      final json = jsonDecode('null') as Object?;
+      expect(json.decodeJsonNullableList<double>(), isNull);
+    });
+
+    test('decodes nullable int list from whole-number doubles', () {
+      final json = jsonDecode('[1,2.0]') as Object?;
+      expect(json.decodeJsonNullableList<int>(), [1, 2]);
+    });
   });
 
   group('decodeMap', () {

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -565,6 +565,25 @@ void main() {
       );
     });
 
+    test('throws for int list with a non-finite double', () {
+      final json = <Object?>[double.infinity];
+      expect(
+        () => json.decodeJsonList<int>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('surfaces the offending element when a double list element is '
+        'invalid', () {
+      final json = jsonDecode('["x"]') as Object?;
+      expect(
+        () => json.decodeJsonList<double>(),
+        throwsA(
+          isA<InvalidTypeException>().having((e) => e.value, 'value', 'x'),
+        ),
+      );
+    });
+
     test('decodes int list of integer-valued JSON numbers', () {
       final json = jsonDecode('[1,2,3]') as Object?;
       expect(json.decodeJsonList<int>(), [1, 2, 3]);


### PR DESCRIPTION
## Summary

A `type: array` of `type: number, format: double` (or `float`) decoded via `decodeJsonList<double>()`, which used `whereType<double>()`. JSON integers like `[1, 2, 3]` are Dart `int`, not `double`, so every element was silently dropped, the length check failed, and decoding threw `InvalidTypeException` — even though RFC 8259 and JSON Schema treat `1` as a perfectly valid `number`/`double`. The `int` list path had the analogous problem with whole-number doubles such as `[1, 2.0]`.

The scalar decoders (`decodeJsonDouble`, `decodeJsonInt`) already coerce these correctly; only the list path was asymmetrically strict.

## Fix

`decodeJsonList<T>` now delegates per element to the existing scalar decoders for the numeric cases:

- `T == double` → `element.decodeJsonDouble(...)` (any JSON number coerces via `num.toDouble()`)
- `T == int` → `element.decodeJsonInt(...)` (accepts `int` and finite whole-number doubles; rejects fractional/non-finite)

All other element types (`String`, `bool`, nested `List`, `Map`, …) continue to use the unchanged `whereType<T>()` path. Reusing the scalar decoders keeps the list and scalar paths in sync and surfaces the offending element on failure instead of a misleading list-level length error.

## Behavior

| Input | Type | Before | After |
|-------|------|--------|-------|
| `[1, 2, 3]` | `List<double>` | throws | `[1.0, 2.0, 3.0]` |
| `[1.5, 2]` | `List<double>` | throws | `[1.5, 2.0]` |
| `[1, 2.0]` | `List<int>` | throws | `[1, 2]` |
| `[1.5]` | `List<int>` | throws | throws (unchanged) |
| `["x"]` / `[true]` / `[null]` | `List<double>`/`List<int>` | throws | throws (unchanged) |

## Tests

Behavioral unit tests added to `json_decoder_test.dart` covering integer-valued double lists, mixed fractional/integer, whole-number-double int lists, fractional/non-numeric rejection, and the nullable variants. All unit suites and 38 integration suites pass; patch coverage 100%.
