### PR TITLE
feat: reserved-preserving encoder + allowReserved flag for scalar query encoders

### DIFF
--- a/packages/tonik_util/lib/src/date.dart
+++ b/packages/tonik_util/lib/src/date.dart
@@ -3,6 +3,7 @@ import 'package:tonik_util/src/decoding/form_decoder.dart';
 import 'package:tonik_util/src/decoding/json_decoder.dart';
 import 'package:tonik_util/src/decoding/simple_decoder.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
 /// A class representing a date without time information.
 ///
@@ -93,12 +94,14 @@ class Date {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -125,12 +128,12 @@ class Date {
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
-  }) {
-    final dateString = toString();
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(dateString)
-        : Uri.encodeComponent(dateString);
-  }
+    bool allowReserved = false,
+  }) => toString().uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
+  );
 
   /// Creates a copy of this [Date] with the given fields replaced
   /// with new values.

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -22,12 +22,14 @@ extension FormUriEncoder on Uri {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -41,12 +43,14 @@ extension FormStringEncoder on String {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -60,12 +64,14 @@ extension FormIntEncoder on int {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -79,12 +85,14 @@ extension FormDoubleEncoder on double {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -98,12 +106,14 @@ extension FormNumEncoder on num {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -117,12 +127,14 @@ extension FormBoolEncoder on bool {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -136,12 +148,14 @@ extension FormDateTimeEncoder on DateTime {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -155,12 +169,14 @@ extension FormBigDecimalEncoder on BigDecimal {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];
@@ -262,12 +278,14 @@ extension FormBinaryEncoder on List<int> {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) => [
     (
       name: paramName,
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
     ),
   ];

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -3,35 +3,76 @@ import 'package:tonik_util/src/encoding/binary_extensions.dart';
 import 'package:tonik_util/src/encoding/datetime_extension.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 
-/// Extensions for URI encoding individual values.
+/// When [allowReserved] is false the result is byte-identical to
+/// [Uri.encodeQueryComponent] / [Uri.encodeComponent]; when true the reserved
+/// set passes through literally while space, `%`, and non-ASCII stay encoded.
+String _encodeUriValue(
+  String value, {
+  required bool allowReserved,
+  required bool useQueryComponent,
+}) {
+  if (!allowReserved) {
+    return useQueryComponent
+        ? Uri.encodeQueryComponent(value)
+        : Uri.encodeComponent(value);
+  }
+
+  // Uri.encodeFull preserves reserved chars but also leaves the
+  // form-urlencoded delimiters & = + literal; as data they are never
+  // delimiters, so they must stay encoded. Encode literal + to %2B before
+  // rendering %20 as +, otherwise a data + and a space become
+  // indistinguishable.
+  var encoded = Uri.encodeFull(value)
+      .replaceAll('+', '%2B')
+      .replaceAll('&', '%26')
+      .replaceAll('=', '%3D');
+  if (useQueryComponent) {
+    encoded = encoded.replaceAll('%20', '+');
+  }
+  return encoded;
+}
 
 /// Extension for URI encoding Uri values.
 extension UriEncoder on Uri {
   /// URI encodes this Uri value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : Uri.encodeComponent(toString());
-  }
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) => _encodeUriValue(
+    toString(),
+    allowReserved: allowReserved,
+    useQueryComponent: useQueryComponent,
+  );
 }
 
 /// Extension for URI encoding String values.
 extension StringUriEncoder on String {
   /// URI encodes this string value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(this)
-        : Uri.encodeComponent(this);
+    return _encodeUriValue(
+      this,
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 
 /// Extension for URI encoding int values.
 extension IntUriEncoder on int {
   /// URI encodes this int value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -41,17 +82,25 @@ extension IntUriEncoder on int {
 /// Extension for URI encoding double values.
 extension DoubleUriEncoder on double {
   /// URI encodes this double value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : Uri.encodeComponent(toString());
-  }
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) => _encodeUriValue(
+    toString(),
+    allowReserved: allowReserved,
+    useQueryComponent: useQueryComponent,
+  );
 }
 
 /// Extension for URI encoding num values.
 extension NumUriEncoder on num {
   /// URI encodes this num value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -61,7 +110,11 @@ extension NumUriEncoder on num {
 /// Extension for URI encoding bool values.
 extension BoolUriEncoder on bool {
   /// URI encodes this bool value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -71,17 +124,25 @@ extension BoolUriEncoder on bool {
 /// Extension for URI encoding DateTime values.
 extension DateTimeUriEncoder on DateTime {
   /// URI encodes this DateTime value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toTimeZonedIso8601String())
-        : Uri.encodeComponent(toTimeZonedIso8601String());
-  }
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) => _encodeUriValue(
+    toTimeZonedIso8601String(),
+    allowReserved: allowReserved,
+    useQueryComponent: useQueryComponent,
+  );
 }
 
 /// Extension for URI encoding BigDecimal values.
 extension BigDecimalUriEncoder on BigDecimal {
   /// URI encodes this BigDecimal value.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -93,17 +154,22 @@ extension BinaryUriEncoder on List<int> {
   /// URI encodes this binary data value.
   ///
   /// Converts the binary data to a UTF-8 string first, then URI encodes it.
-  String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+  }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
     if (isEmpty) {
       return '';
     }
-    final str = decodeToString();
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(str)
-        : Uri.encodeComponent(str);
+    return _encodeUriValue(
+      decodeToString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -3,9 +3,11 @@ import 'package:tonik_util/src/encoding/binary_extensions.dart';
 import 'package:tonik_util/src/encoding/datetime_extension.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 
-/// When [allowReserved] is false the result is byte-identical to
-/// [Uri.encodeQueryComponent] / [Uri.encodeComponent]; when true the reserved
-/// set passes through literally while space, `%`, and non-ASCII stay encoded.
+/// With [allowReserved] false the result is byte-identical to
+/// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
+/// this. With [allowReserved] true most reserved chars pass through literally,
+/// but the form delimiters `& = +` and brackets `[ ]` stay encoded, as do
+/// space, `%`, and non-ASCII.
 String _encodeUriValue(
   String value, {
   required bool allowReserved,
@@ -17,10 +19,9 @@ String _encodeUriValue(
         : Uri.encodeComponent(value);
   }
 
-  // Uri.encodeFull preserves reserved chars but also leaves the
-  // form-urlencoded delimiters & = + literal; as data they are never
-  // delimiters, so they must stay encoded. Encode literal + to %2B before
-  // rendering %20 as +, otherwise a data + and a space become
+  // Uri.encodeFull keeps reserved chars literal, but & and = are data here,
+  // not delimiters, so they must stay encoded. A literal + must become %2B
+  // before a space is rendered as +, otherwise a data + and a space would be
   // indistinguishable.
   var encoded = Uri.encodeFull(value)
       .replaceAll('+', '%2B')

--- a/packages/tonik_util/lib/src/tonik_file/tonik_file.dart
+++ b/packages/tonik_util/lib/src/tonik_file/tonik_file.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'package:collection/collection.dart';
 import 'package:meta/meta.dart';
 
+import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 import 'package:tonik_util/src/tonik_file/file_reader_stub.dart'
     if (dart.library.io) 'package:tonik_util/src/tonik_file/file_reader_io.dart'
     as reader;
@@ -38,6 +39,7 @@ sealed class TonikFile {
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     final raw = toBytes();
     if (raw.isEmpty && !allowEmpty) {
@@ -46,9 +48,11 @@ sealed class TonikFile {
     if (raw.isEmpty) return '';
     const decoder = Utf8Decoder(allowMalformed: true);
     final str = decoder.convert(raw);
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(str)
-        : Uri.encodeComponent(str);
+    return str.uriEncode(
+      allowEmpty: true,
+      useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
+    );
   }
 }
 

--- a/packages/tonik_util/test/src/date_test.dart
+++ b/packages/tonik_util/test/src/date_test.dart
@@ -450,6 +450,23 @@ void main() {
         '2023-12-25',
       );
     });
+
+    test('threads allowReserved into uriEncode as a no-op', () {
+      final date = Date(2023, 12, 25);
+      expect(
+        date.uriEncode(allowEmpty: true, allowReserved: true),
+        '2023-12-25',
+      );
+    });
+
+    test('threads allowReserved into toForm as a no-op', () {
+      final date = Date(2023, 12, 25);
+      final encoded = date
+          .toForm('p', explode: false, allowEmpty: true, allowReserved: true)
+          .single
+          .value;
+      expect(encoded, '2023-12-25');
+    });
   });
 
   group('matrix encoding', () {

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -574,6 +574,16 @@ void main() {
         3.14.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
         const <ParameterEntry>[(name: 'p', value: '3.14')],
       );
+      const num numValue = 3.14;
+      expect(
+        numValue.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: '3.14')],
+      );
       expect(
         true.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
         const <ParameterEntry>[(name: 'p', value: 'true')],

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -486,4 +486,107 @@ void main() {
       },
     );
   });
+
+  group('allowReserved parameter', () {
+    const allReserved = r":/?#[]@!$&'()*+,;=";
+
+    test('FormStringEncoder keeps reserved chars literal', () {
+      expect(
+        allReserved.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: r":/?#%5B%5D@!$%26'()*%2B,;%3D"),
+        ],
+      );
+    });
+
+    test('FormStringEncoder default is byte-identical to encodeComponent', () {
+      expect(
+        allReserved.toForm('p', explode: false, allowEmpty: true),
+        <ParameterEntry>[(name: 'p', value: Uri.encodeComponent(allReserved))],
+      );
+    });
+
+    test('FormStringEncoder composes with useQueryComponent', () {
+      expect(
+        'a+b c'.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a%2Bb+c')],
+      );
+    });
+
+    test('FormUriEncoder threads allowReserved into uriEncode', () {
+      final uri = Uri.parse('https://x.com/p?a=1&b=2');
+      expect(
+        uri.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: 'https://x.com/p?a%3D1%26b%3D2'),
+        ],
+      );
+    });
+
+    test('FormDateTimeEncoder threads allowReserved into uriEncode', () {
+      final dateTime = DateTime.utc(2023, 12, 25, 10, 30, 45);
+      expect(
+        dateTime.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        <ParameterEntry>[(name: 'p', value: dateTime.toIso8601String())],
+      );
+    });
+
+    test('FormBinaryEncoder threads allowReserved into uriEncode', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a:b%20c')],
+      );
+    });
+
+    test('numeric and bool encoders accept the flag as a no-op', () {
+      expect(
+        42.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: '42')],
+      );
+      expect(
+        3.14.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: '3.14')],
+      );
+      expect(
+        true.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: 'true')],
+      );
+      expect(
+        BigDecimal.parse('123.456').toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: '123.456')],
+      );
+    });
+  });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -212,4 +212,126 @@ void main() {
       );
     });
   });
+
+  group('allowReserved', () {
+    const allReserved = r":/?#[]@!$&'()*+,;=";
+
+    test('keeps the reserved set literal except & = + and [ ]', () {
+      expect(
+        allReserved.uriEncode(allowEmpty: true, allowReserved: true),
+        r":/?#%5B%5D@!$%26'()*%2B,;%3D",
+      );
+    });
+
+    test('still encodes space, percent, delimiters and non-ASCII', () {
+      expect('a b'.uriEncode(allowEmpty: true, allowReserved: true), 'a%20b');
+      expect('a%b'.uriEncode(allowEmpty: true, allowReserved: true), 'a%25b');
+      expect('a+b'.uriEncode(allowEmpty: true, allowReserved: true), 'a%2Bb');
+      expect('a&b'.uriEncode(allowEmpty: true, allowReserved: true), 'a%26b');
+      expect('a=b'.uriEncode(allowEmpty: true, allowReserved: true), 'a%3Db');
+      expect(
+        '你好'.uriEncode(allowEmpty: true, allowReserved: true),
+        '%E4%BD%A0%E5%A5%BD',
+      );
+    });
+
+    test('false is byte-identical to Uri.encodeComponent', () {
+      const inputs = [allReserved, 'a b', 'a+b c', 'a%b', '你好'];
+      for (final input in inputs) {
+        expect(
+          input.uriEncode(allowEmpty: true),
+          Uri.encodeComponent(input),
+        );
+      }
+    });
+
+    test('false is byte-identical to Uri.encodeQueryComponent', () {
+      const inputs = [allReserved, 'a b', 'a+b c', 'a%b', '你好'];
+      for (final input in inputs) {
+        expect(
+          input.uriEncode(allowEmpty: true, useQueryComponent: true),
+          Uri.encodeQueryComponent(input),
+        );
+      }
+    });
+
+    test('composes with useQueryComponent rendering space as +', () {
+      expect(
+        'a b'.uriEncode(
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        'a+b',
+      );
+      expect(
+        'a+b c'.uriEncode(
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        'a%2Bb+c',
+      );
+      expect(
+        'a&b=c'.uriEncode(
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        'a%26b%3Dc',
+      );
+    });
+
+    test('Uri keeps reserved chars literal under allowReserved', () {
+      final uri = Uri.parse('https://x.com/p?a=1&b=2');
+      expect(
+        uri.uriEncode(allowEmpty: true, allowReserved: true),
+        'https://x.com/p?a%3D1%26b%3D2',
+      );
+      expect(
+        uri.uriEncode(allowEmpty: true),
+        Uri.encodeComponent(uri.toString()),
+      );
+    });
+
+    test('DateTime keeps colons literal under allowReserved', () {
+      final dateTime = DateTime.utc(2023, 12, 25, 10, 30, 45);
+      final iso = dateTime.toIso8601String();
+      expect(
+        dateTime.uriEncode(allowEmpty: true, allowReserved: true),
+        iso,
+      );
+      expect(
+        dateTime.uriEncode(allowEmpty: true),
+        Uri.encodeComponent(iso),
+      );
+    });
+
+    test('binary keeps reserved chars literal under allowReserved', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.uriEncode(allowEmpty: true, allowReserved: true),
+        'a:b%20c',
+      );
+      expect(
+        value.uriEncode(allowEmpty: true),
+        Uri.encodeComponent('a:b c'),
+      );
+    });
+
+    test('numeric and bool types accept the flag as a no-op', () {
+      expect(42.uriEncode(allowEmpty: true, allowReserved: true), '42');
+      expect(
+        (3.14 as num).uriEncode(allowEmpty: true, allowReserved: true),
+        '3.14',
+      );
+      expect(3.14.uriEncode(allowEmpty: true, allowReserved: true), '3.14');
+      expect(true.uriEncode(allowEmpty: true, allowReserved: true), 'true');
+      expect(
+        BigDecimal.parse('123.456')
+            .uriEncode(allowEmpty: true, allowReserved: true),
+        '123.456',
+      );
+    });
+  });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -282,6 +282,21 @@ void main() {
       );
     });
 
+    test(
+      'query mode escapes a literal percent so %20-looking input is not '
+      'collapsed to a space',
+      () {
+        expect(
+          'a%20b'.uriEncode(
+            allowEmpty: true,
+            useQueryComponent: true,
+            allowReserved: true,
+          ),
+          'a%2520b',
+        );
+      },
+    );
+
     test('Uri keeps reserved chars literal under allowReserved', () {
       final uri = Uri.parse('https://x.com/p?a=1&b=2');
       expect(
@@ -316,6 +331,13 @@ void main() {
       expect(
         value.uriEncode(allowEmpty: true),
         Uri.encodeComponent('a:b c'),
+      );
+    });
+
+    test('double routes through the helper, encoding + in its toString', () {
+      expect(
+        1e21.uriEncode(allowEmpty: false, allowReserved: true),
+        '1e%2B21',
       );
     });
 

--- a/packages/tonik_util/test/src/tonik_file/tonik_file_test.dart
+++ b/packages/tonik_util/test/src/tonik_file/tonik_file_test.dart
@@ -226,6 +226,15 @@ void main() {
       const file = TonikFileBytes([]);
       expect(file.uriEncode(allowEmpty: true), '');
     });
+
+    test('keeps reserved chars literal when allowReserved is true', () {
+      // "a:b c" in UTF-8
+      const file = TonikFileBytes([97, 58, 98, 32, 99]);
+      expect(
+        file.uriEncode(allowEmpty: false, allowReserved: true),
+        'a:b%20c',
+      );
+    });
   });
 
   group('TonikFile sealed dispatch', () {


### PR DESCRIPTION
## Summary

Adds the core reserved-preserving percent-encoder and an `allowReserved` flag (default `false`) to `uriEncode` and `toForm` for `String` and scalar value types in `tonik_util`. This is the runtime foundation for OpenAPI `allowReserved: true` query-parameter support; it is **additive and default-off**, so it ships with **zero wire-behavior change** (no caller passes the flag yet).

## Encoder semantics

When `allowReserved == true`, only characters **outside** (unreserved ∪ reserved) are percent-encoded:

- unreserved: `A-Z a-z 0-9 - . _ ~`
- reserved: `: / ? # [ ] @ ! $ & ' ( ) * + , ; =`

Everything else stays encoded: space → `%20`, `%` → `%25`, control, and non-ASCII.

The form-urlencoded delimiters `& = +` are **never** passed through — they are always `%26 %3D %2B`. As a parameter/property value they are data, not delimiters, so per OAS Appendix E they must stay percent-encoded or the receiver mis-parses the value. The encoder builds on `Uri.encodeFull`, then post-processes `+`→`%2B`, `&`→`%26`, `=`→`%3D`.

The flag **composes** with `useQueryComponent` for the space choice rather than overriding it: query mode renders space as `%20`, urlencoded-body mode (a later step) as `+`. The literal `+`→`%2B` replacement runs **before** any space→`+` rendering so a data `+` and a space stay distinguishable. Every call site in this change uses the query default.

When `allowReserved == false` (the default), output is byte-identical to today's `Uri.encodeComponent` / `Uri.encodeQueryComponent`.

## Scope

- **In:** `uriEncode` + `toForm` for `String`, `int`, `double`, `num`, `bool`, `DateTime`, `BigDecimal`, `Date`, `Uri`, binary (`List<int>`), and `TonikFile`. For numeric/bool/date types the flag is a no-op (they emit no reserved characters) but is accepted for a uniform signature.
- **Out:** `List`/`Map`, delimited / deepObject / AnyModel encoders, and all generator changes — handled in later steps.

The reserved-preserving branch lives in a single private helper (`_encodeUriValue`); the scalar extensions thread the flag through to it.

## Testing

- **Reserved-literal**, **non-reserved-encoded** (incl. `+`/`&`/`=` → `%2B`/`%26`/`%3D` and non-ASCII), and **default-unchanged** (byte-identical to the stdlib) unit tests for `uriEncode` and the scalar `toForm` wrappers.
- `fvm dart analyze packages/`: clean.
- Patch coverage: 100%.
- No integration test (no observable wire change in this step).
