### PR TITLE
fix: encode delimited query array spaces as %20 for non-string items

### DIFF
--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -9,7 +9,7 @@ Tonik generates API clients that use Dart's standard `Uri` class for URL constru
 **Dart's `Uri` class always percent-encodes reserved characters in query strings according to RFC 3986.** This means:
 
 - Pipe characters (`|`) are always encoded as `%7C`
-- Space characters are always encoded as `%20`
+- Space characters are encoded as `%20` in the `spaceDelimited` and `pipeDelimited` styles
 - Other reserved characters (like `&`, `=`, `#`, etc.) are also percent-encoded
 
 This behavior is fundamental to Dart's URI handling and cannot be disabled or customized.

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -684,6 +684,18 @@ paths:
               oneOf:
                 - $ref: '#/components/schemas/Class'
                 - type: integer
+        - name: listEnum
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - high priority
+                - low priority
+                - urgent
       responses:
         '204':
           description: OK
@@ -1038,6 +1050,18 @@ paths:
               oneOf:
                 - $ref: '#/components/schemas/Class'
                 - type: integer
+        - name: listEnum
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - high priority
+                - low priority
+                - urgent
       responses:
         '204':
           description: OK

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -732,6 +732,18 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/OneOfComplex'
+        - name: listEnum
+          in: query
+          style: spaceDelimited
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - high priority
+                - low priority
+                - urgent
       responses:
         '204':
           description: OK
@@ -1098,6 +1110,18 @@ paths:
             type: array
             items:
               $ref: '#/components/schemas/OneOfComplex'
+        - name: listEnum
+          in: query
+          style: pipeDelimited
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - high priority
+                - low priority
+                - urgent
       responses:
         '204':
           description: OK

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -482,7 +482,7 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listNullableString=a+b%2Fc%7C%7Cd',
+        'listNullableString=a%20b%2Fc%7C%7Cd',
       );
     });
 

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -533,6 +533,24 @@ void main() {
         'listOneOfComplexMixed=3%7C4%7C5',
       );
     });
+
+    test('enum with internal space encodes as %20, not +', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedList(
+        listEnum: [
+          PipeDelimitedListParametersArrayModel.highPriority,
+          PipeDelimitedListParametersArrayModel.urgent,
+          PipeDelimitedListParametersArrayModel.lowPriority,
+        ],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listEnum=high%20priority%7Curgent%7Clow%20priority',
+      );
+      expect(success.response.requestOptions.uri.query, isNot(contains('+')));
+    });
   });
 
   group('list - explode true', () {

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -477,7 +477,7 @@ void main() {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testPipeDelimitedList(
         listOneOfPrimitive: [
-          const OneOfPrimitiveString('test'),
+          const OneOfPrimitiveString('white space'),
           const OneOfPrimitiveString('test2'),
         ],
       );
@@ -485,7 +485,7 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listOneOfPrimitive=test%7Ctest2',
+        'listOneOfPrimitive=white%20space%7Ctest2',
       );
     });
 
@@ -549,7 +549,6 @@ void main() {
         success.response.requestOptions.uri.query,
         'listEnum=high%20priority%7Curgent%7Clow%20priority',
       );
-      expect(success.response.requestOptions.uri.query, isNot(contains('+')));
     });
   });
 
@@ -570,13 +569,13 @@ void main() {
     test('oneOfPrimitive', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testPipeDelimitedListExplode(
-        listOneOfPrimitive: [const OneOfPrimitiveString('test')],
+        listOneOfPrimitive: [const OneOfPrimitiveString('white space')],
       );
       expect(response, isA<TonikSuccess<void>>());
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listOneOfPrimitive=test',
+        'listOneOfPrimitive=white%20space',
       );
     });
 
@@ -592,6 +591,23 @@ void main() {
       expect(response, isA<TonikError<void>>());
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
+    });
+
+    test('enum', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedListExplode(
+        listEnum: [
+          PipeDelimitedListExplodeParametersArrayModel.highPriority,
+          PipeDelimitedListExplodeParametersArrayModel.urgent,
+          PipeDelimitedListExplodeParametersArrayModel.lowPriority,
+        ],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listEnum=high%20priority&listEnum=urgent&listEnum=low%20priority',
+      );
     });
   });
 

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -534,7 +534,7 @@ void main() {
       );
     });
 
-    test('enum with internal space encodes as %20, not +', () async {
+    test('enum', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testPipeDelimitedList(
         listEnum: [

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -482,7 +482,7 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listNullableString=a+b%2Fc%20%20d',
+        'listNullableString=a%20b%2Fc%20%20d',
       );
     });
 

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -533,6 +533,24 @@ void main() {
         'listOneOfComplexMixed=3%204%205',
       );
     });
+
+    test('enum with internal space encodes as %20, not +', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedList(
+        listEnum: [
+          SpaceDelimitedListParametersArrayModel.highPriority,
+          SpaceDelimitedListParametersArrayModel.urgent,
+          SpaceDelimitedListParametersArrayModel.lowPriority,
+        ],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listEnum=high%20priority%20urgent%20low%20priority',
+      );
+      expect(success.response.requestOptions.uri.query, isNot(contains('+')));
+    });
   });
 
   group('list - explode true', () {

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -534,7 +534,7 @@ void main() {
       );
     });
 
-    test('enum with internal space encodes as %20, not +', () async {
+    test('enum', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testSpaceDelimitedList(
         listEnum: [

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -477,7 +477,7 @@ void main() {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testSpaceDelimitedList(
         listOneOfPrimitive: [
-          const OneOfPrimitiveString('test'),
+          const OneOfPrimitiveString('white space'),
           const OneOfPrimitiveString('test2'),
         ],
       );
@@ -485,7 +485,7 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listOneOfPrimitive=test%20test2',
+        'listOneOfPrimitive=white%20space%20test2',
       );
     });
 
@@ -549,7 +549,6 @@ void main() {
         success.response.requestOptions.uri.query,
         'listEnum=high%20priority%20urgent%20low%20priority',
       );
-      expect(success.response.requestOptions.uri.query, isNot(contains('+')));
     });
   });
 
@@ -570,13 +569,13 @@ void main() {
     test('oneOfPrimitive', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testSpaceDelimitedListExplode(
-        listOneOfPrimitive: [const OneOfPrimitiveString('test')],
+        listOneOfPrimitive: [const OneOfPrimitiveString('white space')],
       );
       expect(response, isA<TonikSuccess<void>>());
       final success = response as TonikSuccess<void>;
       expect(
         success.response.requestOptions.uri.query,
-        'listOneOfPrimitive=test',
+        'listOneOfPrimitive=white%20space',
       );
     });
 
@@ -592,6 +591,23 @@ void main() {
       expect(response, isA<TonikError<void>>());
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
+    });
+
+    test('enum', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedListExplode(
+        listEnum: [
+          SpaceDelimitedListExplodeParametersArrayModel.highPriority,
+          SpaceDelimitedListExplodeParametersArrayModel.urgent,
+          SpaceDelimitedListExplodeParametersArrayModel.lowPriority,
+        ],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listEnum=high%20priority&listEnum=urgent&listEnum=low%20priority',
+      );
     });
   });
 

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -93,8 +93,7 @@ List<Code> _buildDelimitedCode(
       explode,
       allowEmpty,
       needsMapping: true,
-      mapExpression:
-          'e.uriEncode(allowEmpty: $allowEmpty, useQueryComponent: true)',
+      mapExpression: 'e.uriEncode(allowEmpty: $allowEmpty)',
     ),
 
     AllOfModel() ||

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -1150,7 +1150,7 @@ void main() {
           );
           if (ids != null) {
             for (final value in ids
-                .map((e) => e.uriEncode(allowEmpty: true, useQueryComponent: true))
+                .map((e) => e.uriEncode(allowEmpty: true))
                 .toList()
                 .toSpaceDelimited(
               explode: false,
@@ -1161,7 +1161,7 @@ void main() {
             }
           }
           for (final value in categories
-              .map((e) => e.uriEncode(allowEmpty: true, useQueryComponent: true))
+              .map((e) => e.uriEncode(allowEmpty: true))
               .toList()
               .toPipeDelimited(
             explode: false,
@@ -1856,7 +1856,7 @@ void main() {
         String? _queryParameters({required List<AnonymousModel> $enum}) {
           final _$entries = <ParameterEntry>[];
           for (final value in $enum
-              .map((e) => e.uriEncode(allowEmpty: false, useQueryComponent: true))
+              .map((e) => e.uriEncode(allowEmpty: false))
               .toList()
               .toPipeDelimited(
                 explode: false,

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -54,6 +54,277 @@ void main() {
       );
     }
 
+    group('non-string primitive items encode spaces as %20', () {
+      EnumModel<String> stringEnum() => EnumModel<String>(
+        isDeprecated: false,
+        context: context,
+        values: {
+          const EnumEntry(value: 'high priority'),
+          const EnumEntry(value: 'low priority'),
+        },
+        isNullable: false,
+        examples: const [],
+      );
+
+      test('spaceDelimited enum list (non-explode) omits '
+          'useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'priorities',
+          rawName: 'priorities',
+          model: ListModel(
+            content: stringEnum(),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'priorities',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in priorities
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'priorities', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited enum list (explode) omits useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'priorities',
+          rawName: 'priorities',
+          model: ListModel(
+            content: stringEnum(),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'priorities',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+          explode: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in priorities
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: true,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'priorities', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited integer list (non-explode) omits '
+          'useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'ids',
+          rawName: 'ids',
+          model: ListModel(
+            content: IntegerModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'ids',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in ids
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'ids', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited enum list (non-explode) omits '
+          'useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'priorities',
+          rawName: 'priorities',
+          model: ListModel(
+            content: stringEnum(),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'priorities',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in priorities
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toPipeDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'priorities', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited enum list (explode) omits useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'priorities',
+          rawName: 'priorities',
+          model: ListModel(
+            content: stringEnum(),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'priorities',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          explode: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in priorities
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toPipeDelimited(
+                      explode: true,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'priorities', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited integer list (non-explode) omits '
+          'useQueryComponent', () {
+        final parameter = createParameter(
+          name: 'ids',
+          rawName: 'ids',
+          model: ListModel(
+            content: IntegerModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'ids',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(code, isNot(contains('useQueryComponent')));
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in ids
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toPipeDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'ids', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+    });
+
     group('special characters in rawName', () {
       test(
         'generates valid code when rawName contains single quote '

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -54,7 +54,7 @@ void main() {
       );
     }
 
-    group('non-string primitive items encode spaces as %20', () {
+    group('enum and integer list items', () {
       EnumModel<String> stringEnum() => EnumModel<String>(
         isDeprecated: false,
         context: context,
@@ -66,8 +66,7 @@ void main() {
         examples: const [],
       );
 
-      test('spaceDelimited enum list (non-explode) omits '
-          'useQueryComponent', () {
+      test('generates spaceDelimited enum list (non-explode)', () {
         final parameter = createParameter(
           name: 'priorities',
           rawName: 'priorities',
@@ -109,7 +108,7 @@ void main() {
         );
       });
 
-      test('spaceDelimited enum list (explode) omits useQueryComponent', () {
+      test('generates spaceDelimited enum list (explode)', () {
         final parameter = createParameter(
           name: 'priorities',
           rawName: 'priorities',
@@ -152,8 +151,7 @@ void main() {
         );
       });
 
-      test('spaceDelimited integer list (non-explode) omits '
-          'useQueryComponent', () {
+      test('generates spaceDelimited integer list (non-explode)', () {
         final parameter = createParameter(
           name: 'ids',
           rawName: 'ids',
@@ -195,8 +193,7 @@ void main() {
         );
       });
 
-      test('pipeDelimited enum list (non-explode) omits '
-          'useQueryComponent', () {
+      test('generates pipeDelimited enum list (non-explode)', () {
         final parameter = createParameter(
           name: 'priorities',
           rawName: 'priorities',
@@ -238,7 +235,7 @@ void main() {
         );
       });
 
-      test('pipeDelimited enum list (explode) omits useQueryComponent', () {
+      test('generates pipeDelimited enum list (explode)', () {
         final parameter = createParameter(
           name: 'priorities',
           rawName: 'priorities',
@@ -281,8 +278,7 @@ void main() {
         );
       });
 
-      test('pipeDelimited integer list (non-explode) omits '
-          'useQueryComponent', () {
+      test('generates pipeDelimited integer list (non-explode)', () {
         final parameter = createParameter(
           name: 'ids',
           rawName: 'ids',

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -86,7 +86,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
@@ -129,7 +128,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
@@ -171,7 +169,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
@@ -213,7 +210,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
@@ -256,7 +252,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
@@ -298,7 +293,6 @@ void main() {
         );
 
         final code = emitStatements(codes);
-        expect(code, isNot(contains('useQueryComponent')));
         expect(
           collapseWhitespace(code),
           collapseWhitespace(


### PR DESCRIPTION
## Summary

For `pipeDelimited`/`spaceDelimited` query array parameters, a space inside an item value was encoded as `+` instead of `%20` for every element type except plain strings. The non-string switch arm passed `useQueryComponent: true`, routing to `Uri.encodeQueryComponent` (space → `+`, the `application/x-www-form-urlencoded` convention) rather than `Uri.encodeComponent` (space → `%20`, the correct percent-encoding for a URI query value per RFC 3986 / RFC 6570).

A string-valued enum is the realistic trigger, since it is the only such type whose value can contain a space. The same `"high priority"` string was encoded as `high%20priority` when typed as a free string but `high+priority` when constrained by `enum` — an inconsistency this fix removes.

## Change

Drop `useQueryComponent: true` from the non-`StringModel` arm in `to_delimited_query_parameter_expression_generator.dart` so spaces encode as `%20`, matching the string arm. The legitimate form-urlencoded use of `useQueryComponent: true` for request bodies is untouched.

## Tests

- **Unit** (`tonik_generate`): full-method-body tests for enum and integer lists across spaceDelimited/pipeDelimited and explode false/true, each asserting the emitted body no longer carries `useQueryComponent`.
- **Integration** (`query_parameters`): a string-enum array with space-containing values; asserts the wire query encodes the internal space as `%20` (joined with `%7C` for pipe), with no `+`.

## Verification

- `fvm dart analyze packages/` and `fvm dart analyze integration_test`: clean
- All unit suites + query_parameters integration suite: pass
- Patch coverage: 100%
