### PR TITLE
feat: honor allowReserved for delimited and deepObject query parameters

### DIFF
--- a/integration_test/allow_reserved/allow_reserved_test/test/deep_object_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/deep_object_test.dart
@@ -1,0 +1,64 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  const objectValue = {'k1': 'a/b:c?d@e;f', 'k2': 'g&h=i+j k#l[m]n'};
+
+  group('deepObject allowReserved', () {
+    test(
+        'keeps reserved value survivors literal, encodes form delimiters, '
+        'brackets and hash, and leaves the name brackets intact', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testDeepObjectAllowReserved(
+        reservedObject: objectValue,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedObject%5Bk1%5D=a/b:c?d@e;f'
+        '&reservedObject%5Bk2%5D=g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default object is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testDeepObjectAllowReserved(
+        notReservedObject: objectValue,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedObject%5Bk1%5D=a%2Fb%3Ac%3Fd%40e%3Bf'
+        '&notReservedObject%5Bk2%5D=g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/allow_reserved_test/test/pipe_delimited_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/pipe_delimited_test.dart
@@ -1,0 +1,62 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
+
+  group('pipeDelimited allowReserved', () {
+    test(
+        'keeps reserved survivors literal, encodes form delimiters, brackets '
+        'and hash, and leaves the %7C delimiter intact', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedAllowReserved(
+        reservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedList=a/b:c?d@e;f%7Cg%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default list is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedAllowReserved(
+        notReservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedList=a%2Fb%3Ac%3Fd%40e%3Bf%7Cg%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/allow_reserved_test/test/space_delimited_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/space_delimited_test.dart
@@ -1,0 +1,62 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
+
+  group('spaceDelimited allowReserved', () {
+    test(
+        'keeps reserved survivors literal, encodes form delimiters, brackets '
+        'and hash, and leaves the %20 delimiter intact', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedAllowReserved(
+        reservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedList=a/b:c?d@e;f%20g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default list is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedAllowReserved(
+        notReservedList: listValues,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedList=a%2Fb%3Ac%3Fd%40e%3Bf%20g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/openapi.yaml
+++ b/integration_test/allow_reserved/openapi.yaml
@@ -74,3 +74,93 @@ paths:
       responses:
         '204':
           description: No Content
+  /space-delimited-allow-reserved:
+    get:
+      operationId: testSpaceDelimitedAllowReserved
+      tags:
+        - query
+      summary: Test allowReserved spaceDelimited query array parameters
+      description: >-
+        A spaceDelimited array query parameter with allowReserved next to a
+        sibling array that keeps the default full percent-encoding.
+      parameters:
+        - name: reservedList
+          in: query
+          style: spaceDelimited
+          explode: false
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: notReservedList
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '204':
+          description: No Content
+  /pipe-delimited-allow-reserved:
+    get:
+      operationId: testPipeDelimitedAllowReserved
+      tags:
+        - query
+      summary: Test allowReserved pipeDelimited query array parameters
+      description: >-
+        A pipeDelimited array query parameter with allowReserved next to a
+        sibling array that keeps the default full percent-encoding.
+      parameters:
+        - name: reservedList
+          in: query
+          style: pipeDelimited
+          explode: false
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: notReservedList
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '204':
+          description: No Content
+  /deep-object-allow-reserved:
+    get:
+      operationId: testDeepObjectAllowReserved
+      tags:
+        - query
+      summary: Test allowReserved deepObject query object parameters
+      description: >-
+        A deepObject free-form-object query parameter with allowReserved next to
+        a sibling object that keeps the default full percent-encoding.
+      parameters:
+        - name: reservedObject
+          in: query
+          style: deepObject
+          explode: true
+          allowReserved: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: notReservedObject
+          in: query
+          style: deepObject
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '204':
+          description: No Content

--- a/packages/tonik_generate/lib/src/operation/query_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/query_generator.dart
@@ -99,6 +99,7 @@ class QueryGenerator {
         encoding: encoding,
         explode: resolvedParam.explode,
         allowEmpty: resolvedParam.allowEmptyValue,
+        allowReserved: resolvedParam.allowReserved,
       ).statements;
     }
 
@@ -114,6 +115,7 @@ class QueryGenerator {
     final deepObjectExpression = buildToDeepObjectQueryParameterCode(
       paramName,
       resolvedParam,
+      allowReserved: resolvedParam.allowReserved,
     );
 
     return Block.of([

--- a/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
@@ -9,8 +9,9 @@ import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 /// enums emit code that throws at runtime.
 BuiltExpression buildToDeepObjectQueryParameterCode(
   String parameterName,
-  QueryParameterObject parameter,
-) {
+  QueryParameterObject parameter, {
+  bool allowReserved = false,
+}) {
   final model = parameter.model;
   final rawName = parameter.rawName;
   final explode = parameter.explode;
@@ -23,6 +24,7 @@ BuiltExpression buildToDeepObjectQueryParameterCode(
         {
           'explode': literalBool(explode),
           'allowEmpty': literalBool(allowEmpty),
+          if (allowReserved) 'allowReserved': literalBool(true),
         },
       ),
     );
@@ -40,6 +42,7 @@ BuiltExpression buildToDeepObjectQueryParameterCode(
         resolvedModel,
         explode: explode,
         allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
       ),
     );
   }
@@ -84,6 +87,7 @@ Expression _buildMapDeepObjectExpression(
   MapModel model, {
   required bool explode,
   required bool allowEmpty,
+  required bool allowReserved,
 }) {
   final valueModel = model.valueModel;
   final resolvedValueModel = valueModel.resolved;
@@ -97,6 +101,7 @@ Expression _buildMapDeepObjectExpression(
           {
             'explode': literalBool(explode),
             'allowEmpty': literalBool(allowEmpty),
+            if (allowReserved) 'allowReserved': literalBool(true),
           },
         );
   }
@@ -108,6 +113,7 @@ Expression _buildMapDeepObjectExpression(
       refer('v'),
       valueModel,
       allowEmpty: literalBool(allowEmpty),
+      allowReserved: allowReserved,
     );
 
     final mapEntryClosure = Method(

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -81,8 +81,8 @@ List<Code> _buildDelimitedCode(
   String nullGuard(String encoded) =>
       isContentNullable ? "e == null ? '' : $encoded" : encoded;
 
-  // The generated enum `uriEncode` has no allowReserved parameter, so only
-  // the scalar arm threads it.
+  // The generated enum uriEncode has no allowReserved parameter, so the
+  // enum arm omits it while the scalar arm passes it through.
   final scalarItemArgs = allowReserved
       ? 'allowEmpty: $allowEmpty, allowReserved: true'
       : 'allowEmpty: $allowEmpty';

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -10,6 +10,7 @@ BuiltStatements buildToDelimitedQueryParameterCode(
   required QueryParameterEncoding encoding,
   bool explode = false,
   bool allowEmpty = true,
+  bool allowReserved = false,
 }) {
   return BuiltStatements.simple(
     _buildToDelimitedQueryParameterCode(
@@ -18,6 +19,7 @@ BuiltStatements buildToDelimitedQueryParameterCode(
       encoding: encoding,
       explode: explode,
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     ),
   );
 }
@@ -28,6 +30,7 @@ List<Code> _buildToDelimitedQueryParameterCode(
   required QueryParameterEncoding encoding,
   bool explode = false,
   bool allowEmpty = true,
+  bool allowReserved = false,
 }) {
   final model = parameter.model;
   final encodingName = encoding == QueryParameterEncoding.spaceDelimited
@@ -51,6 +54,7 @@ List<Code> _buildToDelimitedQueryParameterCode(
     encoding: encoding,
     explode: explode,
     allowEmpty: allowEmpty,
+    allowReserved: allowReserved,
     encodingName: encodingName,
     isContentNullable:
         model.isContentNullable || model.content.isEffectivelyNullable,
@@ -64,6 +68,7 @@ List<Code> _buildDelimitedCode(
   required QueryParameterEncoding encoding,
   required bool explode,
   required bool allowEmpty,
+  required bool allowReserved,
   required String encodingName,
   required bool isContentNullable,
 }) {
@@ -76,6 +81,12 @@ List<Code> _buildDelimitedCode(
   String nullGuard(String encoded) =>
       isContentNullable ? "e == null ? '' : $encoded" : encoded;
 
+  // The generated enum `uriEncode` has no allowReserved parameter, so only
+  // the scalar arm threads it.
+  final scalarItemArgs = allowReserved
+      ? 'allowEmpty: $allowEmpty, allowReserved: true'
+      : 'allowEmpty: $allowEmpty';
+
   return switch (contentModel) {
     StringModel() when !isContentNullable => _buildForLoop(
       parameterName,
@@ -83,6 +94,7 @@ List<Code> _buildDelimitedCode(
       methodName,
       explode,
       allowEmpty,
+      allowReserved: allowReserved,
       needsMapping: false,
     ),
 
@@ -94,7 +106,16 @@ List<Code> _buildDelimitedCode(
     DateTimeModel() ||
     DecimalModel() ||
     UriModel() ||
-    DateModel() ||
+    DateModel() => _buildForLoop(
+      parameterName,
+      rawName,
+      methodName,
+      explode,
+      allowEmpty,
+      needsMapping: true,
+      mapExpression: nullGuard('e.uriEncode($scalarItemArgs)'),
+    ),
+
     EnumModel() => _buildForLoop(
       parameterName,
       rawName,
@@ -123,6 +144,7 @@ List<Code> _buildDelimitedCode(
       encoding: encoding,
       explode: explode,
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
       encodingName: encodingName,
       isContentNullable: isContentNullable,
     ),
@@ -144,14 +166,18 @@ List<Code> _buildForLoop(
   bool explode,
   bool allowEmpty, {
   required bool needsMapping,
+  bool allowReserved = false,
   String? mapExpression,
 }) {
+  final delimitedArgs = allowReserved
+      ? 'explode: $explode, allowEmpty: $allowEmpty, allowReserved: true'
+      : 'explode: $explode, allowEmpty: $allowEmpty';
+
   final baseExpression = needsMapping
       ? '$parameterName.map((e) => $mapExpression).toList().$methodName('
             ' explode: $explode, allowEmpty: $allowEmpty,'
             ' alreadyEncoded: true)'
-      : '$parameterName.$methodName('
-            ' explode: $explode, allowEmpty: $allowEmpty)';
+      : '$parameterName.$methodName($delimitedArgs)';
 
   return [
     Code('for (final value in $baseExpression) {'),

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -2508,5 +2508,342 @@ void main() {
         collapseWhitespace(format(expectedMethod)),
       );
     });
+
+    QueryParameterObject stringListParam({
+      required QueryParameterEncoding encoding,
+      required bool allowReserved,
+    }) => QueryParameterObject(
+      name: 'tags',
+      rawName: 'tags',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: true,
+      explode: false,
+      encoding: encoding,
+      allowReserved: allowReserved,
+      model: ListModel(
+        context: context,
+        content: StringModel(context: context),
+        examples: const [],
+      ),
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    test('emits allowReserved for spaceDelimited string list when set', () {
+      final queryParam = stringListParam(
+        encoding: QueryParameterEncoding.spaceDelimited,
+        allowReserved: true,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({List<String>? tags}) {
+          final _$entries = <ParameterEntry>[];
+          if (tags != null) {
+            for (final value in tags.toSpaceDelimited(
+              explode: false,
+              allowEmpty: true,
+              allowReserved: true,
+            )) {
+              _$entries.add((name: r'tags', value: value));
+            }
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'tags', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for spaceDelimited string list by default', () {
+      final queryParam = stringListParam(
+        encoding: QueryParameterEncoding.spaceDelimited,
+        allowReserved: false,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({List<String>? tags}) {
+          final _$entries = <ParameterEntry>[];
+          if (tags != null) {
+            for (final value in tags.toSpaceDelimited(
+              explode: false,
+              allowEmpty: true,
+            )) {
+              _$entries.add((name: r'tags', value: value));
+            }
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'tags', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits allowReserved for pipeDelimited string list when set', () {
+      final queryParam = stringListParam(
+        encoding: QueryParameterEncoding.pipeDelimited,
+        allowReserved: true,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({List<String>? tags}) {
+          final _$entries = <ParameterEntry>[];
+          if (tags != null) {
+            for (final value in tags.toPipeDelimited(
+              explode: false,
+              allowEmpty: true,
+              allowReserved: true,
+            )) {
+              _$entries.add((name: r'tags', value: value));
+            }
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'tags', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for pipeDelimited string list by default', () {
+      final queryParam = stringListParam(
+        encoding: QueryParameterEncoding.pipeDelimited,
+        allowReserved: false,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({List<String>? tags}) {
+          final _$entries = <ParameterEntry>[];
+          if (tags != null) {
+            for (final value in tags.toPipeDelimited(
+              explode: false,
+              allowEmpty: true,
+            )) {
+              _$entries.add((name: r'tags', value: value));
+            }
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'tags', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    QueryParameterObject stringMapDeepObjectParam({
+      required bool allowReserved,
+    }) => QueryParameterObject(
+      name: 'filter',
+      rawName: 'filter',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: true,
+      encoding: QueryParameterEncoding.deepObject,
+      allowReserved: allowReserved,
+      model: MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+        examples: const [],
+      ),
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    test('emits allowReserved for deepObject Map when set', () {
+      final queryParam = stringMapDeepObjectParam(allowReserved: true);
+
+      const expectedMethod = r'''
+        String? _queryParameters({Map<String, String>? filter}) {
+          final _$entries = <ParameterEntry>[];
+          if (filter != null) {
+            _$entries.addAll(
+              filter.toDeepObject(
+                r'filter',
+                explode: true,
+                allowEmpty: false,
+                allowReserved: true,
+              ),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'filter', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for deepObject Map by default', () {
+      final queryParam = stringMapDeepObjectParam(allowReserved: false);
+
+      const expectedMethod = r'''
+        String? _queryParameters({Map<String, String>? filter}) {
+          final _$entries = <ParameterEntry>[];
+          if (filter != null) {
+            _$entries.addAll(
+              filter.toDeepObject(r'filter', explode: true, allowEmpty: false),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'filter', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    QueryParameterObject anyDeepObjectParam({
+      required bool allowReserved,
+    }) => QueryParameterObject(
+      name: 'data',
+      rawName: 'data',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: true,
+      encoding: QueryParameterEncoding.deepObject,
+      allowReserved: allowReserved,
+      model: AnyModel(context: context),
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    test('emits allowReserved for deepObject AnyModel when set', () {
+      final queryParam = anyDeepObjectParam(allowReserved: true);
+
+      const expectedMethod = r'''
+        String? _queryParameters({Object? data}) {
+          final _$entries = <ParameterEntry>[];
+          if (data != null) {
+            _$entries.addAll(
+              encodeAnyToDeepObject(
+                data,
+                r'data',
+                explode: true,
+                allowEmpty: false,
+                allowReserved: true,
+              ),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'data', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('omits allowReserved for deepObject AnyModel by default', () {
+      final queryParam = anyDeepObjectParam(allowReserved: false);
+
+      const expectedMethod = r'''
+        String? _queryParameters({Object? data}) {
+          final _$entries = <ParameterEntry>[];
+          if (data != null) {
+            _$entries.addAll(
+              encodeAnyToDeepObject(
+                data,
+                r'data',
+                explode: true,
+                allowEmpty: false,
+              ),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'data', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
@@ -25,6 +25,7 @@ void main() {
       required Model model,
       required bool explode,
       required bool allowEmpty,
+      bool allowReserved = false,
     }) {
       return QueryParameterObject(
         name: name,
@@ -36,7 +37,7 @@ void main() {
         encoding: QueryParameterEncoding.deepObject,
         explode: explode,
         allowEmptyValue: allowEmpty,
-        allowReserved: false,
+        allowReserved: allowReserved,
         context: context,
         examples: const [],
         defaultValue: null,
@@ -710,6 +711,180 @@ void main() {
             "false), )).toDeepObject(r'aliased_counts', "
             'explode: true, allowEmpty: false, '
             'alreadyEncoded: true, )',
+          ),
+        );
+      });
+    });
+
+    group('allowReserved', () {
+      test('Map<String, String> carries allowReserved when set', () {
+        final parameter = createParameter(
+          name: 'filter',
+          rawName: 'filter',
+          model: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: false,
+          allowReserved: true,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'filter',
+          parameter,
+          allowReserved: true,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            "filter.toDeepObject(r'filter', "
+            'explode: true, allowEmpty: false, allowReserved: true, )',
+          ),
+        );
+      });
+
+      test('Map<String, String> omits allowReserved by default', () {
+        final parameter = createParameter(
+          name: 'filter',
+          rawName: 'filter',
+          model: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: false,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'filter',
+          parameter,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            "filter.toDeepObject(r'filter', "
+            'explode: true, allowEmpty: false, )',
+          ),
+        );
+      });
+
+      test('Map<String, int> threads allowReserved into value encode', () {
+        final parameter = createParameter(
+          name: 'counts',
+          rawName: 'counts',
+          model: MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: false,
+          allowReserved: true,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'counts',
+          parameter,
+          allowReserved: true,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            'counts.map((k, v, ) => MapEntry(k, '
+            'v.uriEncode(allowEmpty: false, allowReserved: true, ), '
+            ")).toDeepObject(r'counts', "
+            'explode: true, allowEmpty: false, '
+            'alreadyEncoded: true, )',
+          ),
+        );
+      });
+
+      test('AnyModel carries allowReserved when set', () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: true,
+          allowEmpty: false,
+          allowReserved: true,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'data',
+          parameter,
+          allowReserved: true,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            "encodeAnyToDeepObject(data, r'data', "
+            'explode: true, allowEmpty: false, allowReserved: true, )',
+          ),
+        );
+      });
+
+      test('AnyModel omits allowReserved by default', () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: true,
+          allowEmpty: false,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'data',
+          parameter,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            "encodeAnyToDeepObject(data, r'data', "
+            'explode: true, allowEmpty: false, )',
+          ),
+        );
+      });
+
+      test('class model object path omits allowReserved even when set', () {
+        final parameter = createParameter(
+          name: 'user',
+          rawName: 'user',
+          model: ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: false,
+          allowReserved: true,
+        );
+
+        final result = buildToDeepObjectQueryParameterCode(
+          'user',
+          parameter,
+          allowReserved: true,
+        );
+
+        final code = result.accept(emitter).toString();
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            "user.toDeepObject(r'user', explode: true, allowEmpty: false, )",
           ),
         );
       });

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -685,6 +685,110 @@ void main() {
         );
       });
 
+      test(
+        'spaceDelimited nullable string list threads allowReserved '
+        'through the null guard',
+        () {
+          final parameter = createParameter(
+            name: 'tags',
+            rawName: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              isContentNullable: true,
+              context: context,
+              examples: const [],
+            ),
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          );
+
+          final codes = buildToDelimitedQueryParameterCode(
+            'tags',
+            parameter,
+            encoding: QueryParameterEncoding.spaceDelimited,
+            allowReserved: true,
+          );
+
+          final code = emitStatements(codes);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+                void test() {
+                  for (final value in tags
+                      .map(
+                        (e) => e == null
+                            ? ''
+                            : e.uriEncode(allowEmpty: true, allowReserved: true),
+                      )
+                      .toList()
+                      .toSpaceDelimited(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                      )) {
+                    _$entries.add((name: r'tags', value: value));
+                  }
+                }
+              '''),
+            ),
+          );
+        },
+      );
+
+      test(
+        'pipeDelimited nullable string list threads allowReserved '
+        'through the null guard',
+        () {
+          final parameter = createParameter(
+            name: 'tags',
+            rawName: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              isContentNullable: true,
+              context: context,
+              examples: const [],
+            ),
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          );
+
+          final codes = buildToDelimitedQueryParameterCode(
+            'tags',
+            parameter,
+            encoding: QueryParameterEncoding.pipeDelimited,
+            allowReserved: true,
+          );
+
+          final code = emitStatements(codes);
+          expect(
+            collapseWhitespace(code),
+            collapseWhitespace(
+              format(r'''
+                void test() {
+                  for (final value in tags
+                      .map(
+                        (e) => e == null
+                            ? ''
+                            : e.uriEncode(allowEmpty: true, allowReserved: true),
+                      )
+                      .toList()
+                      .toPipeDelimited(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                      )) {
+                    _$entries.add((name: r'tags', value: value));
+                  }
+                }
+              '''),
+            ),
+          );
+        },
+      );
+
       test('enum list omits allowReserved even when set', () {
         final parameter = createParameter(
           name: 'priorities',

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -36,6 +36,7 @@ void main() {
       required Model model,
       required bool explode,
       required bool allowEmpty,
+      bool allowReserved = false,
     }) {
       return QueryParameterObject(
         name: name,
@@ -47,7 +48,7 @@ void main() {
         encoding: QueryParameterEncoding.spaceDelimited,
         explode: explode,
         allowEmptyValue: allowEmpty,
-        allowReserved: false,
+        allowReserved: allowReserved,
         context: context,
         examples: const [],
         defaultValue: null,
@@ -484,6 +485,322 @@ void main() {
           );
         },
       );
+    });
+
+    group('allowReserved', () {
+      test('spaceDelimited string list carries allowReserved when set', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toSpaceDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                  allowReserved: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited string list omits allowReserved by default', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toSpaceDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited string list carries allowReserved when set', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toPipeDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                  allowReserved: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited string list omits allowReserved by default', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toPipeDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited scalar list carries allowReserved when set', () {
+        final parameter = createParameter(
+          name: 'ids',
+          rawName: 'ids',
+          model: ListModel(
+            content: IntegerModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'ids',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in ids
+                    .map((e) => e.uriEncode(allowEmpty: true, allowReserved: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'ids', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('enum list omits allowReserved even when set', () {
+        final parameter = createParameter(
+          name: 'priorities',
+          rawName: 'priorities',
+          model: ListModel(
+            content: EnumModel<String>(
+              isDeprecated: false,
+              context: context,
+              values: {
+                const EnumEntry(value: 'high priority'),
+                const EnumEntry(value: 'low priority'),
+              },
+              isNullable: false,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'priorities',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in priorities
+                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'priorities', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('composition list omits allowReserved even when set', () {
+        final parameter = createParameter(
+          name: 'items',
+          rawName: 'items',
+          model: ListModel(
+            content: OneOfModel(
+              isDeprecated: false,
+              name: 'Item',
+              models: {
+                (
+                  discriminatorValue: null,
+                  model: StringModel(context: context),
+                ),
+                (
+                  discriminatorValue: null,
+                  model: IntegerModel(context: context),
+                ),
+              },
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'items',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final item in items) {
+                  if (item.currentEncodingShape != EncodingShape.simple) {
+                    throw EncodingException(
+                      r'Parameter items: spaceDelimited encoding requires simple encoding shape',
+                    );
+                  }
+                }
+                for (final value in items
+                    .map((item) => item.uriEncode(allowEmpty: true))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
+                  _$entries.add((name: r'items', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
     });
   });
 }


### PR DESCRIPTION
## Summary

Threads the parsed `allowReserved` flag through the `spaceDelimited`, `pipeDelimited`, and `deepObject` query parameter generators (and their `AnyModel`/`Map` paths), so reserved characters in string and scalar parameter values survive percent-encoding when a parameter opts into `allowReserved: true`.

Builds on the form-style `allowReserved` work — this branch is stacked on that branch and its diff contains only the delimited/deepObject changes.

## Behavior

For a query parameter with `allowReserved: true`:
- **spaceDelimited / pipeDelimited** string and scalar list values keep reserved survivors literal; the `%20` / `%7C` delimiters are unchanged.
- **deepObject** `Map`/free-form-object values keep reserved survivors literal; the structural `[` `]` name brackets are unchanged.
- The form-urlencoded delimiters (ampersand, equals, plus) inside a value are always percent-encoded to `%26 %3D %2B` (apps are responsible for these per the spec), and `#`, `[`, `]` inside values stay percent-encoded as required for query strings.

When `allowReserved` is not set, output is byte-identical to before.

## Scope

Threading is applied only where the runtime encoders already accept the flag: delimited string/scalar value encoding, the `Map<String, String>` deepObject value encoding, the deepObject simple-value map encoding, and the `AnyModel` deepObject path. Enum and composition `uriEncode` and the object `toDeepObject` interface do not yet carry the flag, so those paths remain byte-identical and are addressed separately.

## Tests

- Generator unit tests: full `_queryParameters` method-body comparisons for each style, with and without `allowReserved`, including explicit assertions that the deferred (enum / composition / object) paths emit no `allowReserved`.
- End-to-end integration cases per style (Imposter-backed) asserting the wire query string.
