### PR TITLE
feat: thread allowReserved through delimited, deepObject and AnyModel value encoders

### DIFF
--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -217,6 +217,11 @@ String encodeAnyToSimple(
 /// `Uri.encodeComponent` (spaces become `%20`); the same flag is threaded
 /// into recursive list/map element encoding.
 ///
+/// When [allowReserved] is true, RFC 3986 reserved characters in primitive
+/// values are kept literal; the flag is threaded into recursive list/map
+/// element encoding. The [ParameterEncodable] branch is intentionally not
+/// threaded — generated models honor the flag in a later step.
+///
 /// Note: when an unsupported nested element raises [EncodingException], the
 /// message identifies only the inner type — no path / key context is attached
 /// to indicate where in the structure the failure originated.
@@ -225,6 +230,7 @@ String encodeAnyToForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -247,42 +253,49 @@ String encodeAnyToForm(
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is int) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is double) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is bool) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is DateTime) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is Uri) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is BigDecimal) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is Map<String, dynamic>) {
@@ -296,6 +309,7 @@ String encodeAnyToForm(
           explode: explode,
           allowEmpty: allowEmpty,
           useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
         ),
     };
     return _formEntriesToString(
@@ -322,6 +336,7 @@ String encodeAnyToForm(
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ),
         )
         .toList();
@@ -351,12 +366,18 @@ String _formEntriesToString(
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// `Map<String, String>` values use extension methods.
 ///
+/// When [allowReserved] is true, RFC 3986 reserved characters in the map
+/// VALUES are kept literal (keys stay `Uri.encodeComponent`-encoded). The
+/// [ParameterEncodable] branch is intentionally not threaded — generated
+/// models honor the flag in a later step.
+///
 /// Note: DeepObject style only makes sense for objects, not primitives.
 List<ParameterEntry> encodeAnyToDeepObject(
   Object? value,
   String paramName, {
   required bool explode,
   required bool allowEmpty,
+  bool allowReserved = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -376,6 +397,7 @@ List<ParameterEntry> encodeAnyToDeepObject(
       paramName,
       explode: explode,
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
   }
   throw EncodingException(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -217,10 +217,10 @@ String encodeAnyToSimple(
 /// `Uri.encodeComponent` (spaces become `%20`); the same flag is threaded
 /// into recursive list/map element encoding.
 ///
-/// When [allowReserved] is true, RFC 3986 reserved characters in primitive
+/// When [allowReserved] is true, most reserved characters in primitive
 /// values are kept literal; the flag is threaded into recursive list/map
 /// element encoding. The [ParameterEncodable] branch is intentionally not
-/// threaded — generated models honor the flag in a later step.
+/// threaded — those models manage their own value encoding.
 ///
 /// Note: when an unsupported nested element raises [EncodingException], the
 /// message identifies only the inner type — no path / key context is attached
@@ -366,10 +366,10 @@ String _formEntriesToString(
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// `Map<String, String>` values use extension methods.
 ///
-/// When [allowReserved] is true, RFC 3986 reserved characters in the map
+/// When [allowReserved] is true, most reserved characters in the map
 /// VALUES are kept literal (keys stay `Uri.encodeComponent`-encoded). The
-/// [ParameterEncodable] branch is intentionally not threaded — generated
-/// models honor the flag in a later step.
+/// [ParameterEncodable] branch is intentionally not threaded — those models
+/// manage their own value encoding.
 ///
 /// Note: DeepObject style only makes sense for objects, not primitives.
 List<ParameterEntry> encodeAnyToDeepObject(

--- a/packages/tonik_util/lib/src/encoding/deep_object_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/deep_object_encoder_extensions.dart
@@ -1,5 +1,6 @@
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
 /// Extensions for encoding values using deepObject style parameter encoding.
 ///
@@ -21,6 +22,10 @@ extension DeepObjectStringMapEncoder on Map<String, String> {
   /// The [allowEmpty] parameter controls whether empty maps are allowed.
   /// The [alreadyEncoded] parameter indicates values are already URI-encoded.
   ///
+  /// When [allowReserved] is true, RFC 3986 reserved characters in each VALUE
+  /// are kept literal. Keys remain `Uri.encodeComponent`-encoded because they
+  /// form part of the parameter name `name[key]`, as do the `[` `]` brackets.
+  ///
   /// Throws [EncodingException] if explode is false.
   /// Throws [EmptyValueException] if the map is empty and allowEmpty is false.
   List<ParameterEntry> toDeepObject(
@@ -28,6 +33,7 @@ extension DeepObjectStringMapEncoder on Map<String, String> {
     required bool explode,
     required bool allowEmpty,
     bool alreadyEncoded = false,
+    bool allowReserved = false,
   }) {
     if (!explode) {
       throw const EncodingException(
@@ -47,7 +53,7 @@ extension DeepObjectStringMapEncoder on Map<String, String> {
       final encodedKey = Uri.encodeComponent(e.key);
       final encodedValue = alreadyEncoded
           ? e.value
-          : Uri.encodeComponent(e.value);
+          : e.value.uriEncode(allowEmpty: true, allowReserved: allowReserved);
       return (name: '$paramName[$encodedKey]', value: encodedValue);
     }).toList();
   }

--- a/packages/tonik_util/lib/src/encoding/deep_object_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/deep_object_encoder_extensions.dart
@@ -22,9 +22,10 @@ extension DeepObjectStringMapEncoder on Map<String, String> {
   /// The [allowEmpty] parameter controls whether empty maps are allowed.
   /// The [alreadyEncoded] parameter indicates values are already URI-encoded.
   ///
-  /// When [allowReserved] is true, RFC 3986 reserved characters in each VALUE
-  /// are kept literal. Keys remain `Uri.encodeComponent`-encoded because they
-  /// form part of the parameter name `name[key]`, as do the `[` `]` brackets.
+  /// When [allowReserved] is true, most reserved characters in each VALUE
+  /// are kept literal. Keys are `Uri.encodeComponent`-encoded because they
+  /// form part of the parameter name `name[key]`; the surrounding `[` `]` are
+  /// emitted literally as name structure.
   ///
   /// Throws [EncodingException] if explode is false.
   /// Throws [EmptyValueException] if the map is empty and allowEmpty is false.

--- a/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
@@ -24,10 +24,14 @@ extension PipeDelimitedStringListEncoder on List<String> {
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
+  ///
+  /// When [allowReserved] is true, RFC 3986 reserved characters are kept
+  /// literal in each item; the `|` delimiter is unaffected.
   List<String> toPipeDelimited({
     required bool explode,
     required bool allowEmpty,
     bool alreadyEncoded = false,
+    bool allowReserved = false,
   }) {
     if (isEmpty) {
       if (!allowEmpty) {
@@ -41,7 +45,10 @@ extension PipeDelimitedStringListEncoder on List<String> {
         return this;
       }
       return map(
-        (item) => item.uriEncode(allowEmpty: allowEmpty),
+        (item) => item.uriEncode(
+          allowEmpty: allowEmpty,
+          allowReserved: allowReserved,
+        ),
       ).toList();
     } else {
       if (alreadyEncoded) {
@@ -49,7 +56,10 @@ extension PipeDelimitedStringListEncoder on List<String> {
       }
       return [
         map(
-          (item) => item.uriEncode(allowEmpty: allowEmpty),
+          (item) => item.uriEncode(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved,
+          ),
         ).join('|'),
       ];
     }
@@ -69,9 +79,13 @@ extension PipeDelimitedBinaryEncoder on List<int> {
   /// The [allowEmpty] parameter controls whether empty lists are allowed:
   /// - When `true`, empty lists return `['']`
   /// - When `false`, empty lists throw an exception
+  ///
+  /// When [allowReserved] is true, RFC 3986 reserved characters in the decoded
+  /// value are kept literal.
   List<String> toPipeDelimited({
     required bool explode,
     required bool allowEmpty,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -79,7 +93,11 @@ extension PipeDelimitedBinaryEncoder on List<int> {
     if (isEmpty) {
       return [''];
     }
-    final str = decodeToString();
-    return [Uri.encodeComponent(str)];
+    return [
+      decodeToString().uriEncode(
+        allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
+      ),
+    ];
   }
 }

--- a/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
@@ -25,7 +25,7 @@ extension PipeDelimitedStringListEncoder on List<String> {
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
   ///
-  /// When [allowReserved] is true, RFC 3986 reserved characters are kept
+  /// When [allowReserved] is true, most reserved characters are kept
   /// literal in each item; the `|` delimiter is unaffected.
   List<String> toPipeDelimited({
     required bool explode,
@@ -80,7 +80,7 @@ extension PipeDelimitedBinaryEncoder on List<int> {
   /// - When `true`, empty lists return `['']`
   /// - When `false`, empty lists throw an exception
   ///
-  /// When [allowReserved] is true, RFC 3986 reserved characters in the decoded
+  /// When [allowReserved] is true, most reserved characters in the decoded
   /// value are kept literal.
   List<String> toPipeDelimited({
     required bool explode,
@@ -95,7 +95,7 @@ extension PipeDelimitedBinaryEncoder on List<int> {
     }
     return [
       decodeToString().uriEncode(
-        allowEmpty: allowEmpty,
+        allowEmpty: true,
         allowReserved: allowReserved,
       ),
     ];

--- a/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
@@ -25,7 +25,7 @@ extension SpaceDelimitedStringListEncoder on List<String> {
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
   ///
-  /// When [allowReserved] is true, RFC 3986 reserved characters are kept
+  /// When [allowReserved] is true, most reserved characters are kept
   /// literal in each item; the `%20` delimiter is unaffected.
   List<String> toSpaceDelimited({
     required bool explode,
@@ -82,7 +82,7 @@ extension SpaceDelimitedBinaryEncoder on List<int> {
   /// - When `true`, empty lists return `['']`
   /// - When `false`, empty lists throw an exception
   ///
-  /// When [allowReserved] is true, RFC 3986 reserved characters in the decoded
+  /// When [allowReserved] is true, most reserved characters in the decoded
   /// value are kept literal.
   List<String> toSpaceDelimited({
     required bool explode,
@@ -97,7 +97,7 @@ extension SpaceDelimitedBinaryEncoder on List<int> {
     }
     return [
       decodeToString().uriEncode(
-        allowEmpty: allowEmpty,
+        allowEmpty: true,
         allowReserved: allowReserved,
       ),
     ];

--- a/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
@@ -24,11 +24,15 @@ extension SpaceDelimitedStringListEncoder on List<String> {
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
+  ///
+  /// When [allowReserved] is true, RFC 3986 reserved characters are kept
+  /// literal in each item; the `%20` delimiter is unaffected.
   List<String> toSpaceDelimited({
     required bool explode,
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool percentEncodeDelimiter = true,
+    bool allowReserved = false,
   }) {
     if (isEmpty) {
       if (!allowEmpty) {
@@ -42,7 +46,10 @@ extension SpaceDelimitedStringListEncoder on List<String> {
         return this;
       }
       return map(
-        (item) => item.uriEncode(allowEmpty: allowEmpty),
+        (item) => item.uriEncode(
+          allowEmpty: allowEmpty,
+          allowReserved: allowReserved,
+        ),
       ).toList();
     } else {
       final delimiter = alreadyEncoded && !percentEncodeDelimiter ? ' ' : '%20';
@@ -51,7 +58,10 @@ extension SpaceDelimitedStringListEncoder on List<String> {
       }
       return [
         map(
-          (item) => item.uriEncode(allowEmpty: allowEmpty),
+          (item) => item.uriEncode(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved,
+          ),
         ).join('%20'),
       ];
     }
@@ -71,9 +81,13 @@ extension SpaceDelimitedBinaryEncoder on List<int> {
   /// The [allowEmpty] parameter controls whether empty lists are allowed:
   /// - When `true`, empty lists return `['']`
   /// - When `false`, empty lists throw an exception
+  ///
+  /// When [allowReserved] is true, RFC 3986 reserved characters in the decoded
+  /// value are kept literal.
   List<String> toSpaceDelimited({
     required bool explode,
     required bool allowEmpty,
+    bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -81,7 +95,11 @@ extension SpaceDelimitedBinaryEncoder on List<int> {
     if (isEmpty) {
       return [''];
     }
-    final str = decodeToString();
-    return [Uri.encodeComponent(str)];
+    return [
+      decodeToString().uriEncode(
+        allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
+      ),
+    ];
   }
 }

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1611,6 +1611,52 @@ void main() {
         );
       });
     });
+
+    group('allowReserved', () {
+      test('honors allowReserved for String primitives', () {
+        expect(
+          encodeAnyToForm(
+            'a&b=c:d',
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'a%26b%3Dc:d',
+        );
+      });
+
+      test('honors allowReserved for nested list primitives', () {
+        expect(
+          encodeAnyToForm(
+            <dynamic>['a:b', 'c&d'],
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'a:b,c%26d',
+        );
+      });
+
+      test('honors allowReserved for nested map primitives', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{'k': 'a&b:c'},
+            explode: true,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'k=a%26b:c',
+        );
+      });
+
+      test('default is byte-identical to Uri.encodeComponent for String', () {
+        const value = 'a&b=c+d:e';
+        expect(
+          encodeAnyToForm(value, explode: false, allowEmpty: true),
+          Uri.encodeComponent(value),
+        );
+      });
+    });
   });
 
   group('encodeAnyToDeepObject', () {
@@ -1825,6 +1871,38 @@ void main() {
           throwsA(isA<EncodingException>()),
         );
       });
+    });
+
+    group('allowReserved', () {
+      test('honors allowReserved for Map values, keys stay encoded', () {
+        final result = encodeAnyToDeepObject(
+          {'a&b': 'c&d:e'},
+          'p',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        expect(result, [
+          (name: 'p[a%26b]', value: 'c%26d:e'),
+        ]);
+      });
+
+      test(
+        'default Map value encoding is byte-identical to encodeComponent',
+        () {
+          const value = 'a&b=c+d:e';
+          expect(
+            encodeAnyToDeepObject(
+              {'q': value},
+              'p',
+              explode: true,
+              allowEmpty: true,
+            ),
+            [(name: 'p[q]', value: Uri.encodeComponent(value))],
+          );
+        },
+      );
     });
   });
 

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1637,6 +1637,27 @@ void main() {
         );
       });
 
+      test('DateTime value keeps : literal under allowReserved', () {
+        final dateTime = DateTime.utc(2024, 1, 2, 12, 30, 45);
+        expect(
+          encodeAnyToForm(
+            dateTime,
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          '2024-01-02T12:30:45.000Z',
+        );
+      });
+
+      test('DateTime value encodes : as %3A by default', () {
+        final dateTime = DateTime.utc(2024, 1, 2, 12, 30, 45);
+        expect(
+          encodeAnyToForm(dateTime, explode: false, allowEmpty: true),
+          '2024-01-02T12%3A30%3A45.000Z',
+        );
+      });
+
       test('honors allowReserved for nested list primitives', () {
         expect(
           encodeAnyToForm(

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1625,6 +1625,18 @@ void main() {
         );
       });
 
+      test('honors allowReserved for Uri values', () {
+        expect(
+          encodeAnyToForm(
+            Uri.parse('https://x/a?b=c&d=e'),
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'https://x/a?b%3Dc%26d%3De',
+        );
+      });
+
       test('honors allowReserved for nested list primitives', () {
         expect(
           encodeAnyToForm(

--- a/packages/tonik_util/test/src/encoding/deep_object_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/deep_object_encoder_extensions_test.dart
@@ -401,5 +401,73 @@ void main() {
         ]);
       });
     });
+
+    group('allowReserved', () {
+      test('keeps reserved chars literal except & = + in VALUE', () {
+        final result =
+            {
+              'q': 'a&b=c+d:e',
+            }.toDeepObject(
+              'p',
+              explode: true,
+              allowEmpty: true,
+              allowReserved: true,
+            );
+
+        expect(result, [
+          (name: 'p[q]', value: 'a%26b%3Dc%2Bd:e'),
+        ]);
+      });
+
+      test(
+        'key stays Uri.encodeComponent-encoded even under allowReserved',
+        () {
+          final result =
+              {
+                'a&b': 'c:d',
+              }.toDeepObject(
+                'p',
+                explode: true,
+                allowEmpty: true,
+                allowReserved: true,
+              );
+
+          expect(result, [
+            (name: 'p[a%26b]', value: 'c:d'),
+          ]);
+        },
+      );
+
+      test(
+        'default VALUE encoding is byte-identical to Uri.encodeComponent',
+        () {
+          const value = 'a&b=c+d:e';
+          expect(
+            {'q': value}.toDeepObject('p', explode: true, allowEmpty: true),
+            [(name: 'p[q]', value: Uri.encodeComponent(value))],
+          );
+        },
+      );
+
+      test('alreadyEncoded short-circuits regardless of allowReserved', () {
+        const map = {'q': 'a%26b'};
+        final withFlag = map.toDeepObject(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          allowReserved: true,
+        );
+        final without = map.toDeepObject(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+        );
+
+        expect(withFlag, without);
+        expect(withFlag, [(name: 'p[q]', value: 'a%26b')]);
+      });
+    });
   });
 }

--- a/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
@@ -172,4 +172,86 @@ void main() {
       expect(result, ['H%C3%ABll%C3%B6']);
     });
   });
+
+  group('allowReserved', () {
+    test('reserved literal except & = + per item, explode=false', () {
+      final result = ['a:b', 'c&d=e+f'].toPipeDelimited(
+        explode: false,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b|c%26d%3De%2Bf']);
+    });
+
+    test('reserved literal except & = + per item, explode=true', () {
+      final result = ['a:b', 'c&d=e+f'].toPipeDelimited(
+        explode: true,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b', 'c%26d%3De%2Bf']);
+    });
+
+    test('literal pipe delimiter is unaffected by allowReserved', () {
+      final result = ['a:b', 'c:d'].toPipeDelimited(
+        explode: false,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b|c:d']);
+    });
+
+    test('default byte-identical to encodeComponent, explode=false', () {
+      const items = ['a:b', 'c&d=e+f', 'x y'];
+      expect(
+        items.toPipeDelimited(explode: false, allowEmpty: true),
+        [items.map(Uri.encodeComponent).join('|')],
+      );
+    });
+
+    test('default byte-identical to encodeComponent, explode=true', () {
+      const items = ['a:b', 'c&d=e+f', 'x y'];
+      expect(
+        items.toPipeDelimited(explode: true, allowEmpty: true),
+        items.map(Uri.encodeComponent).toList(),
+      );
+    });
+
+    test('binary keeps reserved chars literal under allowReserved', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.toPipeDelimited(
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        ['a:b%20c'],
+      );
+    });
+
+    test('binary default is byte-identical to Uri.encodeComponent', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.toPipeDelimited(explode: false, allowEmpty: true),
+        [Uri.encodeComponent('a:b c')],
+      );
+    });
+
+    test('alreadyEncoded short-circuits regardless of allowReserved', () {
+      const items = ['a%26b', 'c%3Dd'];
+      final withFlag = items.toPipeDelimited(
+        explode: false,
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      final without = items.toPipeDelimited(
+        explode: false,
+        allowEmpty: true,
+        alreadyEncoded: true,
+      );
+      expect(withFlag, without);
+      expect(withFlag, ['a%26b|c%3Dd']);
+    });
+  });
 }

--- a/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
@@ -171,6 +171,13 @@ void main() {
       final result = value.toPipeDelimited(explode: false, allowEmpty: true);
       expect(result, ['H%C3%ABll%C3%B6']);
     });
+
+    test('non-empty bytes decoding to empty string yield a single empty '
+        'string with allowEmpty=false', () {
+      const value = [0xEF, 0xBB, 0xBF]; // UTF-8 BOM, stripped on decode
+      final result = value.toPipeDelimited(explode: false, allowEmpty: false);
+      expect(result, ['']);
+    });
   });
 
   group('allowReserved', () {

--- a/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
@@ -204,6 +204,13 @@ void main() {
       final result = value.toSpaceDelimited(explode: false, allowEmpty: true);
       expect(result, ['H%C3%ABll%C3%B6']);
     });
+
+    test('non-empty bytes decoding to empty string yield a single empty '
+        'string with allowEmpty=false', () {
+      const value = [0xEF, 0xBB, 0xBF]; // UTF-8 BOM, stripped on decode
+      final result = value.toSpaceDelimited(explode: false, allowEmpty: false);
+      expect(result, ['']);
+    });
   });
 
   group('allowReserved', () {

--- a/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
@@ -205,4 +205,86 @@ void main() {
       expect(result, ['H%C3%ABll%C3%B6']);
     });
   });
+
+  group('allowReserved', () {
+    test('reserved literal except & = + per item, explode=false', () {
+      final result = ['a:b', 'c&d=e+f'].toSpaceDelimited(
+        explode: false,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b%20c%26d%3De%2Bf']);
+    });
+
+    test('reserved literal except & = + per item, explode=true', () {
+      final result = ['a:b', 'c&d=e+f'].toSpaceDelimited(
+        explode: true,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b', 'c%26d%3De%2Bf']);
+    });
+
+    test('%20 delimiter is unaffected by allowReserved', () {
+      final result = ['a:b', 'c:d'].toSpaceDelimited(
+        explode: false,
+        allowEmpty: true,
+        allowReserved: true,
+      );
+      expect(result, ['a:b%20c:d']);
+    });
+
+    test('default byte-identical to encodeComponent, explode=false', () {
+      const items = ['a:b', 'c&d=e+f', 'x y'];
+      expect(
+        items.toSpaceDelimited(explode: false, allowEmpty: true),
+        [items.map(Uri.encodeComponent).join('%20')],
+      );
+    });
+
+    test('default byte-identical to encodeComponent, explode=true', () {
+      const items = ['a:b', 'c&d=e+f', 'x y'];
+      expect(
+        items.toSpaceDelimited(explode: true, allowEmpty: true),
+        items.map(Uri.encodeComponent).toList(),
+      );
+    });
+
+    test('binary keeps reserved chars literal under allowReserved', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.toSpaceDelimited(
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        ['a:b%20c'],
+      );
+    });
+
+    test('binary default is byte-identical to Uri.encodeComponent', () {
+      const value = [97, 58, 98, 32, 99]; // "a:b c"
+      expect(
+        value.toSpaceDelimited(explode: false, allowEmpty: true),
+        [Uri.encodeComponent('a:b c')],
+      );
+    });
+
+    test('alreadyEncoded short-circuits regardless of allowReserved', () {
+      const items = ['a%26b', 'c%3Dd'];
+      final withFlag = items.toSpaceDelimited(
+        explode: false,
+        allowEmpty: true,
+        alreadyEncoded: true,
+        allowReserved: true,
+      );
+      final without = items.toSpaceDelimited(
+        explode: false,
+        allowEmpty: true,
+        alreadyEncoded: true,
+      );
+      expect(withFlag, without);
+      expect(withFlag, ['a%26b%20c%3Dd']);
+    });
+  });
 }


### PR DESCRIPTION
## Summary

Threads the `allowReserved` flag (default `false`) through the `spaceDelimited`, `pipeDelimited`, and `deepObject` **value** encoders, plus the `encodeAnyToForm` / `encodeAnyToDeepObject` AnyModel helpers, reusing the reserved-preserving helper from the scalar encoders. **Additive and default-off**, so it ships with **zero wire-behavior change** (no caller passes the flag yet).

## What changed

- `SpaceDelimitedStringListEncoder.toSpaceDelimited` / `PipeDelimitedStringListEncoder.toPipeDelimited` (and the binary `List<int>` variants) accept `bool allowReserved = false`, routing each item's value-encode through `String.uriEncode(allowReserved: ...)`. The `%20` / literal `|` join delimiters are unchanged.
- `DeepObjectStringMapEncoder.toDeepObject` accepts `allowReserved`, applied to the **value** only. Keys stay `Uri.encodeComponent`-encoded and the `[` / `]` brackets are unchanged, because the key forms part of the structural parameter name `name[key]`.
- `encodeAnyToForm` / `encodeAnyToDeepObject` accept `allowReserved` and thread it through the primitive value-encode path and the recursive nested list/map-of-primitives path (and the `Map<String,String>` deepObject path). The `ParameterEncodable` (generated-model) branch is intentionally left un-threaded — generated models honor the flag in a later step, and threading it now would require changing the shared encoding interfaces.

## Semantics (spec-grounded)

OAS scopes `allowReserved` to the parameter **value** (RFC 6570 §3.2.3 reserved expansion). When `allowReserved: true`, RFC 3986 reserved characters in a value survive literally, except the form-urlencoded delimiters `& = +` (always `%26 %3D %2B`, per OAS Appendix E); `[ ] #` / `%` / space / non-ASCII stay encoded — all inherited from the shared scalar helper. The join delimiters (`%20`, `|`) and the deepObject `name[key]` structure are applied after value encoding and are non-reserved or structural, so `allowReserved` cannot change them; the tests lock this in. When `allowReserved: false`, every style is byte-identical to the previous output.

## Testing

- Per style (space / pipe / deepObject): reserved value survives literally under `allowReserved: true` with `& = +` → `%26 %3D %2B`; delimiter / bracket output asserted unchanged.
- deepObject: a reserved-bearing **key** stays `Uri.encodeComponent`-encoded even under `allowReserved: true`, while the value passes reserved through.
- AnyModel: primitive value with reserved chars via `encodeAnyToForm` and `encodeAnyToDeepObject` honored under the flag.
- `alreadyEncoded: true` short-circuit asserted identical with and without `allowReserved`.
- Default-unchanged (`allowReserved: false`) byte-identity computed against the stdlib for every style.
- `fvm dart analyze packages/`: clean. Patch coverage: 100%. No integration test (no observable wire change).
