### PR TITLE
feat: honor allowReserved for urlencoded form request-body properties

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -146,6 +146,16 @@ switch (path) {
         }
         break
 
+    case '/form/allow-reserved-collision':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'user_name=ok'
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -156,6 +156,15 @@ switch (path) {
         }
         break
 
+    case '/form/allow-reserved-array':
+        def formBody = 'reserved=ok&tags=a,b'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -128,6 +128,24 @@ switch (path) {
         }
         break
         
+    case '/form/allow-reserved':
+        def formBody = 'reserved=ok&notReserved=ok'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
+    case '/form/allow-reserved-mixed':
+        def formBody = 'reserved=ok'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -397,6 +397,49 @@ void main() {
     });
   });
 
+  group('Per-property allowReserved', () {
+    test(
+      'keeps reserved characters literal for the flagged property and fully '
+      'percent-encodes the sibling',
+      () async {
+        const value = 'a/b:c?d&e=f+g;h,i@j#k[l]m ';
+        const form = AllowReservedForm(reserved: value, notReserved: value);
+
+        final response = await api.postAllowReservedForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedForm>>());
+
+        final requestData = (response as TonikSuccess<AllowReservedForm>)
+            .response
+            .requestOptions
+            .data;
+        expect(
+          requestData,
+          'reserved=a/b:c?d%26e%3Df%2Bg;h,i@j#k[l]m+'
+              '&notReserved=a%2Fb%3Ac%3Fd%26e%3Df%2Bg%3Bh%2Ci%40j%23k%5Bl%5Dm+',
+        );
+      },
+    );
+
+    test(
+      'null-guards a write-only sibling and keeps it fully percent-encoded '
+      'beside the flagged property',
+      () async {
+        const form = AllowReservedMixedForm(reserved: 'a/b:c', secret: 'a/b:c');
+
+        final response = await api.postAllowReservedMixedForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedMixedForm>>());
+
+        final requestData = (response as TonikSuccess<AllowReservedMixedForm>)
+            .response
+            .requestOptions
+            .data;
+        expect(requestData, 'reserved=a/b:c&secret=a%2Fb%3Ac');
+      },
+    );
+  });
+
   group('Content-Type header', () {
     test('sends correct Content-Type header per OpenAPI spec', () async {
       const form = SimpleForm(name: 'Test', age: 20);

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -438,6 +438,25 @@ void main() {
         expect(requestData, 'reserved=a/b:c&secret=a%2Fb%3Ac');
       },
     );
+
+    test(
+      'sends a write property that a read-only sibling forces onto a suffixed '
+      'field, keeping reserved characters literal',
+      () async {
+        const form = AllowReservedCollisionForm(userName2: 'a/b:c');
+
+        final response = await api.postAllowReservedCollisionForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedCollisionForm>>());
+
+        final requestData =
+            (response as TonikSuccess<AllowReservedCollisionForm>)
+                .response
+                .requestOptions
+                .data;
+        expect(requestData, 'user_name=a/b:c');
+      },
+    );
   });
 
   group('Content-Type header', () {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -457,6 +457,27 @@ void main() {
         expect(requestData, 'user_name=a/b:c');
       },
     );
+
+    test(
+      'comma-joins an array sibling into a single entry beside the flagged '
+      'scalar',
+      () async {
+        const form = AllowReservedArrayForm(
+          reserved: 'a/b:c',
+          tags: ['x', 'y', 'z'],
+        );
+
+        final response = await api.postAllowReservedArrayForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedArrayForm>>());
+
+        final requestData = (response as TonikSuccess<AllowReservedArrayForm>)
+            .response
+            .requestOptions
+            .data;
+        expect(requestData, 'reserved=a/b:c&tags=x,y,z');
+      },
+    );
   });
 
   group('Content-Type header', () {

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -379,6 +379,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/AllowReservedCollisionForm'
 
+  /form/allow-reserved-array:
+    post:
+      operationId: postAllowReservedArrayForm
+      tags:
+        - form
+      summary: Post form where a flagged scalar sits beside an array property
+      description: >-
+        Tests that an array sibling of a flagged allowReserved scalar is
+        comma-joined into a single entry, matching the object path, rather than
+        exploded into repeated keys.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllowReservedArrayForm'
+            encoding:
+              reserved:
+                allowReserved: true
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllowReservedArrayForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -560,3 +587,18 @@ components:
         user_name:
           type: string
           description: Write property that must reference its suffixed field name
+
+    AllowReservedArrayForm:
+      type: object
+      required:
+        - reserved
+        - tags
+      properties:
+        reserved:
+          type: string
+          description: Value that keeps reserved characters literal
+        tags:
+          type: array
+          items:
+            type: string
+          description: Array sibling comma-joined into a single entry

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -294,6 +294,63 @@ paths:
               schema:
                 type: string
 
+  /form/allow-reserved:
+    post:
+      operationId: postAllowReservedForm
+      tags:
+        - form
+      summary: Post form where one property opts into allowReserved
+      description: >-
+        Tests that a body property flagged allowReserved keeps reserved
+        characters literal in the sent body, while a sibling property without
+        the flag is fully percent-encoded.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllowReservedForm'
+            encoding:
+              reserved:
+                allowReserved: true
+              notReserved:
+                allowReserved: false
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllowReservedForm'
+
+  /form/allow-reserved-mixed:
+    post:
+      operationId: postAllowReservedMixedForm
+      tags:
+        - form
+      summary: Post form where an allowReserved scalar sits beside a write-only
+        sibling
+      description: >-
+        Tests that a flagged allowReserved scalar keeps reserved characters
+        literal while a write-only sibling (nullable field, null-guarded) is
+        still emitted on the per-property path.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllowReservedMixedForm'
+            encoding:
+              reserved:
+                allowReserved: true
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllowReservedMixedForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -435,3 +492,30 @@ components:
         field2:
           type: integer
           example: 100
+
+    AllowReservedForm:
+      type: object
+      required:
+        - reserved
+        - notReserved
+      properties:
+        reserved:
+          type: string
+          description: Value that keeps reserved characters literal
+        notReserved:
+          type: string
+          description: Value that is fully percent-encoded
+
+    AllowReservedMixedForm:
+      type: object
+      required:
+        - reserved
+        - secret
+      properties:
+        reserved:
+          type: string
+          description: Value that keeps reserved characters literal
+        secret:
+          type: string
+          writeOnly: true
+          description: Write-only field, nullable in the client and null-guarded

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -351,6 +351,34 @@ paths:
               schema:
                 $ref: '#/components/schemas/AllowReservedMixedForm'
 
+  /form/allow-reserved-collision:
+    post:
+      operationId: postAllowReservedCollisionForm
+      tags:
+        - form
+      summary: Post form where a read-only sibling forces a write property onto a
+        suffixed field name
+      description: >-
+        Tests that a write property whose normalized name collides with a
+        read-only sibling references the suffixed field the object path assigns
+        it when the per-property allowReserved path activates.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllowReservedCollisionForm'
+            encoding:
+              user_name:
+                allowReserved: true
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllowReservedCollisionForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -519,3 +547,16 @@ components:
           type: string
           writeOnly: true
           description: Write-only field, nullable in the client and null-guarded
+
+    AllowReservedCollisionForm:
+      type: object
+      required:
+        - user_name
+      properties:
+        user-name:
+          type: string
+          readOnly: true
+          description: Read-only sibling that normalizes to the same Dart field name
+        user_name:
+          type: string
+          description: Write property that must reference its suffixed field name

--- a/packages/tonik_core/lib/src/model/request_body.dart
+++ b/packages/tonik_core/lib/src/model/request_body.dart
@@ -8,17 +8,12 @@ sealed class RequestBody {
   final String? name;
   final Context context;
 
-  /// The description of the request body.
-  /// For aliases, this may override the referenced request body's description.
   String? get description;
 
-  /// Returns the number of content objects in this request body.
   int get contentCount;
 
-  /// Returns the resolved content of this request body.
   Set<RequestContent> get resolvedContent;
 
-  /// Returns whether this request body is required.
   bool get isRequired;
 }
 

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -139,6 +139,7 @@ class DataGenerator {
                   perProperty ? 'value.value' : 'value',
                   c.model,
                   useQueryComponent: true,
+                  useImmutableCollections: useImmutableCollections,
                   encoding: perProperty ? c.encoding : null,
                 ).code,
               )
@@ -289,6 +290,7 @@ class DataGenerator {
           'body',
           model,
           useQueryComponent: true,
+          useImmutableCollections: useImmutableCollections,
           encoding: content.first.encoding,
         );
         bodyCode

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -3,6 +3,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/to_form_value_expression_generator.dart';
@@ -124,13 +125,21 @@ class DataGenerator {
               ..add(jsonBuilt.unsafeRawBody.code)
               ..add(const Code(','));
           case .form:
+            // The per-property path emits a bare list literal, so it takes the
+            // full `value.value` receiver; the object path relies on the
+            // `value.` prefix combining with its own `value` receiver.
+            final formModel = c.model.resolved;
+            final perProperty =
+                formModel is ClassModel &&
+                formBodyHasAllowReserved(c.encoding, formModel);
             switchCases
-              ..add(const Code(' value => value.'))
+              ..add(Code(perProperty ? ' value => ' : ' value => value.'))
               ..add(
                 buildToFormValueExpression(
-                  'value',
+                  perProperty ? 'value.value' : 'value',
                   c.model,
                   useQueryComponent: true,
+                  encoding: perProperty ? c.encoding : null,
                 ).code,
               )
               ..add(const Code(','));
@@ -280,6 +289,7 @@ class DataGenerator {
           'body',
           model,
           useQueryComponent: true,
+          encoding: content.first.encoding,
         );
         bodyCode
           ..clear()

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -142,8 +142,9 @@ bool formBodyHasAllowReserved(
 buildClassFormEntriesExpression(
   Expression receiver,
   ClassModel model,
-  Map<String, PropertyEncoding>? encoding,
-) {
+  Map<String, PropertyEncoding>? encoding, {
+  bool useImmutableCollections = false,
+}) {
   // Normalize the full set first, then drop read-only, so a write property
   // keeps the same suffix the object path (class_generator) assigns it — a
   // read-only sibling that normalizes to the same name still consumes a suffix.
@@ -157,6 +158,7 @@ buildClassFormEntriesExpression(
       receiver.property(normalizedName),
       property,
       encoding?[property.name]?.allowReserved ?? false,
+      useImmutableCollections: useImmutableCollections,
     );
     if (entryCodes == null) {
       return (entries: null, unencodableProperty: property.name);
@@ -173,31 +175,40 @@ buildClassFormEntriesExpression(
 }
 
 /// Emits the spread/element code for one class property, or null when the
-/// property model cannot be encoded per-property. The field is null-guarded
-/// whenever it could hold null — a superset of the object path's field rule
-/// that also covers effectively-nullable backing models.
+/// property model cannot be encoded per-property. Null-guards the field when it
+/// can hold null: nullable, optional, write-only, or backed by an effectively-
+/// nullable model.
 List<Code>? _buildPropertyFormEntry(
   Expression field,
   Property property,
-  bool allowReserved,
-) {
+  bool allowReserved, {
+  bool useImmutableCollections = false,
+}) {
   final propertyNameLiteral = specLiteralString(property.name);
+  // The object path routes the property name through `Map.toForm`, which
+  // URI-encodes each key; the per-property path must encode the name the same
+  // way. Names are never allowReserved, so this defaults to false.
+  final encodedName = propertyNameLiteral.property('uriEncode').call([], {
+    'allowEmpty': literalBool(true),
+    'useQueryComponent': literalBool(true),
+  });
   final resolved = property.model.resolved;
+
+  // A map property makes the object path's `parameterProperties` throw
+  // (a complex property that is not a simple-content list), so the per-property
+  // path must be unencodable too rather than emitting a diverging entry.
+  if (resolved is MapModel) return null;
 
   // AnyModel is deferred like enum/composition, so mirror the object path
   // (class_generator `parameterProperties` + `Map<String,String>.toForm`
-  // with alreadyEncoded) byte-for-byte: the name is URI-encoded, the value is
-  // the raw `toString()` passed through unencoded.
+  // with alreadyEncoded) byte-for-byte: the value is the raw `toString()`
+  // passed through unencoded.
   if (resolved is AnyModel) {
-    final name = propertyNameLiteral.property('uriEncode').call([], {
-      'allowEmpty': literalBool(true),
-      'useQueryComponent': literalBool(true),
-    });
     final value = field
         .nullSafeProperty('toString')
         .call([])
         .ifNullThen(literalString(''));
-    final entry = literalRecord([], {'name': name, 'value': value});
+    final entry = literalRecord([], {'name': encodedName, 'value': value});
     return [entry.code, const Code(',')];
   }
 
@@ -206,10 +217,37 @@ List<Code>? _buildPropertyFormEntry(
   final fieldCanBeNull =
       isNullable || !property.isRequired || property.isWriteOnly;
 
+  // A list property nested in a form body is comma-joined into a single entry
+  // by the object path (`list.uriEncode` in `parameterProperties`, then a
+  // single `Map` entry), never exploded into repeated keys; mirror that here
+  // rather than delegating to the exploding shared form builder. allowReserved
+  // is not threaded because the object path never applies it to lists.
+  if (resolved is ListModel) {
+    if (!resolved.hasSimpleContent) return null;
+    final value = buildUriEncodeExpression(
+      fieldCanBeNull ? field.nullChecked : field,
+      resolved,
+      allowEmpty: literalBool(true),
+      useQueryComponent: literalBool(true),
+      useImmutableCollections: useImmutableCollections,
+    ).expression;
+    final record = literalRecord([], {'name': encodedName, 'value': value});
+    if (!fieldCanBeNull) {
+      return [record.code, const Code(',')];
+    }
+    return _nullGuardedEntries(
+      field: field,
+      encodedName: encodedName,
+      property: property,
+      isNullable: isNullable,
+      entries: literalList([record]),
+    );
+  }
+
   final entries = buildFormEntriesValueExpression(
     fieldCanBeNull ? field.nullChecked : field,
     property.model,
-    paramName: propertyNameLiteral,
+    paramName: encodedName,
     explode: literalBool(true),
     allowEmpty: literalBool(true),
     useQueryComponent: literalBool(true),
@@ -221,6 +259,26 @@ List<Code>? _buildPropertyFormEntry(
     return [const Code('...'), entries.code, const Code(',')];
   }
 
+  return _nullGuardedEntries(
+    field: field,
+    encodedName: encodedName,
+    property: property,
+    isNullable: isNullable,
+    entries: entries,
+  );
+}
+
+/// Wraps [entries] (a `List<ParameterEntry>`) in a null guard on [field]. When
+/// the field is required and non-nullable, a null value throws; otherwise it
+/// yields a single empty-valued entry — matching the object path's
+/// `else if (allowEmpty)` branch.
+List<Code> _nullGuardedEntries({
+  required Expression field,
+  required Expression encodedName,
+  required Property property,
+  required bool isNullable,
+  required Expression entries,
+}) {
   final whenNull = property.isRequired && !isNullable
       ? generateEncodingExceptionExpression(
           'Required property ${property.name} is null.',
@@ -228,7 +286,7 @@ List<Code>? _buildPropertyFormEntry(
         )
       : literalList([
           literalRecord([], {
-            'name': propertyNameLiteral,
+            'name': encodedName,
             'value': literalString(''),
           }),
         ]);

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -1,7 +1,10 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 
 /// Returns null for the throwing cases (never/binary/complex map) and the
@@ -49,6 +52,9 @@ Expression? buildFormEntriesValueExpression(
     case NumberModel():
       return toForm(receiver, reserved: allowReserved);
 
+    // The generated toForm for enums and compositions has no allowReserved
+    // parameter, so the flag is deferred for these types — threading it would
+    // not compile.
     case EnumModel():
     case ClassModel():
     case AllOfModel():
@@ -105,6 +111,137 @@ Expression? buildFormEntriesValueExpression(
     default:
       return null;
   }
+}
+
+/// Gates the per-property form-body path, which only an `allowReserved` flag
+/// needs. It stays on the byte-identical object-level `body.toForm()` path
+/// unless a writable, emitted property of [model] carries the flag — a flag on
+/// a read-only property or an unmatched key has no emitted effect.
+bool formBodyHasAllowReserved(
+  Map<String, PropertyEncoding>? encoding,
+  ClassModel model,
+) {
+  if (encoding == null) return false;
+  final emittedNames = {
+    for (final property in model.properties)
+      if (!property.isReadOnly) property.name,
+  };
+  return encoding.entries.any(
+    (e) => (e.value.allowReserved ?? false) && emittedNames.contains(e.key),
+  );
+}
+
+/// Emits form entries one property at a time so a mix of per-property
+/// `allowReserved` flags is honored — the object-level `toForm` encodes every
+/// property uniformly and cannot express the mix. On success `entries` holds
+/// the list expression; when a property model is not form-encodable
+/// per-property, `unencodableProperty` names it so the caller can surface an
+/// `EncodingException` rather than falling back to a path that would silently
+/// drop `allowReserved` from a sibling that opted in.
+({Expression? entries, String? unencodableProperty})
+buildClassFormEntriesExpression(
+  Expression receiver,
+  ClassModel model,
+  Map<String, PropertyEncoding>? encoding,
+) {
+  final writeProperties = model.properties
+      .where((p) => !p.isReadOnly)
+      .toList();
+  final normalizedProps = normalizeProperties(writeProperties);
+
+  final propertyCodes = <Code>[];
+  for (final (:normalizedName, :property) in normalizedProps) {
+    final entryCodes = _buildPropertyFormEntry(
+      receiver.property(normalizedName),
+      property,
+      encoding?[property.name]?.allowReserved ?? false,
+    );
+    if (entryCodes == null) {
+      return (entries: null, unencodableProperty: property.name);
+    }
+    propertyCodes.addAll(entryCodes);
+  }
+
+  return (
+    entries: CodeExpression(
+      Block.of([const Code('['), ...propertyCodes, const Code(']')]),
+    ),
+    unencodableProperty: null,
+  );
+}
+
+/// Emits the spread/element code for one class property, or null when the
+/// property model cannot be encoded per-property. Field nullability mirrors the
+/// object path (`class_generator`): a field is nullable when the property is
+/// nullable, optional, write-only, or backed by an effectively-nullable model.
+List<Code>? _buildPropertyFormEntry(
+  Expression field,
+  Property property,
+  bool allowReserved,
+) {
+  final propertyNameLiteral = specLiteralString(property.name);
+  final resolved = property.model.resolved;
+
+  // Free-form objects encode via encodeAnyToForm, which accepts null and owns
+  // its own value encoding, so allowReserved is deferred here as it is for the
+  // enum/composition arm of buildFormEntriesValueExpression.
+  if (resolved is AnyModel) {
+    final value = refer(
+      'encodeAnyToForm',
+      'package:tonik_util/tonik_util.dart',
+    ).call([field], {
+      'explode': literalBool(true),
+      'allowEmpty': literalBool(true),
+      'useQueryComponent': literalBool(true),
+    });
+    final entry = literalRecord([], {
+      'name': propertyNameLiteral,
+      'value': value,
+    });
+    return [entry.code, const Code(',')];
+  }
+
+  final isNullable =
+      property.isNullable || property.model.isEffectivelyNullable;
+  final fieldCanBeNull =
+      isNullable || !property.isRequired || property.isWriteOnly;
+
+  final entries = buildFormEntriesValueExpression(
+    fieldCanBeNull ? field.nullChecked : field,
+    property.model,
+    paramName: propertyNameLiteral,
+    explode: literalBool(true),
+    allowEmpty: literalBool(true),
+    useQueryComponent: literalBool(true),
+    allowReserved: allowReserved,
+  );
+  if (entries == null) return null;
+
+  if (!fieldCanBeNull) {
+    return [const Code('...'), entries.code, const Code(',')];
+  }
+
+  final whenNull = property.isRequired && !isNullable
+      ? generateEncodingExceptionExpression(
+          'Required property ${property.name} is null.',
+          raw: true,
+        )
+      : literalList([
+          literalRecord([], {
+            'name': propertyNameLiteral,
+            'value': literalString(''),
+          }),
+        ]);
+
+  return [
+    const Code('...('),
+    field.notEqualTo(literalNull).code,
+    const Code(' ? '),
+    entries.code,
+    const Code(' : '),
+    whenNull.code,
+    const Code('),'),
+  ];
 }
 
 Expression? _buildListFormEntriesExpression(

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -144,10 +144,12 @@ buildClassFormEntriesExpression(
   ClassModel model,
   Map<String, PropertyEncoding>? encoding,
 ) {
-  final writeProperties = model.properties
-      .where((p) => !p.isReadOnly)
+  // Normalize the full set first, then drop read-only, so a write property
+  // keeps the same suffix the object path (class_generator) assigns it — a
+  // read-only sibling that normalizes to the same name still consumes a suffix.
+  final normalizedProps = normalizeProperties(model.properties.toList())
+      .where((p) => !p.property.isReadOnly)
       .toList();
-  final normalizedProps = normalizeProperties(writeProperties);
 
   final propertyCodes = <Code>[];
   for (final (:normalizedName, :property) in normalizedProps) {
@@ -171,9 +173,9 @@ buildClassFormEntriesExpression(
 }
 
 /// Emits the spread/element code for one class property, or null when the
-/// property model cannot be encoded per-property. Field nullability mirrors the
-/// object path (`class_generator`): a field is nullable when the property is
-/// nullable, optional, write-only, or backed by an effectively-nullable model.
+/// property model cannot be encoded per-property. The field is null-guarded
+/// whenever it could hold null — a superset of the object path's field rule
+/// that also covers effectively-nullable backing models.
 List<Code>? _buildPropertyFormEntry(
   Expression field,
   Property property,
@@ -182,22 +184,20 @@ List<Code>? _buildPropertyFormEntry(
   final propertyNameLiteral = specLiteralString(property.name);
   final resolved = property.model.resolved;
 
-  // Free-form objects encode via encodeAnyToForm, which accepts null and owns
-  // its own value encoding, so allowReserved is deferred here as it is for the
-  // enum/composition arm of buildFormEntriesValueExpression.
+  // AnyModel is deferred like enum/composition, so mirror the object path
+  // (class_generator `parameterProperties` + `Map<String,String>.toForm`
+  // with alreadyEncoded) byte-for-byte: the name is URI-encoded, the value is
+  // the raw `toString()` passed through unencoded.
   if (resolved is AnyModel) {
-    final value = refer(
-      'encodeAnyToForm',
-      'package:tonik_util/tonik_util.dart',
-    ).call([field], {
-      'explode': literalBool(true),
+    final name = propertyNameLiteral.property('uriEncode').call([], {
       'allowEmpty': literalBool(true),
       'useQueryComponent': literalBool(true),
     });
-    final entry = literalRecord([], {
-      'name': propertyNameLiteral,
-      'value': value,
-    });
+    final value = field
+        .nullSafeProperty('toString')
+        .call([])
+        .ifNullThen(literalString(''));
+    final entry = literalRecord([], {'name': name, 'value': value});
     return [entry.code, const Code(',')];
   }
 

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -10,6 +10,7 @@ BuiltExpression buildToFormValueExpression(
   required bool useQueryComponent,
   bool explodeLiteral = true,
   bool allowEmptyLiteral = true,
+  bool useImmutableCollections = false,
   Map<String, PropertyEncoding>? encoding,
 }) {
   final receiver = refer(valueExpression);
@@ -35,6 +36,7 @@ BuiltExpression buildToFormValueExpression(
       receiver,
       resolved,
       encoding,
+      useImmutableCollections: useImmutableCollections,
     );
     if (entries != null) {
       return BuiltExpression.simple(_entriesToBody(entries));

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -10,6 +10,7 @@ BuiltExpression buildToFormValueExpression(
   required bool useQueryComponent,
   bool explodeLiteral = true,
   bool allowEmptyLiteral = true,
+  Map<String, PropertyEncoding>? encoding,
 }) {
   final receiver = refer(valueExpression);
   final resolved = model.resolved;
@@ -25,6 +26,27 @@ BuiltExpression buildToFormValueExpression(
     return BuiltExpression.simple(
       generateEncodingExceptionExpression(
         'Form encoding not supported for map types.',
+      ),
+    );
+  }
+
+  if (resolved is ClassModel && formBodyHasAllowReserved(encoding, resolved)) {
+    final (:entries, :unencodableProperty) = buildClassFormEntriesExpression(
+      receiver,
+      resolved,
+      encoding,
+    );
+    if (entries != null) {
+      return BuiltExpression.simple(_entriesToBody(entries));
+    }
+    // A sibling opted into allowReserved but a property is not per-property
+    // encodable; surfacing the failure keeps the flag from being silently
+    // dropped by the uniform object path.
+    return BuiltExpression.simple(
+      generateEncodingExceptionExpression(
+        'Cannot form-encode body: property "$unencodableProperty" is not '
+        'per-property encodable.',
+        raw: true,
       ),
     );
   }

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1228,6 +1228,83 @@ void main() {
       );
 
       test(
+        'null-guards an optional form body before the per-property list',
+        () {
+          final formModel = ClassModel(
+            name: 'OptionalReservedForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = Operation(
+            operationId: 'postOptionalReserved',
+            path: '/optional-reserved',
+            method: HttpMethod.post,
+            requestBody: RequestBodyObject(
+              name: 'optionalReserved',
+              context: testContext,
+              description: null,
+              isRequired: false,
+              content: {
+                RequestContent(
+                  model: formModel,
+                  contentType: ContentType.form,
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  examples: const [],
+                  encoding: {
+                    'reserved': const PropertyEncoding(allowReserved: true),
+                  },
+                ),
+              },
+            ),
+            responses: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            queryParameters: const {},
+            headers: const {},
+            context: testContext,
+            tags: const {},
+            isDeprecated: false,
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+            Object? _data({OptionalReservedForm? body}) {
+              if (body == null) return null;
+              return [
+                ...body.reserved.toForm(
+                  r'reserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
         'keeps object-level toForm when no property opts into allowReserved',
         () {
           final formModel = ClassModel(
@@ -1597,6 +1674,167 @@ void main() {
                 ),
                 ...body.status.toForm(
                   r'status',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+                ...body.choice.toForm(
+                  r'choice',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'opens the per-property path for a sole flagged enum yet defers its '
+        'allowReserved',
+        () {
+          final formModel = ClassModel(
+            name: 'EnumOnlyForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'status',
+                model: EnumModel<String>(
+                  name: 'Status',
+                  values: {
+                    const EnumEntry(value: 'active'),
+                    const EnumEntry(value: 'inactive'),
+                  },
+                  isNullable: false,
+                  isDeprecated: false,
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postEnumOnly',
+            model: formModel,
+            encoding: {
+              'status': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required EnumOnlyForm body}) {
+              return [
+                ...body.name.toForm(
+                  r'name',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+                ...body.status.toForm(
+                  r'status',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'opens the per-property path for a sole flagged composition yet defers '
+        'its allowReserved',
+        () {
+          final formModel = ClassModel(
+            name: 'CompositionOnlyForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'choice',
+                model: OneOfModel(
+                  name: 'Choice',
+                  models: {
+                    (
+                      discriminatorValue: null,
+                      model: StringModel(context: testContext),
+                    ),
+                    (
+                      discriminatorValue: null,
+                      model: IntegerModel(context: testContext),
+                    ),
+                  },
+                  isDeprecated: false,
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postCompositionOnly',
+            model: formModel,
+            encoding: {
+              'choice': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required CompositionOnlyForm body}) {
+              return [
+                ...body.name.toForm(
+                  r'name',
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1194,26 +1194,26 @@ void main() {
             Object? _data({required ReservedForm body}) {
               return [
                 ...body.reserved.toForm(
-                  r'reserved',
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                   allowReserved: true,
                 ),
                 ...body.notReserved.toForm(
-                  r'notReserved',
+                  r'notReserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                 ),
                 ...(body.optional != null
                     ? body.optional!.toForm(
-                        r'optional',
+                        r'optional'.uriEncode(allowEmpty: true, useQueryComponent: true),
                         explode: true,
                         allowEmpty: true,
                         useQueryComponent: true,
                       )
-                    : [(name: r'optional', value: '')]),
+                    : [(name: r'optional'.uriEncode(allowEmpty: true, useQueryComponent: true), value: '')]),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
           ''';
@@ -1285,7 +1285,7 @@ void main() {
               if (body == null) return null;
               return [
                 ...body.reserved.toForm(
-                  r'reserved',
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -1420,7 +1420,7 @@ void main() {
             Object? _data({required SecretForm body}) {
               return [
                 ...body.reserved.toForm(
-                  r'reserved',
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -1428,7 +1428,7 @@ void main() {
                 ),
                 ...(body.secret != null
                     ? body.secret!.toForm(
-                        r'secret',
+                        r'secret'.uriEncode(allowEmpty: true, useQueryComponent: true),
                         explode: true,
                         allowEmpty: true,
                         useQueryComponent: true,
@@ -1491,7 +1491,7 @@ void main() {
             Object? _data({required MetaForm body}) {
               return [
                 ...body.reserved.toForm(
-                  r'reserved',
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -1664,20 +1664,20 @@ void main() {
             Object? _data({required ComboForm body}) {
               return [
                 ...body.reserved.toForm(
-                  r'reserved',
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                   allowReserved: true,
                 ),
                 ...body.status.toForm(
-                  r'status',
+                  r'status'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                 ),
                 ...body.choice.toForm(
-                  r'choice',
+                  r'choice'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -1749,13 +1749,13 @@ void main() {
             Object? _data({required EnumOnlyForm body}) {
               return [
                 ...body.name.toForm(
-                  r'name',
+                  r'name'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                 ),
                 ...body.status.toForm(
-                  r'status',
+                  r'status'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -1832,16 +1832,284 @@ void main() {
             Object? _data({required CompositionOnlyForm body}) {
               return [
                 ...body.name.toForm(
-                  r'name',
+                  r'name'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
                 ),
                 ...body.choice.toForm(
-                  r'choice',
+                  r'choice'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'URI-encodes a property name containing a special character in the '
+        'per-property path',
+        () {
+          final formModel = ClassModel(
+            name: 'SpacedForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'a b',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postSpaced',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required SpacedForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                ...body.aB.toForm(
+                  r'a b'.uriEncode(allowEmpty: true, useQueryComponent: true),
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'comma-joins a list property into a single entry like the object path',
+        () {
+          final formModel = ClassModel(
+            name: 'ListForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'tags',
+                model: ListModel(
+                  content: StringModel(context: testContext),
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postList',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required ListForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                (
+                  name: r'tags'.uriEncode(allowEmpty: true, useQueryComponent: true),
+                  value: body.tags.uriEncode(allowEmpty: true, useQueryComponent: true),
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'throws for a map property because the object path rejects it too',
+        () {
+          final formModel = ClassModel(
+            name: 'MapForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'meta',
+                model: MapModel(
+                  valueModel: StringModel(context: testContext),
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postMap',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = '''
+            Object? _data({required MapForm body}) {
+              return throw EncodingException(
+                r'Cannot form-encode body: property "meta" is not per-property encodable.',
+              );
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'opens the per-property path for a sole flagged free-form property yet '
+        'defers its allowReserved',
+        () {
+          final formModel = ClassModel(
+            name: 'AnyOnlyForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'metadata',
+                model: AnyModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postAnyOnly',
+            model: formModel,
+            encoding: {
+              'metadata': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required AnyOnlyForm body}) {
+              return [
+                ...body.name.toForm(
+                  r'name'.uriEncode(allowEmpty: true, useQueryComponent: true),
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+                (
+                  name: r'metadata'.uriEncode(
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                  ),
+                  value: body.metadata?.toString() ?? '',
                 ),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
@@ -1960,7 +2228,7 @@ void main() {
             Object? _data({required CollisionForm body}) {
               return [
                 ...body.userName2.toForm(
-                  r'user_name',
+                  r'user_name'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
@@ -2501,14 +2769,14 @@ void main() {
                 final CreateUserJson value => value.value.toJson(),
                 final CreateUserXWwwFormUrlencoded value => [
                   ...value.value.reserved.toForm(
-                    r'reserved',
+                    r'reserved'.uriEncode(allowEmpty: true, useQueryComponent: true),
                     explode: true,
                     allowEmpty: true,
                     useQueryComponent: true,
                     allowReserved: true,
                   ),
                   ...value.value.plain.toForm(
-                    r'plain',
+                    r'plain'.uriEncode(allowEmpty: true, useQueryComponent: true),
                     explode: true,
                     allowEmpty: true,
                     useQueryComponent: true,

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1448,8 +1448,8 @@ void main() {
       );
 
       test(
-        'encodes a free-form sibling via encodeAnyToForm while keeping '
-        'allowReserved on the flagged scalar',
+        'mirrors the object-path encoding for a free-form sibling while '
+        'keeping allowReserved on the flagged scalar',
         () {
           final formModel = ClassModel(
             name: 'MetaForm',
@@ -1498,13 +1498,11 @@ void main() {
                   allowReserved: true,
                 ),
                 (
-                  name: r'metadata',
-                  value: encodeAnyToForm(
-                    body.metadata,
-                    explode: true,
+                  name: r'metadata'.uriEncode(
                     allowEmpty: true,
                     useQueryComponent: true,
                   ),
+                  value: body.metadata?.toString() ?? '',
                 ),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
@@ -1905,6 +1903,70 @@ void main() {
                   .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
                   .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                   .join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'references the suffixed field name a read-only sibling forces onto a '
+        'colliding write property',
+        () {
+          final formModel = ClassModel(
+            name: 'CollisionForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'user-name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isReadOnly: true,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'user_name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postCollision',
+            model: formModel,
+            encoding: {
+              'user_name': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required CollisionForm body}) {
+              return [
+                ...body.userName2.toForm(
+                  r'user_name',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
           ''';
 

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1116,6 +1116,568 @@ void main() {
           collapseWhitespace(format(expectedMethod)),
         );
       });
+
+      test(
+        'applies per-property allowReserved to a flagged property while '
+        'leaving siblings fully percent-encoded',
+        () {
+          final formModel = ClassModel(
+            name: 'ReservedForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'notReserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'optional',
+                model: StringModel(context: testContext),
+                isRequired: false,
+                isNullable: true,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = Operation(
+            operationId: 'postReserved',
+            path: '/reserved',
+            method: HttpMethod.post,
+            requestBody: RequestBodyObject(
+              name: 'reserved',
+              context: testContext,
+              description: null,
+              isRequired: true,
+              content: {
+                RequestContent(
+                  model: formModel,
+                  contentType: ContentType.form,
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  examples: const [],
+                  encoding: {
+                    'reserved': const PropertyEncoding(allowReserved: true),
+                    'notReserved': const PropertyEncoding(allowReserved: false),
+                  },
+                ),
+              },
+            ),
+            responses: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            queryParameters: const {},
+            headers: const {},
+            context: testContext,
+            tags: const {},
+            isDeprecated: false,
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required ReservedForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                ...body.notReserved.toForm(
+                  r'notReserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+                ...(body.optional != null
+                    ? body.optional!.toForm(
+                        r'optional',
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                      )
+                    : [(name: r'optional', value: '')]),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'keeps object-level toForm when no property opts into allowReserved',
+        () {
+          final formModel = ClassModel(
+            name: 'PlainForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'name',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = Operation(
+            operationId: 'postPlain',
+            path: '/plain',
+            method: HttpMethod.post,
+            requestBody: RequestBodyObject(
+              name: 'plain',
+              context: testContext,
+              description: null,
+              isRequired: true,
+              content: {
+                RequestContent(
+                  model: formModel,
+                  contentType: ContentType.form,
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  examples: const [],
+                  encoding: {
+                    'name': const PropertyEncoding(allowReserved: false),
+                  },
+                ),
+              },
+            ),
+            responses: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            queryParameters: const {},
+            headers: const {},
+            context: testContext,
+            tags: const {},
+            isDeprecated: false,
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required PlainForm body}) {
+              return body
+                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+                  .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                  .join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'null-guards a write-only property that a flagged sibling forces onto '
+        'the per-property path',
+        () {
+          final formModel = ClassModel(
+            name: 'SecretForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'secret',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isWriteOnly: true,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postSecret',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required SecretForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                ...(body.secret != null
+                    ? body.secret!.toForm(
+                        r'secret',
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                      )
+                    : throw EncodingException(r'Required property secret is null.')),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'encodes a free-form sibling via encodeAnyToForm while keeping '
+        'allowReserved on the flagged scalar',
+        () {
+          final formModel = ClassModel(
+            name: 'MetaForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'metadata',
+                model: AnyModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postMeta',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required MetaForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                (
+                  name: r'metadata',
+                  value: encodeAnyToForm(
+                    body.metadata,
+                    explode: true,
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                  ),
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'throws rather than dropping allowReserved when a sibling is not '
+        'per-property encodable',
+        () {
+          final formModel = ClassModel(
+            name: 'BadForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'items',
+                model: ListModel(
+                  content: ClassModel(
+                    name: 'Item',
+                    isDeprecated: false,
+                    properties: const [],
+                    context: testContext,
+                    examples: const [],
+                  ),
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postBad',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = '''
+            Object? _data({required BadForm body}) {
+              return throw EncodingException(
+                r'Cannot form-encode body: property "items" is not per-property encodable.',
+              );
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'defers allowReserved for enum and composition properties while '
+        'applying it to the flagged scalar',
+        () {
+          final formModel = ClassModel(
+            name: 'ComboForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'status',
+                model: EnumModel<String>(
+                  name: 'Status',
+                  values: {
+                    const EnumEntry(value: 'active'),
+                    const EnumEntry(value: 'inactive'),
+                  },
+                  isNullable: false,
+                  isDeprecated: false,
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'choice',
+                model: OneOfModel(
+                  name: 'Choice',
+                  models: {
+                    (
+                      discriminatorValue: null,
+                      model: StringModel(context: testContext),
+                    ),
+                    (
+                      discriminatorValue: null,
+                      model: IntegerModel(context: testContext),
+                    ),
+                  },
+                  isDeprecated: false,
+                  context: testContext,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postCombo',
+            model: formModel,
+            encoding: {
+              'reserved': const PropertyEncoding(allowReserved: true),
+              'status': const PropertyEncoding(allowReserved: true),
+              'choice': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required ComboForm body}) {
+              return [
+                ...body.reserved.toForm(
+                  r'reserved',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  allowReserved: true,
+                ),
+                ...body.status.toForm(
+                  r'status',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+                ...body.choice.toForm(
+                  r'choice',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                ),
+              ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'stays on the object path when only a read-only property carries '
+        'allowReserved',
+        () {
+          final formModel = ClassModel(
+            name: 'ReadOnlyForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'visible',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'hidden',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isReadOnly: true,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = _formOperation(
+            operationId: 'postReadOnly',
+            model: formModel,
+            encoding: {
+              'hidden': const PropertyEncoding(allowReserved: true),
+            },
+            context: testContext,
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required ReadOnlyForm body}) {
+              return body
+                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+                  .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                  .join('&');
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
     });
 
     group('multipart request bodies', () {
@@ -1542,6 +2104,116 @@ void main() {
                     .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
                     .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                     .join('&'),
+              };
+            }
+          ''';
+
+          final method = generator.generateDataMethod(operation);
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
+        'applies per-property allowReserved in the form arm of a '
+        'multi-content body',
+        () {
+          final jsonModel = ClassModel(
+            name: 'JsonPayload',
+            isDeprecated: false,
+            properties: const [],
+            context: testContext,
+            examples: const [],
+          );
+
+          final formModel = ClassModel(
+            name: 'FormPayload',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'reserved',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'plain',
+                model: StringModel(context: testContext),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: testContext,
+            examples: const [],
+          );
+
+          final operation = Operation(
+            operationId: 'createUser',
+            path: '/users',
+            method: HttpMethod.post,
+            requestBody: RequestBodyObject(
+              name: 'createUser',
+              context: testContext,
+              description: null,
+              isRequired: true,
+              content: {
+                RequestContent(
+                  model: jsonModel,
+                  contentType: ContentType.json,
+                  rawContentType: 'application/json',
+                  examples: const [],
+                ),
+                RequestContent(
+                  model: formModel,
+                  contentType: ContentType.form,
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  examples: const [],
+                  encoding: {
+                    'reserved': const PropertyEncoding(allowReserved: true),
+                    'plain': const PropertyEncoding(allowReserved: false),
+                  },
+                ),
+              },
+            ),
+            responses: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            queryParameters: const {},
+            headers: const {},
+            context: testContext,
+            tags: const {},
+            isDeprecated: false,
+            securitySchemes: const {},
+          );
+
+          const expectedMethod = r'''
+            Object? _data({required CreateUser body}) {
+              return switch (body) {
+                final CreateUserJson value => value.value.toJson(),
+                final CreateUserXWwwFormUrlencoded value => [
+                  ...value.value.reserved.toForm(
+                    r'reserved',
+                    explode: true,
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                    allowReserved: true,
+                  ),
+                  ...value.value.plain.toForm(
+                    r'plain',
+                    explode: true,
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                  ),
+                ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&'),
               };
             }
           ''';
@@ -1995,4 +2667,41 @@ void main() {
       },
     );
   });
+}
+
+Operation _formOperation({
+  required String operationId,
+  required ClassModel model,
+  required Map<String, PropertyEncoding> encoding,
+  required Context context,
+}) {
+  return Operation(
+    operationId: operationId,
+    path: '/$operationId',
+    method: HttpMethod.post,
+    requestBody: RequestBodyObject(
+      name: operationId,
+      context: context,
+      description: null,
+      isRequired: true,
+      content: {
+        RequestContent(
+          model: model,
+          contentType: ContentType.form,
+          rawContentType: 'application/x-www-form-urlencoded',
+          examples: const [],
+          encoding: encoding,
+        ),
+      },
+    ),
+    responses: const {},
+    pathParameters: const {},
+    cookieParameters: const {},
+    queryParameters: const {},
+    headers: const {},
+    context: context,
+    tags: const {},
+    isDeprecated: false,
+    securitySchemes: const {},
+  );
 }

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -6,8 +6,8 @@ import 'package:tonik_util/src/encoding/encoding_exception.dart';
 /// With [allowReserved] false the result is byte-identical to
 /// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
 /// this. With [allowReserved] true reserved chars including `[ ]` pass through
-/// literally; only the form delimiters `& = +`, space, `%`, and non-ASCII stay
-/// encoded.
+/// literally; the form delimiters `& =`, along with `+`, space, `%`, and
+/// non-ASCII, stay encoded.
 String _encodeUriValue(
   String value, {
   required bool allowReserved,

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -5,9 +5,9 @@ import 'package:tonik_util/src/encoding/encoding_exception.dart';
 
 /// With [allowReserved] false the result is byte-identical to
 /// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
-/// this. With [allowReserved] true most reserved chars pass through literally,
-/// but the form delimiters `& = +` and brackets `[ ]` stay encoded, as do
-/// space, `%`, and non-ASCII.
+/// this. With [allowReserved] true reserved chars including `[ ]` pass through
+/// literally; only the form delimiters `& = +`, space, `%`, and non-ASCII stay
+/// encoded.
 String _encodeUriValue(
   String value, {
   required bool allowReserved,
@@ -22,11 +22,14 @@ String _encodeUriValue(
   // Uri.encodeFull keeps reserved chars literal, but & and = are data here,
   // not delimiters, so they must stay encoded. A literal + must become %2B
   // before a space is rendered as +, otherwise a data + and a space would be
-  // indistinguishable.
+  // indistinguishable. encodeFull predates RFC 3986 treating [ ] as reserved
+  // and still percent-encodes them, so restore those to literal.
   var encoded = Uri.encodeFull(value)
       .replaceAll('+', '%2B')
       .replaceAll('&', '%26')
-      .replaceAll('=', '%3D');
+      .replaceAll('=', '%3D')
+      .replaceAll('%5B', '[')
+      .replaceAll('%5D', ']');
   if (useQueryComponent) {
     encoded = encoded.replaceAll('%20', '+');
   }

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -6,8 +6,8 @@ import 'package:tonik_util/src/encoding/encoding_exception.dart';
 /// With [allowReserved] false the result is byte-identical to
 /// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
 /// this. With [allowReserved] true reserved chars including `[ ]` pass through
-/// literally; the form delimiters `& =`, along with `+`, space, `%`, and
-/// non-ASCII, stay encoded.
+/// literally; the form delimiters `& =`, along with `+`, `%`, and non-ASCII,
+/// stay encoded, and a space becomes `%20` (or `+` under [useQueryComponent]).
 String _encodeUriValue(
   String value, {
   required bool allowReserved,

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -534,7 +534,7 @@ void main() {
           allowReserved: true,
         ),
         const <ParameterEntry>[
-          (name: 'p', value: r":/?#%5B%5D@!$%26'()*%2B,;%3D"),
+          (name: 'p', value: r":/?#[]@!$%26'()*%2B,;%3D"),
         ],
       );
     });

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -228,10 +228,10 @@ void main() {
   group('allowReserved', () {
     const allReserved = r":/?#[]@!$&'()*+,;=";
 
-    test('keeps the reserved set literal except & = + and [ ]', () {
+    test('keeps the reserved set literal except & = +', () {
       expect(
         allReserved.uriEncode(allowEmpty: true, allowReserved: true),
-        r":/?#%5B%5D@!$%26'()*%2B,;%3D",
+        r":/?#[]@!$%26'()*%2B,;%3D",
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -309,6 +309,17 @@ void main() {
       },
     );
 
+    test('a literal percent sequence is not decoded back into a bracket', () {
+      expect(
+        '%5B'.uriEncode(allowEmpty: true, allowReserved: true),
+        '%255B',
+      );
+      expect(
+        'a%5Bb'.uriEncode(allowEmpty: true, allowReserved: true),
+        'a%255Bb',
+      );
+    });
+
     test('Uri keeps reserved chars literal under allowReserved', () {
       final uri = Uri.parse('https://x.com/p?a=1&b=2');
       expect(


### PR DESCRIPTION
## Summary

Threads per-property `allowReserved` from the request body's encoding into **urlencoded (`application/x-www-form-urlencoded`) form-body** generation. A body property that opts into `allowReserved` now keeps reserved characters literal in the sent body, while sibling properties stay fully percent-encoded. Output is byte-identical when no property opts in.

## Behavior

A urlencoded body is sent as a raw Dio `data` string and never passes through Dart's `Uri`, so under `allowReserved` the reserved set behaves differently from the query surface:

- `/ : ? ; , @` **and** `#`, `[`, `]` are sent **literally** in the body (they are not delimiters in a body, and there is no `Uri` to force-encode them).
- The form-urlencoded delimiters stay percent-encoded even under `allowReserved` — `&`→`%26`, `=`→`%3D`, a literal `+`→`%2B` — because they are structural in a form body; a space renders as `+`.
- A sibling property without `allowReserved` is fully percent-encoded (unchanged).

To send `[` `]` literally in the body, the shared reserved-preserving encoder now leaves them literal under `allowReserved`. **The query surface is unaffected**: query assembly goes through `Uri.replace(query:)`, which re-encodes `[ ]`→`%5B %5D` at the wire, so query/delimited/deepObject output is unchanged (verified by the existing query integration suite).

## Scope

Only `allowReserved` is threaded — no per-property `style`/`explode` for form bodies. Body property types that cannot yet carry `allowReserved` (enum, composition) keep their existing encoding (deferred). A body property that cannot be encoded per-property surfaces an `EncodingException` naming the property, rather than silently dropping the flag.

## Tests

- Generator unit: full `_data` method-body comparisons — a body with an `allowReserved` property beside a plain sibling; the no-opt-in byte-identical case; a write-only sibling null-guard; a free-form (AnyModel) sibling; the enum/composition deferral; the unencodable-property throw; and the read-only-only gate staying on the object path.
- Integration (Imposter): assertions on the **sent request body** — reserved property keeps `# [ ]` and `/ : ? ; , @` literal, form delimiters percent-encoded, space as `+`; sibling fully percent-encoded. The existing query suite continues to assert `%5B %5D` at the wire (no regression).
- tonik_util encoder unit tests updated for the `[ ]`-literal-under-`allowReserved` behavior (`allowReserved: false` output unchanged).
