### PR TITLE
fix: base64-encode byte parameters before percent-encoding

### DIFF
--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -1658,8 +1658,91 @@ paths:
         '204':
           description: OK
 
+  /form-byte-object:
+    get:
+      operationId: testFormByteObject
+      tags:
+        - query
+      summary: Test form-style object with a base64 property
+      description: >-
+        Demonstrates an object query parameter whose byte property is
+        base64-encoded then percent-encoded on the wire
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/Filter'
+      responses:
+        '204':
+          description: OK
+
+  /form-byte-composite:
+    get:
+      operationId: testFormByteComposite
+      tags:
+        - query
+      summary: Test form-style composite lists with a base64 member
+      description: >-
+        Demonstrates anyOf, oneOf and allOf list query parameters whose byte
+        member is base64-encoded then percent-encoded on the wire
+      parameters:
+        - name: anyOfByte
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/AnyOfByte'
+        - name: oneOfByte
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/OneOfByte'
+        - name: allOfByte
+          in: query
+          style: form
+          explode: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/AllOfByte'
+      responses:
+        '204':
+          description: OK
+
 components:
   schemas:
+    Filter:
+      type: object
+      required:
+        - signature
+      properties:
+        signature:
+          type: string
+          format: byte
+        label:
+          type: string
+    AnyOfByte:
+      anyOf:
+        - type: string
+          format: byte
+        - type: integer
+    OneOfByte:
+      oneOf:
+        - type: string
+          format: byte
+        - type: integer
+    AllOfByte:
+      allOf:
+        - type: string
+          format: byte
     Class:
       type: object
       required:

--- a/integration_test/query_parameters/query_parameters_test/test/byte_composite_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/byte_composite_test.dart
@@ -1,0 +1,120 @@
+import 'package:dio/dio.dart';
+import 'package:query_parameters_api/query_parameters_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('anyOf byte member', () {
+    test('base64-encodes byte member then percent-encodes on the wire',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormByteComposite(
+        anyOfByte: const [
+          AnyOfByte(tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF])),
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyOfByte=3q2%2B7w%3D%3D',
+      );
+    });
+
+    test('decoder round-trips the encoder output', () {
+      const value = AnyOfByte(
+        tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
+      );
+
+      final wire = value.uriEncode(allowEmpty: false);
+      final decoded = AnyOfByte.fromSimple(wire, explode: true);
+
+      expect(decoded.tonikFile?.toBytes(), [0xDE, 0xAD, 0xBE, 0xEF]);
+    });
+  });
+
+  group('oneOf byte member', () {
+    test('base64-encodes byte member then percent-encodes on the wire',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormByteComposite(
+        oneOfByte: const <OneOfByte>[
+          OneOfByteBase64(TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF])),
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'oneOfByte=3q2%2B7w%3D%3D',
+      );
+    });
+
+    test('decoder round-trips the encoder output', () {
+      const value = OneOfByteBase64(TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]));
+
+      final wire = value.uriEncode(allowEmpty: false);
+      final decoded = OneOfByte.fromSimple(wire, explode: true);
+
+      expect(decoded, isA<OneOfByteBase64>());
+      expect(
+        (decoded as OneOfByteBase64).value.toBytes(),
+        [0xDE, 0xAD, 0xBE, 0xEF],
+      );
+    });
+  });
+
+  group('allOf byte member', () {
+    test('base64-encodes byte member then percent-encodes on the wire',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormByteComposite(
+        allOfByte: const [
+          AllOfByte(tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF])),
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'allOfByte=3q2%2B7w%3D%3D',
+      );
+    });
+
+    test('decoder round-trips the encoder output', () {
+      const value = AllOfByte(
+        tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
+      );
+
+      final wire = value.uriEncode(allowEmpty: false);
+      final decoded = AllOfByte.fromSimple(wire, explode: true);
+
+      expect(decoded.tonikFile.toBytes(), [0xDE, 0xAD, 0xBE, 0xEF]);
+    });
+  });
+}

--- a/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
@@ -1,0 +1,64 @@
+import 'package:dio/dio.dart';
+import 'package:query_parameters_api/query_parameters_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('form object with byte property', () {
+    test('base64-encodes byte property then percent-encodes on the wire',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormByteObject(
+        filter: const Filter(
+          signature: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
+        ),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'signature=3q2%2B7w%3D%3D',
+      );
+    });
+
+    test('decoder round-trips the encoder output for a byte property', () {
+      const filter = Filter(
+        signature: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
+        label: 'release',
+      );
+
+      final encoded = filter.parameterProperties();
+      final wire = [
+        for (final entry in encoded.entries)
+          '${entry.key}=${entry.value}',
+      ].join('&');
+
+      final decoded = Filter.fromForm(wire, explode: true);
+      expect(decoded.signature.toBytes(), [0xDE, 0xAD, 0xBE, 0xEF]);
+      expect(decoded.label, 'release');
+    });
+  });
+}

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -24,6 +24,7 @@ import 'package:tonik_generate/src/util/to_label_parameter_expression_generator.
 import 'package:tonik_generate/src/util/to_matrix_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_simple_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 /// A generator for creating Dart classes from allOf model definitions.
@@ -1440,9 +1441,10 @@ class AllOfGenerator {
     if (ap is TypedAdditionalProperties &&
         ap.valueModel.encodingShape == EncodingShape.simple) {
       final uriEncodeCall = ap.valueModel.isEffectivelyNullable
-          ? r'_$e.value?.uriEncode(allowEmpty: allowEmpty) '
-                "?? ''"
-          : r'_$e.value.uriEncode(allowEmpty: allowEmpty)';
+          ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
+                ".uriEncode(allowEmpty: allowEmpty) ?? ''"
+          : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
+                '.uriEncode(allowEmpty: allowEmpty)';
       return [
         Code('''
 for (final _\$e in $apFieldName.entries) {
@@ -1707,6 +1709,34 @@ for (final _\$e in $apFieldName.entries) {
     final primarySimpleReceiver = isPrimaryFieldNullable
         ? refer(primaryField.normalizedName).nullChecked
         : refer(primaryField.normalizedName);
+    final primaryResolved = primaryField.property.model.resolved;
+
+    final Code simpleBody;
+    if (primaryResolved is Base64Model) {
+      simpleBody = primarySimpleReceiver
+          .property('toBase64String')
+          .call([])
+          .property('toSimple')
+          .call([], {
+            'explode': refer('explode'),
+            'allowEmpty': refer('allowEmpty'),
+          })
+          .returned
+          .statement;
+    } else if (primaryResolved is BinaryModel) {
+      simpleBody = generateEncodingExceptionExpression(
+        'Binary data cannot be simple-encoded',
+      ).statement;
+    } else {
+      simpleBody = primarySimpleReceiver
+          .property('toSimple')
+          .call([], {
+            'explode': refer('explode'),
+            'allowEmpty': refer('allowEmpty'),
+          })
+          .returned
+          .statement;
+    }
 
     return Method(
       (b) => b
@@ -1715,16 +1745,7 @@ for (final _\$e in $apFieldName.entries) {
         ..returns = refer('String', 'dart:core')
         ..optionalParameters.addAll(buildEncodingParameters())
         ..lambda = false
-        ..body = Block.of([
-          primarySimpleReceiver
-              .property('toSimple')
-              .call([], {
-                'explode': refer('explode'),
-                'allowEmpty': refer('allowEmpty'),
-              })
-              .returned
-              .statement,
-        ]),
+        ..body = Block.of([simpleBody]),
     );
   }
 
@@ -1790,6 +1811,22 @@ for (final _\$e in $apFieldName.entries) {
         if (entries != null) return entries;
         return generateEncodingExceptionExpression(
           'Lists with complex content are not supported for encoding',
+        );
+      }
+      if (resolved is Base64Model) {
+        return receiver
+            .property('toBase64String')
+            .call([])
+            .property('toForm')
+            .call([refer('paramName')], {
+              'explode': refer('explode'),
+              'allowEmpty': refer('allowEmpty'),
+              'useQueryComponent': refer('useQueryComponent'),
+            });
+      }
+      if (resolved is BinaryModel) {
+        return generateEncodingExceptionExpression(
+          'Binary data cannot be form-encoded',
         );
       }
       return receiver.property('toForm').call([refer('paramName')], {
@@ -2194,6 +2231,34 @@ for (final _\$e in $apFieldName.entries) {
     final primaryLabelReceiver = isPrimaryFieldNullable
         ? refer(primaryField.normalizedName).nullChecked
         : refer(primaryField.normalizedName);
+    final primaryResolved = primaryField.property.model.resolved;
+
+    final Code labelBody;
+    if (primaryResolved is Base64Model) {
+      labelBody = primaryLabelReceiver
+          .property('toBase64String')
+          .call([])
+          .property('toLabel')
+          .call([], {
+            'explode': refer('explode'),
+            'allowEmpty': refer('allowEmpty'),
+          })
+          .returned
+          .statement;
+    } else if (primaryResolved is BinaryModel) {
+      labelBody = generateEncodingExceptionExpression(
+        'Binary data cannot be label-encoded',
+      ).statement;
+    } else {
+      labelBody = primaryLabelReceiver
+          .property('toLabel')
+          .call([], {
+            'explode': refer('explode'),
+            'allowEmpty': refer('allowEmpty'),
+          })
+          .returned
+          .statement;
+    }
 
     return Method(
       (b) => b
@@ -2202,14 +2267,7 @@ for (final _\$e in $apFieldName.entries) {
         ..returns = refer('String', 'dart:core')
         ..optionalParameters.addAll(buildEncodingParameters())
         ..lambda = false
-        ..body = primaryLabelReceiver
-            .property('toLabel')
-            .call([], {
-              'explode': refer('explode'),
-              'allowEmpty': refer('allowEmpty'),
-            })
-            .returned
-            .statement,
+        ..body = labelBody,
     );
   }
 
@@ -2556,7 +2614,7 @@ for (final _\$e in $apFieldName.entries) {
             ? refer(simpleProp.normalizedName).nullChecked
             : refer(simpleProp.normalizedName);
         bodyCode.add(
-          receiver
+          uriEncodeReceiverExpression(simpleProp.property.model, receiver)
               .property('uriEncode')
               .call([], {
                 'allowEmpty': refer('allowEmpty'),
@@ -2681,10 +2739,12 @@ for (final _\$e in $apFieldName.entries) {
         if (isNullable) Code('if (${prop.normalizedName} != null) {'),
         declareFinal('_\$${prop.normalizedName}Encoded')
             .assign(
-              receiver.property('uriEncode').call([], {
-                'allowEmpty': refer('allowEmpty'),
-                'useQueryComponent': refer('useQueryComponent'),
-              }),
+              uriEncodeReceiverExpression(prop.property.model, receiver)
+                  .property('uriEncode')
+                  .call([], {
+                    'allowEmpty': refer('allowEmpty'),
+                    'useQueryComponent': refer('useQueryComponent'),
+                  }),
             )
             .statement,
         refer(r'_$values').property('add').call([

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -23,6 +23,7 @@ import 'package:tonik_generate/src/util/to_label_parameter_expression_generator.
 import 'package:tonik_generate/src/util/to_matrix_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_simple_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 @immutable
@@ -2362,11 +2363,13 @@ class AnyOfGenerator {
           ..add(const Code('}'));
       } else {
         // Simple or mixed types can call uriEncode
+        final receiver = uriEncodeReceiver(propertyModel, '$name!');
         body
           ..add(Code('if ($name != null) {'))
           ..add(
             Code(
-              '''return $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);''',
+              'return $receiver.uriEncode(allowEmpty: allowEmpty, '
+              'useQueryComponent: useQueryComponent);',
             ),
           )
           ..add(const Code('}'));

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1225,9 +1225,11 @@ class ClassGenerator {
     if (ap is TypedAdditionalProperties &&
         ap.valueModel.encodingShape == EncodingShape.simple) {
       final uriEncodeCall = ap.valueModel.isEffectivelyNullable
-          ? r'_$e.value?.uriEncode(allowEmpty: allowEmpty, '
+          ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
+                '.uriEncode(allowEmpty: allowEmpty, '
                 "useQueryComponent: useQueryComponent) ?? ''"
-          : r'_$e.value.uriEncode(allowEmpty: allowEmpty, '
+          : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
+                '.uriEncode(allowEmpty: allowEmpty, '
                 'useQueryComponent: useQueryComponent)';
       return [
         Code('''
@@ -1325,8 +1327,18 @@ for (final _\$e in $apFieldName.entries) {
         continue;
       }
 
-      if (isRequired && !isNullable) {
-        if (isFieldNullable) {
+      if (isRequired && !isNullable && !isFieldNullable) {
+        propertyAssignments.add(
+          Code(
+            '_\$result[${specLiteralStringCode(propertyName)}] = '
+            '${uriEncodeReceiver(model, name)}.uriEncode('
+            'allowEmpty: allowEmpty, '
+            'useQueryComponent: useQueryComponent);',
+          ),
+        );
+      } else {
+        final checkedReceiver = uriEncodeReceiver(model, '$name!');
+        if (isRequired && !isNullable) {
           propertyAssignments
             ..add(Code('if ($name == null) {'))
             ..add(
@@ -1339,37 +1351,20 @@ for (final _\$e in $apFieldName.entries) {
             ..add(
               Code(
                 '_\$result[${specLiteralStringCode(propertyName)}] = '
-                '$name!.uriEncode(allowEmpty: allowEmpty, '
+                '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
                 'useQueryComponent: useQueryComponent);',
               ),
             );
         } else {
           propertyAssignments.add(
-            Code(
-              '_\$result[${specLiteralStringCode(propertyName)}] = '
-              '$name.uriEncode(allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent);',
-            ),
+            Code('''
+if ($name != null) {
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+} else if (allowEmpty) {
+  _\$result[${specLiteralStringCode(propertyName)}] = '';
+}'''),
           );
         }
-      } else if (isRequired && isNullable) {
-        propertyAssignments.add(
-          Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-        );
-      } else {
-        propertyAssignments.add(
-          Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-        );
       }
     }
 
@@ -1435,8 +1430,18 @@ if ($name != null) {
       final isFieldNullable = isNullable || prop.property.isWriteOnly;
 
       if (fieldModel.encodingShape == EncodingShape.simple) {
-        if (isRequired && !isNullable) {
-          if (isFieldNullable) {
+        if (isRequired && !isNullable && !isFieldNullable) {
+          propertyAssignments.add(
+            Code(
+              '_\$result[${specLiteralStringCode(propertyName)}] = '
+              '${uriEncodeReceiver(fieldModel, name)}.uriEncode('
+              'allowEmpty: allowEmpty, '
+              'useQueryComponent: useQueryComponent);',
+            ),
+          );
+        } else {
+          final checkedReceiver = uriEncodeReceiver(fieldModel, '$name!');
+          if (isRequired && !isNullable) {
             propertyAssignments
               ..add(Code('if ($name == null) {'))
               ..add(
@@ -1449,28 +1454,20 @@ if ($name != null) {
               ..add(
                 Code(
                   '_\$result[${specLiteralStringCode(propertyName)}] = '
-                  '$name!.uriEncode(allowEmpty: allowEmpty, '
+                  '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
                   'useQueryComponent: useQueryComponent);',
                 ),
               );
           } else {
             propertyAssignments.add(
-              Code(
-                '_\$result[${specLiteralStringCode(propertyName)}] = '
-                '$name.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent);',
-              ),
-            );
-          }
-        } else {
-          propertyAssignments.add(
-            Code('''
+              Code('''
 if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
 } else if (allowEmpty) {
   _\$result[${specLiteralStringCode(propertyName)}] = '';
 }'''),
-          );
+            );
+          }
         }
       } else if (fieldModel is ListModel && fieldModel.hasSimpleContent) {
         final valueRef = (isRequired && !isNullable)
@@ -1601,8 +1598,18 @@ if ($name != null) {
       }
 
       if (model.encodingShape == .simple) {
-        if (isRequired && !isNullable) {
-          if (isFieldNullable) {
+        if (isRequired && !isNullable && !isFieldNullable) {
+          propertyAssignments.add(
+            Code(
+              '_\$result[${specLiteralStringCode(propertyName)}] = '
+              '${uriEncodeReceiver(model, name)}.uriEncode('
+              'allowEmpty: allowEmpty, '
+              'useQueryComponent: useQueryComponent);',
+            ),
+          );
+        } else {
+          final checkedReceiver = uriEncodeReceiver(model, '$name!');
+          if (isRequired && !isNullable) {
             propertyAssignments
               ..add(Code('if ($name == null) {'))
               ..add(
@@ -1615,37 +1622,20 @@ if ($name != null) {
               ..add(
                 Code(
                   '_\$result[${specLiteralStringCode(propertyName)}] = '
-                  '$name!.uriEncode(allowEmpty: allowEmpty, '
+                  '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
                   'useQueryComponent: useQueryComponent);',
                 ),
               );
           } else {
             propertyAssignments.add(
-              Code(
-                '_\$result[${specLiteralStringCode(propertyName)}] = '
-                '$name.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent);',
-              ),
+              Code('''
+if ($name != null) {
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+} else if (allowEmpty) {
+  _\$result[${specLiteralStringCode(propertyName)}] = '';
+}'''),
             );
           }
-        } else if (isRequired && isNullable) {
-          propertyAssignments.add(
-            Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-          );
-        } else {
-          propertyAssignments.add(
-            Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $name!.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-          );
         }
       } else {
         final isFieldNullable = isNullable || !isRequired;

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -21,6 +21,7 @@ import 'package:tonik_generate/src/util/to_label_parameter_expression_generator.
 import 'package:tonik_generate/src/util/to_matrix_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_simple_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 /// A generator for creating sealed Dart classes from OneOf model definitions.
@@ -1877,10 +1878,13 @@ class OneOfGenerator {
         }
 
         caseCodes.addAll([
-          refer('value').property('uriEncode').call([], {
-            'allowEmpty': refer('allowEmpty'),
-            'useQueryComponent': refer('useQueryComponent'),
-          }).code,
+          uriEncodeReceiverExpression(modelType, refer('value'))
+              .property('uriEncode')
+              .call([], {
+                'allowEmpty': refer('allowEmpty'),
+                'useQueryComponent': refer('useQueryComponent'),
+              })
+              .code,
           const Code(','),
         ]);
       }

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -22,6 +22,21 @@ BuiltExpression buildUriEncodeExpression(
   );
 }
 
+/// Adapts [receiver] for a `.uriEncode()` call. A `format: byte`
+/// ([Base64Model]) value is percent-encoded from its base64 text, not its raw
+/// bytes, so it is converted with `.toBase64String()` first.
+String uriEncodeReceiver(Model model, String receiver) =>
+    model.resolved is Base64Model ? '$receiver.toBase64String()' : receiver;
+
+/// Adapts [receiver] for a `.uriEncode()` call, building a code_builder
+/// [Expression]. A `format: byte` ([Base64Model]) value is percent-encoded
+/// from its base64 text, not its raw bytes, so it is converted with
+/// `.toBase64String()` first.
+Expression uriEncodeReceiverExpression(Model model, Expression receiver) =>
+    model.resolved is Base64Model
+    ? receiver.property('toBase64String').call([])
+    : receiver;
+
 Expression _buildUriEncodeExpression(
   Expression valueExpression,
   Model model, {
@@ -41,13 +56,17 @@ Expression _buildUriEncodeExpression(
     NumberModel() ||
     BinaryModel() ||
     Base64Model() ||
-    EnumModel() => valueExpression.property('uriEncode').call(
-      [],
-      {
-        'allowEmpty': allowEmpty,
-        'useQueryComponent': ?useQueryComponent,
-      },
-    ),
+    EnumModel() =>
+      uriEncodeReceiverExpression(
+        model,
+        valueExpression,
+      ).property('uriEncode').call(
+        [],
+        {
+          'allowEmpty': allowEmpty,
+          'useQueryComponent': ?useQueryComponent,
+        },
+      ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
       refer(
         'encodeAnyToUri',

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -22,16 +22,15 @@ BuiltExpression buildUriEncodeExpression(
   );
 }
 
-/// Adapts [receiver] for a `.uriEncode()` call. A `format: byte`
-/// ([Base64Model]) value is percent-encoded from its base64 text, not its raw
-/// bytes, so it is converted with `.toBase64String()` first.
+/// A `format: byte` ([Base64Model]) value is percent-encoded from its base64
+/// text, not its raw bytes, so [receiver] is converted with `.toBase64String()`
+/// before `.uriEncode()`.
 String uriEncodeReceiver(Model model, String receiver) =>
     model.resolved is Base64Model ? '$receiver.toBase64String()' : receiver;
 
-/// Adapts [receiver] for a `.uriEncode()` call, building a code_builder
-/// [Expression]. A `format: byte` ([Base64Model]) value is percent-encoded
-/// from its base64 text, not its raw bytes, so it is converted with
-/// `.toBase64String()` first.
+/// A `format: byte` ([Base64Model]) value is percent-encoded from its base64
+/// text, not its raw bytes, so [receiver] is converted with `.toBase64String()`
+/// before `.uriEncode()`.
 Expression uriEncodeReceiverExpression(Model model, Expression receiver) =>
     model.resolved is Base64Model
     ? receiver.property('toBase64String').call([])

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -2509,6 +2509,294 @@ void main() {
         );
       },
     );
+
+    test(
+      'base64-encodes byte property before uriEncode',
+      () {
+        final byteAlias = AliasModel(
+          name: 'Signature',
+          model: Base64Model(context: context),
+          context: context,
+          isNullable: true,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'AllOfNullableByte',
+          models: {byteAlias},
+          context: context,
+          examples: const [],
+        );
+
+        nameManager.prime(
+          models: {model, byteAlias},
+          requestBodies: const <RequestBody>[],
+          responses: const <Response>[],
+          operations: const <Operation>[],
+          tags: const <Tag>[],
+          servers: const <Server>[],
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final generated = format(combinedClass.accept(emitter).toString());
+
+        const expectedUriEncode = r'''
+          @override
+          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+            final _$values = <String>{};
+            if (signature != null) {
+              final _$signatureEncoded = signature!.toBase64String().uriEncode(
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+              );
+              _$values.add(_$signatureEncoded);
+            }
+            if (_$values.length > 1) {
+              throw EncodingException(
+                r'Inconsistent allOf encoding for AllOfNullableByte: all values must encode to the same result',
+              );
+            }
+            if (_$values.isEmpty) {
+              throw EncodingException(
+                r'Cannot encode AllOfNullableByte to encoding: all properties are null',
+              );
+            }
+            return _$values.first;
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedUriEncode)),
+        );
+      },
+    );
+  });
+
+  group('byte member parameter styles', () {
+    AllOfModel byteModel() {
+      final byteAlias = AliasModel(
+        name: 'Signature',
+        model: Base64Model(context: context),
+        context: context,
+        isNullable: true,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = AllOfModel(
+        isDeprecated: false,
+        name: 'AllOfByte',
+        models: {byteAlias},
+        context: context,
+        examples: const [],
+      );
+      nameManager.prime(
+        models: {model, byteAlias},
+        requestBodies: const <RequestBody>[],
+        responses: const <Response>[],
+        operations: const <Operation>[],
+        tags: const <Tag>[],
+        servers: const <Server>[],
+      );
+      return model;
+    }
+
+    AllOfModel binaryModel() {
+      final model = AllOfModel(
+        isDeprecated: false,
+        name: 'AllOfBinary',
+        models: {BinaryModel(context: context)},
+        context: context,
+        examples: const [],
+      );
+      nameManager.prime(
+        models: {model},
+        requestBodies: const <RequestBody>[],
+        responses: const <Response>[],
+        operations: const <Operation>[],
+        tags: const <Tag>[],
+        servers: const <Server>[],
+      );
+      return model;
+    }
+
+    String methodSource(AllOfModel model, String methodName) {
+      final klass = generator.generateClass(model);
+      final method = klass.methods.firstWhere((m) => m.name == methodName);
+      return format(method.accept(emitter).toString());
+    }
+
+    test('toSimple base64-encodes byte member', () {
+      const expected = '''
+@override
+String toSimple({required bool explode, required bool allowEmpty}) {
+  return signature!.toBase64String().toSimple(
+    explode: explode,
+    allowEmpty: allowEmpty,
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(byteModel(), 'toSimple')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toForm base64-encodes byte member', () {
+      const expected = '''
+@override
+List<ParameterEntry> toForm(
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+  bool useQueryComponent = false,
+}) {
+  return signature!.toBase64String().toForm(
+    paramName,
+    explode: explode,
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(byteModel(), 'toForm')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toLabel base64-encodes byte member', () {
+      const expected = '''
+@override
+String toLabel({required bool explode, required bool allowEmpty}) {
+  return signature!.toBase64String().toLabel(
+    explode: explode,
+    allowEmpty: allowEmpty,
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(byteModel(), 'toLabel')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toMatrix base64-encodes byte member', () {
+      const expected = r'''
+@override
+String toMatrix(
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+}) {
+  final _$values = <String>{};
+  if (signature != null) {
+    final _$signatureMatrix = signature!.toBase64String().toMatrix(
+      paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+    );
+    _$values.add(_$signatureMatrix);
+  }
+  if (_$values.length > 1) {
+    throw EncodingException(
+      r'Inconsistent allOf matrix encoding for AllOfByte: all values must encode to the same result',
+    );
+  }
+  if (_$values.isEmpty) {
+    throw EncodingException(
+      r'Cannot encode AllOfByte to encoding: all properties are null',
+    );
+  }
+  return _$values.first;
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(byteModel(), 'toMatrix')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toSimple throws for binary member', () {
+      const expected = '''
+@override
+String toSimple({required bool explode, required bool allowEmpty}) {
+  throw EncodingException('Binary data cannot be simple-encoded');
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(binaryModel(), 'toSimple')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toForm throws for binary member', () {
+      const expected = '''
+@override
+List<ParameterEntry> toForm(
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+  bool useQueryComponent = false,
+}) {
+  return throw EncodingException('Binary data cannot be form-encoded');
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(binaryModel(), 'toForm')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toLabel throws for binary member', () {
+      const expected = '''
+@override
+String toLabel({required bool explode, required bool allowEmpty}) {
+  throw EncodingException('Binary data cannot be label-encoded');
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(binaryModel(), 'toLabel')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('toMatrix throws for binary member', () {
+      const expected = r'''
+@override
+String toMatrix(
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+}) {
+  final _$values = <String>{};
+  final _$tonikFileMatrix = throw EncodingException(
+    'Binary data cannot be matrix-encoded',
+  );
+  _$values.add(_$tonikFileMatrix);
+  if (_$values.length > 1) {
+    throw EncodingException(
+      r'Inconsistent allOf matrix encoding for AllOfBinary: all values must encode to the same result',
+    );
+  }
+  return _$values.first;
+}
+''';
+
+      expect(
+        collapseWhitespace(methodSource(binaryModel(), 'toMatrix')),
+        collapseWhitespace(format(expected)),
+      );
+    });
   });
 
   group('toForm', () {
@@ -3899,6 +4187,142 @@ class Holder {
     );
     for (final _$e in additionalProperties.entries) {
       _$mergedProperties[_$e.key] = _$e.value.uriEncode(allowEmpty: allowEmpty);
+    }
+    return _$mergedProperties;
+  }''';
+
+          final combinedClass = generator.generateClass(model);
+          expect(
+            collapseWhitespace(
+              format(combinedClass.accept(emitter).toString()),
+            ),
+            contains(collapseWhitespace(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'base64-encodes typed byte additionalProperties values before '
+        'uriEncode',
+        () {
+          final model = AllOfModel(
+            isDeprecated: false,
+            name: 'TypedByteExtended',
+            models: {
+              ClassModel(
+                isDeprecated: false,
+                name: 'Base',
+                context: context,
+                properties: [
+                  Property(
+                    name: 'name',
+                    model: StringModel(context: context),
+                    isRequired: true,
+                    isNullable: false,
+                    isDeprecated: false,
+                    examples: const [],
+                    defaultValue: null,
+                  ),
+                ],
+                examples: const [],
+              ),
+            },
+            context: context,
+            additionalProperties: TypedAdditionalProperties(
+              valueModel: Base64Model(context: context),
+            ),
+            examples: const [],
+          );
+
+          const expectedMethod = r'''
+  Map<String, String> parameterProperties({
+    bool allowEmpty = true,
+    bool allowLists = true,
+  }) {
+    final _$mergedProperties = <String, String>{};
+    _$mergedProperties.addAll(
+      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+    );
+    for (final _$e in additionalProperties.entries) {
+      _$mergedProperties[_$e.key] = _$e.value.toBase64String().uriEncode(
+        allowEmpty: allowEmpty,
+      );
+    }
+    return _$mergedProperties;
+  }''';
+
+          final combinedClass = generator.generateClass(model);
+          expect(
+            collapseWhitespace(
+              format(combinedClass.accept(emitter).toString()),
+            ),
+            contains(collapseWhitespace(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'base64-encodes nullable typed byte additionalProperties values',
+        () {
+          final nullableByte = AliasModel(
+            name: 'NullableSignature',
+            model: Base64Model(context: context),
+            context: context,
+            isNullable: true,
+            examples: const [],
+            defaultValue: null,
+          );
+
+          final model = AllOfModel(
+            isDeprecated: false,
+            name: 'NullableByteExtended',
+            models: {
+              ClassModel(
+                isDeprecated: false,
+                name: 'Base',
+                context: context,
+                properties: [
+                  Property(
+                    name: 'name',
+                    model: StringModel(context: context),
+                    isRequired: true,
+                    isNullable: false,
+                    isDeprecated: false,
+                    examples: const [],
+                    defaultValue: null,
+                  ),
+                ],
+                examples: const [],
+              ),
+            },
+            context: context,
+            additionalProperties: TypedAdditionalProperties(
+              valueModel: nullableByte,
+            ),
+            examples: const [],
+          );
+
+          nameManager.prime(
+            models: {model, nullableByte},
+            requestBodies: const <RequestBody>[],
+            responses: const <Response>[],
+            operations: const <Operation>[],
+            tags: const <Tag>[],
+            servers: const <Server>[],
+          );
+
+          const expectedMethod = r'''
+  Map<String, String> parameterProperties({
+    bool allowEmpty = true,
+    bool allowLists = true,
+  }) {
+    final _$mergedProperties = <String, String>{};
+    _$mergedProperties.addAll(
+      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+    );
+    for (final _$e in additionalProperties.entries) {
+      _$mergedProperties[_$e.key] =
+          _$e.value?.toBase64String().uriEncode(allowEmpty: allowEmpty) ?? '';
     }
     return _$mergedProperties;
   }''';

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -2573,6 +2573,83 @@ void main() {
         );
       },
     );
+
+    test(
+      'base64-encodes byte property in dynamic-shape uriEncode',
+      () {
+        final byteAlias = AliasModel(
+          name: 'Signature',
+          model: Base64Model(context: context),
+          context: context,
+          isNullable: true,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final statusOneOf = OneOfModel(
+          isDeprecated: false,
+          name: 'Status',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (
+              discriminatorValue: null,
+              model: ClassModel(
+                isDeprecated: false,
+                name: 'State',
+                properties: const [],
+                context: context,
+                examples: const [],
+              ),
+            ),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'DynamicByte',
+          models: {byteAlias, statusOneOf},
+          context: context,
+          examples: const [],
+        );
+
+        nameManager.prime(
+          models: {model, byteAlias, statusOneOf},
+          requestBodies: const <RequestBody>[],
+          responses: const <Response>[],
+          operations: const <Operation>[],
+          tags: const <Tag>[],
+          servers: const <Server>[],
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final method = combinedClass.methods.firstWhere(
+          (m) => m.name == 'uriEncode',
+        );
+        final methodCode = format(method.accept(emitter).toString());
+
+        const expectedUriEncode = '''
+@override
+String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  if (currentEncodingShape != EncodingShape.simple) {
+    throw EncodingException(
+      r'Cannot uriEncode DynamicByte: contains complex types',
+    );
+  }
+  return signature!.toBase64String().uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+}
+''';
+
+        expect(
+          collapseWhitespace(methodCode),
+          collapseWhitespace(format(expectedUriEncode)),
+        );
+      },
+    );
   });
 
   group('byte member parameter styles', () {

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -3274,6 +3274,66 @@ String toLabel({required bool explode, required bool allowEmpty}) {
         expect(generated.trim(), format(expectedMethod).trim());
       },
     );
+
+    test(
+      'uriEncode converts Base64Model variant via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final model = AnyOfModel(
+          isDeprecated: false,
+          name: 'AnyOfBase64',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final klass = generator.generateClass(model);
+        final uriEncodeMethod = klass.methods.firstWhere(
+          (m) => m.name == 'uriEncode',
+        );
+        final generated = format(uriEncodeMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+@override
+String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  if (tonikFile != null) {
+    return tonikFile!.toBase64String().uriEncode(
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  if (text != null) {
+    throw EncodingException(
+      r'Cannot uriEncode AnyOfBase64: contains complex type',
+    );
+  }
+  throw EncodingException(r'Cannot uriEncode AnyOfBase64: no value set');
+}
+''';
+
+        expect(generated.trim(), format(expectedMethod).trim());
+      },
+    );
   });
 
   group('AnyModel in AnyOf', () {

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -2262,5 +2262,243 @@ Map<String, String> parameterProperties({
         );
       },
     );
+
+    test(
+      'base64-encodes byte property in list-shaped parameterProperties',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'signature',
+              model: Base64Model(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: false,
+              isNullable: true,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final method = result.methods.firstWhere(
+          (m) => m.name == 'parameterProperties',
+        );
+        final methodCode = format(method.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  if (!allowLists && tags != null) {
+    throw EncodingException('Lists are not supported in this encoding style');
+  }
+  final _$result = <String, String>{};
+  _$result[r'signature'] = signature.toBase64String().uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+  if (tags != null) {
+    _$result[r'tags'] = tags!.uriEncode(
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  } else if (allowEmpty) {
+    _$result[r'tags'] = '';
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(methodCode),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'base64-encodes byte property in mixed-shape parameterProperties',
+      () {
+        final oneOfModel = OneOfModel(
+          isDeprecated: false,
+          name: 'StringOrClass',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (
+              discriminatorValue: null,
+              model: ClassModel(
+                isDeprecated: false,
+                name: 'NestedClass',
+                properties: [
+                  Property(
+                    name: 'value',
+                    model: StringModel(context: context),
+                    isRequired: true,
+                    isNullable: false,
+                    isDeprecated: false,
+                    examples: const [],
+                    defaultValue: null,
+                  ),
+                ],
+                context: context,
+                examples: const [],
+              ),
+            ),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'ByteMixedContainer',
+          properties: [
+            Property(
+              name: 'signature',
+              model: Base64Model(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'value',
+              model: oneOfModel,
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final method = result.methods.firstWhere(
+          (m) => m.name == 'parameterProperties',
+        );
+        final methodCode = format(method.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  _$result[r'signature'] = signature.toBase64String().uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+  if (value.currentEncodingShape == EncodingShape.simple) {
+    _$result[r'value'] = value.toSimple(explode: false, allowEmpty: allowEmpty);
+  } else {
+    throw EncodingException(
+      r'parameterProperties not supported for ByteMixedContainer: contains complex types',
+    );
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(methodCode),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'base64-encodes nullable byte additionalProperties values before '
+      'percent-encoding',
+      () {
+        final nullableByte = AliasModel(
+          name: 'NullableSignature',
+          model: Base64Model(context: context),
+          context: context,
+          isNullable: true,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          additionalProperties: TypedAdditionalProperties(
+            valueModel: nullableByte,
+          ),
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final method = result.methods.firstWhere(
+          (m) => m.name == 'parameterProperties',
+        );
+        final methodCode = format(method.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  _$result[r'name'] = name.uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+  for (final _$e in additionalProperties.entries) {
+    _$result[_$e.key] =
+        _$e.value?.toBase64String().uriEncode(
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+        ) ??
+        '';
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(methodCode),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
   });
 }

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -2060,5 +2060,207 @@ Map<String, String> parameterProperties({
         );
       },
     );
+
+    test(
+      'base64-encodes required non-null byte property before percent-encoding',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'signature',
+              model: Base64Model(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  _$result[r'signature'] = signature.toBase64String().uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'base64-encodes required nullable byte property before percent-encoding',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'signature',
+              model: Base64Model(context: context),
+              isRequired: true,
+              isNullable: true,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  if (signature != null) {
+    _$result[r'signature'] = signature!.toBase64String().uriEncode(
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  } else if (allowEmpty) {
+    _$result[r'signature'] = '';
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'base64-encodes optional byte property before percent-encoding',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'signature',
+              model: Base64Model(context: context),
+              isRequired: false,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  if (signature != null) {
+    _$result[r'signature'] = signature!.toBase64String().uriEncode(
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  } else if (allowEmpty) {
+    _$result[r'signature'] = '';
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'base64-encodes byte additionalProperties values before '
+      'percent-encoding',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'Filter',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          additionalProperties: TypedAdditionalProperties(
+            valueModel: Base64Model(context: context),
+          ),
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+}) {
+  final _$result = <String, String>{};
+  _$result[r'name'] = name.uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+  );
+  for (final _$e in additionalProperties.entries) {
+    _$result[_$e.key] = _$e.value.toBase64String().uriEncode(
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+    );
+  }
+  return _$result;
+}
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4088,6 +4088,67 @@ bool operator ==(Object other) {
         );
       },
     );
+
+    test(
+      'uriEncode converts Base64Model variant via toBase64String',
+      () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'Text',
+          properties: [
+            Property(
+              name: 'content',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'Value',
+          models: {
+            (discriminatorValue: null, model: classModel),
+            (discriminatorValue: null, model: Base64Model(context: context)),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'Value');
+        final uriEncodeMethod = baseClass.methods.firstWhere(
+          (m) => m.name == 'uriEncode',
+        );
+        final generated = format(uriEncodeMethod.accept(emitter).toString());
+
+        const expectedMethod = '''
+          @override
+          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+            return switch (this) {
+              ValueBase64(:final value) => value.toBase64String().uriEncode(
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+              ),
+              ValueText() => throw EncodingException(
+                r'Cannot uriEncode Value: variant contains complex type',
+              ),
+            };
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
   });
 
   group('recursion splicing', () {

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -167,7 +167,7 @@ void main() {
       );
     });
 
-    test('generates uriEncode call for Base64Model', () {
+    test('base64-encodes Base64Model before uriEncode', () {
       final model = Base64Model(context: context);
       final expression = buildUriEncodeExpression(
         refer('value'),
@@ -177,7 +177,30 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty);
+        final result = value.toBase64String().uriEncode(allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('base64-encodes Base64Model with useQueryComponent', () {
+      final model = Base64Model(context: context);
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        useQueryComponent: refer('useQueryComponent'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.toBase64String().uriEncode(
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+        );
       ''';
 
       expect(
@@ -469,7 +492,7 @@ void main() {
       );
     });
 
-    test('generates map expression for List<Base64Model>', () {
+    test('base64-encodes each element for List<Base64Model>', () {
       final model = ListModel(
         content: Base64Model(context: context),
         context: context,
@@ -484,7 +507,7 @@ void main() {
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
         final result = value
-            .map((e) => e.uriEncode(allowEmpty: allowEmpty))
+            .map((e) => e.toBase64String().uriEncode(allowEmpty: allowEmpty))
             .toList()
             .uriEncode(allowEmpty: allowEmpty);
       ''';

--- a/packages/tonik_util/lib/src/decoding/form_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/form_decoder.dart
@@ -238,9 +238,10 @@ extension FormDecoder on String? {
 
   /// Decodes a base64-encoded form string to binary data (`List<int>`).
   ///
-  /// The base64 alphabet and padding are percent-encoded on the wire, so the
-  /// value is percent-decoded before base64 decoding — like [decodeFormString].
-  /// Throws [InvalidTypeException] if the value is null or not valid base64.
+  /// Base64 output can contain `+`, `/` and `=`, which are percent-encoded on
+  /// the wire, so the value is percent-decoded before base64 decoding, like
+  /// [decodeFormString].
+  /// Throws [InvalidTypeException] if the value is null or cannot be decoded.
   List<int> decodeFormBase64({String? context}) {
     if (this == null) {
       throw InvalidTypeException(

--- a/packages/tonik_util/lib/src/decoding/form_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/form_decoder.dart
@@ -238,8 +238,9 @@ extension FormDecoder on String? {
 
   /// Decodes a base64-encoded form string to binary data (`List<int>`).
   ///
-  /// Expects a valid base64-encoded string.
-  /// Throws [InvalidTypeException] if the value is null.
+  /// The base64 alphabet and padding are percent-encoded on the wire, so the
+  /// value is percent-decoded before base64 decoding — like [decodeFormString].
+  /// Throws [InvalidTypeException] if the value is null or not valid base64.
   List<int> decodeFormBase64({String? context}) {
     if (this == null) {
       throw InvalidTypeException(
@@ -251,7 +252,15 @@ extension FormDecoder on String? {
     if (this!.isEmpty) {
       return <int>[];
     }
-    return base64.decode(this!);
+    try {
+      return base64.decode(Uri.decodeQueryComponent(this!));
+    } on Object {
+      throw InvalidTypeException(
+        value: this!,
+        targetType: List<int>,
+        context: context,
+      );
+    }
   }
 
   /// Decodes a base64-encoded form string to nullable binary data.

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -240,8 +240,10 @@ extension SimpleDecoder on String? {
 
   /// Decodes a base64-encoded string to binary data (`List<int>`).
   ///
-  /// Expects a valid base64-encoded string.
-  /// Throws [InvalidTypeException] if the value is null.
+  /// The base64 alphabet and padding are percent-encoded on the wire, so the
+  /// value is percent-decoded before base64 decoding, like
+  /// [decodeSimpleString].
+  /// Throws [InvalidTypeException] if the value is null or not valid base64.
   List<int> decodeSimpleBase64({String? context}) {
     if (this == null) {
       throw InvalidTypeException(
@@ -253,7 +255,15 @@ extension SimpleDecoder on String? {
     if (this!.isEmpty) {
       return <int>[];
     }
-    return base64.decode(this!);
+    try {
+      return base64.decode(Uri.decodeComponent(this!));
+    } on Object {
+      throw InvalidTypeException(
+        value: this!,
+        targetType: List<int>,
+        context: context,
+      );
+    }
   }
 
   /// Decodes a base64-encoded string to nullable binary data.

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -240,10 +240,10 @@ extension SimpleDecoder on String? {
 
   /// Decodes a base64-encoded string to binary data (`List<int>`).
   ///
-  /// The base64 alphabet and padding are percent-encoded on the wire, so the
-  /// value is percent-decoded before base64 decoding, like
+  /// Base64 output can contain `+`, `/` and `=`, which are percent-encoded on
+  /// the wire, so the value is percent-decoded before base64 decoding, like
   /// [decodeSimpleString].
-  /// Throws [InvalidTypeException] if the value is null or not valid base64.
+  /// Throws [InvalidTypeException] if the value is null or cannot be decoded.
   List<int> decodeSimpleBase64({String? context}) {
     if (this == null) {
       throw InvalidTypeException(

--- a/packages/tonik_util/test/src/decoding/form_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/form_decoder_test.dart
@@ -619,9 +619,35 @@ void main() {
         expect(decoded, original);
       });
 
+      test('percent-decodes base64 padding before decoding', () {
+        const encoded = '3q2%2B7w%3D%3D';
+        final result = encoded.decodeFormBase64();
+        expect(result, [0xDE, 0xAD, 0xBE, 0xEF]);
+      });
+
+      test('percent-decodes base64 forward slashes before decoding', () {
+        const encoded = '%2F%2F8%3D';
+        final result = encoded.decodeFormBase64();
+        expect(result, [0xFF, 0xFF]);
+      });
+
       test('throws InvalidTypeException if value is null', () {
         expect(
           () => null.decodeFormBase64(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws InvalidTypeException for non-base64 content', () {
+        expect(
+          () => 'not base64!'.decodeFormBase64(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws InvalidTypeException for malformed percent-escape', () {
+        expect(
+          () => '%ZZ'.decodeFormBase64(),
           throwsA(isA<InvalidTypeException>()),
         );
       });

--- a/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
@@ -482,9 +482,35 @@ void main() {
         expect(decoded, original);
       });
 
+      test('percent-decodes base64 padding before decoding', () {
+        const encoded = '3q2%2B7w%3D%3D';
+        final result = encoded.decodeSimpleBase64();
+        expect(result, [0xDE, 0xAD, 0xBE, 0xEF]);
+      });
+
+      test('percent-decodes base64 forward slashes before decoding', () {
+        const encoded = '%2F%2F8%3D';
+        final result = encoded.decodeSimpleBase64();
+        expect(result, [0xFF, 0xFF]);
+      });
+
       test('throws InvalidTypeException if value is null', () {
         expect(
           () => null.decodeSimpleBase64(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws InvalidTypeException for non-base64 content', () {
+        expect(
+          () => 'not base64!'.decodeSimpleBase64(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
+      test('throws InvalidTypeException for malformed percent-escape', () {
+        expect(
+          () => '%ZZ'.decodeSimpleBase64(),
           throwsA(isA<InvalidTypeException>()),
         );
       });


### PR DESCRIPTION
## Problem

A `string` / `format: byte` value serialized as a **parameter** (a property of an object, or a member of an `allOf`/`anyOf`/`oneOf`) was UTF‑8‑decoded and percent‑encoded instead of being emitted as its RFC 4648 base64 text. This produced the wrong bytes on the wire, was **lossy** for non‑UTF‑8 data (bytes collapsed to the U+FFFD replacement character), and was inconsistent with the generated decoders — so a client round‑tripping its own request threw a `FormatException`.

The JSON path (`toJson`) and a top‑level single `byte` query parameter already encoded correctly; the affected paths were `byte` values nested inside objects, composite (`allOf`/`anyOf`/`oneOf`) members, lists, and deep objects.

## Fix

Byte values now base64‑encode first, then percent‑encode — `value.toBase64String().uriEncode(...)` — mirroring the JSON path. This is applied consistently across the `form`, `simple`, `label`, `matrix`, and `deepObject` styles for:

- object properties (`ClassModel`) and typed additional‑properties;
- `allOf` / `anyOf` / `oneOf` composite members.

The shared `Base64Model` receiver logic is centralized in two helpers (`uriEncodeReceiver` / `uriEncodeReceiverExpression`). `allOf`'s `toSimple` / `toForm` / `toLabel` paths gained the same byte handling (and the same `EncodingException` guard for binary) that `anyOf` / `oneOf` already had, so an `allOf` with a byte member now generates compiling, correct code.

On the decode side, `decodeFormBase64` / `decodeSimpleBase64` now percent‑decode before base64‑decoding (so the round‑trip succeeds) and report malformed input as a typed `InvalidTypeException` rather than leaking a raw `ArgumentError`/`FormatException`. `decodeJsonBase64` is unchanged (JSON values are not percent‑encoded).

`format: binary` (`BinaryModel`) encoding is intentionally unchanged, and the shared `TonikFile.uriEncode()` helper is untouched.

## Example

Object parameter `filter` (`style: form, explode: true`) with a byte property `signature` holding `[0xDE, 0xAD, 0xBE, 0xEF]` (base64 `3q2+7w==`):

- Before: `signature=%DE%AD%EF%BF%BD%EF%BF%BD` (lossy, undecodable)
- After: `signature=3q2%2B7w%3D%3D`

## Testing

- Unit tests (full method‑body comparisons) for the object‑property, composite‑member, and `useQueryComponent` byte paths, plus the decoder percent‑decode and malformed‑input cases.
- Integration tests (live server, round‑trip) covering the byte object property and `anyOf` / `oneOf` / `allOf` byte members, each asserting the exact wire value and a successful decode round‑trip.
- `dart analyze` clean for `packages/` and `--fatal-infos integration_test`; full unit + integration suites pass; patch coverage 100%.
