### PR TITLE
feat: honor allowReserved for form-style query parameters

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -135,6 +135,11 @@ jobs:
           cd integration_test/query_parameters/query_parameters_test
           dart test --concurrency=2
 
+      - name: Run allow reserved integration tests
+        run: |
+          cd integration_test/allow_reserved/allow_reserved_test
+          dart test --concurrency=2
+
       - name: Run type arrays integration tests
         run: |
           cd integration_test/type_arrays/type_arrays_test

--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@
 /integration_test/fastify_type_provider_zod/fastify_type_provider_zod_api
 /integration_test/composition/composition_api
 /integration_test/query_parameters/query_parameters_api
+/integration_test/allow_reserved/allow_reserved_api
 /integration_test/path_encoding/path_encoding_api
 /integration_test/petstore_config/petstore_api
 /integration_test/petstore_config/petstore_filtering_api

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -1,49 +1,106 @@
-# URI Encoding Limitations
+# URI Encoding and `allowReserved`
 
 ## Overview
 
-Tonik generates API clients that use Dart's standard `Uri` class for URL construction. This has important implications for how query parameters are encoded, particularly for OpenAPI's `pipeDelimited` and `spaceDelimited` parameter styles and the `allowReserved` property.
+Tonik generates API clients that build URLs with Dart's standard `Uri` class.
+For most parameter styles this means reserved characters in query strings are
+percent-encoded according to RFC 3986. For **form-style query parameters**,
+Tonik additionally honors OpenAPI's `allowReserved` property by encoding the
+value itself before handing it to `Uri`, so the reserved set is preserved on the
+wire. This applies to primitive, string, array, free-form object
+(`additionalProperties`), and free-form (`Object`/`any`) values. Parameters whose
+schema is an object with defined properties, an enum, or a composition do not yet
+honor it — see [Styles and schemas that do not yet honor
+`allowReserved`](#styles-and-schemas-that-do-not-yet-honor-allowreserved).
 
-## The Limitation
+This document explains exactly which characters are kept literal, which are
+encoded, and why.
 
-**Dart's `Uri` class always percent-encodes reserved characters in query strings according to RFC 3986.** This means:
+## `allowReserved: true` for Form Query Parameters
 
-- Pipe characters (`|`) are always encoded as `%7C`
-- Space characters are encoded as `%20` in the `spaceDelimited` and `pipeDelimited` styles
-- Other reserved characters (like `&`, `=`, `#`, etc.) are also percent-encoded
-
-This behavior is fundamental to Dart's URI handling and cannot be disabled or customized.
-
-## Impact on OpenAPI Features
-
-### `allowReserved: true`
-
-OpenAPI 3.0 allows parameters to specify `allowReserved: true`, which indicates that reserved characters should NOT be percent-encoded. **Tonik cannot implement this feature** because Dart's `Uri` class does not support unencoded reserved characters in query strings.
+OpenAPI 3.0 lets a query parameter set `allowReserved: true` to indicate that the
+reserved characters defined in RFC 3986 should be sent literally instead of
+percent-encoded.
 
 ```yaml
-# This OpenAPI parameter specification...
 parameters:
   - name: path
     in: query
+    style: form
+    allowReserved: true
     schema:
       type: string
-    allowReserved: true  # ← Cannot be honored in Dart
 ```
 
-### `pipeDelimited` Style
+For form-style query parameters, Tonik honors this. Given a value such as
+`a/b:c?d@e,f`, the generated client sends:
 
-For array parameters with `style: pipeDelimited`, the OpenAPI specification expects values to be separated by unencoded pipe characters:
+```
+?path=a/b:c?d@e,f
+```
+
+The reserved characters `/ : ? @ ; ,` (and the other RFC 3986 sub-delimiters)
+pass through literally. A sibling parameter **without** `allowReserved` keeps the
+default behavior and is fully percent-encoded:
+
+```
+?path=a%2Fb%3Ac%3Fd%40e%2Cf
+```
+
+### Characters that are still encoded
+
+Even with `allowReserved: true`, a few characters are always encoded. This is
+required for the value to remain a well-formed query string — it is conformance,
+not a Tonik shortfall.
+
+| Character | Sent as | Reason |
+|-----------|---------|--------|
+| `&`       | `%26`   | Separates one parameter from the next. |
+| `=`       | `%3D`   | Separates a parameter name from its value. |
+| `+`       | `%2B`   | Reserved so a literal `+` is never confused with an encoded space. |
+| space     | `%20`   | Spaces are not permitted literally in a URL. |
+| `#`       | `%23`   | A literal `#` would start the URL fragment. |
+| `[` `]`   | `%5B` `%5D` | The application is responsible for these; they are encoded for query strings. |
+| `%`       | `%25`   | A `%` outside a valid percent-encoded triple must be encoded. |
+
+The OpenAPI description of `allowReserved` makes the application responsible for
+`& = +` (the form-urlencoded delimiters) as well as `[ ] #`; OAS Appendix E is
+authoritative for the `& = +` set. Tonik encodes `& = +` **inside the value**
+itself (to `%26 %3D %2B`) rather than relying on Dart's `Uri`, because `Uri`
+treats them as structural and would otherwise leave a data `&` or `=`
+indistinguishable from a real delimiter.
+
+### Query strings and urlencoded request bodies
+
+The same value encoding is used for query strings and for
+`application/x-www-form-urlencoded` request bodies (the latter is delivered by a
+later release). Both surfaces percent-encode the **same** `& = +` set. They
+differ in only two ways:
+
+- `# [ ]` are encoded in a query string but may stay literal in a request body.
+- A space renders as `%20` in a query string and as `+` in a urlencoded body.
+
+## Styles and Schemas That Do Not Yet Honor `allowReserved`
+
+`allowReserved` is currently applied to **form-style** query parameters. The
+`spaceDelimited`, `pipeDelimited`, and `deepObject` styles still percent-encode
+reserved characters, because Dart's `Uri` class always encodes them and the value
+is not pre-encoded for these styles.
+
+Within form style, parameters whose schema is an **object with defined
+properties**, an **enum**, or a **`oneOf` / `anyOf` / `allOf`** composition also
+do not yet honor `allowReserved`. Their values are serialized by the model's own
+encoding, which always percent-encodes the reserved set. Primitive, string,
+array, and free-form object (`additionalProperties`) parameters honor it.
+
+### `pipeDelimited` Style
 
 ```
 Expected:  ?colors=red|green|blue
 Actual:    ?colors=red%7Cgreen%7Cblue
 ```
 
-Tonik generates code that produces the encoded form (`%7C`) because that's what Dart's `Uri` class produces.
-
 ### `spaceDelimited` Style
-
-Similarly, for `style: spaceDelimited`, spaces are encoded as `%20`:
 
 ```
 Expected:  ?colors=red green blue
@@ -52,72 +109,69 @@ Actual:    ?colors=red%20green%20blue
 
 ### `deepObject` Style
 
-For `style: deepObject`, square brackets are used as structural syntax to denote nested object properties:
-
 ```
 Expected:  ?filter[color]=red&filter[size]=large
 Actual:    ?filter%5Bcolor%5D=red&filter%5Bsize%5D=large
 ```
 
-The square brackets `[` and `]` are encoded as `%5B` and `%5D` respectively. While these brackets are part of the parameter name syntax in deepObject encoding, Dart's `Uri` class treats them as reserved characters that must be encoded.
+The square brackets `[` and `]` are part of the parameter-name syntax in
+`deepObject` encoding, but they are encoded as `%5B` and `%5D`.
 
 ## Null Array Elements in Parameters
 
-OpenAPI's parameter styles (`form`, `simple`, `label`, `matrix`, `spaceDelimited`, `pipeDelimited`, `deepObject`) are based on RFC 6570 URI Templates, which have **no representation for a `null` element inside an array**. So when an array with nullable items (`items: { nullable: true }`, or `type: [T, "null"]` in OAS 3.1) is used as a path, query, or header parameter, there is no standard way to put `null` on the wire.
+OpenAPI's parameter styles (`form`, `simple`, `label`, `matrix`, `spaceDelimited`,
+`pipeDelimited`, `deepObject`) are based on RFC 6570 URI Templates, which have
+**no representation for a `null` element inside an array**. So when an array with
+nullable items (`items: { nullable: true }`, or `type: [T, "null"]` in OAS 3.1)
+is used as a path, query, or header parameter, there is no standard way to put
+`null` on the wire.
 
 Tonik handles this pragmatically:
 
-- **Sending a request:** a `null` element is encoded as an empty string. For example, `['a', null, 'b']` becomes `a,,b`.
-- **Reading a response:** an empty element cannot be reliably turned back into `null`. String items decode it as the empty string `''`; typed items (e.g. `List<int?>`) cannot decode an empty element and will report a decoding error.
+- **Sending a request:** a `null` element is encoded as an empty string. For
+  example, `['a', null, 'b']` becomes `a,,b`.
+- **Reading a response:** an empty element cannot be reliably turned back into
+  `null`. String items decode it as the empty string `''`; typed items (e.g.
+  `List<int?>`) cannot decode an empty element and will report a decoding error.
 
-Nullable array items are fully supported in **JSON request and response bodies**, where `null` is a well-defined value. In **URL parameters** they are encoded best-effort but are not round-trippable, because the parameter styles themselves do not define null elements. If you control the API, prefer non-nullable array items for parameters.
+Nullable array items are fully supported in **JSON request and response bodies**,
+where `null` is a well-defined value. In **URL parameters** they are encoded
+best-effort but are not round-trippable, because the parameter styles themselves
+do not define null elements. If you control the API, prefer non-nullable array
+items for parameters.
 
-## Why This Works in Practice
+## Why Percent-Encoding Still Works in Practice
 
-Despite these encoding differences, **the generated clients work correctly** with most servers because:
+When a parameter is fully percent-encoded (no `allowReserved`, or a style that
+does not yet honor it), the generated clients still work correctly with most
+servers because:
 
-1. **HTTP servers automatically decode query parameters**: When a server receives `%7C`, it decodes it back to `|` before processing the parameter value.
-
-2. **RFC 3986 compliance**: Percent-encoding reserved characters is the standard, safe way to transmit data in URLs. Most servers expect and handle this correctly.
-
-3. **Functional equivalence**: From the server's perspective, `red%7Cgreen%7Cblue` and `red|green|blue` represent the same data after URL decoding.
-
-## Industry Context
-
-This limitation is **not unique to Tonik**. It affects the entire Dart ecosystem:
-
-- The official `openapi-generator` for Dart (both `dart` and `dart-dio` generators) have the same limitation
-- All Dart HTTP clients that use the standard `Uri` class are affected
-- This is a conscious trade-off: Dart prioritizes RFC 3986 compliance over OpenAPI's optional `allowReserved` feature
-
-## Workarounds
-
-If you absolutely need unencoded reserved characters in URLs, you have limited options:
-
-### 1. Server-Side Acceptance (Recommended)
-
-Ensure your API server correctly decodes percent-encoded query parameters. This is the standard behavior for most HTTP servers and frameworks.
-
-### 2. Custom HTTP Client Adapter
-
-You could implement a custom Dio `HttpClientAdapter` that manipulates the raw HTTP request string before sending it. However, this is complex, fragile, and not recommended.
+1. **HTTP servers automatically decode query parameters.** When a server
+   receives `%7C`, it decodes it back to `|` before processing the value.
+2. **RFC 3986 compliance.** Percent-encoding reserved characters is the standard,
+   safe way to transmit data in URLs.
+3. **Functional equivalence.** From the server's perspective, `red%7Cgreen` and
+   `red|green` represent the same data after URL decoding.
 
 ## Testing Considerations
 
-When writing tests for Tonik-generated clients, expect percent-encoded values in query strings:
+When asserting on query strings, expect the reserved set to survive for
+`allowReserved` form parameters and to be percent-encoded otherwise:
 
 ```dart
-// In your tests, expect encoded pipes:
+// allowReserved form parameter — reserved survivors stay literal:
 expect(
   response.requestOptions.uri.query,
-  'colors=red%7Cgreen%7Cblue',  // Not 'colors=red|green|blue'
+  'path=a/b:c?d@e,f',
+);
+
+// Default parameter — fully percent-encoded:
+expect(
+  response.requestOptions.uri.query,
+  'path=a%2Fb%3Ac%3Fd%40e%2Cf',
 );
 ```
 
-## Related OpenAPI Issues
+## Related OpenAPI Discussion
 
-This limitation has been discussed in the OpenAPI community:
-
-- [OpenAPI Generator Issue #812](https://github.com/OpenAPITools/openapi-generator/issues/812) - Dart generator doesn't support allowReserved
-- [OpenAPI Specification Issue #1840](https://github.com/OAI/OpenAPI-Specification/issues/1840) - Discussion about allowReserved implementation challenges
-
+- [OpenAPI Specification Issue #1840](https://github.com/OAI/OpenAPI-Specification/issues/1840) - Discussion about `allowReserved` implementation challenges

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -41,9 +41,11 @@ For form-style query parameters, Tonik honors this. Given a value such as
 ?path=a/b:c?d@e,f
 ```
 
-The reserved characters `/ : ? @ ; ,` (and the remaining RFC 3986 reserved
-characters, except `& = +`) pass through literally. A sibling parameter **without**
-`allowReserved` keeps the default behavior and is fully percent-encoded:
+The reserved characters `/ : ? @ ; ,` (and most other RFC 3986 reserved
+characters) pass through literally; the exceptions — `& = +`, `# [ ]`, space, and
+`%` — are percent-encoded as described under *Characters that are still encoded*
+below. A sibling parameter **without** `allowReserved` keeps the default behavior
+and is fully percent-encoded:
 
 ```
 ?path=a%2Fb%3Ac%3Fd%40e%2Cf
@@ -71,7 +73,7 @@ Tonik encodes `& = +` **inside the value** itself (to `%26 %3D %2B`) rather than
 relying on Dart's `Uri`, because `Uri` treats them as structural and would
 otherwise leave a data `&` or `=` indistinguishable from a real delimiter.
 
-### Query strings and urlencoded request bodies
+### urlencoded request bodies
 
 Encoding for `application/x-www-form-urlencoded` request bodies is planned for a
 later release.
@@ -89,8 +91,8 @@ properties**, an **enum**, or a **`oneOf` / `anyOf` / `allOf`** composition also
 do not yet honor `allowReserved`. Their values are serialized by the model's own
 encoding, which always percent-encodes the reserved set. The same applies to
 **arrays whose items** are enums, objects, compositions, or free-form
-(`Object`/`any`) values: each element is serialized by its own encoding, which
-still percent-encodes the reserved set. Note the asymmetry — a scalar free-form
+(`Object`/`any`) values: these item types are not encoded with `allowReserved`.
+Note the asymmetry — a scalar free-form
 (`Object`/`any`) value is honored, but an array of free-form/`any` items is not:
 each array element is serialized through an encoder that does not yet accept
 `allowReserved`.

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -1,110 +1,49 @@
-# URI Encoding and `allowReserved`
+# URI Encoding Limitations
 
 ## Overview
 
-Tonik generates API clients that build URLs with Dart's standard `Uri` class.
-For most parameter styles this means reserved characters in query strings are
-percent-encoded according to RFC 3986. For **form-style query parameters**,
-Tonik additionally honors OpenAPI's `allowReserved` property by encoding the
-value itself before handing it to `Uri`, so the reserved set is preserved on the
-wire. This applies to primitive, string, or byte values, arrays of primitive,
-string, or byte items, free-form objects (`additionalProperties`), and free-form
-(`Object`/`any`) values. Parameters whose schema is an object with defined
-properties, an enum, a composition, an array of those, or an array of free-form
-(`Object`/`any`) items do not yet honor it —
-see [Styles and schemas that do not yet honor
-`allowReserved`](#styles-and-schemas-that-do-not-yet-honor-allowreserved).
+Tonik generates API clients that use Dart's standard `Uri` class for URL construction. This has important implications for how query parameters are encoded, particularly for OpenAPI's `pipeDelimited` and `spaceDelimited` parameter styles and the `allowReserved` property.
 
-This document explains exactly which characters are kept literal, which are
-encoded, and why.
+## The Limitation
 
-## `allowReserved: true` for Form Query Parameters
+**Dart's `Uri` class always percent-encodes reserved characters in query strings according to RFC 3986.** This means:
 
-OpenAPI 3.0 lets a query parameter set `allowReserved: true` to indicate that the
-reserved characters defined in RFC 3986 should be sent literally instead of
-percent-encoded.
+- Pipe characters (`|`) are always encoded as `%7C`
+- Space characters are encoded as `%20` in the `spaceDelimited` and `pipeDelimited` styles
+- Other reserved characters (like `&`, `=`, `#`, etc.) are also percent-encoded
+
+This behavior is fundamental to Dart's URI handling and cannot be disabled or customized.
+
+## Impact on OpenAPI Features
+
+### `allowReserved: true`
+
+OpenAPI 3.0 allows parameters to specify `allowReserved: true`, which indicates that reserved characters should NOT be percent-encoded. **Tonik cannot implement this feature** because Dart's `Uri` class does not support unencoded reserved characters in query strings.
 
 ```yaml
+# This OpenAPI parameter specification...
 parameters:
   - name: path
     in: query
-    style: form
-    allowReserved: true
     schema:
       type: string
+    allowReserved: true  # ← Cannot be honored in Dart
 ```
-
-For form-style query parameters, Tonik honors this. Given a value such as
-`a/b:c?d@e,f`, the generated client sends:
-
-```
-?path=a/b:c?d@e,f
-```
-
-The reserved characters `/ : ? @ ; ,` (and most other RFC 3986 reserved
-characters) pass through literally; the exceptions — `& = +`, `# [ ]`, space, and
-`%` — are percent-encoded as described under *Characters that are still encoded*
-below. A sibling parameter **without** `allowReserved` keeps the default behavior
-and is fully percent-encoded:
-
-```
-?path=a%2Fb%3Ac%3Fd%40e%2Cf
-```
-
-### Characters that are still encoded
-
-Even with `allowReserved: true`, a few characters are always encoded. This is
-required for the value to remain a well-formed query string — it is conformance,
-not a Tonik shortfall.
-
-| Character | Sent as | Reason |
-|-----------|---------|--------|
-| `&`       | `%26`   | Separates one parameter from the next. |
-| `=`       | `%3D`   | Separates a parameter name from its value. |
-| `+`       | `%2B`   | Reserved so a literal `+` is never confused with an encoded space. |
-| space     | `%20`   | Spaces are not permitted literally in a URL. |
-| `#`       | `%23`   | A literal `#` would start the URL fragment. |
-| `[` `]`   | `%5B` `%5D` | The application is responsible for these; they are encoded for query strings. |
-| `%`       | `%25`   | A `%` outside a valid percent-encoded triple must be encoded. |
-
-The OpenAPI description of `allowReserved` makes the application responsible for
-`& = +` (the form-urlencoded delimiters, per OAS Appendix E) as well as `[ ] #`.
-Tonik encodes `& = +` **inside the value** itself (to `%26 %3D %2B`) rather than
-relying on Dart's `Uri`, because `Uri` treats them as structural and would
-otherwise leave a data `&` or `=` indistinguishable from a real delimiter.
-
-### urlencoded request bodies
-
-Encoding for `application/x-www-form-urlencoded` request bodies is planned for a
-later release.
-
-## Styles and Schemas That Do Not Yet Honor `allowReserved`
-
-`allowReserved` is currently applied to **form-style** query parameters. The
-`spaceDelimited`, `pipeDelimited`, and `deepObject` styles still percent-encode
-reserved characters. The runtime already supports preserving the reserved set for
-these styles; the generated clients do not yet thread `allowReserved` through to
-them. A later release will wire it in.
-
-Within form style, parameters whose schema is an **object with defined
-properties**, an **enum**, or a **`oneOf` / `anyOf` / `allOf`** composition also
-do not yet honor `allowReserved`. Their values are serialized by the model's own
-encoding, which always percent-encodes the reserved set. The same applies to
-**arrays whose items** are enums, objects, compositions, or free-form
-(`Object`/`any`) values: these item types are not encoded with `allowReserved`.
-Note the asymmetry — a scalar free-form
-(`Object`/`any`) value is honored, but an array of free-form/`any` items is not:
-each array element is serialized through an encoder that does not yet accept
-`allowReserved`.
 
 ### `pipeDelimited` Style
+
+For array parameters with `style: pipeDelimited`, the OpenAPI specification expects values to be separated by unencoded pipe characters:
 
 ```
 Expected:  ?colors=red|green|blue
 Actual:    ?colors=red%7Cgreen%7Cblue
 ```
 
+Tonik generates code that produces the encoded form (`%7C`) because that's what Dart's `Uri` class produces.
+
 ### `spaceDelimited` Style
+
+Similarly, for `style: spaceDelimited`, spaces are encoded as `%20`:
 
 ```
 Expected:  ?colors=red green blue
@@ -113,69 +52,72 @@ Actual:    ?colors=red%20green%20blue
 
 ### `deepObject` Style
 
+For `style: deepObject`, square brackets are used as structural syntax to denote nested object properties:
+
 ```
 Expected:  ?filter[color]=red&filter[size]=large
 Actual:    ?filter%5Bcolor%5D=red&filter%5Bsize%5D=large
 ```
 
-The square brackets `[` and `]` are part of the parameter-name syntax in
-`deepObject` encoding, but they are encoded as `%5B` and `%5D`.
+The square brackets `[` and `]` are encoded as `%5B` and `%5D` respectively. While these brackets are part of the parameter name syntax in deepObject encoding, Dart's `Uri` class treats them as reserved characters that must be encoded.
 
 ## Null Array Elements in Parameters
 
-OpenAPI's parameter styles (`form`, `simple`, `label`, `matrix`, `spaceDelimited`,
-`pipeDelimited`, `deepObject`) are based on RFC 6570 URI Templates, which have
-**no representation for a `null` element inside an array**. So when an array with
-nullable items (`items: { nullable: true }`, or `type: [T, "null"]` in OAS 3.1)
-is used as a path, query, or header parameter, there is no standard way to put
-`null` on the wire.
+OpenAPI's parameter styles (`form`, `simple`, `label`, `matrix`, `spaceDelimited`, `pipeDelimited`, `deepObject`) are based on RFC 6570 URI Templates, which have **no representation for a `null` element inside an array**. So when an array with nullable items (`items: { nullable: true }`, or `type: [T, "null"]` in OAS 3.1) is used as a path, query, or header parameter, there is no standard way to put `null` on the wire.
 
 Tonik handles this pragmatically:
 
-- **Sending a request:** a `null` element is encoded as an empty string. For
-  example, `['a', null, 'b']` becomes `a,,b`.
-- **Reading a response:** an empty element cannot be reliably turned back into
-  `null`. String items decode it as the empty string `''`; typed items (e.g.
-  `List<int?>`) cannot decode an empty element and will report a decoding error.
+- **Sending a request:** a `null` element is encoded as an empty string. For example, `['a', null, 'b']` becomes `a,,b`.
+- **Reading a response:** an empty element cannot be reliably turned back into `null`. String items decode it as the empty string `''`; typed items (e.g. `List<int?>`) cannot decode an empty element and will report a decoding error.
 
-Nullable array items are fully supported in **JSON request and response bodies**,
-where `null` is a well-defined value. In **URL parameters** they are encoded
-best-effort but are not round-trippable, because the parameter styles themselves
-do not define null elements. If you control the API, prefer non-nullable array
-items for parameters.
+Nullable array items are fully supported in **JSON request and response bodies**, where `null` is a well-defined value. In **URL parameters** they are encoded best-effort but are not round-trippable, because the parameter styles themselves do not define null elements. If you control the API, prefer non-nullable array items for parameters.
 
-## Why Percent-Encoding Still Works in Practice
+## Why This Works in Practice
 
-When a parameter is fully percent-encoded (no `allowReserved`, or a style that
-does not yet honor it), the generated clients still work correctly with most
-servers because:
+Despite these encoding differences, **the generated clients work correctly** with most servers because:
 
-1. **HTTP servers automatically decode query parameters.** When a server
-   receives `%7C`, it decodes it back to `|` before processing the value.
-2. **RFC 3986 compliance.** Percent-encoding reserved characters is the standard,
-   safe way to transmit data in URLs.
-3. **Functional equivalence.** From the server's perspective, `red%7Cgreen` and
-   `red|green` represent the same data after URL decoding.
+1. **HTTP servers automatically decode query parameters**: When a server receives `%7C`, it decodes it back to `|` before processing the parameter value.
+
+2. **RFC 3986 compliance**: Percent-encoding reserved characters is the standard, safe way to transmit data in URLs. Most servers expect and handle this correctly.
+
+3. **Functional equivalence**: From the server's perspective, `red%7Cgreen%7Cblue` and `red|green|blue` represent the same data after URL decoding.
+
+## Industry Context
+
+This limitation is **not unique to Tonik**. It affects the entire Dart ecosystem:
+
+- The official `openapi-generator` for Dart (both `dart` and `dart-dio` generators) have the same limitation
+- All Dart HTTP clients that use the standard `Uri` class are affected
+- This is a conscious trade-off: Dart prioritizes RFC 3986 compliance over OpenAPI's optional `allowReserved` feature
+
+## Workarounds
+
+If you absolutely need unencoded reserved characters in URLs, you have limited options:
+
+### 1. Server-Side Acceptance (Recommended)
+
+Ensure your API server correctly decodes percent-encoded query parameters. This is the standard behavior for most HTTP servers and frameworks.
+
+### 2. Custom HTTP Client Adapter
+
+You could implement a custom Dio `HttpClientAdapter` that manipulates the raw HTTP request string before sending it. However, this is complex, fragile, and not recommended.
 
 ## Testing Considerations
 
-When asserting on query strings, expect the reserved set to survive for
-`allowReserved` form parameters and to be percent-encoded otherwise:
+When writing tests for Tonik-generated clients, expect percent-encoded values in query strings:
 
 ```dart
-// allowReserved form parameter — reserved survivors stay literal:
+// In your tests, expect encoded pipes:
 expect(
   response.requestOptions.uri.query,
-  'path=a/b:c?d@e,f',
-);
-
-// Default parameter — fully percent-encoded:
-expect(
-  response.requestOptions.uri.query,
-  'path=a%2Fb%3Ac%3Fd%40e%2Cf',
+  'colors=red%7Cgreen%7Cblue',  // Not 'colors=red|green|blue'
 );
 ```
 
-## Related OpenAPI Discussion
+## Related OpenAPI Issues
 
-- [OpenAPI Specification Issue #1840](https://github.com/OAI/OpenAPI-Specification/issues/1840) - Discussion about `allowReserved` implementation challenges
+This limitation has been discussed in the OpenAPI community:
+
+- [OpenAPI Generator Issue #812](https://github.com/OpenAPITools/openapi-generator/issues/812) - Dart generator doesn't support allowReserved
+- [OpenAPI Specification Issue #1840](https://github.com/OAI/OpenAPI-Specification/issues/1840) - Discussion about allowReserved implementation challenges
+

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -7,10 +7,11 @@ For most parameter styles this means reserved characters in query strings are
 percent-encoded according to RFC 3986. For **form-style query parameters**,
 Tonik additionally honors OpenAPI's `allowReserved` property by encoding the
 value itself before handing it to `Uri`, so the reserved set is preserved on the
-wire. This applies to primitive, string, array, free-form object
-(`additionalProperties`), and free-form (`Object`/`any`) values. Parameters whose
-schema is an object with defined properties, an enum, or a composition do not yet
-honor it — see [Styles and schemas that do not yet honor
+wire. This applies to primitive and string values, arrays of primitive, string,
+or byte items, free-form objects (`additionalProperties`), and free-form
+(`Object`/`any`) values. Parameters whose schema is an object with defined
+properties, an enum, a composition, or an array of those do not yet honor it —
+see [Styles and schemas that do not yet honor
 `allowReserved`](#styles-and-schemas-that-do-not-yet-honor-allowreserved).
 
 This document explains exactly which characters are kept literal, which are
@@ -39,9 +40,9 @@ For form-style query parameters, Tonik honors this. Given a value such as
 ?path=a/b:c?d@e,f
 ```
 
-The reserved characters `/ : ? @ ; ,` (and the other RFC 3986 sub-delimiters)
-pass through literally. A sibling parameter **without** `allowReserved` keeps the
-default behavior and is fully percent-encoded:
+The reserved characters `/ : ? @ ; ,` (and other RFC 3986 sub-delimiters, but
+not `& = +`) pass through literally. A sibling parameter **without**
+`allowReserved` keeps the default behavior and is fully percent-encoded:
 
 ```
 ?path=a%2Fb%3Ac%3Fd%40e%2Cf
@@ -72,26 +73,33 @@ indistinguishable from a real delimiter.
 
 ### Query strings and urlencoded request bodies
 
-The same value encoding is used for query strings and for
-`application/x-www-form-urlencoded` request bodies (the latter is delivered by a
-later release). Both surfaces percent-encode the **same** `& = +` set. They
+This release applies the value encoding to query strings only. A later release
+will extend the same encoding to `application/x-www-form-urlencoded` request
+bodies. Both surfaces will percent-encode the **same** `& = +` set, and will
 differ in only two ways:
 
-- `# [ ]` are encoded in a query string but may stay literal in a request body.
-- A space renders as `%20` in a query string and as `+` in a urlencoded body.
+- `# [ ]` are encoded in a query string but will be allowed to stay literal in a
+  request body.
+- A space renders as `%20` in a query string and will render as `+` in a
+  urlencoded body.
 
 ## Styles and Schemas That Do Not Yet Honor `allowReserved`
 
 `allowReserved` is currently applied to **form-style** query parameters. The
 `spaceDelimited`, `pipeDelimited`, and `deepObject` styles still percent-encode
-reserved characters, because Dart's `Uri` class always encodes them and the value
-is not pre-encoded for these styles.
+reserved characters. The runtime already supports preserving the reserved set for
+these styles; the generated clients do not yet thread `allowReserved` through to
+them. A later release will wire it in.
 
 Within form style, parameters whose schema is an **object with defined
 properties**, an **enum**, or a **`oneOf` / `anyOf` / `allOf`** composition also
 do not yet honor `allowReserved`. Their values are serialized by the model's own
-encoding, which always percent-encodes the reserved set. Primitive, string,
-array, and free-form object (`additionalProperties`) parameters honor it.
+encoding, which always percent-encodes the reserved set. The same applies to
+**arrays whose items** are enums, objects, or compositions: each element is
+serialized by its own encoding, which still percent-encodes the reserved set.
+Parameters honor `allowReserved` when their schema is a primitive, a string, an
+array of primitive, string, or byte items, a free-form object
+(`additionalProperties`), or a free-form `Object`/`any` value.
 
 ### `pipeDelimited` Style
 

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -7,8 +7,8 @@ For most parameter styles this means reserved characters in query strings are
 percent-encoded according to RFC 3986. For **form-style query parameters**,
 Tonik additionally honors OpenAPI's `allowReserved` property by encoding the
 value itself before handing it to `Uri`, so the reserved set is preserved on the
-wire. This applies to primitive and string values, arrays of primitive, string,
-or byte items, free-form objects (`additionalProperties`), and free-form
+wire. This applies to primitive, string, or byte values, arrays of primitive,
+string, or byte items, free-form objects (`additionalProperties`), and free-form
 (`Object`/`any`) values. Parameters whose schema is an object with defined
 properties, an enum, a composition, or an array of those do not yet honor it —
 see [Styles and schemas that do not yet honor
@@ -65,11 +65,10 @@ not a Tonik shortfall.
 | `%`       | `%25`   | A `%` outside a valid percent-encoded triple must be encoded. |
 
 The OpenAPI description of `allowReserved` makes the application responsible for
-`& = +` (the form-urlencoded delimiters) as well as `[ ] #`; OAS Appendix E is
-authoritative for the `& = +` set. Tonik encodes `& = +` **inside the value**
-itself (to `%26 %3D %2B`) rather than relying on Dart's `Uri`, because `Uri`
-treats them as structural and would otherwise leave a data `&` or `=`
-indistinguishable from a real delimiter.
+`& = +` (the form-urlencoded delimiters, per OAS Appendix E) as well as `[ ] #`.
+Tonik encodes `& = +` **inside the value** itself (to `%26 %3D %2B`) rather than
+relying on Dart's `Uri`, because `Uri` treats them as structural and would
+otherwise leave a data `&` or `=` indistinguishable from a real delimiter.
 
 ### Query strings and urlencoded request bodies
 
@@ -95,10 +94,14 @@ Within form style, parameters whose schema is an **object with defined
 properties**, an **enum**, or a **`oneOf` / `anyOf` / `allOf`** composition also
 do not yet honor `allowReserved`. Their values are serialized by the model's own
 encoding, which always percent-encodes the reserved set. The same applies to
-**arrays whose items** are enums, objects, or compositions: each element is
-serialized by its own encoding, which still percent-encodes the reserved set.
-Parameters honor `allowReserved` when their schema is a primitive, a string, an
-array of primitive, string, or byte items, a free-form object
+**arrays whose items** are enums, objects, compositions, or free-form
+(`Object`/`any`) values: each element is serialized by its own encoding, which
+still percent-encodes the reserved set. Note the asymmetry — a scalar
+free-form/`any` value *is* honored (it encodes through `encodeAnyToForm`), but an
+array of free-form/`any` items is not, because its elements route through
+`encodeAnyToUri`, which has no `allowReserved` parameter.
+Parameters honor `allowReserved` when their schema is a primitive, string, or
+byte value, an array of primitive, string, or byte items, a free-form object
 (`additionalProperties`), or a free-form `Object`/`any` value.
 
 ### `pipeDelimited` Style

--- a/docs/uri_encoding_limitations.md
+++ b/docs/uri_encoding_limitations.md
@@ -10,7 +10,8 @@ value itself before handing it to `Uri`, so the reserved set is preserved on the
 wire. This applies to primitive, string, or byte values, arrays of primitive,
 string, or byte items, free-form objects (`additionalProperties`), and free-form
 (`Object`/`any`) values. Parameters whose schema is an object with defined
-properties, an enum, a composition, or an array of those do not yet honor it —
+properties, an enum, a composition, an array of those, or an array of free-form
+(`Object`/`any`) items do not yet honor it —
 see [Styles and schemas that do not yet honor
 `allowReserved`](#styles-and-schemas-that-do-not-yet-honor-allowreserved).
 
@@ -40,8 +41,8 @@ For form-style query parameters, Tonik honors this. Given a value such as
 ?path=a/b:c?d@e,f
 ```
 
-The reserved characters `/ : ? @ ; ,` (and other RFC 3986 sub-delimiters, but
-not `& = +`) pass through literally. A sibling parameter **without**
+The reserved characters `/ : ? @ ; ,` (and the remaining RFC 3986 reserved
+characters, except `& = +`) pass through literally. A sibling parameter **without**
 `allowReserved` keeps the default behavior and is fully percent-encoded:
 
 ```
@@ -72,15 +73,8 @@ otherwise leave a data `&` or `=` indistinguishable from a real delimiter.
 
 ### Query strings and urlencoded request bodies
 
-This release applies the value encoding to query strings only. A later release
-will extend the same encoding to `application/x-www-form-urlencoded` request
-bodies. Both surfaces will percent-encode the **same** `& = +` set, and will
-differ in only two ways:
-
-- `# [ ]` are encoded in a query string but will be allowed to stay literal in a
-  request body.
-- A space renders as `%20` in a query string and will render as `+` in a
-  urlencoded body.
+Encoding for `application/x-www-form-urlencoded` request bodies is planned for a
+later release.
 
 ## Styles and Schemas That Do Not Yet Honor `allowReserved`
 
@@ -96,13 +90,10 @@ do not yet honor `allowReserved`. Their values are serialized by the model's own
 encoding, which always percent-encodes the reserved set. The same applies to
 **arrays whose items** are enums, objects, compositions, or free-form
 (`Object`/`any`) values: each element is serialized by its own encoding, which
-still percent-encodes the reserved set. Note the asymmetry — a scalar
-free-form/`any` value *is* honored (it encodes through `encodeAnyToForm`), but an
-array of free-form/`any` items is not, because its elements route through
-`encodeAnyToUri`, which has no `allowReserved` parameter.
-Parameters honor `allowReserved` when their schema is a primitive, string, or
-byte value, an array of primitive, string, or byte items, a free-form object
-(`additionalProperties`), or a free-form `Object`/`any` value.
+still percent-encodes the reserved set. Note the asymmetry — a scalar free-form
+(`Object`/`any`) value is honored, but an array of free-form/`any` items is not:
+each array element is serialized through an encoder that does not yet accept
+`allowReserved`.
 
 ### `pipeDelimited` Style
 

--- a/integration_test/allow_reserved/allow_reserved_test/.gitignore
+++ b/integration_test/allow_reserved/allow_reserved_test/.gitignore
@@ -1,0 +1,7 @@
+# https://dart.dev/guides/libraries/private-files
+# Created by `dart pub`
+.dart_tool/
+
+# Avoid committing pubspec.lock for library packages; see
+# https://dart.dev/guides/libraries/private-files#pubspeclock.
+pubspec.lock

--- a/integration_test/allow_reserved/allow_reserved_test/.gitignore
+++ b/integration_test/allow_reserved/allow_reserved_test/.gitignore
@@ -1,7 +1,2 @@
-# https://dart.dev/guides/libraries/private-files
-# Created by `dart pub`
 .dart_tool/
-
-# Avoid committing pubspec.lock for library packages; see
-# https://dart.dev/guides/libraries/private-files#pubspeclock.
 pubspec.lock

--- a/integration_test/allow_reserved/allow_reserved_test/analysis_options.yaml
+++ b/integration_test/allow_reserved/allow_reserved_test/analysis_options.yaml
@@ -1,0 +1,6 @@
+include: package:very_good_analysis/analysis_options.yaml
+
+linter:
+  rules:
+    public_member_api_docs: false
+    avoid_print: false

--- a/integration_test/allow_reserved/allow_reserved_test/dart_test.yaml
+++ b/integration_test/allow_reserved/allow_reserved_test/dart_test.yaml
@@ -1,0 +1,1 @@
+concurrency: 1

--- a/integration_test/allow_reserved/allow_reserved_test/imposter/imposter-config.json
+++ b/integration_test/allow_reserved/allow_reserved_test/imposter/imposter-config.json
@@ -1,0 +1,7 @@
+{
+  "plugin": "openapi",
+  "specFile": "../../openapi.yaml",
+  "response": {
+    "scriptFile": "response.groovy"
+  }
+}

--- a/integration_test/allow_reserved/allow_reserved_test/imposter/response.groovy
+++ b/integration_test/allow_reserved/allow_reserved_test/imposter/response.groovy
@@ -1,0 +1,8 @@
+// Get the response status from the request header
+def headers = context.request.headers
+def responseStatus = headers['X-Response-Status'] ?: headers['x-response-status'] ?: '200'
+
+// Set the response status code and use the OpenAPI specification
+respond()
+    .withStatusCode(Integer.parseInt(responseStatus))
+    .usingDefaultBehaviour()

--- a/integration_test/allow_reserved/allow_reserved_test/pubspec.yaml
+++ b/integration_test/allow_reserved/allow_reserved_test/pubspec.yaml
@@ -1,0 +1,27 @@
+name: allow_reserved_test
+description: A sample command-line application.
+version: 1.0.0
+publish_to: none
+
+environment:
+  sdk: '>=3.10.0 <4.0.0'
+
+dependencies:
+  allow_reserved_api:
+    path: ../allow_reserved_api
+  dio: ^5.8.0
+  path: ^1.9.1
+  tonik_util: ^0.4.1
+
+dev_dependencies:
+  big_decimal: ^0.7.0
+  test: ^1.25.15
+  test_helpers:
+    path: ../../test_helpers
+  very_good_analysis: ^10.2.0
+
+
+
+dependency_overrides:
+  tonik_util:
+    path: ../../../packages/tonik_util

--- a/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
@@ -26,8 +26,6 @@ void main() {
     );
   }
 
-  // Reserved survivors (/ : ? @ ; ,), the form delimiters (& = +), a space and
-  // (# [ ]) so a single value exercises every encoding branch at once.
   const value = 'a/b:c?d@e;f,g&h=i+j k#l[m]n';
 
   group('form allowReserved', () {
@@ -75,8 +73,6 @@ void main() {
     });
   });
 
-  // The reserved survivors and the encodables are split across two items so the
-  // comma joining the non-explode list stays an unambiguous delimiter.
   const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
 
   group('form allowReserved list', () {

--- a/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
@@ -31,8 +31,9 @@ void main() {
   const value = 'a/b:c?d@e;f,g&h=i+j k#l[m]n';
 
   group('form allowReserved', () {
-    test('keeps the reserved set literal and encodes only the survivors',
-        () async {
+    test(
+        'keeps reserved survivors literal and encodes only the form '
+        'delimiters, space, and bracket/hash chars', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormAllowReserved(reserved: value);
 
@@ -79,8 +80,9 @@ void main() {
   const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
 
   group('form allowReserved list', () {
-    test('keeps reserved survivors literal and encodes only the survivors',
-        () async {
+    test(
+        'keeps reserved survivors literal and encodes only the form '
+        'delimiters, space, and bracket/hash chars', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormAllowReservedList(
         reservedList: listValues,

--- a/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_test.dart
@@ -1,0 +1,111 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  // Reserved survivors (/ : ? @ ; ,), the form delimiters (& = +), a space and
+  // (# [ ]) so a single value exercises every encoding branch at once.
+  const value = 'a/b:c?d@e;f,g&h=i+j k#l[m]n';
+
+  group('form allowReserved', () {
+    test('keeps the reserved set literal and encodes only the survivors',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReserved(reserved: value);
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reserved=a/b:c?d@e;f,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default parameter is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReserved(notReserved: value);
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReserved=a%2Fb%3Ac%3Fd%40e%3Bf%2Cg%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('reserved and default siblings encode the same value differently',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReserved(
+        reserved: value,
+        notReserved: value,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reserved=a/b:c?d@e;f,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn'
+        '&notReserved=a%2Fb%3Ac%3Fd%40e%3Bf%2Cg%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+
+  // The reserved survivors and the encodables are split across two items so the
+  // comma joining the non-explode list stays an unambiguous delimiter.
+  const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
+
+  group('form allowReserved list', () {
+    test('keeps reserved survivors literal and encodes only the survivors',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedList(
+        reservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedList=a/b:c?d@e;f,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default list is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedList(
+        notReservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedList=a%2Fb%3Ac%3Fd%40e%3Bf,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/openapi.yaml
+++ b/integration_test/allow_reserved/openapi.yaml
@@ -1,0 +1,76 @@
+openapi: 3.0.4
+info:
+  title: Allow Reserved API
+  description: >-
+    OpenAPI specification showcasing form query parameters that opt into
+    allowReserved, alongside sibling parameters that do not.
+  version: 1.0.0
+  contact:
+    name: Example
+    url: https://example.com
+    email: example@example.com
+
+servers:
+  - url: https://api.example.com/v1
+
+tags:
+  - name: query
+    description: Operations demonstrating allowReserved query parameters
+
+paths:
+  /form-allow-reserved:
+    get:
+      operationId: testFormAllowReserved
+      tags:
+        - query
+      summary: Test allowReserved form query parameters
+      description: >-
+        A form query parameter with allowReserved next to a sibling that keeps
+        the default full percent-encoding.
+      parameters:
+        - name: reserved
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            type: string
+        - name: notReserved
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: No Content
+  /form-allow-reserved-list:
+    get:
+      operationId: testFormAllowReservedList
+      tags:
+        - query
+      summary: Test allowReserved form query array parameters
+      description: >-
+        A non-nullable array form query parameter with allowReserved next to a
+        sibling array that keeps the default full percent-encoding.
+      parameters:
+        - name: reservedList
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: notReservedList
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '204':
+          description: No Content

--- a/packages/tonik_generate/lib/src/operation/query_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/query_generator.dart
@@ -87,6 +87,7 @@ class QueryGenerator {
         resolvedParam,
         explode: resolvedParam.explode,
         allowEmpty: resolvedParam.allowEmptyValue,
+        allowReserved: resolvedParam.allowReserved,
       ).statements;
     }
 

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -50,8 +50,7 @@ Expression? buildFormEntriesValueExpression(
       return toForm(receiver, reserved: allowReserved);
 
     // Generated models (enums, objects, and compositions) implement their own
-    // toForm and do not expose allowReserved; they manage their own value
-    // encoding.
+    // toForm and do not expose allowReserved.
     case EnumModel():
     case ClassModel():
     case AllOfModel():

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -49,8 +49,9 @@ Expression? buildFormEntriesValueExpression(
     case NumberModel():
       return toForm(receiver, reserved: allowReserved);
 
-    // Generated models (enums and composites) implement their own toForm and
-    // do not expose allowReserved; they manage their own value encoding.
+    // Generated models (enums, objects, and compositions) implement their own
+    // toForm and do not expose allowReserved; they manage their own value
+    // encoding.
     case EnumModel():
     case ClassModel():
     case AllOfModel():

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -16,6 +16,7 @@ Expression? buildFormEntriesValueExpression(
   required Expression explode,
   required Expression allowEmpty,
   Expression? useQueryComponent,
+  bool allowReserved = false,
 }) {
   final toFormArgs = <String, Expression>{
     'explode': explode,
@@ -23,14 +24,18 @@ Expression? buildFormEntriesValueExpression(
     'useQueryComponent': ?useQueryComponent,
   };
 
-  Expression toForm(Expression target, {bool alreadyEncoded = false}) =>
-      target.property('toForm').call(
-        [paramName],
-        {
-          ...toFormArgs,
-          if (alreadyEncoded) 'alreadyEncoded': literalBool(true),
-        },
-      );
+  Expression toForm(
+    Expression target, {
+    bool alreadyEncoded = false,
+    bool reserved = false,
+  }) => target.property('toForm').call(
+    [paramName],
+    {
+      ...toFormArgs,
+      if (alreadyEncoded) 'alreadyEncoded': literalBool(true),
+      if (reserved) 'allowReserved': literalBool(true),
+    },
+  );
 
   switch (model) {
     case StringModel():
@@ -42,6 +47,10 @@ Expression? buildFormEntriesValueExpression(
     case IntegerModel():
     case DoubleModel():
     case NumberModel():
+      return toForm(receiver, reserved: allowReserved);
+
+    // Generated models (enums and composites) implement their own toForm and
+    // do not expose allowReserved; they manage their own value encoding.
     case EnumModel():
     case ClassModel():
     case AllOfModel():
@@ -50,7 +59,10 @@ Expression? buildFormEntriesValueExpression(
       return toForm(receiver);
 
     case Base64Model():
-      return toForm(receiver.property('toBase64String').call([]));
+      return toForm(
+        receiver.property('toBase64String').call([]),
+        reserved: allowReserved,
+      );
 
     case MapModel():
       final converted = buildMapToStringMapExpression(
@@ -60,7 +72,7 @@ Expression? buildFormEntriesValueExpression(
       );
       if (converted == null) return null;
       // Conversion does not URI-encode, so the Map extension must still encode.
-      return toForm(converted);
+      return toForm(converted, reserved: allowReserved);
 
     case final ListModel m:
       return _buildListFormEntriesExpression(
@@ -71,6 +83,7 @@ Expression? buildFormEntriesValueExpression(
         isContentNullable:
             m.isContentNullable || m.content.isEffectivelyNullable,
         toForm: toForm,
+        allowReserved: allowReserved,
       );
 
     case AliasModel():
@@ -81,6 +94,7 @@ Expression? buildFormEntriesValueExpression(
         explode: explode,
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       );
 
     case NeverModel():
@@ -101,12 +115,18 @@ Expression? _buildListFormEntriesExpression(
   required Expression allowEmpty,
   required Expression? useQueryComponent,
   required bool isContentNullable,
-  required Expression Function(Expression, {bool alreadyEncoded}) toForm,
+  required Expression Function(
+    Expression, {
+    bool alreadyEncoded,
+    bool reserved,
+  })
+  toForm,
+  required bool allowReserved,
 }) {
   final resolved = contentModel.resolved;
 
   if (resolved is StringModel && !isContentNullable) {
-    return toForm(receiver);
+    return toForm(receiver, reserved: allowReserved);
   }
 
   // The base64 string still needs URI-encoding, so it is not passed as
@@ -123,7 +143,7 @@ Expression? _buildListFormEntriesExpression(
         ])
         .property('toList')
         .call([]);
-    return toForm(mapped);
+    return toForm(mapped, reserved: allowReserved);
   }
 
   final encodedElements = _buildEncodedElementsList(
@@ -132,6 +152,7 @@ Expression? _buildListFormEntriesExpression(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
     isContentNullable: isContentNullable,
+    allowReserved: allowReserved,
   );
   if (encodedElements == null) return null;
 
@@ -144,6 +165,7 @@ Expression? _buildEncodedElementsList(
   required Expression allowEmpty,
   required Expression? useQueryComponent,
   required bool isContentNullable,
+  required bool allowReserved,
 }) {
   if (!_isUriEncodableElement(contentModel)) return null;
 
@@ -152,6 +174,7 @@ Expression? _buildEncodedElementsList(
     contentModel,
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   ).expression;
 
   final elementEncode = isContentNullable

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -49,8 +49,6 @@ Expression? buildFormEntriesValueExpression(
     case NumberModel():
       return toForm(receiver, reserved: allowReserved);
 
-    // Generated models (enums, objects, and compositions) implement their own
-    // toForm and do not expose allowReserved.
     case EnumModel():
     case ClassModel():
     case AllOfModel():

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -11,6 +11,7 @@ BuiltStatements buildToFormQueryParameterCode(
   QueryParameterObject parameter, {
   bool explode = false,
   bool allowEmpty = true,
+  bool allowReserved = false,
 }) {
   return BuiltStatements.simple(
     _buildToFormQueryParameterCode(
@@ -18,6 +19,7 @@ BuiltStatements buildToFormQueryParameterCode(
       parameter,
       explode: explode,
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     ),
   );
 }
@@ -27,6 +29,7 @@ List<Code> _buildToFormQueryParameterCode(
   QueryParameterObject parameter, {
   required bool explode,
   required bool allowEmpty,
+  required bool allowReserved,
 }) {
   final model = parameter.model;
   final rawName = parameter.rawName;
@@ -56,6 +59,7 @@ List<Code> _buildToFormQueryParameterCode(
             {
               'explode': literalBool(explode),
               'allowEmpty': literalBool(allowEmpty),
+              if (allowReserved) 'allowReserved': literalBool(true),
             },
           )
           .code,
@@ -69,6 +73,7 @@ List<Code> _buildToFormQueryParameterCode(
     paramName: specLiteralString(rawName),
     explode: literalBool(explode),
     allowEmpty: literalBool(allowEmpty),
+    allowReserved: allowReserved,
   );
 
   if (value == null) {

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -10,6 +10,7 @@ BuiltExpression buildUriEncodeExpression(
   required Expression allowEmpty,
   Expression? useQueryComponent,
   bool useImmutableCollections = false,
+  bool allowReserved = false,
 }) {
   return BuiltExpression.simple(
     _buildUriEncodeExpression(
@@ -18,6 +19,7 @@ BuiltExpression buildUriEncodeExpression(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
       useImmutableCollections: useImmutableCollections,
+      allowReserved: allowReserved,
     ),
   );
 }
@@ -42,6 +44,7 @@ Expression _buildUriEncodeExpression(
   required Expression allowEmpty,
   Expression? useQueryComponent,
   bool useImmutableCollections = false,
+  bool allowReserved = false,
 }) {
   return switch (model) {
     StringModel() ||
@@ -64,6 +67,10 @@ Expression _buildUriEncodeExpression(
         {
           'allowEmpty': allowEmpty,
           'useQueryComponent': ?useQueryComponent,
+          // Generated enums override uriEncode without an allowReserved
+          // parameter, so the flag only applies to the built-in encoders.
+          if (allowReserved && model is! EnumModel)
+            'allowReserved': literalBool(true),
         },
       ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
@@ -97,6 +104,7 @@ Expression _buildUriEncodeExpression(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
       useImmutableCollections: useImmutableCollections,
+      allowReserved: allowReserved,
     ),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for URI encoding.',

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -86,12 +86,14 @@ Expression _buildUriEncodeExpression(
           'useQueryComponent': ?useQueryComponent,
         },
       ),
+    // Whole-collection encoding drops allowReserved for now (a later step).
     MapModel() => _buildMapUriEncodeExpression(
       valueExpression,
       model,
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
     ),
+    // Whole-collection encoding drops allowReserved for now (a later step).
     final ListModel m => _buildListUriEncodeExpression(
       valueExpression,
       m.content,

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -86,14 +86,14 @@ Expression _buildUriEncodeExpression(
           'useQueryComponent': ?useQueryComponent,
         },
       ),
-    // Whole-collection encoding drops allowReserved for now (a later step).
+    // Whole-collection Map/List encoding does not thread allowReserved to its
+    // elements.
     MapModel() => _buildMapUriEncodeExpression(
       valueExpression,
       model,
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
     ),
-    // Whole-collection encoding drops allowReserved for now (a later step).
     final ListModel m => _buildListUriEncodeExpression(
       valueExpression,
       m.content,

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -67,15 +67,11 @@ Expression _buildUriEncodeExpression(
         {
           'allowEmpty': allowEmpty,
           'useQueryComponent': ?useQueryComponent,
-          // Generated enums override uriEncode without an allowReserved
-          // parameter, so the flag only applies to the built-in encoders.
           if (allowReserved && model is! EnumModel)
             'allowReserved': literalBool(true),
         },
       ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
-      // encodeAnyToUri has no allowReserved parameter, so the flag is not
-      // forwarded here.
       refer(
         'encodeAnyToUri',
         'package:tonik_util/tonik_util.dart',
@@ -86,8 +82,6 @@ Expression _buildUriEncodeExpression(
           'useQueryComponent': ?useQueryComponent,
         },
       ),
-    // Whole-collection Map/List encoding does not thread allowReserved to its
-    // elements.
     MapModel() => _buildMapUriEncodeExpression(
       valueExpression,
       model,

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -74,6 +74,8 @@ Expression _buildUriEncodeExpression(
         },
       ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
+      // encodeAnyToUri has no allowReserved parameter, so the flag is not
+      // forwarded here.
       refer(
         'encodeAnyToUri',
         'package:tonik_util/tonik_util.dart',

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -2103,5 +2103,410 @@ void main() {
         collapseWhitespace(format(expectedMethod)),
       );
     });
+
+    Operation buildOperation(QueryParameterObject queryParam) => Operation(
+      operationId: 'op',
+      context: context,
+      summary: 'op',
+      description: 'op',
+      tags: const {},
+      isDeprecated: false,
+      path: '/items',
+      method: HttpMethod.get,
+      headers: const {},
+      queryParameters: {queryParam},
+      pathParameters: const {},
+      cookieParameters: const {},
+      responses: const {},
+      securitySchemes: const {},
+    );
+
+    test('emits allowReserved: true for form string parameter when set', () {
+      final queryParam = QueryParameterObject(
+        name: 'path',
+        rawName: 'path',
+        description: 'A path filter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: true,
+        model: StringModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required String path}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            path.toForm(
+              r'path',
+              explode: false,
+              allowEmpty: false,
+              allowReserved: true,
+            ),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'path', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for form string parameter when not set', () {
+      final queryParam = QueryParameterObject(
+        name: 'path',
+        rawName: 'path',
+        description: 'A path filter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: false,
+        model: StringModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required String path}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            path.toForm(r'path', explode: false, allowEmpty: false),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'path', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('threads allowReserved into list-element uriEncode when set', () {
+      final queryParam = QueryParameterObject(
+        name: 'tags',
+        rawName: 'tags',
+        description: 'Tag filters',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: true,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: true,
+        model: ListModel(
+          context: context,
+          content: StringModel(context: context),
+          isContentNullable: true,
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required List<String?> tags}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            tags
+                .map(
+                  (e) => e == null
+                      ? ''
+                      : e.uriEncode(allowEmpty: false, allowReserved: true),
+                )
+                .toList()
+                .toForm(
+                  r'tags',
+                  explode: true,
+                  allowEmpty: false,
+                  alreadyEncoded: true,
+                ),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'tags', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('threads allowReserved into encodeAnyToForm for AnyModel', () {
+      final queryParam = QueryParameterObject(
+        name: 'meta',
+        rawName: 'meta',
+        description: 'Arbitrary metadata',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: true,
+        model: AnyModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required Object? meta}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.add((
+            name: r'meta',
+            value: encodeAnyToForm(
+              meta,
+              explode: false,
+              allowEmpty: false,
+              allowReserved: true,
+            ),
+          ));
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'meta', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test(
+      'emits allowReserved: true on the non-nullable list fast path when set',
+      () {
+        final queryParam = QueryParameterObject(
+          name: 'tags',
+          rawName: 'tags',
+          description: 'Tag filters',
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          encoding: QueryParameterEncoding.form,
+          allowReserved: true,
+          model: ListModel(
+            context: context,
+            content: StringModel(context: context),
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        const expectedMethod = r'''
+          String? _queryParameters({required List<String> tags}) {
+            final _$entries = <ParameterEntry>[];
+            _$entries.addAll(
+              tags.toForm(
+                r'tags',
+                explode: false,
+                allowEmpty: false,
+                allowReserved: true,
+              ),
+            );
+            if (_$entries.isEmpty) {
+              return null;
+            }
+            return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          }
+        ''';
+
+        final method = generator.generateQueryParametersMethod(
+          buildOperation(queryParam),
+          [(normalizedName: 'tags', parameter: queryParam)],
+        );
+
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'omits allowReserved on the non-nullable list fast path when not set',
+      () {
+        final queryParam = QueryParameterObject(
+          name: 'tags',
+          rawName: 'tags',
+          description: 'Tag filters',
+          isRequired: true,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          explode: false,
+          encoding: QueryParameterEncoding.form,
+          allowReserved: false,
+          model: ListModel(
+            context: context,
+            content: StringModel(context: context),
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        const expectedMethod = r'''
+        String? _queryParameters({required List<String> tags}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            tags.toForm(r'tags', explode: false, allowEmpty: false),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+        final method = generator.generateQueryParametersMethod(
+          buildOperation(queryParam),
+          [(normalizedName: 'tags', parameter: queryParam)],
+        );
+
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test('emits allowReserved: true for free-form map parameter when set', () {
+      final queryParam = QueryParameterObject(
+        name: 'filter',
+        rawName: 'filter',
+        description: 'A free-form filter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: true,
+        model: MapModel(
+          context: context,
+          valueModel: StringModel(context: context),
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required Map<String, String> filter}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            filter.toForm(
+              r'filter',
+              explode: false,
+              allowEmpty: false,
+              allowReserved: true,
+            ),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'filter', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for free-form map parameter when not set', () {
+      final queryParam = QueryParameterObject(
+        name: 'filter',
+        rawName: 'filter',
+        description: 'A free-form filter',
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        explode: false,
+        encoding: QueryParameterEncoding.form,
+        allowReserved: false,
+        model: MapModel(
+          context: context,
+          valueModel: StringModel(context: context),
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required Map<String, String> filter}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            filter.toForm(r'filter', explode: false, allowEmpty: false),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'filter', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -186,6 +186,31 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('enum form param omits allowReserved even when set', () {
+      final result = build(
+        EnumModel<String>(
+          name: 'Color',
+          values: {
+            const EnumEntry<String>(value: 'red'),
+            const EnumEntry<String>(value: 'green'),
+          },
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          context: context,
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('list element uriEncode adds allowReserved when set', () {
       final result = build(
         ListModel(
@@ -232,6 +257,28 @@ void main() {
         test() {
           value
               .map((e) => e.uriEncode(allowEmpty: true))
+              .toList()
+              .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('free-form list element omits allowReserved even when set', () {
+      final result = build(
+        ListModel(
+          content: AnyModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value
+              .map((e) => _i1.encodeAnyToUri(e, allowEmpty: true))
               .toList()
               .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
         }

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -211,6 +211,47 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('object form param omits allowReserved even when set', () {
+      final result = build(
+        ClassModel(
+          name: 'Form',
+          isDeprecated: false,
+          properties: const [],
+          context: context,
+          examples: const [],
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('composite form param omits allowReserved even when set', () {
+      final result = build(
+        OneOfModel(
+          models: const {},
+          isDeprecated: false,
+          examples: const [],
+          context: context,
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('list element uriEncode adds allowReserved when set', () {
       final result = build(
         ListModel(

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -35,6 +35,7 @@ void main() {
     Model model, {
     bool explode = true,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     final result = buildFormEntriesValueExpression(
       refer('value'),
@@ -43,6 +44,7 @@ void main() {
       explode: literalBool(explode),
       allowEmpty: literalBool(true),
       useQueryComponent: useQueryComponent ? literalBool(true) : null,
+      allowReserved: allowReserved,
     );
     expect(result, isNotNull);
     return result!;
@@ -128,6 +130,116 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('scalar adds allowReserved when set', () {
+      final result = build(
+        StringModel(context: context),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('Base64Model adds allowReserved on the base64 string when set', () {
+      final result = build(
+        Base64Model(context: context),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toBase64String().toForm(
+            'p',
+            explode: true,
+            allowEmpty: true,
+            allowReserved: true,
+          );
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('AliasModel threads allowReserved to its target', () {
+      final result = build(
+        AliasModel(
+          name: 'Filter',
+          model: StringModel(context: context),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('list element uriEncode adds allowReserved when set', () {
+      final result = build(
+        ListModel(
+          content: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value
+              .map((e) => e.uriEncode(allowEmpty: true, allowReserved: true))
+              .toList()
+              .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('enum list element omits allowReserved even when set', () {
+      final result = build(
+        ListModel(
+          content: EnumModel<String>(
+            name: 'Color',
+            values: {
+              const EnumEntry<String>(value: 'red'),
+              const EnumEntry<String>(value: 'green'),
+            },
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            context: context,
+          ),
+          context: context,
+          examples: const [],
+        ),
+        allowReserved: true,
+      );
+
+      final expected = format('''
+        test() {
+          value
+              .map((e) => e.uriEncode(allowEmpty: true))
+              .toList()
+              .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('MapModel with string values encodes the receiver directly', () {
       final model = MapModel(
         valueModel: StringModel(context: context),
@@ -140,6 +252,24 @@ void main() {
       final expected = format('''
         test() {
           value.toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('MapModel with string values threads allowReserved when set', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+
+      final result = build(model, allowReserved: true);
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
         }
       ''');
 
@@ -200,6 +330,25 @@ void main() {
       final expected = format('''
         test() {
           value.toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ListModel with non-nullable string content threads allowReserved '
+        'on the fast path when set', () {
+      final model = ListModel(
+        content: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+
+      final result = build(model, allowReserved: true);
+
+      final expected = format('''
+        test() {
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
         }
       ''');
 
@@ -282,6 +431,33 @@ void main() {
               .map((e) => e.toBase64String())
               .toList()
               .toForm('p', explode: true, allowEmpty: true);
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ListModel with Base64 content threads allowReserved on the fast '
+        'path when set', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        context: context,
+        examples: const [],
+      );
+
+      final result = build(model, allowReserved: true);
+
+      final expected = format('''
+        test() {
+          value
+              .map((e) => e.toBase64String())
+              .toList()
+              .toForm(
+                'p',
+                explode: true,
+                allowEmpty: true,
+                allowReserved: true,
+              );
         }
       ''');
 

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -43,6 +43,82 @@ void main() {
       );
     });
 
+    test('adds allowReserved for StringModel when set', () {
+      final model = StringModel(context: context);
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: true,
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty, allowReserved: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('omits allowReserved for EnumModel even when set', () {
+      final model = EnumModel<String>(
+        name: 'Color',
+        values: {
+          const EnumEntry<String>(value: 'red'),
+          const EnumEntry<String>(value: 'green'),
+        },
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        context: context,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: true,
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('threads allowReserved through AliasModel to its target', () {
+      final model = AliasModel(
+        name: 'Filter',
+        model: StringModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: true,
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty, allowReserved: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test('generates uriEncode call for IntegerModel', () {
       final model = IntegerModel(context: context);
       final expression = buildUriEncodeExpression(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -98,6 +98,11 @@ melos:
         cd integration_test/query_parameters/query_parameters_test
         dart test
 
+    test-integration-allow-reserved:
+      run: |
+        cd integration_test/allow_reserved/allow_reserved_test
+        dart test
+
     test-integration-path-encoding:
       run: |
         cd integration_test/path_encoding/path_encoding_test
@@ -251,6 +256,7 @@ melos:
         melos run test-integration-fastify-type-provider-zod
         melos run test-integration-composition
         melos run test-integration-query-parameters
+        melos run test-integration-allow-reserved
         melos run test-integration-path-encoding
         melos run test-integration-binary-models
         melos run test-integration-structured-syntax-suffix

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -105,6 +105,7 @@ rm -rf simple_encoding/simple_encoding_api
 rm -rf fastify_type_provider_zod/fastify_type_provider_zod_api
 rm -rf composition/composition_api
 rm -rf query_parameters/query_parameters_api
+rm -rf allow_reserved/allow_reserved_api
 rm -rf path_encoding/path_encoding_api
 rm -rf binary_models/binary_models_api
 rm -rf structured_syntax_suffix/structured_syntax_suffix_api
@@ -176,6 +177,9 @@ add_dependency_overrides_recursive "composition/composition_api"
 
 $TONIK_BINARY -p query_parameters_api -s query_parameters/openapi.yaml -o query_parameters
 add_dependency_overrides_recursive "query_parameters/query_parameters_api"
+
+$TONIK_BINARY -p allow_reserved_api -s allow_reserved/openapi.yaml -o allow_reserved
+add_dependency_overrides_recursive "allow_reserved/allow_reserved_api"
 
 $TONIK_BINARY -p path_encoding_api -s path_encoding/openapi.yaml -o path_encoding
 add_dependency_overrides_recursive "path_encoding/path_encoding_api"
@@ -280,6 +284,7 @@ echo "Running dart pub get for all generated packages in parallel..."
   cd fastify_type_provider_zod/fastify_type_provider_zod_api && dart pub get &
   cd composition/composition_api && dart pub get &
   cd query_parameters/query_parameters_api && dart pub get &
+  cd allow_reserved/allow_reserved_api && dart pub get &
   cd path_encoding/path_encoding_api && dart pub get &
   cd binary_models/binary_models_api && dart pub get &
   cd structured_syntax_suffix/structured_syntax_suffix_api && dart pub get &
@@ -343,6 +348,7 @@ restore_test_package_overrides "simple_encoding/simple_encoding_test/pubspec.yam
 restore_test_package_overrides "fastify_type_provider_zod/fastify_type_provider_zod_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "composition/composition_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "query_parameters/query_parameters_test/pubspec.yaml" "../../../packages/tonik_util"
+restore_test_package_overrides "allow_reserved/allow_reserved_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "path_encoding/path_encoding_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "binary_models/binary_models_test/pubspec.yaml" "../../../packages/tonik_util"
 restore_test_package_overrides "structured_syntax_suffix/structured_syntax_suffix_test/pubspec.yaml" "../../../packages/tonik_util"
@@ -385,6 +391,7 @@ echo "Running dart pub get for all test packages in parallel..."
   cd fastify_type_provider_zod/fastify_type_provider_zod_test && dart pub get &
   cd composition/composition_test && dart pub get &
   cd query_parameters/query_parameters_test && dart pub get &
+  cd allow_reserved/allow_reserved_test && dart pub get &
   cd path_encoding/path_encoding_test && dart pub get &
   cd binary_models/binary_models_test && dart pub get &
   cd structured_syntax_suffix/structured_syntax_suffix_test && dart pub get &


### PR DESCRIPTION
## Summary

Makes the generated client honor OpenAPI's `allowReserved` for **form-style query parameters** — the first wire-visible step of the `allowReserved` work (the runtime support landed earlier). The generator threads the already-parsed `allowReserved` flag into the emitted `toForm(...)` / `uriEncode(...)` / `encodeAnyToForm(...)` calls, emitting `allowReserved: true` **only** when the spec sets it so existing generated clients stay byte-identical when it is unset.

## What changed

- **Generator threading** — `query_generator.dart` passes the parameter's `allowReserved` into the form branch, threaded through `to_form_query_parameter_expression_generator.dart` → `form_entries_expression_builder.dart` → `uri_encode_expression_generator.dart`. Every form value path honors it: scalar, string, array (primitive/string/byte elements), free-form object (`additionalProperties`), and free-form (`Object`) values. The emit is conditional, so a parameter without `allowReserved` produces exactly today's output.
- **Deferred (unchanged encoding)** — complex generated object/enum/composition (`oneOf`/`anyOf`/`allOf`) form params keep their own encoding, and the `spaceDelimited` / `pipeDelimited` / `deepObject` styles are not yet covered (later work).
- **Integration suite** — a new `integration_test/allow_reserved/` suite (scalar and array form params, each with a reserved and a default sibling) asserts the real wire query.

## Wire behavior

For a form query param with `allowReserved: true` and value `a/b:c?d@e;f,g&h=i+j k#l[m]n`:
- **reserved param** → `a/b:c?d@e;f,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn` — the reserved set `/ : ? @ ; ,` is literal; only the form-urlencoded delimiters (`&`→`%26`, `=`→`%3D`, `+`→`%2B`), the space (`%20`), and the query-string-illegal `# [ ]` (`%23 %5B %5D`) are encoded.
- **default sibling** → fully percent-encoded (`a%2Fb%3Ac...`), unchanged from today.

## Docs

The `docs/uri_encoding_limitations.md` rewrite is intentionally **not** in this PR. That doc will get a single comprehensive rewrite once the remaining `allowReserved` work (delimited/deepObject styles, generated-model values, and urlencoded bodies) lands, rather than churning it per step.

## Testing

- Generator unit tests: full `_queryParameters` method-body comparisons (`collapseWhitespace()` + `DartFormatter`) for scalar, non-nullable `List<String>`, `Map`, and AnyModel form params — each in both the `allowReserved: true` and default (arg-absent) forms.
- Integration: the new suite asserts `response.requestOptions.uri.query` for scalar and array form params via Imposter.
- `fvm dart analyze packages/` and `fvm dart analyze integration_test` both clean (including CI `--fatal-infos`). Patch coverage 100%.
