### PR TITLE
feat: thread allowReserved through List and Map form encoders

### DIFF
--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -9,10 +9,16 @@ import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 /// callers join with the separator for their context — `&` for query strings
 /// and urlencoded bodies, `; ` for cookies.
 
-String _encodeValue(String value, {required bool useQueryComponent}) =>
-    useQueryComponent
-        ? Uri.encodeQueryComponent(value)
-        : Uri.encodeComponent(value);
+// allowEmpty is true because the list/map-level empty checks already ran.
+String _encodeValue(
+  String value, {
+  required bool useQueryComponent,
+  bool allowReserved = false,
+}) => value.uriEncode(
+  allowEmpty: true,
+  useQueryComponent: useQueryComponent,
+  allowReserved: allowReserved,
+);
 
 /// Extension for encoding Uri values.
 extension FormUriEncoder on Uri {
@@ -194,6 +200,7 @@ extension FormStringListEncoder on List<String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -207,6 +214,7 @@ extension FormStringListEncoder on List<String> {
             allowEmpty: allowEmpty,
             alreadyEncoded: alreadyEncoded,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ),
         ),
       ];
@@ -218,7 +226,11 @@ extension FormStringListEncoder on List<String> {
           name: paramName,
           value: alreadyEncoded
               ? item
-              : _encodeValue(item, useQueryComponent: useQueryComponent),
+              : _encodeValue(
+                  item,
+                  useQueryComponent: useQueryComponent,
+                  allowReserved: allowReserved,
+                ),
         ),
     ];
   }
@@ -237,6 +249,7 @@ extension FormStringMapEncoder on Map<String, String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -251,6 +264,7 @@ extension FormStringMapEncoder on Map<String, String> {
             alreadyEncoded: alreadyEncoded,
             encodeKeys: false,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ),
         ),
       ];
@@ -259,10 +273,18 @@ extension FormStringMapEncoder on Map<String, String> {
     return [
       for (final e in entries)
         (
-          name: _encodeValue(e.key, useQueryComponent: useQueryComponent),
+          name: _encodeValue(
+            e.key,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+          ),
           value: alreadyEncoded
               ? e.value
-              : _encodeValue(e.value, useQueryComponent: useQueryComponent),
+              : _encodeValue(
+                  e.value,
+                  useQueryComponent: useQueryComponent,
+                  allowReserved: allowReserved,
+                ),
         ),
     ];
   }

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -9,7 +9,7 @@ import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 /// callers join with the separator for their context — `&` for query strings
 /// and urlencoded bodies, `; ` for cookies.
 
-// allowEmpty is true because the list/map-level empty checks already ran.
+// Items, keys, and values may be empty strings; encode to '' rather than throw.
 String _encodeValue(
   String value, {
   required bool useQueryComponent,

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -185,6 +185,7 @@ extension StringListUriEncoder on List<String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -199,9 +200,11 @@ extension StringListUriEncoder on List<String> {
     }
 
     return map(
-      (item) => useQueryComponent
-          ? Uri.encodeQueryComponent(item)
-          : Uri.encodeComponent(item),
+      (item) => _encodeUriValue(
+        item,
+        allowReserved: allowReserved,
+        useQueryComponent: useQueryComponent,
+      ),
     ).join(',');
   }
 }
@@ -214,6 +217,7 @@ extension StringMapUriEncoder on Map<String, String> {
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
     bool encodeKeys = true,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -223,20 +227,17 @@ extension StringMapUriEncoder on Map<String, String> {
       return '';
     }
 
-    String encodeKey(String key) => encodeKeys
-        ? (useQueryComponent
-              ? Uri.encodeQueryComponent(key)
-              : Uri.encodeComponent(key))
-        : key;
-    final encodeValue = useQueryComponent
-        ? Uri.encodeQueryComponent
-        : Uri.encodeComponent;
+    String encode(String value) => _encodeUriValue(
+      value,
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
 
     return entries
         .expand(
           (e) => [
-            encodeKey(e.key),
-            if (alreadyEncoded) e.value else encodeValue(e.value),
+            if (encodeKeys) encode(e.key) else e.key,
+            if (alreadyEncoded) e.value else encode(e.value),
           ],
         )
         .join(',');

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -731,5 +731,67 @@ void main() {
       expect(without, const <ParameterEntry>[(name: 'k', value: 'a:b')]);
       expect(with_, without);
     });
+
+    test('list query mode renders space as + and data + as %2B per item '
+        '(explode=false)', () {
+      expect(
+        ['a b', 'c+d'].toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a+b,c%2Bd')],
+      );
+    });
+
+    test('list query mode renders space as + and data + as %2B per item '
+        '(explode=true)', () {
+      expect(
+        ['a b', 'c+d'].toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: 'a+b'),
+          (name: 'p', value: 'c%2Bd'),
+        ],
+      );
+    });
+
+    test('map query mode renders space as + and data + as %2B in keys and '
+        'values', () {
+      expect(
+        {'a b': 'c+d', 'e+f': 'g h'}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'a+b', value: 'c%2Bd'),
+          (name: 'e%2Bf', value: 'g+h'),
+        ],
+      );
+    });
+
+    test('map encodes reserved key while passing already-encoded value '
+        'through verbatim', () {
+      expect(
+        {'a&b': 'c%3Ad'}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'a%26b', value: 'c%3Ad')],
+      );
+    });
   });
 }

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -249,6 +249,20 @@ void main() {
       );
     });
 
+    test(
+      'explode=true encodes an empty item to an empty value among populated '
+      'items',
+      () {
+        expect(
+          ['', 'a'].toForm('p', explode: true, allowEmpty: true),
+          const <ParameterEntry>[
+            (name: 'p', value: ''),
+            (name: 'p', value: 'a'),
+          ],
+        );
+      },
+    );
+
     test('URL-encodes special characters in list items', () {
       expect(
         [
@@ -335,6 +349,27 @@ void main() {
       expect(
         () => <String, String>{}.toForm('p', explode: true, allowEmpty: false),
         throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test(
+      'explode=true encodes an empty value to an empty value among populated '
+      'entries',
+      () {
+        expect(
+          {'k': '', 'a': 'b'}.toForm('p', explode: true, allowEmpty: true),
+          const <ParameterEntry>[
+            (name: 'k', value: ''),
+            (name: 'a', value: 'b'),
+          ],
+        );
+      },
+    );
+
+    test('explode=true encodes an empty key to an empty name', () {
+      expect(
+        {'': 'v'}.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: '', value: 'v')],
       );
     });
 
@@ -709,6 +744,17 @@ void main() {
               name: Uri.encodeComponent(e.key),
               value: Uri.encodeComponent(e.value),
             ),
+        ],
+      );
+      expect(
+        map.toForm('p', explode: false, allowEmpty: true),
+        <ParameterEntry>[
+          (
+            name: 'p',
+            value: map.entries
+                .expand((e) => [e.key, Uri.encodeComponent(e.value)])
+                .join(','),
+          ),
         ],
       );
     });

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -598,5 +598,138 @@ void main() {
         const <ParameterEntry>[(name: 'p', value: '123.456')],
       );
     });
+
+    test('list explode=false keeps reserved literal, encodes & = + per '
+        'item', () {
+      expect(
+        ['a:b', 'c&d', 'e=f', 'g+h'].toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a:b,c%26d,e%3Df,g%2Bh')],
+      );
+    });
+
+    test('list explode=true keeps reserved literal, encodes & = + per '
+        'item', () {
+      expect(
+        ['a:b', 'c&d', 'e=f', 'g+h'].toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: 'a:b'),
+          (name: 'p', value: 'c%26d'),
+          (name: 'p', value: 'e%3Df'),
+          (name: 'p', value: 'g%2Bh'),
+        ],
+      );
+    });
+
+    test('list default is byte-identical to encodeComponent', () {
+      const items = ['a:b', 'c&d', 'e=f', 'g+h'];
+      expect(
+        items.toForm('p', explode: false, allowEmpty: true),
+        <ParameterEntry>[
+          (name: 'p', value: items.map(Uri.encodeComponent).join(',')),
+        ],
+      );
+      expect(
+        items.toForm('p', explode: true, allowEmpty: true),
+        <ParameterEntry>[
+          for (final item in items)
+            (name: 'p', value: Uri.encodeComponent(item)),
+        ],
+      );
+    });
+
+    test('list alreadyEncoded short-circuit is identical with/without '
+        'flag', () {
+      const items = ['a:b', 'c&d'];
+      final without = items.toForm(
+        'p',
+        explode: true,
+        allowEmpty: true,
+        alreadyEncoded: true,
+      );
+      final with_ = items.toForm(
+        'p',
+        explode: true,
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      expect(without, const <ParameterEntry>[
+        (name: 'p', value: 'a:b'),
+        (name: 'p', value: 'c&d'),
+      ]);
+      expect(with_, without);
+    });
+
+    test('map explode=true keeps reserved literal, encodes & = + in keys and '
+        'values', () {
+      expect(
+        {'a&b': 'c:d', 'e:f': 'g=h'}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'a%26b', value: 'c:d'),
+          (name: 'e:f', value: 'g%3Dh'),
+        ],
+      );
+    });
+
+    test('map explode=false keeps reserved literal in values, keys '
+        'untouched', () {
+      expect(
+        {'a:b': 'c=d'}.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a:b,c%3Dd')],
+      );
+    });
+
+    test('map default is byte-identical to encodeComponent', () {
+      const map = {'a&b': 'c:d', 'e=f': 'g+h'};
+      expect(
+        map.toForm('p', explode: true, allowEmpty: true),
+        <ParameterEntry>[
+          for (final e in map.entries)
+            (
+              name: Uri.encodeComponent(e.key),
+              value: Uri.encodeComponent(e.value),
+            ),
+        ],
+      );
+    });
+
+    test('map alreadyEncoded short-circuit is identical with/without flag', () {
+      const map = {'k': 'a:b'};
+      final without = map.toForm(
+        'p',
+        explode: true,
+        allowEmpty: true,
+        alreadyEncoded: true,
+      );
+      final with_ = map.toForm(
+        'p',
+        explode: true,
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      expect(without, const <ParameterEntry>[(name: 'k', value: 'a:b')]);
+      expect(with_, without);
+    });
   });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -431,5 +431,40 @@ void main() {
       expect(without, 'k,a:b');
       expect(with_, without);
     });
+
+    test('list query mode renders space as + and data + as %2B per item', () {
+      expect(
+        ['a b', 'c+d'].uriEncode(
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        'a+b,c%2Bd',
+      );
+    });
+
+    test('map query mode renders space as + and data + as %2B in keys and '
+        'values', () {
+      expect(
+        {'a b': 'c+d', 'e+f': 'g h'}.uriEncode(
+          allowEmpty: true,
+          useQueryComponent: true,
+          allowReserved: true,
+        ),
+        'a+b,c%2Bd,e%2Bf,g+h',
+      );
+    });
+
+    test('map encodes reserved key while passing already-encoded value '
+        'through verbatim', () {
+      expect(
+        {'a&b': 'c%3Ad'}.uriEncode(
+          allowEmpty: true,
+          alreadyEncoded: true,
+          allowReserved: true,
+        ),
+        'a%26b,c%3Ad',
+      );
+    });
   });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -159,6 +159,10 @@ void main() {
       final list = ['single'];
       expect(list.uriEncode(allowEmpty: true), 'single');
     });
+
+    test('encodes an empty item as an empty comma-joined segment', () {
+      expect(['', 'a'].uriEncode(allowEmpty: true), ',a');
+    });
   });
 
   group('StringMapUriEncoder', () {
@@ -210,6 +214,14 @@ void main() {
         map.uriEncode(allowEmpty: true),
         'key,not%20encoded',
       );
+    });
+
+    test('encodes an empty value as an empty comma-joined segment', () {
+      expect({'k': '', 'a': 'b'}.uriEncode(allowEmpty: true), 'k,,a,b');
+    });
+
+    test('encodes an empty key as an empty comma-joined segment', () {
+      expect({'': 'v', 'a': 'b'}.uriEncode(allowEmpty: true), ',v,a,b');
     });
   });
 

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -355,5 +355,81 @@ void main() {
         '123.456',
       );
     });
+
+    test('list keeps reserved chars literal but encodes & = + per item', () {
+      expect(
+        ['a:b', 'c&d', 'e=f', 'g+h'].uriEncode(
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        'a:b,c%26d,e%3Df,g%2Bh',
+      );
+    });
+
+    test('list default is byte-identical to encodeComponent per item', () {
+      const items = ['a:b', 'c&d', 'e=f', 'g+h', 'i j'];
+      expect(
+        items.uriEncode(allowEmpty: true),
+        items.map(Uri.encodeComponent).join(','),
+      );
+    });
+
+    test('list alreadyEncoded short-circuit is identical with/without flag', () {
+      const items = ['a:b', 'c&d'];
+      final without = items.uriEncode(allowEmpty: true, alreadyEncoded: true);
+      final with_ = items.uriEncode(
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      expect(without, 'a:b,c&d');
+      expect(with_, without);
+    });
+
+    test('map keeps reserved chars literal but encodes & = + in keys and '
+        'values', () {
+      expect(
+        {'a&b': 'c=d', 'e:f': 'g+h'}.uriEncode(
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        'a%26b,c%3Dd,e:f,g%2Bh',
+      );
+    });
+
+    test('map encodeKeys false leaves keys untouched under allowReserved', () {
+      expect(
+        {'a&b': 'c=d'}.uriEncode(
+          allowEmpty: true,
+          allowReserved: true,
+          encodeKeys: false,
+        ),
+        'a&b,c%3Dd',
+      );
+    });
+
+    test('map default is byte-identical to encodeComponent per key/value', () {
+      const map = {'a&b': 'c:d', 'e=f': 'g+h'};
+      expect(
+        map.uriEncode(allowEmpty: true),
+        map.entries
+            .expand(
+              (e) => [Uri.encodeComponent(e.key), Uri.encodeComponent(e.value)],
+            )
+            .join(','),
+      );
+    });
+
+    test('map alreadyEncoded short-circuit is identical with/without flag', () {
+      const map = {'k': 'a:b'};
+      final without = map.uriEncode(allowEmpty: true, alreadyEncoded: true);
+      final with_ = map.uriEncode(
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      expect(without, 'k,a:b');
+      expect(with_, without);
+    });
   });
 }


### PR DESCRIPTION
## Summary

Threads the `allowReserved` flag (default `false`) through the `List<String>` and `Map<String,String>` `uriEncode` / `toForm` paths in `tonik_util`, reusing the reserved-preserving helper introduced for the scalar encoders. **Additive and default-off**, so it ships with **zero wire-behavior change** (no caller passes the flag yet).

## What changed

- `StringListUriEncoder.uriEncode` and `StringMapUriEncoder.uriEncode` now accept `bool allowReserved = false` and route each item / key / value through the shared `_encodeUriValue` helper.
- `FormStringListEncoder.toForm` and `FormStringMapEncoder.toForm` accept `allowReserved` and thread it through **both** explode and non-explode paths.
- The form `_encodeValue` helper now delegates to `String.uriEncode(allowEmpty: true, ...)`, threading the flag (the collection-level empty guards run first, and an empty item/value still encodes to `''`).
- The Map `uriEncode` refactor collapses the old `encodeKey`/`encodeValue` closures into a single `encode` helper while preserving the exact `encodeKeys` gating (keys encoded only when `encodeKeys` is true) and `alreadyEncoded` short-circuit (values/items emitted as-is, never re-encoded).

## Semantics

When `allowReserved: true`, RFC 3986 reserved characters survive literally **inside** an item / key / value, except the form-urlencoded delimiters `& = +`, which stay `%26 %3D %2B` (per OAS Appendix E, they are data here, not delimiters). Space / `%` / non-ASCII remain encoded. The structural `&` / `=` that join entries and pairs are added by callers and stay literal. When `allowReserved: false`, every path is byte-identical to the previous `Uri.encodeComponent` / `Uri.encodeQueryComponent` output.

## Testing

- List (explode true & false) and Map (keys & values, `encodeKeys: false`) reserved-literal + `& = +` → `%26 %3D %2B` cases.
- `alreadyEncoded: true` short-circuit asserted identical **with and without** `allowReserved`.
- Default-unchanged (`allowReserved: false`) byte-identity computed against the stdlib for every path.
- `fvm dart analyze packages/`: clean. Patch coverage: 100%. No integration test (no observable wire change).
