### PR TITLE
feat!: honor allowReserved for object, enum and composition query parameters

### DIFF
--- a/integration_test/allow_reserved/allow_reserved_test/test/form_enum_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_enum_test.dart
@@ -1,0 +1,96 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('form allowReserved enum', () {
+    test('keeps reserved survivors literal and encodes the form delimiters',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedEnum(
+        reserved: ReservedChoice.gAmpersandHEqualsIPlusJ,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reserved=g%26h%3Di%2Bj',
+      );
+    });
+
+    test('sibling default enum is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedEnum(
+        notReserved: ReservedChoice.gAmpersandHEqualsIPlusJ,
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReserved=g%26h%3Di%2Bj',
+      );
+    });
+  });
+
+  group('form allowReserved enum list', () {
+    test('keeps reserved survivors literal and encodes the form delimiters',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedEnumList(
+        reservedList: [
+          ReservedChoice.aSlashBc,
+          ReservedChoice.gAmpersandHEqualsIPlusJ,
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedList=a/b:c,g%26h%3Di%2Bj',
+      );
+    });
+
+    test('sibling default enum list is fully percent-encoded', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormAllowReservedEnumList(
+        notReservedList: [
+          ReservedChoice.aSlashBc,
+          ReservedChoice.gAmpersandHEqualsIPlusJ,
+        ],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedList=a%2Fb%3Ac,g%26h%3Di%2Bj',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/allow_reserved_test/test/form_object_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_object_test.dart
@@ -1,0 +1,62 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  const listValues = ['a/b:c?d@e;f', 'g&h=i+j k#l[m]n'];
+
+  group('form allowReserved object with list property', () {
+    test('keeps the list-property items reserved chars literal', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormObjectAllowReserved(
+        reservedObject: const ReservedListObject(tags: listValues),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedObject=tags,a/b:c?d@e;f,g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+
+    test('sibling default object list property is fully percent-encoded',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormObjectAllowReserved(
+        notReservedObject: const ReservedListObject(tags: listValues),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'notReservedObject=tags,a%2Fb%3Ac%3Fd%40e%3Bf,'
+        'g%26h%3Di%2Bj%20k%23l%5Bm%5Dn',
+      );
+    });
+  });
+}

--- a/integration_test/allow_reserved/openapi.yaml
+++ b/integration_test/allow_reserved/openapi.yaml
@@ -44,6 +44,32 @@ paths:
       responses:
         '204':
           description: No Content
+  /form-allow-reserved-enum:
+    get:
+      operationId: testFormAllowReservedEnum
+      tags:
+        - query
+      summary: Test allowReserved form query enum parameters
+      description: >-
+        A form query enum parameter with allowReserved next to a sibling enum
+        that keeps the default full percent-encoding.
+      parameters:
+        - name: reserved
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/ReservedChoice'
+        - name: notReserved
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/ReservedChoice'
+      responses:
+        '204':
+          description: No Content
   /form-allow-reserved-list:
     get:
       operationId: testFormAllowReservedList
@@ -71,6 +97,36 @@ paths:
             type: array
             items:
               type: string
+      responses:
+        '204':
+          description: No Content
+  /form-allow-reserved-enum-list:
+    get:
+      operationId: testFormAllowReservedEnumList
+      tags:
+        - query
+      summary: Test allowReserved form query enum array parameters
+      description: >-
+        A non-nullable array-of-enum form query parameter with allowReserved
+        next to a sibling array that keeps the default full percent-encoding.
+      parameters:
+        - name: reservedList
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ReservedChoice'
+        - name: notReservedList
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/ReservedChoice'
       responses:
         '204':
           description: No Content
@@ -164,3 +220,50 @@ paths:
       responses:
         '204':
           description: No Content
+
+  /form-object-allow-reserved:
+    get:
+      operationId: testFormObjectAllowReserved
+      tags:
+        - query
+      summary: Test allowReserved form query object parameters with a list property
+      description: >-
+        A form-style object query parameter with allowReserved whose typed
+        object holds a string-list property, next to a sibling object that keeps
+        the default full percent-encoding.
+      parameters:
+        - name: reservedObject
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/ReservedListObject'
+        - name: notReservedObject
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/ReservedListObject'
+      responses:
+        '204':
+          description: No Content
+
+components:
+  schemas:
+    ReservedChoice:
+      type: string
+      enum:
+        - a/b:c
+        - g&h=i+j
+
+    ReservedListObject:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          description: String list whose items keep reserved chars literal

--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -165,6 +165,15 @@ switch (path) {
         }
         break
 
+    case '/form/allow-reserved-enum':
+        def formBody = 'choice=a%2Fb%3Ac'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -478,6 +478,26 @@ void main() {
         expect(requestData, 'reserved=a/b:c&tags=x,y,z');
       },
     );
+
+    test(
+      'keeps reserved characters literal for a flagged enum property through '
+      'the shared form-entries path',
+      () async {
+        const form = AllowReservedEnumForm(
+          choice: AllowReservedEnumFormChoiceModel.gAmpersandHEqualsIPlusJ,
+        );
+
+        final response = await api.postAllowReservedEnumForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedEnumForm>>());
+
+        final requestData = (response as TonikSuccess<AllowReservedEnumForm>)
+            .response
+            .requestOptions
+            .data;
+        expect(requestData, 'choice=g%26h%3Di%2Bj');
+      },
+    );
   });
 
   group('Content-Type header', () {

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -406,6 +406,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/AllowReservedArrayForm'
 
+  /form/allow-reserved-enum:
+    post:
+      operationId: postAllowReservedEnumForm
+      tags:
+        - form
+      summary: Post form where an enum property opts into allowReserved
+      description: >-
+        Tests that an enum body property flagged allowReserved keeps reserved
+        characters literal in the sent body through the shared form-entries
+        path.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllowReservedEnumForm'
+            encoding:
+              choice:
+                allowReserved: true
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllowReservedEnumForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -602,3 +629,15 @@ components:
           items:
             type: string
           description: Array sibling comma-joined into a single entry
+
+    AllowReservedEnumForm:
+      type: object
+      required:
+        - choice
+      properties:
+        choice:
+          type: string
+          enum:
+            - a/b:c
+            - g&h=i+j
+          description: Enum value that keeps reserved characters literal

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1282,10 +1282,7 @@ class AllOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = buildEmptyMapStringString().returned.statement,
       );
     }
@@ -1312,10 +1309,7 @@ class AllOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..lambda = true
           ..body = generateEncodingExceptionExpression(message, raw: true).code,
       );
@@ -1331,10 +1325,7 @@ class AllOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..lambda = true
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
@@ -1349,10 +1340,7 @@ class AllOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
             'contains primitive types',
@@ -1382,6 +1370,7 @@ class AllOfGenerator {
                   {
                     'allowEmpty': refer('allowEmpty'),
                     'allowLists': refer('allowLists'),
+                    'allowReserved': refer('allowReserved'),
                   },
                 ),
           ]).statement,
@@ -1399,6 +1388,7 @@ class AllOfGenerator {
                   {
                     'allowEmpty': refer('allowEmpty'),
                     'allowLists': refer('allowLists'),
+                    'allowReserved': refer('allowReserved'),
                   },
                 ),
           ]).statement,
@@ -1418,10 +1408,7 @@ class AllOfGenerator {
       (b) => b
         ..name = 'parameterProperties'
         ..returns = buildMapStringStringType()
-        ..optionalParameters.addAll([
-          buildBoolParameter('allowEmpty', defaultValue: true),
-          buildBoolParameter('allowLists', defaultValue: true),
-        ])
+        ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..body = Block.of(propertyMergingLines),
     );
   }
@@ -1442,9 +1429,11 @@ class AllOfGenerator {
         ap.valueModel.encodingShape == EncodingShape.simple) {
       final uriEncodeCall = ap.valueModel.isEffectivelyNullable
           ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
-                ".uriEncode(allowEmpty: allowEmpty) ?? ''"
+                '.uriEncode(allowEmpty: allowEmpty, '
+                "allowReserved: allowReserved) ?? ''"
           : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
-                '.uriEncode(allowEmpty: allowEmpty)';
+                '.uriEncode(allowEmpty: allowEmpty, '
+                'allowReserved: allowReserved)';
       return [
         Code('''
 for (final _\$e in $apFieldName.entries) {
@@ -1822,6 +1811,7 @@ for (final _\$e in $apFieldName.entries) {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
               'useQueryComponent': refer('useQueryComponent'),
+              'allowReserved': refer('allowReserved'),
             });
       }
       if (resolved is BinaryModel) {
@@ -1833,6 +1823,7 @@ for (final _\$e in $apFieldName.entries) {
         'explode': refer('explode'),
         'allowEmpty': refer('allowEmpty'),
         'useQueryComponent': refer('useQueryComponent'),
+        'allowReserved': refer('allowReserved'),
       });
     }
 
@@ -1908,6 +1899,7 @@ for (final _\$e in $apFieldName.entries) {
     final delegateToParameterProperties = refer('parameterProperties')
         .call([], {
           'allowEmpty': refer('allowEmpty'),
+          'allowReserved': refer('allowReserved'),
         })
         .property('toForm')
         .call([refer('paramName')], {
@@ -2619,6 +2611,7 @@ for (final _\$e in $apFieldName.entries) {
               .call([], {
                 'allowEmpty': refer('allowEmpty'),
                 'useQueryComponent': refer('useQueryComponent'),
+                'allowReserved': refer('allowReserved'),
               })
               .returned
               .statement,
@@ -2632,22 +2625,7 @@ for (final _\$e in $apFieldName.entries) {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'uriEncode'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll([
-            Parameter(
-              (b) => b
-                ..name = 'allowEmpty'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..required = true,
-            ),
-            Parameter(
-              (b) => b
-                ..name = 'useQueryComponent'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..defaultTo = literalBool(false).code,
-            ),
-          ])
+          ..optionalParameters.addAll(buildUriEncodeParameters())
           ..lambda = false
           ..body = Block.of(bodyCode),
       );
@@ -2664,22 +2642,7 @@ for (final _\$e in $apFieldName.entries) {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'uriEncode'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll([
-            Parameter(
-              (b) => b
-                ..name = 'allowEmpty'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..required = true,
-            ),
-            Parameter(
-              (b) => b
-                ..name = 'useQueryComponent'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..defaultTo = literalBool(false).code,
-            ),
-          ])
+          ..optionalParameters.addAll(buildUriEncodeParameters())
           ..lambda = false
           ..body = generateEncodingExceptionExpression(
             'Cannot uriEncode $className: contains complex types',
@@ -2694,22 +2657,7 @@ for (final _\$e in $apFieldName.entries) {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'uriEncode'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll([
-            Parameter(
-              (b) => b
-                ..name = 'allowEmpty'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..required = true,
-            ),
-            Parameter(
-              (b) => b
-                ..name = 'useQueryComponent'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..defaultTo = literalBool(false).code,
-            ),
-          ])
+          ..optionalParameters.addAll(buildUriEncodeParameters())
           ..lambda = true
           ..body = literalString('').code,
       );
@@ -2744,6 +2692,7 @@ for (final _\$e in $apFieldName.entries) {
                   .call([], {
                     'allowEmpty': refer('allowEmpty'),
                     'useQueryComponent': refer('useQueryComponent'),
+                    'allowReserved': refer('allowReserved'),
                   }),
             )
             .statement,
@@ -2778,22 +2727,7 @@ for (final _\$e in $apFieldName.entries) {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'uriEncode'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll([
-          Parameter(
-            (b) => b
-              ..name = 'allowEmpty'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..required = true,
-          ),
-          Parameter(
-            (b) => b
-              ..name = 'useQueryComponent'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..defaultTo = literalBool(false).code,
-          ),
-        ])
+        ..optionalParameters.addAll(buildUriEncodeParameters())
         ..lambda = false
         ..body = Block.of(valueCollectionCode),
     );

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -1364,6 +1364,7 @@ class AnyOfGenerator {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
                 'useQueryComponent': refer('useQueryComponent'),
+                'allowReserved': refer('allowReserved'),
               },
             ),
       );
@@ -1381,6 +1382,7 @@ class AnyOfGenerator {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
             'useQueryComponent': refer('useQueryComponent'),
+            'allowReserved': refer('allowReserved'),
           },
         ),
       );
@@ -1419,7 +1421,7 @@ class AnyOfGenerator {
           Code(
             'final _\$${fieldName}Form = '
             '$fieldName!.parameterProperties('
-            'allowEmpty: allowEmpty);',
+            'allowEmpty: allowEmpty, allowReserved: allowReserved);',
           ),
         );
         if (needsMapValues) {
@@ -1452,6 +1454,7 @@ class AnyOfGenerator {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
             'useQueryComponent': refer('useQueryComponent'),
+            'allowReserved': refer('allowReserved'),
           },
         ),
       );
@@ -1464,7 +1467,7 @@ class AnyOfGenerator {
           Code(
             'final _\$${fieldName}Form = '
             '$fieldName!.parameterProperties('
-            'allowEmpty: allowEmpty);',
+            'allowEmpty: allowEmpty, allowReserved: allowReserved);',
           ),
         );
       if (needsMapValues) {
@@ -1702,10 +1705,7 @@ class AnyOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
             'contains only simple types',
@@ -1866,10 +1866,7 @@ class AnyOfGenerator {
       (b) => b
         ..name = 'parameterProperties'
         ..returns = buildMapStringStringType()
-        ..optionalParameters.addAll([
-          buildBoolParameter('allowEmpty', defaultValue: true),
-          buildBoolParameter('allowLists', defaultValue: true),
-        ])
+        ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..lambda = false
         ..body = Block.of(body),
     );
@@ -1916,7 +1913,7 @@ class AnyOfGenerator {
           Code(
             r'_$mapValues.add('
             '$fieldName!.parameterProperties(allowEmpty: allowEmpty, '
-            'allowLists: allowLists));',
+            'allowLists: allowLists, allowReserved: allowReserved));',
           ),
         );
 
@@ -1948,7 +1945,7 @@ class AnyOfGenerator {
         Code(
           r'_$mapValues.add('
           '$fieldName!.parameterProperties(allowEmpty: allowEmpty, '
-          'allowLists: allowLists));',
+          'allowLists: allowLists, allowReserved: allowReserved));',
         ),
       ];
 
@@ -2369,7 +2366,8 @@ class AnyOfGenerator {
           ..add(
             Code(
               'return $receiver.uriEncode(allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent);',
+              'useQueryComponent: useQueryComponent, '
+              'allowReserved: allowReserved);',
             ),
           )
           ..add(const Code('}'));
@@ -2388,22 +2386,7 @@ class AnyOfGenerator {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'uriEncode'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll([
-          Parameter(
-            (b) => b
-              ..name = 'allowEmpty'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..required = true,
-          ),
-          Parameter(
-            (b) => b
-              ..name = 'useQueryComponent'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..defaultTo = literalBool(false).code,
-          ),
-        ])
+        ..optionalParameters.addAll(buildUriEncodeParameters())
         ..lambda = false
         ..body = Block.of(body),
     );

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1227,10 +1227,12 @@ class ClassGenerator {
       final uriEncodeCall = ap.valueModel.isEffectivelyNullable
           ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
                 '.uriEncode(allowEmpty: allowEmpty, '
-                "useQueryComponent: useQueryComponent) ?? ''"
+                'useQueryComponent: useQueryComponent, '
+                "allowReserved: allowReserved) ?? ''"
           : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
                 '.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent)';
+                'useQueryComponent: useQueryComponent, '
+                'allowReserved: allowReserved)';
       return [
         Code('''
 for (final _\$e in $apFieldName.entries) {
@@ -1286,6 +1288,7 @@ for (final _\$e in $apFieldName.entries) {
           ..required = false
           ..defaultTo = literalFalse.code,
       ),
+      buildBoolParameter('allowReserved'),
     ];
   }
 
@@ -1333,7 +1336,8 @@ for (final _\$e in $apFieldName.entries) {
             '_\$result[${specLiteralStringCode(propertyName)}] = '
             '${uriEncodeReceiver(model, name)}.uriEncode('
             'allowEmpty: allowEmpty, '
-            'useQueryComponent: useQueryComponent);',
+            'useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved);',
           ),
         );
       } else {
@@ -1352,14 +1356,15 @@ for (final _\$e in $apFieldName.entries) {
               Code(
                 '_\$result[${specLiteralStringCode(propertyName)}] = '
                 '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent);',
+                'useQueryComponent: useQueryComponent, '
+                'allowReserved: allowReserved);',
               ),
             );
         } else {
           propertyAssignments.add(
             Code('''
 if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
 } else if (allowEmpty) {
   _\$result[${specLiteralStringCode(propertyName)}] = '';
 }'''),
@@ -1436,7 +1441,8 @@ if ($name != null) {
               '_\$result[${specLiteralStringCode(propertyName)}] = '
               '${uriEncodeReceiver(fieldModel, name)}.uriEncode('
               'allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent);',
+              'useQueryComponent: useQueryComponent, '
+              'allowReserved: allowReserved);',
             ),
           );
         } else {
@@ -1455,14 +1461,15 @@ if ($name != null) {
                 Code(
                   '_\$result[${specLiteralStringCode(propertyName)}] = '
                   '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                  'useQueryComponent: useQueryComponent);',
+                  'useQueryComponent: useQueryComponent, '
+                  'allowReserved: allowReserved);',
                 ),
               );
           } else {
             propertyAssignments.add(
               Code('''
 if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
 } else if (allowEmpty) {
   _\$result[${specLiteralStringCode(propertyName)}] = '';
 }'''),
@@ -1479,6 +1486,7 @@ if ($name != null) {
           allowEmpty: refer('allowEmpty'),
           useQueryComponent: refer('useQueryComponent'),
           useImmutableCollections: useImmutableCollections,
+          allowReserved: refer('allowReserved'),
         );
 
         final assignmentExpr = refer(
@@ -1604,7 +1612,8 @@ if ($name != null) {
               '_\$result[${specLiteralStringCode(propertyName)}] = '
               '${uriEncodeReceiver(model, name)}.uriEncode('
               'allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent);',
+              'useQueryComponent: useQueryComponent, '
+              'allowReserved: allowReserved);',
             ),
           );
         } else {
@@ -1623,14 +1632,15 @@ if ($name != null) {
                 Code(
                   '_\$result[${specLiteralStringCode(propertyName)}] = '
                   '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                  'useQueryComponent: useQueryComponent);',
+                  'useQueryComponent: useQueryComponent, '
+                  'allowReserved: allowReserved);',
                 ),
               );
           } else {
             propertyAssignments.add(
               Code('''
 if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
 } else if (allowEmpty) {
   _\$result[${specLiteralStringCode(propertyName)}] = '';
 }'''),
@@ -1996,6 +2006,7 @@ if ($name != null) {
             .call([], {
               'allowEmpty': refer('allowEmpty'),
               'useQueryComponent': refer('useQueryComponent'),
+              'allowReserved': refer('allowReserved'),
             })
             .property('toForm')
             .call(
@@ -2084,12 +2095,13 @@ if ($name != null) {
             ..type = refer('String', 'dart:core'),
         ),
       )
-      ..optionalParameters.addAll(buildEncodingParameters())
+      ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
             .call([], {
               'allowEmpty': refer('allowEmpty'),
               'allowLists': literalBool(false),
+              'allowReserved': refer('allowReserved'),
             })
             .property('toDeepObject')
             .call(
@@ -2110,22 +2122,7 @@ if ($name != null) {
       ..annotations.add(refer('override', 'dart:core'))
       ..name = 'uriEncode'
       ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll([
-        Parameter(
-          (b) => b
-            ..name = 'allowEmpty'
-            ..type = refer('bool', 'dart:core')
-            ..named = true
-            ..required = true,
-        ),
-        Parameter(
-          (b) => b
-            ..name = 'useQueryComponent'
-            ..type = refer('bool', 'dart:core')
-            ..named = true
-            ..defaultTo = literalBool(false).code,
-        ),
-      ])
+      ..optionalParameters.addAll(buildUriEncodeParameters())
       ..lambda = false
       ..body = generateEncodingExceptionExpression(
         'Cannot uriEncode $className: complex types cannot be URI-encoded',

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -470,7 +470,8 @@ return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty);
           ..optionalParameters.addAll(buildFormEncodingParameters())
           ..body = const Code(
             'rawValue.toForm(paramName, explode: explode, '
-            'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent)',
+            'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved)',
           ),
       );
     }
@@ -498,7 +499,7 @@ return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty);
           const Code('}'),
           const Code(
             '''
-return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
 ''',
           ),
         ]),
@@ -557,26 +558,11 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           ..annotations.add(refer('override', 'dart:core'))
           ..returns = refer('String', 'dart:core')
           ..lambda = true
-          ..optionalParameters.addAll([
-            Parameter(
-              (b) => b
-                ..name = 'allowEmpty'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..required = true,
-            ),
-            Parameter(
-              (b) => b
-                ..name = 'useQueryComponent'
-                ..type = refer('bool', 'dart:core')
-                ..named = true
-                ..required = false
-                ..defaultTo = literalFalse.code,
-            ),
-          ])
+          ..optionalParameters.addAll(buildUriEncodeParameters())
           ..body = const Code(
             'rawValue.uriEncode(allowEmpty: allowEmpty, '
-            'useQueryComponent: useQueryComponent)',
+            'useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved)',
           ),
       );
     }
@@ -587,23 +573,7 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
         ..annotations.add(refer('override', 'dart:core'))
         ..returns = refer('String', 'dart:core')
         ..lambda = false
-        ..optionalParameters.addAll([
-          Parameter(
-            (b) => b
-              ..name = 'allowEmpty'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..required = true,
-          ),
-          Parameter(
-            (b) => b
-              ..name = 'useQueryComponent'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..required = false
-              ..defaultTo = literalFalse.code,
-          ),
-        ])
+        ..optionalParameters.addAll(buildUriEncodeParameters())
         ..body = Block.of([
           Code('if (this == $actualEnumName.$fallbackNormalizedName) {'),
           generateEncodingExceptionExpression(
@@ -613,7 +583,8 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           const Code('}'),
           const Code(
             'return rawValue.uriEncode(allowEmpty: allowEmpty, '
-            'useQueryComponent: useQueryComponent);',
+            'useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved);',
           ),
         ]),
     );

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -1114,6 +1114,13 @@ class OneOfGenerator {
           useQueryComponent: refer('useQueryComponent'),
         );
 
+    Map<String, Expression> memberFormArgs() => {
+      'explode': refer('explode'),
+      'allowEmpty': refer('allowEmpty'),
+      'useQueryComponent': refer('useQueryComponent'),
+      'allowReserved': refer('allowReserved'),
+    };
+
     final caseCodes = <Code>[];
 
     for (final m in stableModelSorter.sortDiscriminatedModels(model.models)) {
@@ -1162,6 +1169,7 @@ class OneOfGenerator {
           const Code('...'),
           refer('value').property('parameterProperties').call([], {
             'allowEmpty': refer('allowEmpty'),
+            'allowReserved': refer('allowReserved'),
           }).code,
           const Code(','),
           Code(
@@ -1184,11 +1192,10 @@ class OneOfGenerator {
             const Code('? '),
             ...discriminatedMap,
             const Code(' : '),
-            refer('value').property('toForm').call([refer('paramName')], {
-              'explode': refer('explode'),
-              'allowEmpty': refer('allowEmpty'),
-              'useQueryComponent': refer('useQueryComponent'),
-            }).code,
+            refer('value')
+                .property('toForm')
+                .call([refer('paramName')], memberFormArgs())
+                .code,
           ]);
         } else {
           addValueArm(discriminatedMap);
@@ -1205,11 +1212,7 @@ class OneOfGenerator {
               .property('toBase64String')
               .call([])
               .property('toForm')
-              .call([refer('paramName')], {
-                'explode': refer('explode'),
-                'allowEmpty': refer('allowEmpty'),
-                'useQueryComponent': refer('useQueryComponent'),
-              })
+              .call([refer('paramName')], memberFormArgs())
               .code,
         ]);
       } else if (resolvedType is BinaryModel) {
@@ -1218,11 +1221,10 @@ class OneOfGenerator {
         addThrowArm('Map types cannot be form-encoded');
       } else {
         addValueArm([
-          refer('value').property('toForm').call([refer('paramName')], {
-            'explode': refer('explode'),
-            'allowEmpty': refer('allowEmpty'),
-            'useQueryComponent': refer('useQueryComponent'),
-          }).code,
+          refer('value')
+              .property('toForm')
+              .call([refer('paramName')], memberFormArgs())
+              .code,
         ]);
       }
     }
@@ -1358,10 +1360,7 @@ class OneOfGenerator {
         (b) => b
           ..name = 'parameterProperties'
           ..returns = buildMapStringStringType()
-          ..optionalParameters.addAll([
-            buildBoolParameter('allowEmpty', defaultValue: true),
-            buildBoolParameter('allowLists', defaultValue: true),
-          ])
+          ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
             'only contains primitive types',
@@ -1422,6 +1421,7 @@ class OneOfGenerator {
             refer('value').property('parameterProperties').call([], {
               'allowEmpty': refer('allowEmpty'),
               'allowLists': refer('allowLists'),
+              'allowReserved': refer('allowReserved'),
             }).code,
             const Code(','),
             Code(
@@ -1446,6 +1446,7 @@ class OneOfGenerator {
             refer('value').property('parameterProperties').call([], {
               'allowEmpty': refer('allowEmpty'),
               'allowLists': refer('allowLists'),
+              'allowReserved': refer('allowReserved'),
             }).code,
             const Code(': '),
             generateEncodingExceptionExpression(
@@ -1492,6 +1493,7 @@ class OneOfGenerator {
               refer('value').property('parameterProperties').call([], {
                 'allowEmpty': refer('allowEmpty'),
                 'allowLists': refer('allowLists'),
+                'allowReserved': refer('allowReserved'),
               }).code,
               const Code(','),
               Code(
@@ -1505,6 +1507,7 @@ class OneOfGenerator {
               refer('value').property('parameterProperties').call([], {
                 'allowEmpty': refer('allowEmpty'),
                 'allowLists': refer('allowLists'),
+                'allowReserved': refer('allowReserved'),
               }).code,
             );
           }
@@ -1523,10 +1526,7 @@ class OneOfGenerator {
       (b) => b
         ..name = 'parameterProperties'
         ..returns = buildMapStringStringType()
-        ..optionalParameters.addAll([
-          buildBoolParameter('allowEmpty', defaultValue: true),
-          buildBoolParameter('allowLists', defaultValue: true),
-        ])
+        ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..lambda = false
         ..body = body,
     );
@@ -1883,6 +1883,7 @@ class OneOfGenerator {
               .call([], {
                 'allowEmpty': refer('allowEmpty'),
                 'useQueryComponent': refer('useQueryComponent'),
+                'allowReserved': refer('allowReserved'),
               })
               .code,
           const Code(','),
@@ -1901,22 +1902,7 @@ class OneOfGenerator {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'uriEncode'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll([
-          Parameter(
-            (b) => b
-              ..name = 'allowEmpty'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..required = true,
-          ),
-          Parameter(
-            (b) => b
-              ..name = 'useQueryComponent'
-              ..type = refer('bool', 'dart:core')
-              ..named = true
-              ..defaultTo = literalBool(false).code,
-          ),
-        ])
+        ..optionalParameters.addAll(buildUriEncodeParameters())
         ..lambda = false
         ..body = body,
     );

--- a/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
+++ b/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
@@ -26,10 +26,7 @@ Method buildReadOnlyParameterPropertiesMethod(Code exceptionBody) {
     (b) => b
       ..name = 'parameterProperties'
       ..returns = buildMapStringStringType()
-      ..optionalParameters.addAll([
-        buildBoolParameter('allowEmpty', defaultValue: true),
-        buildBoolParameter('allowLists', defaultValue: true),
-      ])
+      ..optionalParameters.addAll(buildParameterPropertiesParameters())
       ..lambda = true
       ..body = exceptionBody,
   );
@@ -42,22 +39,7 @@ Method buildReadOnlyUriEncodeMethod(Code exceptionBody) {
       ..annotations.add(refer('override', 'dart:core'))
       ..name = 'uriEncode'
       ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll([
-        Parameter(
-          (b) => b
-            ..name = 'allowEmpty'
-            ..type = refer('bool', 'dart:core')
-            ..named = true
-            ..required = true,
-        ),
-        Parameter(
-          (b) => b
-            ..name = 'useQueryComponent'
-            ..type = refer('bool', 'dart:core')
-            ..named = true
-            ..defaultTo = literalBool(false).code,
-        ),
-      ])
+      ..optionalParameters.addAll(buildUriEncodeParameters())
       ..lambda = true
       ..body = exceptionBody,
   );
@@ -165,7 +147,7 @@ Method buildReadOnlyToDeepObjectMethod(Code exceptionBody) {
             ..type = refer('String', 'dart:core'),
         ),
       )
-      ..optionalParameters.addAll(buildEncodingParameters())
+      ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
       ..lambda = true
       ..body = exceptionBody,
   );
@@ -264,12 +246,13 @@ Method buildToDeepObjectMethod() {
             ..type = refer('String', 'dart:core'),
         ),
       )
-      ..optionalParameters.addAll(buildEncodingParameters())
+      ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
             .call([], {
               'allowEmpty': refer('allowEmpty'),
               'allowLists': literalBool(false),
+              'allowReserved': refer('allowReserved'),
             })
             .property('toDeepObject')
             .call(

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -52,15 +52,12 @@ Expression? buildFormEntriesValueExpression(
     case NumberModel():
       return toForm(receiver, reserved: allowReserved);
 
-    // The generated toForm for enums and compositions has no allowReserved
-    // parameter, so the flag is deferred for these types — threading it would
-    // not compile.
     case EnumModel():
     case ClassModel():
     case AllOfModel():
     case OneOfModel():
     case AnyOfModel():
-      return toForm(receiver);
+      return toForm(receiver, reserved: allowReserved);
 
     case Base64Model():
       return toForm(
@@ -145,9 +142,6 @@ buildClassFormEntriesExpression(
   Map<String, PropertyEncoding>? encoding, {
   bool useImmutableCollections = false,
 }) {
-  // Normalize the full set first, then drop read-only, so a write property
-  // keeps the same suffix the object path (class_generator) assigns it — a
-  // read-only sibling that normalizes to the same name still consumes a suffix.
   final normalizedProps = normalizeProperties(model.properties.toList())
       .where((p) => !p.property.isReadOnly)
       .toList();
@@ -185,24 +179,14 @@ List<Code>? _buildPropertyFormEntry(
   bool useImmutableCollections = false,
 }) {
   final propertyNameLiteral = specLiteralString(property.name);
-  // The object path routes the property name through `Map.toForm`, which
-  // URI-encodes each key; the per-property path must encode the name the same
-  // way. Names are never allowReserved, so this defaults to false.
   final encodedName = propertyNameLiteral.property('uriEncode').call([], {
     'allowEmpty': literalBool(true),
     'useQueryComponent': literalBool(true),
   });
   final resolved = property.model.resolved;
 
-  // A map property makes the object path's `parameterProperties` throw
-  // (a complex property that is not a simple-content list), so the per-property
-  // path must be unencodable too rather than emitting a diverging entry.
   if (resolved is MapModel) return null;
 
-  // AnyModel is deferred like enum/composition, so mirror the object path
-  // (class_generator `parameterProperties` + `Map<String,String>.toForm`
-  // with alreadyEncoded) byte-for-byte: the value is the raw `toString()`
-  // passed through unencoded.
   if (resolved is AnyModel) {
     final value = field
         .nullSafeProperty('toString')
@@ -217,11 +201,6 @@ List<Code>? _buildPropertyFormEntry(
   final fieldCanBeNull =
       isNullable || !property.isRequired || property.isWriteOnly;
 
-  // A list property nested in a form body is comma-joined into a single entry
-  // by the object path (`list.uriEncode` in `parameterProperties`, then a
-  // single `Map` entry), never exploded into repeated keys; mirror that here
-  // rather than delegating to the exploding shared form builder. allowReserved
-  // is not threaded because the object path never applies it to lists.
   if (resolved is ListModel) {
     if (!resolved.hasSimpleContent) return null;
     final value = buildUriEncodeExpression(
@@ -367,7 +346,7 @@ Expression? _buildEncodedElementsList(
     contentModel,
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
-    allowReserved: allowReserved,
+    allowReserved: allowReserved ? literalBool(true) : null,
   ).expression;
 
   final elementEncode = isContentNullable

--- a/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_deep_object_query_parameter_expression_generator.dart
@@ -56,6 +56,7 @@ BuiltExpression buildToDeepObjectQueryParameterCode(
             {
               'explode': literalBool(explode),
               'allowEmpty': literalBool(allowEmpty),
+              if (allowReserved) 'allowReserved': literalBool(true),
             },
           ),
     );
@@ -113,7 +114,7 @@ Expression _buildMapDeepObjectExpression(
       refer('v'),
       valueModel,
       allowEmpty: literalBool(allowEmpty),
-      allowReserved: allowReserved,
+      allowReserved: allowReserved ? literalBool(true) : null,
     );
 
     final mapEntryClosure = Method(

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -81,8 +81,6 @@ List<Code> _buildDelimitedCode(
   String nullGuard(String encoded) =>
       isContentNullable ? "e == null ? '' : $encoded" : encoded;
 
-  // The generated enum uriEncode has no allowReserved parameter, so the
-  // enum arm omits it while the scalar arm passes it through.
   final scalarItemArgs = allowReserved
       ? 'allowEmpty: $allowEmpty, allowReserved: true'
       : 'allowEmpty: $allowEmpty';
@@ -123,7 +121,7 @@ List<Code> _buildDelimitedCode(
       explode,
       allowEmpty,
       needsMapping: true,
-      mapExpression: nullGuard('e.uriEncode(allowEmpty: $allowEmpty)'),
+      mapExpression: nullGuard('e.uriEncode($scalarItemArgs)'),
     ),
 
     AllOfModel() ||
@@ -135,6 +133,7 @@ List<Code> _buildDelimitedCode(
       explode,
       allowEmpty,
       encodingName,
+      allowReserved: allowReserved,
     ),
 
     AliasModel() => _buildDelimitedCode(
@@ -195,8 +194,13 @@ List<Code> _buildForLoopWithRuntimeCheck(
   String methodName,
   bool explode,
   bool allowEmpty,
-  String encodingName,
-) {
+  String encodingName, {
+  required bool allowReserved,
+}) {
+  final itemArgs = allowReserved
+      ? 'allowEmpty: $allowEmpty, allowReserved: true'
+      : 'allowEmpty: $allowEmpty';
+
   if (explode) {
     return [
       Code('for (final item in $parameterName) { '),
@@ -215,7 +219,7 @@ List<Code> _buildForLoopWithRuntimeCheck(
       Code(
         r'_$entries'
         '.add((name: ${specLiteralStringCode(rawName)}, value: '
-        'item.uriEncode(allowEmpty: $allowEmpty)));',
+        'item.uriEncode($itemArgs)));',
       ),
       const Code('}'),
     ];
@@ -237,7 +241,7 @@ List<Code> _buildForLoopWithRuntimeCheck(
       const Code('}'),
       Code(
         'for (final value in $parameterName.map((item) => item'
-        ' .uriEncode(allowEmpty: $allowEmpty)).toList()'
+        ' .uriEncode($itemArgs)).toList()'
         ' .$methodName(explode: $explode, allowEmpty: $allowEmpty, '
         ' alreadyEncoded: true)) {',
       ),

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -231,17 +231,32 @@ List<Parameter> buildEncodingParameters() => [
   buildBoolParameter('allowEmpty', required: true),
 ];
 
-/// Returns a list of encoding parameters for form encoding, which includes
-/// explode, allowEmpty, and useQueryComponent (optional with default false).
+/// Encoding parameters for form-style `toForm`.
 List<Parameter> buildFormEncodingParameters() => [
   ...buildEncodingParameters(),
-  Parameter(
-    (b) => b
-      ..name = 'useQueryComponent'
-      ..type = refer('bool', 'dart:core')
-      ..named = true
-      ..defaultTo = literalFalse.code,
-  ),
+  buildBoolParameter('useQueryComponent'),
+  buildBoolParameter('allowReserved'),
+];
+
+/// Shared parameters for every composite `parameterProperties` method.
+List<Parameter> buildParameterPropertiesParameters() => [
+  buildBoolParameter('allowEmpty', defaultValue: true),
+  buildBoolParameter('allowLists', defaultValue: true),
+  buildBoolParameter('allowReserved'),
+];
+
+/// Encoding parameters for `toDeepObject`, kept separate from
+/// [buildEncodingParameters] so matrix/label/simple never carry allowReserved.
+List<Parameter> buildDeepObjectEncodingParameters() => [
+  ...buildEncodingParameters(),
+  buildBoolParameter('allowReserved'),
+];
+
+/// Parameters for an inline `uriEncode` signature.
+List<Parameter> buildUriEncodeParameters() => [
+  buildBoolParameter('allowEmpty', required: true),
+  buildBoolParameter('useQueryComponent'),
+  buildBoolParameter('allowReserved'),
 ];
 
 /// Returns a LiteralMapExpression for an empty [Map<String, String>] literal.

--- a/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/uri_encode_expression_generator.dart
@@ -10,7 +10,7 @@ BuiltExpression buildUriEncodeExpression(
   required Expression allowEmpty,
   Expression? useQueryComponent,
   bool useImmutableCollections = false,
-  bool allowReserved = false,
+  Expression? allowReserved,
 }) {
   return BuiltExpression.simple(
     _buildUriEncodeExpression(
@@ -44,7 +44,7 @@ Expression _buildUriEncodeExpression(
   required Expression allowEmpty,
   Expression? useQueryComponent,
   bool useImmutableCollections = false,
-  bool allowReserved = false,
+  Expression? allowReserved,
 }) {
   return switch (model) {
     StringModel() ||
@@ -67,8 +67,7 @@ Expression _buildUriEncodeExpression(
         {
           'allowEmpty': allowEmpty,
           'useQueryComponent': ?useQueryComponent,
-          if (allowReserved && model is! EnumModel)
-            'allowReserved': literalBool(true),
+          'allowReserved': ?allowReserved,
         },
       ),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
@@ -80,6 +79,7 @@ Expression _buildUriEncodeExpression(
         {
           'allowEmpty': allowEmpty,
           'useQueryComponent': ?useQueryComponent,
+          'allowReserved': ?allowReserved,
         },
       ),
     MapModel() => _buildMapUriEncodeExpression(
@@ -87,6 +87,7 @@ Expression _buildUriEncodeExpression(
       model,
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     ),
     final ListModel m => _buildListUriEncodeExpression(
       valueExpression,
@@ -94,6 +95,7 @@ Expression _buildUriEncodeExpression(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
       useImmutableCollections: useImmutableCollections,
+      allowReserved: allowReserved,
       isContentNullable: m.isContentNullable || m.content.isEffectivelyNullable,
     ),
     AliasModel() => _buildUriEncodeExpression(
@@ -117,6 +119,7 @@ Expression _buildListUriEncodeExpression(
   required bool isContentNullable,
   Expression? useQueryComponent,
   bool useImmutableCollections = false,
+  Expression? allowReserved,
 }) {
   // When using immutable collections, the value is an IList. The .uriEncode()
   // extension is defined on List, not IList, so unlock to a regular List first.
@@ -129,6 +132,12 @@ Expression _buildListUriEncodeExpression(
   Expression nullGuard(Expression encoded) => isContentNullable
       ? refer('e').equalTo(literalNull).conditional(literalString(''), encoded)
       : encoded;
+
+  final wholeListArgs = <String, Expression>{
+    'allowEmpty': allowEmpty,
+    'useQueryComponent': ?useQueryComponent,
+    'allowReserved': ?allowReserved,
+  };
 
   return switch (contentModel) {
     StringModel() when isContentNullable =>
@@ -144,20 +153,8 @@ Expression _buildListUriEncodeExpression(
           .property('toList')
           .call([])
           .property('uriEncode')
-          .call(
-            [],
-            {
-              'allowEmpty': allowEmpty,
-              'useQueryComponent': ?useQueryComponent,
-            },
-          ),
-    StringModel() => listExpr.property('uriEncode').call(
-      [],
-      {
-        'allowEmpty': allowEmpty,
-        'useQueryComponent': ?useQueryComponent,
-      },
-    ),
+          .call([], wholeListArgs),
+    StringModel() => listExpr.property('uriEncode').call([], wholeListArgs),
     IntegerModel() ||
     DoubleModel() ||
     NumberModel() ||
@@ -183,6 +180,7 @@ Expression _buildListUriEncodeExpression(
                     contentModel,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
                   ),
                 ).code,
             ).closure,
@@ -190,13 +188,7 @@ Expression _buildListUriEncodeExpression(
           .property('toList')
           .call([])
           .property('uriEncode')
-          .call(
-            [],
-            {
-              'allowEmpty': allowEmpty,
-              'useQueryComponent': ?useQueryComponent,
-            },
-          ),
+          .call([], wholeListArgs),
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() =>
       listExpr
           .property('map')
@@ -216,6 +208,7 @@ Expression _buildListUriEncodeExpression(
                           {
                             'allowEmpty': allowEmpty,
                             'useQueryComponent': ?useQueryComponent,
+                            'allowReserved': ?allowReserved,
                           },
                         )
                         .code,
@@ -224,18 +217,13 @@ Expression _buildListUriEncodeExpression(
           .property('toList')
           .call([])
           .property('uriEncode')
-          .call(
-            [],
-            {
-              'allowEmpty': allowEmpty,
-              'useQueryComponent': ?useQueryComponent,
-            },
-          ),
+          .call([], wholeListArgs),
     MapModel() => _buildListMapContentUriEncodeExpression(
       listExpr,
       contentModel,
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     ),
     AliasModel() => _buildListUriEncodeExpression(
       valueExpression,
@@ -243,6 +231,7 @@ Expression _buildListUriEncodeExpression(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
       useImmutableCollections: useImmutableCollections,
+      allowReserved: allowReserved,
       isContentNullable: isContentNullable,
     ),
     _ => generateEncodingExceptionExpression(
@@ -256,6 +245,7 @@ Expression _buildMapUriEncodeExpression(
   MapModel model, {
   required Expression allowEmpty,
   Expression? useQueryComponent,
+  Expression? allowReserved,
 }) {
   final converted = buildMapToStringMapExpression(
     valueExpression,
@@ -274,6 +264,7 @@ Expression _buildMapUriEncodeExpression(
     {
       'allowEmpty': allowEmpty,
       'useQueryComponent': ?useQueryComponent,
+      'allowReserved': ?allowReserved,
     },
   );
 }
@@ -283,6 +274,7 @@ Expression _buildListMapContentUriEncodeExpression(
   MapModel contentModel, {
   required Expression allowEmpty,
   Expression? useQueryComponent,
+  Expression? allowReserved,
 }) {
   final converted = buildMapToStringMapExpression(
     refer('e'),
@@ -309,6 +301,7 @@ Expression _buildListMapContentUriEncodeExpression(
               {
                 'allowEmpty': allowEmpty,
                 'useQueryComponent': ?useQueryComponent,
+                'allowReserved': ?allowReserved,
               },
             ).code,
         ).closure,
@@ -321,6 +314,7 @@ Expression _buildListMapContentUriEncodeExpression(
         {
           'allowEmpty': allowEmpty,
           'useQueryComponent': ?useQueryComponent,
+          'allowReserved': ?allowReserved,
         },
       );
 }

--- a/packages/tonik_generate/test/src/model/all_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_deep_object_generator_test.dart
@@ -57,10 +57,10 @@ void main() {
             .toString(),
         'String',
       );
-      expect(toDeepObjectMethod.optionalParameters.length, 2);
+      expect(toDeepObjectMethod.optionalParameters.length, 3);
       expect(
         toDeepObjectMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty']),
+        containsAll(['explode', 'allowEmpty', 'allowReserved']),
       );
     });
 
@@ -79,8 +79,8 @@ void main() {
       final generatedClass = generator.generateClass(model);
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -138,8 +138,8 @@ void main() {
       final generatedClass = generator.generateClass(model);
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -162,8 +162,8 @@ void main() {
       final generatedClass = generator.generateClass(model);
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -189,8 +189,8 @@ void main() {
       final generatedClass = generator.generateClass(model);
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -215,8 +215,8 @@ void main() {
       final generatedClass = generator.generateClass(model);
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -140,8 +140,11 @@ void main() {
       final combinedClass = generator.generateClass(model);
 
       const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toForm(
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved,
+          ).toForm(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
@@ -222,13 +225,16 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
             );
           }
-          return parameterProperties(allowEmpty: allowEmpty).toForm(
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved,
+          ).toForm(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
@@ -260,12 +266,13 @@ void main() {
       final combinedClass = generator.generateClass(model);
 
       const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return bigDecimal.toForm(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
         }
       ''';
@@ -337,12 +344,13 @@ void main() {
         final combinedClass = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return status.toForm(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
         }
       ''';
@@ -469,7 +477,7 @@ void main() {
         final combinedClass = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-          List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+          List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             throw EncodingException(
               'Form encoding not supported: contains complex types',
             );
@@ -530,7 +538,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
@@ -543,6 +551,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$intForm);
           _$values.add(_$intForm.map((e) => e.value).join(','));
@@ -551,6 +560,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$choiceForm);
           _$values.add(_$choiceForm.map((e) => e.value).join(','));
@@ -706,7 +716,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode MultiDynamic: mixing simple values (primitives/enums) and complex types is not supported',
@@ -719,6 +729,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$flexibleAForm);
           _$values.add(_$flexibleAForm.map((e) => e.value).join(','));
@@ -727,6 +738,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$flexibleBForm);
           _$values.add(_$flexibleBForm.map((e) => e.value).join(','));
@@ -735,6 +747,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$stringForm);
           _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -832,7 +845,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode ComplexMixed: mixing simple values (primitives/enums) and complex types is not supported',
@@ -845,6 +858,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$flexibleValueForm);
           _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
@@ -853,6 +867,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$bigDecimalForm);
           _$values.add(_$bigDecimalForm.map((e) => e.value).join(','));
@@ -861,6 +876,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$choiceForm);
           _$values.add(_$choiceForm.map((e) => e.value).join(','));
@@ -869,6 +885,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$stringForm);
           _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -906,7 +923,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
           final _$listForm = list
@@ -960,7 +977,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
           final _$listForm = list
@@ -1041,7 +1058,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
@@ -1054,6 +1071,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$flexibleValueForm);
           _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
@@ -1062,6 +1080,7 @@ void main() {
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           _$entryLists.add(_$intForm);
           _$values.add(_$intForm.map((e) => e.value).join(','));

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1469,6 +1469,7 @@ void main() {
           required bool explode,
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
@@ -1746,6 +1747,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) =>
           throw EncodingException(
             r'parameterProperties not supported for AllOfIntList: contains array types',
@@ -1806,6 +1808,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) =>
           throw EncodingException(
             r'parameterProperties not supported for AllOfMixedListClass: allOf mixing arrays with other types is not supported',
@@ -1852,6 +1855,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) =>
           throw EncodingException(
             r'parameterProperties not supported for AllOfMixedListPrimitive: allOf mixing arrays with other types is not supported',
@@ -1981,18 +1985,21 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) {
             final _$mergedProperties = <String, String>{};
             _$mergedProperties.addAll(
               testClass1.parameterProperties(
                 allowEmpty: allowEmpty,
                 allowLists: allowLists,
+                allowReserved: allowReserved,
               ),
             );
             _$mergedProperties.addAll(
               testClass2.parameterProperties(
                 allowEmpty: allowEmpty,
                 allowLists: allowLists,
+                allowReserved: allowReserved,
               ),
             );
             return _$mergedProperties;
@@ -2030,6 +2037,7 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) =>
             throw EncodingException(
               r'parameterProperties not supported for AllOfWithList: contains array types',
@@ -2067,6 +2075,7 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) =>
             throw EncodingException(
               r'parameterProperties not supported for AllOfWithMap: contains map types',
@@ -2124,6 +2133,7 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) =>
             throw EncodingException(
               r'parameterProperties not supported for AllOfMixedMapClass: contains map types',
@@ -2423,7 +2433,13 @@ void main() {
         (m) => m.name == 'uriEncode',
       );
 
-      expect(uriEncodeMethod.optionalParameters, hasLength(2));
+      expect(uriEncodeMethod.optionalParameters, hasLength(3));
+
+      final allowReservedParam = uriEncodeMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final allowEmptyParam = uriEncodeMethod.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -2480,12 +2496,13 @@ void main() {
 
         const expectedUriEncode = r'''
           @override
-          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+          String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             final _$values = <String>{};
             if (nullableInt != null) {
               final _$nullableIntEncoded = nullableInt!.uriEncode(
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$values.add(_$nullableIntEncoded);
             }
@@ -2544,12 +2561,13 @@ void main() {
 
         const expectedUriEncode = r'''
           @override
-          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+          String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             final _$values = <String>{};
             if (signature != null) {
               final _$signatureEncoded = signature!.toBase64String().uriEncode(
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$values.add(_$signatureEncoded);
             }
@@ -2631,7 +2649,7 @@ void main() {
 
         const expectedUriEncode = '''
 @override
-String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
   if (currentEncodingShape != EncodingShape.simple) {
     throw EncodingException(
       r'Cannot uriEncode DynamicByte: contains complex types',
@@ -2640,6 +2658,7 @@ String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
   return signature!.toBase64String().uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
 }
 ''';
@@ -2730,12 +2749,14 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   return signature!.toBase64String().toForm(
     paramName,
     explode: explode,
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
 }
 ''';
@@ -2822,6 +2843,7 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   return throw EncodingException('Binary data cannot be form-encoded');
 }
@@ -2895,7 +2917,13 @@ String toMatrix(
         (m) => m.name == 'toForm',
       );
 
-      expect(toFormMethod.optionalParameters.length, 3);
+      expect(toFormMethod.optionalParameters.length, 4);
+
+      final allowReservedParam = toFormMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final explodeParam = toFormMethod.optionalParameters.firstWhere(
         (p) => p.name == 'explode',
@@ -2981,6 +3009,7 @@ String toMatrix(
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             if (currentEncodingShape == EncodingShape.mixed) {
               throw EncodingException(
@@ -2995,6 +3024,7 @@ String toMatrix(
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$entryLists.add(_$statusForm);
               _$values.add(_$statusForm.map((e) => e.value).join(','));
@@ -3004,6 +3034,7 @@ String toMatrix(
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -4201,10 +4232,15 @@ class Holder {
   Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
+    bool allowReserved = false,
   }) {
     final _$mergedProperties = <String, String>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      $base.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+        allowReserved: allowReserved,
+      ),
     );
     for (final _$e in additionalProperties.entries) {
       _$mergedProperties[_$e.key] = _$e.value?.toString() ?? '';
@@ -4257,13 +4293,21 @@ class Holder {
   Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
+    bool allowReserved = false,
   }) {
     final _$mergedProperties = <String, String>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      $base.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+        allowReserved: allowReserved,
+      ),
     );
     for (final _$e in additionalProperties.entries) {
-      _$mergedProperties[_$e.key] = _$e.value.uriEncode(allowEmpty: allowEmpty);
+      _$mergedProperties[_$e.key] = _$e.value.uriEncode(
+        allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
+      );
     }
     return _$mergedProperties;
   }''';
@@ -4315,14 +4359,20 @@ class Holder {
   Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
+    bool allowReserved = false,
   }) {
     final _$mergedProperties = <String, String>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      $base.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+        allowReserved: allowReserved,
+      ),
     );
     for (final _$e in additionalProperties.entries) {
       _$mergedProperties[_$e.key] = _$e.value.toBase64String().uriEncode(
         allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
       );
     }
     return _$mergedProperties;
@@ -4392,14 +4442,23 @@ class Holder {
   Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
+    bool allowReserved = false,
   }) {
     final _$mergedProperties = <String, String>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      $base.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+        allowReserved: allowReserved,
+      ),
     );
     for (final _$e in additionalProperties.entries) {
       _$mergedProperties[_$e.key] =
-          _$e.value?.toBase64String().uriEncode(allowEmpty: allowEmpty) ?? '';
+          _$e.value?.toBase64String().uriEncode(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved,
+          ) ??
+          '';
     }
     return _$mergedProperties;
   }''';
@@ -4456,10 +4515,15 @@ class Holder {
   Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
+    bool allowReserved = false,
   }) {
     final _$mergedProperties = <String, String>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      $base.parameterProperties(
+        allowEmpty: allowEmpty,
+        allowLists: allowLists,
+        allowReserved: allowReserved,
+      ),
     );
     if (additionalProperties.isNotEmpty) {
       throw EncodingException(

--- a/packages/tonik_generate/test/src/model/all_of_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_parameter_encoding_test.dart
@@ -55,10 +55,10 @@ void main() {
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
         'Map<String,String>',
       );
-      expect(method.optionalParameters.length, 2);
+      expect(method.optionalParameters.length, 3);
       expect(
         method.optionalParameters.map((p) => p.name),
-        containsAll(['allowEmpty', 'allowLists']),
+        containsAll(['allowEmpty', 'allowLists', 'allowReserved']),
       );
     });
 
@@ -80,6 +80,7 @@ void main() {
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   throw EncodingException(
     r'parameterProperties not supported for Combined: contains primitive types',
@@ -117,10 +118,15 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mergedProperties = <String, String>{};
   _$mergedProperties.addAll(
-    $base.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+    $base.parameterProperties(
+      allowEmpty: allowEmpty,
+      allowLists: allowLists,
+      allowReserved: allowReserved,
+    ),
   );
   return _$mergedProperties;
 }
@@ -157,6 +163,7 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   throw EncodingException(
     r'parameterProperties not supported for Mixed: contains primitive types',
@@ -201,18 +208,21 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mergedProperties = <String, String>{};
   _$mergedProperties.addAll(
     firstModel.parameterProperties(
       allowEmpty: allowEmpty,
       allowLists: allowLists,
+      allowReserved: allowReserved,
     ),
   );
   _$mergedProperties.addAll(
     secondModel.parameterProperties(
       allowEmpty: allowEmpty,
       allowLists: allowLists,
+      allowReserved: allowReserved,
     ),
   );
   return _$mergedProperties;
@@ -292,18 +302,21 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mergedProperties = <String, String>{};
   _$mergedProperties.addAll(
     stringOrComplex.parameterProperties(
       allowEmpty: allowEmpty,
       allowLists: allowLists,
+      allowReserved: allowReserved,
     ),
   );
   _$mergedProperties.addAll(
     simpleModel.parameterProperties(
       allowEmpty: allowEmpty,
       allowLists: allowLists,
+      allowReserved: allowReserved,
     ),
   );
   return _$mergedProperties;
@@ -333,6 +346,7 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   return <String, String>{};
 }

--- a/packages/tonik_generate/test/src/model/all_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_schema_level_read_write_only_test.dart
@@ -159,6 +159,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
@@ -181,6 +182,7 @@ void main() {
         String uriEncode({
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );

--- a/packages/tonik_generate/test/src/model/any_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_deep_object_generator_test.dart
@@ -57,10 +57,10 @@ void main() {
             .toString(),
         'String',
       );
-      expect(toDeepObjectMethod.optionalParameters.length, 2);
+      expect(toDeepObjectMethod.optionalParameters.length, 3);
       expect(
         toDeepObjectMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty']),
+        containsAll(['explode', 'allowEmpty', 'allowReserved']),
       );
     });
 
@@ -80,8 +80,8 @@ void main() {
       final generatedCode = generatedClass.accept(emitter).toString();
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -145,8 +145,8 @@ void main() {
       final generatedCode = generatedClass.accept(emitter).toString();
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -172,8 +172,8 @@ void main() {
       final generatedCode = generatedClass.accept(emitter).toString();
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -198,8 +198,8 @@ void main() {
       final generatedCode = generatedClass.accept(emitter).toString();
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -264,8 +264,8 @@ void main() {
       final generatedCode = generatedClass.accept(emitter).toString();
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -90,10 +90,15 @@ void main() {
         'List<ParameterEntry>',
       );
       expect(toFormMethod.requiredParameters.single.name, 'paramName');
-      expect(toFormMethod.optionalParameters, hasLength(3));
+      expect(toFormMethod.optionalParameters, hasLength(4));
       expect(
         toFormMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty', 'useQueryComponent']),
+        containsAll([
+          'explode',
+          'allowEmpty',
+          'useQueryComponent',
+          'allowReserved',
+        ]),
       );
       expect(
         toFormMethod.optionalParameters.take(2).every((p) => p.required),
@@ -580,7 +585,7 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
           if (int != null) {
@@ -589,6 +594,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$intForm);
             _$values.add(_$intForm.map((e) => e.value).join(','));
@@ -599,6 +605,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -654,10 +661,13 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$mapValues = <Map<String, String>>[];
           if (a != null) {
-            final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty);
+            final _$aForm = a!.parameterProperties(
+              allowEmpty: allowEmpty,
+              allowReserved: allowReserved,
+            );
             _$mapValues.add(_$aForm);
           }
           final _$map = <String, String>{};
@@ -733,16 +743,22 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$mapValues = <Map<String, String>>[];
           String? _$discriminatorValue;
           if (a != null) {
-            final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty);
+            final _$aForm = a!.parameterProperties(
+              allowEmpty: allowEmpty,
+              allowReserved: allowReserved,
+            );
             _$mapValues.add(_$aForm);
             _$discriminatorValue ??= r'a';
           }
           if (b != null) {
-            final _$bForm = b!.parameterProperties(allowEmpty: allowEmpty);
+            final _$bForm = b!.parameterProperties(
+              allowEmpty: allowEmpty,
+              allowReserved: allowReserved,
+            );
             _$mapValues.add(_$bForm);
             _$discriminatorValue ??= r'b';
           }
@@ -804,12 +820,15 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
           final _$mapValues = <Map<String, String>>[];
           if (data != null) {
-            final _$dataForm = data!.parameterProperties(allowEmpty: allowEmpty);
+            final _$dataForm = data!.parameterProperties(
+              allowEmpty: allowEmpty,
+              allowReserved: allowReserved,
+            );
             _$mapValues.add(_$dataForm);
           }
           if (string != null) {
@@ -818,6 +837,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -976,6 +996,7 @@ void main() {
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             final _$entryLists = <List<ParameterEntry>>[];
             final _$values = <String>{};
@@ -988,6 +1009,7 @@ void main() {
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
                   );
                   _$entryLists.add(_$innerChoiceForm);
                   _$values.add(_$innerChoiceForm.map((e) => e.value).join(','));
@@ -995,6 +1017,7 @@ void main() {
                 case EncodingShape.complex:
                   final _$innerChoiceForm = innerChoice!.parameterProperties(
                     allowEmpty: allowEmpty,
+                    allowReserved: allowReserved,
                   );
                   _$mapValues.add(_$innerChoiceForm);
                   break;
@@ -1010,6 +1033,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$entryLists.add(_$stringForm);
               _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -1102,6 +1126,7 @@ void main() {
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             final _$entryLists = <List<ParameterEntry>>[];
             final _$values = <String>{};
@@ -1114,6 +1139,7 @@ void main() {
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
                   );
                   _$entryLists.add(_$innerAnyOfForm);
                   _$values.add(_$innerAnyOfForm.map((e) => e.value).join(','));
@@ -1121,6 +1147,7 @@ void main() {
                 case EncodingShape.complex:
                   final _$innerAnyOfForm = innerAnyOf!.parameterProperties(
                     allowEmpty: allowEmpty,
+                    allowReserved: allowReserved,
                   );
                   _$mapValues.add(_$innerAnyOfForm);
                   break;
@@ -1136,6 +1163,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$entryLists.add(_$stringForm);
               _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -1218,6 +1246,7 @@ void main() {
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             final _$entryLists = <List<ParameterEntry>>[];
             final _$values = <String>{};
@@ -1225,6 +1254,7 @@ void main() {
             if (myClass != null) {
               final _$myClassForm = myClass!.parameterProperties(
                 allowEmpty: allowEmpty,
+                allowReserved: allowReserved,
               );
               _$mapValues.add(_$myClassForm);
             }
@@ -1234,6 +1264,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$entryLists.add(_$intForm);
               _$values.add(_$intForm.map((e) => e.value).join(','));
@@ -1244,6 +1275,7 @@ void main() {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               );
               _$entryLists.add(_$stringForm);
               _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -1497,6 +1529,7 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) {
             final _$mapValues = <Map<String, String>>[];
             if (myClass != null) {
@@ -1504,6 +1537,7 @@ void main() {
                 myClass!.parameterProperties(
                   allowEmpty: allowEmpty,
                   allowLists: allowLists,
+                  allowReserved: allowReserved,
                 ),
               );
             }
@@ -1544,6 +1578,7 @@ void main() {
           required bool explode,
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
@@ -1556,6 +1591,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -820,7 +820,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
           toFormMethod.returns?.accept(emitter).toString(),
           'List<ParameterEntry>',
         );
-        expect(toFormMethod.optionalParameters.length, 3);
+        expect(toFormMethod.optionalParameters.length, 4);
         expect(
           toFormMethod.optionalParameters.any((p) => p.name == 'explode'),
           isTrue,
@@ -832,6 +832,12 @@ String toSimple({required bool explode, required bool allowEmpty}) {
         expect(
           toFormMethod.optionalParameters.any(
             (p) => p.name == 'useQueryComponent',
+          ),
+          isTrue,
+        );
+        expect(
+          toFormMethod.optionalParameters.any(
+            (p) => p.name == 'allowReserved',
           ),
           isTrue,
         );
@@ -848,12 +854,14 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$mapValues = <Map<String, String>>[];
   String? _$discriminatorValue;
   if (company != null) {
     final _$companyForm = company!.parameterProperties(
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
     _$mapValues.add(_$companyForm);
     _$discriminatorValue ??= r'company';
@@ -861,6 +869,7 @@ List<ParameterEntry> toForm(
   if (person != null) {
     final _$personForm = person!.parameterProperties(
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
     _$mapValues.add(_$personForm);
     _$discriminatorValue ??= r'person';
@@ -1085,7 +1094,13 @@ String toSimple({required bool explode, required bool allowEmpty}) {
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
         'Map<String,String>',
       );
-      expect(method.optionalParameters.length, 2);
+      expect(method.optionalParameters.length, 3);
+
+      final allowReservedParam = method.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final allowEmptyParam = method.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -1131,10 +1146,10 @@ String toSimple({required bool explode, required bool allowEmpty}) {
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   if (user != null) {
-    _$mapValues.add( user!.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists), );
+    _$mapValues.add( user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
   }
   final _$map = <String, String>{};
   for (final _$m in _$mapValues) {
@@ -1186,13 +1201,13 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   if (admin != null) {
-    _$mapValues.add( admin!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, ), );
+    _$mapValues.add( admin!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
   }
   if (user != null) {
-    _$mapValues.add( user!.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists), );
+    _$mapValues.add( user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
   }
   final _$map = <String, String>{};
   for (final _$m in _$mapValues) {
@@ -1249,11 +1264,11 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   String? _$discriminatorValue;
   if (data != null) {
-    _$mapValues.add( data!.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists), );
+    _$mapValues.add( data!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
     _$discriminatorValue ??= r'data';
   }
   final _$map = <String, String>{};
@@ -1313,7 +1328,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   if (innerChoice != null) {
     switch (innerChoice!.currentEncodingShape) {
@@ -1323,7 +1338,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         );
       case EncodingShape.complex:
         _$mapValues.add(
-          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, ),
+          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ),
         );
         break;
       case EncodingShape.mixed:
@@ -1395,7 +1410,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   String? _$discriminatorValue;
   if (innerChoice != null) {
@@ -1406,7 +1421,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         );
       case EncodingShape.complex:
         _$mapValues.add(
-          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, ),
+          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ),
         );
         _$discriminatorValue ??= r'inner';
         break;
@@ -1486,10 +1501,10 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   if (complexData != null) {
-    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, ), );
+    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
   }
   if (innerChoice != null) {
     throw EncodingException(
@@ -1548,10 +1563,10 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   final _$mapValues = <Map<String, String>>[];
   if (complexData != null) {
-    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, ), );
+    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ), );
   }
   if (string != null) {
     throw EncodingException(
@@ -1593,7 +1608,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, }) {
+Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, }) {
   throw EncodingException(
     r'parameterProperties not supported for SimpleChoice: contains only simple types',
   );
@@ -1644,6 +1659,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mapValues = <Map<String, String>>[];
   if (admin != null) {
@@ -1651,12 +1667,13 @@ Map<String, String> parameterProperties({
       admin!.parameterProperties(
         allowEmpty: allowEmpty,
         allowLists: allowLists,
+        allowReserved: allowReserved,
       ),
     );
   }
   if (user != null) {
     _$mapValues.add(
-      user!.parameterProperties(allowEmpty: allowEmpty, allowLists: allowLists),
+      user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, ),
     );
   }
   final _$map = <String, String>{};
@@ -1702,6 +1719,7 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mapValues = <Map<String, String>>[];
   if (list != null) {
@@ -1769,6 +1787,7 @@ Map<String, String> parameterProperties({
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mapValues = <Map<String, String>>[];
   if (innerChoice != null) {
@@ -1782,6 +1801,7 @@ Map<String, String> parameterProperties({
           innerChoice!.parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: allowLists,
+            allowReserved: allowReserved,
           ),
         );
         break;
@@ -2332,7 +2352,13 @@ Map<String, String> parameterProperties({
         (m) => m.name == 'uriEncode',
       );
 
-      expect(uriEncodeMethod.optionalParameters, hasLength(2));
+      expect(uriEncodeMethod.optionalParameters, hasLength(3));
+
+      final allowReservedParam = uriEncodeMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final allowEmptyParam = uriEncodeMethod.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -2375,7 +2401,13 @@ Map<String, String> parameterProperties({
         (m) => m.name == 'toForm',
       );
 
-      expect(toFormMethod.optionalParameters.length, 3);
+      expect(toFormMethod.optionalParameters.length, 4);
+
+      final allowReservedParam = toFormMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final explodeParam = toFormMethod.optionalParameters.firstWhere(
         (p) => p.name == 'explode',
@@ -2483,6 +2515,7 @@ Map<String, String> parameterProperties({
           required bool explode,
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
@@ -2496,6 +2529,7 @@ Map<String, String> parameterProperties({
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -2571,6 +2605,7 @@ Map<String, String> parameterProperties({
           required bool explode,
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
@@ -2590,6 +2625,7 @@ Map<String, String> parameterProperties({
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -3135,6 +3171,7 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$entryLists = <List<ParameterEntry>>[];
   final _$values = <String>{};
@@ -3145,6 +3182,7 @@ List<ParameterEntry> toForm(
       explode: explode,
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
     _$entryLists.add(_$tonikFileForm);
     _$values.add(_$tonikFileForm.map((e) => e.value).join(','));
@@ -3152,6 +3190,7 @@ List<ParameterEntry> toForm(
   if (text != null) {
     final _$textForm = text!.parameterProperties(
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
     _$mapValues.add(_$textForm);
   }
@@ -3315,11 +3354,12 @@ String toLabel({required bool explode, required bool allowEmpty}) {
 
         const expectedMethod = '''
 @override
-String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
   if (tonikFile != null) {
     return tonikFile!.toBase64String().uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (text != null) {
@@ -3419,6 +3459,7 @@ EncodingShape get currentEncodingShape {
 Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
+  bool allowReserved = false,
 }) {
   final _$mapValues = <Map<String, String>>[];
   if (object != null) {
@@ -3431,6 +3472,7 @@ Map<String, String> parameterProperties({
       detailedFilter!.parameterProperties(
         allowEmpty: allowEmpty,
         allowLists: allowLists,
+        allowReserved: allowReserved,
       ),
     );
   }
@@ -3508,6 +3550,7 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$entryLists = <List<ParameterEntry>>[];
   final _$values = <String>{};
@@ -3520,6 +3563,7 @@ List<ParameterEntry> toForm(
   if (detailedFilter != null) {
     final _$detailedFilterForm = detailedFilter!.parameterProperties(
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
     _$mapValues.add(_$detailedFilterForm);
   }
@@ -3671,7 +3715,7 @@ String toMatrix(
 
       const expected = '''
 @override
-String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
   if (object != null) {
     throw EncodingException(
       r'AnyModel variant of MixedFilter cannot be URI encoded',

--- a/packages/tonik_generate/test/src/model/any_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_schema_level_read_write_only_test.dart
@@ -177,9 +177,47 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
+      ''';
+
+      expect(
+        collapseWhitespace(classCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
+
+  group('schema-level readOnly toDeepObject', () {
+    test('toDeepObject threads allowReserved into the read-only '
+        'parameterProperties stub', () {
+      final model = buildSchemaReadOnlyModel(context);
+      final specs = generator.generateClasses(model);
+      final baseClass = specs.whereType<Class>().firstWhere(
+        (c) => c.name == 'ServerEvent',
+      );
+      final classCode = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+        List<ParameterEntry> toDeepObject(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          bool allowReserved = false,
+        }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowLists: false,
+            allowReserved: allowReserved,
+          ).toDeepObject(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+          );
+        }
       ''';
 
       expect(
@@ -202,6 +240,7 @@ void main() {
         String uriEncode({
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );

--- a/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
@@ -72,7 +72,7 @@ void main() {
             .toString(),
         'String',
       );
-      expect(toDeepObjectMethod.optionalParameters.length, 2);
+      expect(toDeepObjectMethod.optionalParameters.length, 3);
       expect(toDeepObjectMethod.optionalParameters.first.name, 'explode');
       expect(toDeepObjectMethod.optionalParameters.first.required, isTrue);
       expect(toDeepObjectMethod.optionalParameters.first.named, isTrue);
@@ -82,15 +82,18 @@ void main() {
             .toString(),
         'bool',
       );
-      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowEmpty');
-      expect(toDeepObjectMethod.optionalParameters.last.required, isTrue);
-      expect(toDeepObjectMethod.optionalParameters.last.named, isTrue);
+      expect(toDeepObjectMethod.optionalParameters[1].name, 'allowEmpty');
+      expect(toDeepObjectMethod.optionalParameters[1].required, isTrue);
+      expect(toDeepObjectMethod.optionalParameters[1].named, isTrue);
       expect(
-        toDeepObjectMethod.optionalParameters.last.type
+        toDeepObjectMethod.optionalParameters[1].type
             ?.accept(emitter)
             .toString(),
         'bool',
       );
+      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowReserved');
+      expect(toDeepObjectMethod.optionalParameters.last.required, isFalse);
+      expect(toDeepObjectMethod.optionalParameters.last.named, isTrue);
     });
 
     test('generates toDeepObject method for empty model', () {
@@ -112,13 +115,13 @@ void main() {
       );
       expect(toDeepObjectMethod.requiredParameters.length, 1);
       expect(toDeepObjectMethod.requiredParameters.first.name, 'paramName');
-      expect(toDeepObjectMethod.optionalParameters.length, 2);
+      expect(toDeepObjectMethod.optionalParameters.length, 3);
       expect(toDeepObjectMethod.optionalParameters.first.name, 'explode');
-      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowEmpty');
+      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowReserved');
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -167,8 +170,8 @@ void main() {
         );
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -223,8 +226,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -264,8 +267,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -301,8 +304,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -338,8 +341,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -400,8 +403,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 
@@ -437,8 +440,8 @@ void main() {
         final result = generator.generateClass(model);
 
         const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -61,7 +61,16 @@ void main() {
         parameterPropertiesMethod.returns?.accept(emitter).toString(),
         'Map<String,String>',
       );
-      expect(parameterPropertiesMethod.optionalParameters.length, 3);
+      expect(parameterPropertiesMethod.optionalParameters.length, 4);
+
+      final allowReservedParam = parameterPropertiesMethod.optionalParameters
+          .firstWhere((p) => p.name == 'allowReserved');
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
+      expect(
+        allowReservedParam.defaultTo?.accept(emitter).toString(),
+        'false',
+      );
 
       final allowEmptyParam = parameterPropertiesMethod.optionalParameters
           .firstWhere((p) => p.name == 'allowEmpty');
@@ -142,16 +151,19 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'id'] = id.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (name != null) {
     _$result[r'name'] = name!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'name'] = '';
@@ -184,6 +196,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   return <String, String>{};
 }
@@ -231,12 +244,14 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (nullableName != null) {
     _$result[r'nullable_name'] = nullableName!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'nullable_name'] = '';
@@ -245,6 +260,7 @@ Map<String, String> parameterProperties({
     _$result[r'nullable_count'] = nullableCount!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'nullable_count'] = '';
@@ -297,6 +313,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) =>
   throw EncodingException(
     r'parameterProperties not supported for User: contains complex types',
@@ -371,6 +388,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (value.currentEncodingShape == EncodingShape.simple) {
@@ -453,6 +471,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (data.currentEncodingShape == EncodingShape.simple) {
@@ -529,6 +548,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (combined.currentEncodingShape == EncodingShape.simple) {
@@ -590,16 +610,19 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (count != null) {
     _$result[r'count'] = count!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'count'] = '';
@@ -658,6 +681,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) =>
   throw EncodingException(
     r'parameterProperties not supported for ComplexContainer: contains complex types',
@@ -729,6 +753,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (value != null) {
@@ -920,16 +945,19 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (count != null) {
     _$result[r'count'] = count!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'count'] = '';
@@ -937,6 +965,7 @@ Map<String, String> parameterProperties({
   _$result[r'active'] = active.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (data1.currentEncodingShape == EncodingShape.simple) {
     _$result[r'data1'] = data1.toSimple(
@@ -1020,6 +1049,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && tags != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1029,6 +1059,7 @@ Map<String, String> parameterProperties({
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -1097,6 +1128,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && ids != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1111,12 +1143,14 @@ Map<String, String> parameterProperties({
           (e) => e.uriEncode(
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ),
         )
         .toList()
         .uriEncode(
           allowEmpty: allowEmpty,
           useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
         );
   } else if (allowEmpty) {
     _$result[r'ids'] = '';
@@ -1125,6 +1159,7 @@ Map<String, String> parameterProperties({
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -1180,6 +1215,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1188,6 +1224,7 @@ Map<String, String> parameterProperties({
   _$result[r'tags'] = tags.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   return _$result;
 }
@@ -1249,6 +1286,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && tags != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1257,11 +1295,13 @@ Map<String, String> parameterProperties({
   _$result[r'id'] = id.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (tags != null) {
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -1334,6 +1374,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) =>
     throw EncodingException(
       r'parameterProperties not supported for ComplexListContainer: contains complex types',
@@ -1398,6 +1439,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && statuses != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1409,12 +1451,14 @@ Map<String, String> parameterProperties({
           (e) => e.uriEncode(
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ),
         )
         .toList()
         .uriEncode(
           allowEmpty: allowEmpty,
           useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
         );
   } else if (allowEmpty) {
     _$result[r'statuses'] = '';
@@ -1464,6 +1508,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1472,6 +1517,7 @@ Map<String, String> parameterProperties({
   _$result[r'tags'] = tags.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   return _$result;
 }
@@ -1518,6 +1564,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && tags != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1527,6 +1574,7 @@ Map<String, String> parameterProperties({
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -1584,6 +1632,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && tags != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1592,11 +1641,13 @@ Map<String, String> parameterProperties({
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (tags != null) {
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -1650,15 +1701,18 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   _$result[r'age'] = age.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   return _$result;
 }
@@ -1714,12 +1768,14 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (description != null) {
     _$result[r'description'] = description!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'description'] = '';
@@ -1792,6 +1848,7 @@ if (description != null) {
   _$result[r'description'] = description!.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
 } else if (allowEmpty) {
   _$result[r'description'] = '';
@@ -1893,10 +1950,12 @@ List<ParameterEntry> toForm(
   required bool explode,
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   return parameterProperties(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   ).toForm(
     paramName,
     explode: explode,
@@ -2040,12 +2099,14 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (label != null) {
     _$result[r'label'] = label!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'label'] = '';
@@ -2090,11 +2151,13 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'signature'] = signature.toBase64String().uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   return _$result;
 }
@@ -2136,12 +2199,14 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (signature != null) {
     _$result[r'signature'] = signature!.toBase64String().uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'signature'] = '';
@@ -2186,12 +2251,14 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   if (signature != null) {
     _$result[r'signature'] = signature!.toBase64String().uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'signature'] = '';
@@ -2240,16 +2307,19 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   for (final _$e in additionalProperties.entries) {
     _$result[_$e.key] = _$e.value.toBase64String().uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   return _$result;
@@ -2308,6 +2378,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists && tags != null) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -2316,11 +2387,13 @@ Map<String, String> parameterProperties({
   _$result[r'signature'] = signature.toBase64String().uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (tags != null) {
     _$result[r'tags'] = tags!.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   } else if (allowEmpty) {
     _$result[r'tags'] = '';
@@ -2407,11 +2480,13 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'signature'] = signature.toBase64String().uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   if (value.currentEncodingShape == EncodingShape.simple) {
     _$result[r'value'] = value.toSimple(explode: false, allowEmpty: allowEmpty);
@@ -2476,17 +2551,20 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   final _$result = <String, String>{};
   _$result[r'name'] = name.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   for (final _$e in additionalProperties.entries) {
     _$result[_$e.key] =
         _$e.value?.toBase64String().uriEncode(
           allowEmpty: allowEmpty,
           useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
         ) ??
         '';
   }

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -117,7 +117,7 @@ void main() {
 
         const expectedUriEncode = '''
           @override
-          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+          String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             throw EncodingException(
               r'Cannot uriEncode User: complex types cannot be URI-encoded',
             );
@@ -144,7 +144,7 @@ void main() {
 
         const expectedUriEncode = '''
           @override
-          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+          String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             throw EncodingException(
               r'Cannot uriEncode Empty: complex types cannot be URI-encoded',
             );
@@ -1357,10 +1357,12 @@ String paramName, {
 required bool explode,
 required bool allowEmpty,
 bool useQueryComponent = false,
+bool allowReserved = false,
 }) {
 return parameterProperties(
 allowEmpty: allowEmpty,
 useQueryComponent: useQueryComponent,
+allowReserved: allowReserved,
 ).toForm(
 paramName,
 explode: explode,
@@ -1376,6 +1378,7 @@ Map<String, String> parameterProperties({
   bool allowEmpty = true,
   bool allowLists = true,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (!allowLists) {
     throw EncodingException('Lists are not supported in this encoding style');
@@ -1384,6 +1387,7 @@ Map<String, String> parameterProperties({
   _$result[r'tags'] = tags.uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
+    allowReserved: allowReserved,
   );
   return _$result;
 }
@@ -1469,7 +1473,7 @@ Map<String, String> parameterProperties({
         );
         expect(toFormMethod.requiredParameters.length, 1);
         expect(toFormMethod.requiredParameters[0].name, 'paramName');
-        expect(toFormMethod.optionalParameters.length, 3);
+        expect(toFormMethod.optionalParameters.length, 4);
         expect(toFormMethod.optionalParameters[0].name, 'explode');
         expect(toFormMethod.optionalParameters[0].required, isTrue);
         expect(toFormMethod.optionalParameters[0].named, isTrue);
@@ -1479,6 +1483,9 @@ Map<String, String> parameterProperties({
         expect(toFormMethod.optionalParameters[2].name, 'useQueryComponent');
         expect(toFormMethod.optionalParameters[2].required, isFalse);
         expect(toFormMethod.optionalParameters[2].named, isTrue);
+        expect(toFormMethod.optionalParameters[3].name, 'allowReserved');
+        expect(toFormMethod.optionalParameters[3].required, isFalse);
+        expect(toFormMethod.optionalParameters[3].named, isTrue);
       });
 
       test('generates toForm method for complex properties', () {
@@ -1507,8 +1514,8 @@ Map<String, String> parameterProperties({
         final result = generator.generateClass(model);
 
         const expectedToFormBody = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
           }
         ''';
 
@@ -1530,8 +1537,8 @@ Map<String, String> parameterProperties({
         final result = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
           }
         ''';
 
@@ -1778,8 +1785,8 @@ Map<String, String> parameterProperties({
           final result = generator.generateClass(model);
 
           const expectedToFormMethod = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
           }
         ''';
 
@@ -2876,16 +2883,19 @@ Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     final _$result = <String, String>{};
     _$result[r'name'] = name.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
     for (final _$e in additionalProperties.entries) {
       _$result[_$e.key] = _$e.value.uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       );
     }
     return _$result;
@@ -2935,11 +2945,13 @@ Map<String, String> parameterProperties({
     bool allowEmpty = true,
     bool allowLists = true,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     final _$result = <String, String>{};
     _$result[r'version'] = version.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
     if (additionalProperties.isNotEmpty) {
       throw EncodingException(

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -1289,11 +1289,13 @@ void main() {
     bool allowEmpty = true,
     bool allowLists = true,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     final _$result = <String, String>{};
     _$result[r'name'] = name.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
     for (final _$e in additionalProperties.entries) {
       _$result[_$e.key] = _$e.value?.toString() ?? '';

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -392,11 +392,13 @@ void main() {
           bool allowEmpty = true,
           bool allowLists = true,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           final _$result = <String, String>{};
           _$result[r'name'] = name.uriEncode(
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           if (password == null) {
             throw EncodingException(r'Required property password is null.');
@@ -404,6 +406,7 @@ void main() {
           _$result[r'password'] = password!.uriEncode(
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           );
           return _$result;
         }
@@ -449,10 +452,12 @@ void main() {
           required bool explode,
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
           ).toForm(
             paramName,
             explode: explode,
@@ -530,10 +535,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,

--- a/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
@@ -220,6 +220,7 @@ void main() {
           bool allowEmpty = true,
           bool allowLists = true,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerStatus is read-only and cannot be encoded.',
         );

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -1231,7 +1231,7 @@ void main() {
         );
         expect(toForm.requiredParameters, hasLength(1));
         expect(toForm.requiredParameters.single.name, 'paramName');
-        expect(toForm.optionalParameters, hasLength(3));
+        expect(toForm.optionalParameters, hasLength(4));
 
         final explodeParam = toForm.optionalParameters.firstWhere(
           (p) => p.name == 'explode',
@@ -1265,7 +1265,8 @@ void main() {
         expect(
           body,
           'rawValue.toForm(paramName, explode: explode, '
-          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent)',
+          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+          'allowReserved: allowReserved)',
         );
         expect(toForm.lambda, isTrue);
       });
@@ -1294,13 +1295,14 @@ void main() {
           'List<ParameterEntry>',
         );
         expect(toForm.requiredParameters.single.name, 'paramName');
-        expect(toForm.optionalParameters, hasLength(3));
+        expect(toForm.optionalParameters, hasLength(4));
 
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
           'rawValue.toForm(paramName, explode: explode, '
-          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent)',
+          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+          'allowReserved: allowReserved)',
         );
         expect(toForm.lambda, isTrue);
       });
@@ -1328,13 +1330,14 @@ void main() {
           'List<ParameterEntry>',
         );
         expect(toForm.requiredParameters.single.name, 'paramName');
-        expect(toForm.optionalParameters, hasLength(3));
+        expect(toForm.optionalParameters, hasLength(4));
 
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
           'rawValue.toForm(paramName, explode: explode, '
-          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent)',
+          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+          'allowReserved: allowReserved)',
         );
         expect(toForm.lambda, isTrue);
       });
@@ -1363,13 +1366,14 @@ void main() {
           'List<ParameterEntry>',
         );
         expect(toForm.requiredParameters.single.name, 'paramName');
-        expect(toForm.optionalParameters, hasLength(3));
+        expect(toForm.optionalParameters, hasLength(4));
 
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
           'rawValue.toForm(paramName, explode: explode, '
-          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent)',
+          'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+          'allowReserved: allowReserved)',
         );
         expect(toForm.lambda, isTrue);
       });
@@ -1670,7 +1674,7 @@ void main() {
         );
 
         expect(uriEncode.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(uriEncode.optionalParameters, hasLength(2));
+        expect(uriEncode.optionalParameters, hasLength(3));
 
         final allowEmptyParam = uriEncode.optionalParameters.firstWhere(
           (p) => p.name == 'allowEmpty',
@@ -1697,7 +1701,7 @@ void main() {
         expect(
           body,
           'rawValue.uriEncode(allowEmpty: allowEmpty, '
-          'useQueryComponent: useQueryComponent)',
+          'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
       });
@@ -1722,7 +1726,7 @@ void main() {
         );
 
         expect(uriEncode.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(uriEncode.optionalParameters, hasLength(2));
+        expect(uriEncode.optionalParameters, hasLength(3));
 
         final useQueryComponentParam = uriEncode.optionalParameters.firstWhere(
           (p) => p.name == 'useQueryComponent',
@@ -1742,7 +1746,7 @@ void main() {
         expect(
           body,
           'rawValue.uriEncode(allowEmpty: allowEmpty, '
-          'useQueryComponent: useQueryComponent)',
+          'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
       });
@@ -1766,7 +1770,7 @@ void main() {
         );
 
         expect(uriEncode.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(uriEncode.optionalParameters, hasLength(2));
+        expect(uriEncode.optionalParameters, hasLength(3));
 
         final useQueryComponentParam = uriEncode.optionalParameters.firstWhere(
           (p) => p.name == 'useQueryComponent',
@@ -1786,7 +1790,7 @@ void main() {
         expect(
           body,
           'rawValue.uriEncode(allowEmpty: allowEmpty, '
-          'useQueryComponent: useQueryComponent)',
+          'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
       });
@@ -1999,14 +2003,14 @@ void main() {
         );
         expect(toForm.requiredParameters.single.name, 'paramName');
         expect(toForm.lambda, isFalse);
-        expect(toForm.optionalParameters, hasLength(3));
+        expect(toForm.optionalParameters, hasLength(4));
 
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         const expectedBody = '''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+          return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2111,7 +2115,7 @@ void main() {
 
         expect(uriEncode.returns?.accept(DartEmitter()).toString(), 'String');
         expect(uriEncode.lambda, isFalse);
-        expect(uriEncode.optionalParameters, hasLength(2));
+        expect(uriEncode.optionalParameters, hasLength(3));
 
         final allowEmptyParam = uriEncode.optionalParameters.firstWhere(
           (p) => p.name == 'allowEmpty',
@@ -2139,7 +2143,7 @@ void main() {
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent);
+          return rawValue.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });

--- a/packages/tonik_generate/test/src/model/one_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_deep_object_generator_test.dart
@@ -54,10 +54,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,
@@ -94,10 +96,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,
@@ -172,10 +176,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,
@@ -212,10 +218,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,
@@ -251,10 +259,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,
@@ -330,10 +340,12 @@ void main() {
           String paramName, {
           required bool explode,
           required bool allowEmpty,
+          bool allowReserved = false,
         }) {
           return parameterProperties(
             allowEmpty: allowEmpty,
             allowLists: false,
+            allowReserved: allowReserved,
           ).toDeepObject(
             paramName,
             explode: explode,

--- a/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
@@ -55,19 +55,21 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Result');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             ResultError(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             ),
             ResultSuccess(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             ),
           };
         }
@@ -120,17 +122,21 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             ResponseMessage(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             ),
             ResponseUser(:final value) =>
               {
-                ...value.parameterProperties(allowEmpty: allowEmpty),
+                ...value.parameterProperties(
+                  allowEmpty: allowEmpty,
+                  allowReserved: allowReserved,
+                ),
                 r'type': r'user',
               }.toForm(
                 paramName,
@@ -171,10 +177,15 @@ void main() {
         'List<ParameterEntry>',
       );
       expect(toFormMethod.requiredParameters.single.name, 'paramName');
-      expect(toFormMethod.optionalParameters, hasLength(3));
+      expect(toFormMethod.optionalParameters, hasLength(4));
       expect(
         toFormMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty', 'useQueryComponent']),
+        containsAll([
+          'explode',
+          'allowEmpty',
+          'useQueryComponent',
+          'allowReserved',
+        ]),
       );
       expect(
         toFormMethod.optionalParameters.take(2).every((p) => p.required),
@@ -453,13 +464,14 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             OuterInner(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             ),
           };
         }
@@ -517,12 +529,15 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             OuterInner(:final value) =>
               value.currentEncodingShape == EncodingShape.complex
                   ? {
-                      ...value.parameterProperties(allowEmpty: allowEmpty),
+                      ...value.parameterProperties(
+                  allowEmpty: allowEmpty,
+                  allowReserved: allowReserved,
+                ),
                       r'type': r'inner',
                     }.toForm(
                       paramName,
@@ -536,6 +551,7 @@ void main() {
                       explode: explode,
                       allowEmpty: allowEmpty,
                       useQueryComponent: useQueryComponent,
+                      allowReserved: allowReserved,
                     ),
           };
         }
@@ -626,12 +642,15 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             OuterInnerA(:final value) =>
               value.currentEncodingShape == EncodingShape.complex
                   ? {
-                      ...value.parameterProperties(allowEmpty: allowEmpty),
+                      ...value.parameterProperties(
+                  allowEmpty: allowEmpty,
+                  allowReserved: allowReserved,
+                ),
                       r'type': r'a',
                     }.toForm(
                       paramName,
@@ -645,11 +664,15 @@ void main() {
                       explode: explode,
                       allowEmpty: allowEmpty,
                       useQueryComponent: useQueryComponent,
+                      allowReserved: allowReserved,
                     ),
             OuterInnerB(:final value) =>
               value.currentEncodingShape == EncodingShape.complex
                   ? {
-                      ...value.parameterProperties(allowEmpty: allowEmpty),
+                      ...value.parameterProperties(
+                  allowEmpty: allowEmpty,
+                  allowReserved: allowReserved,
+                ),
                       r'type': r'b',
                     }.toForm(
                       paramName,
@@ -663,6 +686,7 @@ void main() {
                       explode: explode,
                       allowEmpty: allowEmpty,
                       useQueryComponent: useQueryComponent,
+                      allowReserved: allowReserved,
                     ),
           };
         }
@@ -699,7 +723,7 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, }) {
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
           return switch (this) {
             WithBinaryBinary() => throw EncodingException(
               'Binary data cannot be form-encoded',
@@ -709,6 +733,7 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
             ),
           };
         }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -776,7 +776,13 @@ void main() {
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
         'Map<String,String>',
       );
-      expect(method.optionalParameters.length, 2);
+      expect(method.optionalParameters.length, 3);
+
+      final allowReservedParam = method.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final allowEmptyParam = method.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -826,6 +832,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) =>
           throw EncodingException(
             r'parameterProperties not supported for Value: only contains primitive types',
@@ -865,6 +872,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) =>
           throw EncodingException(
             r'parameterProperties not supported for Value: only contains primitive types',
@@ -913,11 +921,13 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             ResponseUser(:final value) => value.parameterProperties(
               allowEmpty: allowEmpty,
               allowLists: allowLists,
+              allowReserved: allowReserved,
             ),
           };
         }
@@ -985,12 +995,14 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             EntityCompany(:final value) => {
               ...value.parameterProperties(
                 allowEmpty: allowEmpty,
                 allowLists: allowLists,
+                allowReserved: allowReserved,
               ),
               r'type': r'company',
             },
@@ -998,6 +1010,7 @@ void main() {
               ...value.parameterProperties(
                 allowEmpty: allowEmpty,
                 allowLists: allowLists,
+                allowReserved: allowReserved,
               ),
               r'type': r'person',
             },
@@ -1050,11 +1063,13 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             ValueUser(:final value) => value.parameterProperties(
               allowEmpty: allowEmpty,
               allowLists: allowLists,
+              allowReserved: allowReserved,
             ),
             ValueString() => throw EncodingException(
               r'parameterProperties not supported for Value: cannot determine properties at runtime',
@@ -1113,6 +1128,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             ResponseMessage() => throw EncodingException(
@@ -1122,6 +1138,7 @@ void main() {
               ...value.parameterProperties(
                 allowEmpty: allowEmpty,
                 allowLists: allowLists,
+                allowReserved: allowReserved,
               ),
               r'type': r'user',
             },
@@ -1187,12 +1204,14 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex
               ? value.parameterProperties(
                   allowEmpty: allowEmpty,
                   allowLists: allowLists,
+                  allowReserved: allowReserved,
                 )
               : throw EncodingException(
                   r'parameterProperties not supported for Outer: cannot determine properties at runtime',
@@ -1260,6 +1279,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) {
           return switch (this) {
             OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex
@@ -1267,6 +1287,7 @@ void main() {
                   ...value.parameterProperties(
                     allowEmpty: allowEmpty,
                     allowLists: allowLists,
+                    allowReserved: allowReserved,
                   ),
                   r'type': r'inner',
                 }
@@ -1557,7 +1578,13 @@ void main() {
         (m) => m.name == 'uriEncode',
       );
 
-      expect(uriEncodeMethod.optionalParameters, hasLength(2));
+      expect(uriEncodeMethod.optionalParameters, hasLength(3));
+
+      final allowReservedParam = uriEncodeMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final allowEmptyParam = uriEncodeMethod.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -1601,7 +1628,13 @@ void main() {
         (m) => m.name == 'toForm',
       );
 
-      expect(toFormMethod.optionalParameters.length, 3);
+      expect(toFormMethod.optionalParameters.length, 4);
+
+      final allowReservedParam = toFormMethod.optionalParameters.firstWhere(
+        (p) => p.name == 'allowReserved',
+      );
+      expect(allowReservedParam.named, isTrue);
+      expect(allowReservedParam.required, isFalse);
 
       final explodeParam = toFormMethod.optionalParameters.firstWhere(
         (p) => p.name == 'explode',
@@ -1877,6 +1910,7 @@ void main() {
             Map<String, String> parameterProperties({
               bool allowEmpty = true,
               bool allowLists = true,
+              bool allowReserved = false,
             }) {
               return switch (this) {
                 ValueList() => throw EncodingException(
@@ -2146,6 +2180,7 @@ void main() {
                 required bool explode,
                 required bool allowEmpty,
                 bool useQueryComponent = false,
+                bool allowReserved = false,
               }) {
                 return switch (this) {
                   ValueList(:final value) => value.toForm(
@@ -2159,6 +2194,7 @@ void main() {
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
                   ),
                 };
               }
@@ -2213,6 +2249,7 @@ void main() {
                 required bool explode,
                 required bool allowEmpty,
                 bool useQueryComponent = false,
+                bool allowReserved = false,
               }) {
                 return switch (this) {
                   ValueList() => throw EncodingException(
@@ -2223,6 +2260,7 @@ void main() {
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
                   ),
                 };
               }
@@ -2379,6 +2417,7 @@ void main() {
               Map<String, String> parameterProperties({
                 bool allowEmpty = true,
                 bool allowLists = true,
+                bool allowReserved = false,
               }) {
                 return switch (this) {
                   ValueList() => throw EncodingException(
@@ -2550,6 +2589,7 @@ void main() {
           Map<String, String> parameterProperties({
             bool allowEmpty = true,
             bool allowLists = true,
+            bool allowReserved = false,
           }) {
             return switch (this) {
               ValueDetails(:final value) => value == null
@@ -2557,6 +2597,7 @@ void main() {
                 : value.parameterProperties(
                     allowEmpty: allowEmpty,
                     allowLists: allowLists,
+                    allowReserved: allowReserved,
                   ),
             };
           }
@@ -2832,6 +2873,7 @@ void main() {
               required bool explode,
               required bool allowEmpty,
               bool useQueryComponent = false,
+              bool allowReserved = false,
             }) {
               return switch (this) {
                 ValueTags() => throw EncodingException(
@@ -2842,6 +2884,7 @@ void main() {
                   explode: explode,
                   allowEmpty: allowEmpty,
                   useQueryComponent: useQueryComponent,
+                  allowReserved: allowReserved,
                 ),
               };
             }
@@ -3156,6 +3199,7 @@ bool operator ==(Object other) {
               required bool explode,
               required bool allowEmpty,
               bool useQueryComponent = false,
+              bool allowReserved = false,
             }) {
               return switch (this) {
                 ValueUnknown() => throw EncodingException(
@@ -3166,6 +3210,7 @@ bool operator ==(Object other) {
                   explode: explode,
                   allowEmpty: allowEmpty,
                   useQueryComponent: useQueryComponent,
+                  allowReserved: allowReserved,
                 ),
               };
             }
@@ -3844,6 +3889,7 @@ bool operator ==(Object other) {
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             return switch (this) {
               ValueBase64(:final value) => value.toBase64String().toForm(
@@ -3851,12 +3897,14 @@ bool operator ==(Object other) {
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               ),
               ValueText(:final value) => value.toForm(
                 paramName,
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               ),
             };
           }
@@ -3925,6 +3973,7 @@ bool operator ==(Object other) {
             required bool explode,
             required bool allowEmpty,
             bool useQueryComponent = false,
+            bool allowReserved = false,
           }) {
             return switch (this) {
               ValueNullableData(:final value) =>
@@ -3935,12 +3984,14 @@ bool operator ==(Object other) {
                         explode: explode,
                         allowEmpty: allowEmpty,
                         useQueryComponent: useQueryComponent,
+                        allowReserved: allowReserved,
                       ),
               ValueText(:final value) => value.toForm(
                 paramName,
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               ),
             };
           }
@@ -4130,11 +4181,12 @@ bool operator ==(Object other) {
 
         const expectedMethod = '''
           @override
-          String uriEncode({required bool allowEmpty, bool useQueryComponent = false}) {
+          String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, }) {
             return switch (this) {
               ValueBase64(:final value) => value.toBase64String().uriEncode(
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
               ),
               ValueText() => throw EncodingException(
                 r'Cannot uriEncode Value: variant contains complex type',

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1338,7 +1338,7 @@ void main() {
         expectContainsBody(
           'List<ParameterEntry> toForm( String paramName, { required bool '
           'explode, required bool allowEmpty, bool useQueryComponent = false, '
-          '}) => $throwExpr',
+          'bool allowReserved = false, }) => $throwExpr',
         );
       });
 
@@ -1359,7 +1359,8 @@ void main() {
       test('uriEncode', () {
         expectContainsBody(
           'String uriEncode({ required bool allowEmpty, bool '
-          'useQueryComponent = false, }) => $throwExpr',
+          'useQueryComponent = false, bool allowReserved = false, }) => '
+          '$throwExpr',
         );
       });
 
@@ -1372,14 +1373,16 @@ void main() {
       test('parameterProperties', () {
         expectContainsBody(
           'Map<String, String> parameterProperties({ bool allowEmpty = true, '
-          'bool allowLists = true, }) => $throwExpr',
+          'bool allowLists = true, bool allowReserved = false, }) => '
+          '$throwExpr',
         );
       });
 
       test('toDeepObject', () {
         expectContainsBody(
           'List<ParameterEntry> toDeepObject( String paramName, { required '
-          'bool explode, required bool allowEmpty, }) => $throwExpr',
+          'bool explode, required bool allowEmpty, bool allowReserved = false, '
+          '}) => $throwExpr',
         );
       });
     });

--- a/packages/tonik_generate/test/src/model/one_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_schema_level_read_write_only_test.dart
@@ -173,6 +173,7 @@ void main() {
         Map<String, String> parameterProperties({
           bool allowEmpty = true,
           bool allowLists = true,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
@@ -196,6 +197,7 @@ void main() {
         String uriEncode({
           required bool allowEmpty,
           bool useQueryComponent = false,
+          bool allowReserved = false,
         }) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1585,8 +1585,8 @@ void main() {
       );
 
       test(
-        'defers allowReserved for enum and composition properties while '
-        'applying it to the flagged scalar',
+        'threads allowReserved through enum and composition properties '
+        'alongside the flagged scalar',
         () {
           final formModel = ClassModel(
             name: 'ComboForm',
@@ -1675,12 +1675,14 @@ void main() {
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
+                  allowReserved: true,
                 ),
                 ...body.choice.toForm(
                   r'choice'.uriEncode(allowEmpty: true, useQueryComponent: true),
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
+                  allowReserved: true,
                 ),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
@@ -1696,7 +1698,7 @@ void main() {
       );
 
       test(
-        'opens the per-property path for a sole flagged enum yet defers its '
+        'opens the per-property path for a sole flagged enum and threads its '
         'allowReserved',
         () {
           final formModel = ClassModel(
@@ -1759,6 +1761,7 @@ void main() {
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
+                  allowReserved: true,
                 ),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }
@@ -1774,8 +1777,8 @@ void main() {
       );
 
       test(
-        'opens the per-property path for a sole flagged composition yet defers '
-        'its allowReserved',
+        'opens the per-property path for a sole flagged composition and '
+        'threads its allowReserved',
         () {
           final formModel = ClassModel(
             name: 'CompositionOnlyForm',
@@ -1842,6 +1845,7 @@ void main() {
                   explode: true,
                   allowEmpty: true,
                   useQueryComponent: true,
+                  allowReserved: true,
                 ),
               ].map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
             }

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -186,7 +186,7 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('enum form param omits allowReserved even when set', () {
+    test('enum form param threads allowReserved into toForm when set', () {
       final result = build(
         EnumModel<String>(
           name: 'Color',
@@ -204,14 +204,14 @@ void main() {
 
       final expected = format('''
         test() {
-          value.toForm('p', explode: true, allowEmpty: true);
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
         }
       ''');
 
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('object form param omits allowReserved even when set', () {
+    test('object form param threads allowReserved into toForm when set', () {
       final result = build(
         ClassModel(
           name: 'Form',
@@ -225,14 +225,14 @@ void main() {
 
       final expected = format('''
         test() {
-          value.toForm('p', explode: true, allowEmpty: true);
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
         }
       ''');
 
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('composite form param omits allowReserved even when set', () {
+    test('composite form param threads allowReserved into toForm when set', () {
       final result = build(
         OneOfModel(
           models: const {},
@@ -245,7 +245,7 @@ void main() {
 
       final expected = format('''
         test() {
-          value.toForm('p', explode: true, allowEmpty: true);
+          value.toForm('p', explode: true, allowEmpty: true, allowReserved: true);
         }
       ''');
 
@@ -274,7 +274,7 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('enum list element omits allowReserved even when set', () {
+    test('enum list element threads allowReserved into uriEncode when set', () {
       final result = build(
         ListModel(
           content: EnumModel<String>(
@@ -297,7 +297,7 @@ void main() {
       final expected = format('''
         test() {
           value
-              .map((e) => e.uriEncode(allowEmpty: true))
+              .map((e) => e.uriEncode(allowEmpty: true, allowReserved: true))
               .toList()
               .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
         }
@@ -306,7 +306,8 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('free-form list element omits allowReserved even when set', () {
+    test('free-form list element threads allowReserved into encodeAnyToUri '
+        'when set', () {
       final result = build(
         ListModel(
           content: AnyModel(context: context),
@@ -319,7 +320,7 @@ void main() {
       final expected = format('''
         test() {
           value
-              .map((e) => _i1.encodeAnyToUri(e, allowEmpty: true))
+              .map((e) => _i1.encodeAnyToUri(e, allowEmpty: true, allowReserved: true))
               .toList()
               .toForm('p', explode: true, allowEmpty: true, alreadyEncoded: true);
         }

--- a/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_deep_object_query_parameter_expression_generator_test.dart
@@ -858,7 +858,8 @@ void main() {
         );
       });
 
-      test('class model object path omits allowReserved even when set', () {
+      test('class model object path threads allowReserved into toDeepObject '
+          'when set', () {
         final parameter = createParameter(
           name: 'user',
           rawName: 'user',
@@ -884,7 +885,8 @@ void main() {
         expect(
           collapseWhitespace(code),
           collapseWhitespace(
-            "user.toDeepObject(r'user', explode: true, allowEmpty: false, )",
+            "user.toDeepObject(r'user', explode: true, allowEmpty: false, "
+            'allowReserved: true, )',
           ),
         );
       });

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -789,7 +789,8 @@ void main() {
         },
       );
 
-      test('enum list omits allowReserved even when set', () {
+      test('enum list threads allowReserved into each item uriEncode when set',
+          () {
         final parameter = createParameter(
           name: 'priorities',
           rawName: 'priorities',
@@ -826,7 +827,7 @@ void main() {
             format(r'''
               void test() {
                 for (final value in priorities
-                    .map((e) => e.uriEncode(allowEmpty: true))
+                    .map((e) => e.uriEncode(allowEmpty: true, allowReserved: true))
                     .toList()
                     .toSpaceDelimited(
                       explode: false,
@@ -841,7 +842,8 @@ void main() {
         );
       });
 
-      test('composition list omits allowReserved even when set', () {
+      test('composition list threads allowReserved into each item uriEncode '
+          'when set', () {
         final parameter = createParameter(
           name: 'items',
           rawName: 'items',
@@ -891,7 +893,7 @@ void main() {
                   }
                 }
                 for (final value in items
-                    .map((item) => item.uriEncode(allowEmpty: true))
+                    .map((item) => item.uriEncode(allowEmpty: true, allowReserved: true))
                     .toList()
                     .toSpaceDelimited(
                       explode: false,

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -49,7 +49,7 @@ void main() {
         refer('value'),
         model,
         allowEmpty: refer('allowEmpty'),
-        allowReserved: true,
+        allowReserved: literalBool(true),
       );
 
       final generated = format('final result = ${expression.accept(emitter)};');
@@ -63,7 +63,7 @@ void main() {
       );
     });
 
-    test('omits allowReserved for EnumModel even when set', () {
+    test('adds allowReserved for EnumModel when set', () {
       final model = EnumModel<String>(
         name: 'Color',
         values: {
@@ -79,12 +79,12 @@ void main() {
         refer('value'),
         model,
         allowEmpty: refer('allowEmpty'),
-        allowReserved: true,
+        allowReserved: literalBool(true),
       );
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty);
+        final result = value.uriEncode(allowEmpty: allowEmpty, allowReserved: true);
       ''';
 
       expect(
@@ -105,7 +105,7 @@ void main() {
         refer('value'),
         model,
         allowEmpty: refer('allowEmpty'),
-        allowReserved: true,
+        allowReserved: literalBool(true),
       );
 
       final generated = format('final result = ${expression.accept(emitter)};');
@@ -427,6 +427,31 @@ void main() {
       );
     });
 
+    test('threads allowReserved into the whole-list encode for '
+        'List<String> when set', () {
+      final model = ListModel(
+        content: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: literalBool(true),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty, allowReserved: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test('generates map expression for List<int>', () {
       final model = ListModel(
         content: IntegerModel(context: context),
@@ -445,6 +470,34 @@ void main() {
             .map((e) => e.uriEncode(allowEmpty: allowEmpty))
             .toList()
             .uriEncode(allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('threads allowReserved into both element and whole-list encode for '
+        'List<int> when set', () {
+      final model = ListModel(
+        content: IntegerModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: literalBool(true),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value
+            .map((e) => e.uriEncode(allowEmpty: allowEmpty, allowReserved: true))
+            .toList()
+            .uriEncode(allowEmpty: allowEmpty, allowReserved: true);
       ''';
 
       expect(
@@ -612,6 +665,34 @@ void main() {
             .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty))
             .toList()
             .uriEncode(allowEmpty: allowEmpty);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('threads allowReserved into encodeAnyToUri and the whole-list '
+        'encode for List<AnyModel> when set', () {
+      final model = ListModel(
+        content: AnyModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: literalBool(true),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value
+            .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty, allowReserved: true))
+            .toList()
+            .uriEncode(allowEmpty: allowEmpty, allowReserved: true);
       ''';
 
       expect(
@@ -834,6 +915,30 @@ void main() {
       );
     });
 
+    test('threads allowReserved into the map uriEncode when set', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: literalBool(true),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.uriEncode(allowEmpty: allowEmpty, allowReserved: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test(
       'generates map and uriEncode for MapModel with IntegerModel values',
       () {
@@ -950,6 +1055,52 @@ void main() {
               )
               .toList()
               .uriEncode(allowEmpty: allowEmpty);
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
+    test('threads allowReserved into inner-map and whole-list encode for '
+        'List<Map<String, int>> when set', () {
+      final model = ListModel(
+        content: MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+      );
+      final expression = buildUriEncodeExpression(
+        refer('value'),
+        model,
+        allowEmpty: refer('allowEmpty'),
+        allowReserved: literalBool(true),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal(
+            'result',
+          ).assign(expression.expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map(
+                (e) => e
+                    .map((k, v) => MapEntry(k, v.toString()))
+                    .uriEncode(allowEmpty: allowEmpty, allowReserved: true),
+              )
+              .toList()
+              .uriEncode(allowEmpty: allowEmpty, allowReserved: true);
         }
       ''');
 

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -219,8 +219,8 @@ String encodeAnyToSimple(
 ///
 /// When [allowReserved] is true, most reserved characters in primitive
 /// values are kept literal; the flag is threaded into recursive list/map
-/// element encoding. The [ParameterEncodable] branch is intentionally not
-/// threaded — those models manage their own value encoding.
+/// element encoding and forwarded to the [ParameterEncodable] branch so those
+/// models honor it in their own value encoding.
 ///
 /// Note: when an unsupported nested element raises [EncodingException], the
 /// message identifies only the inner type — no path / key context is attached
@@ -245,6 +245,7 @@ String encodeAnyToForm(
         explode: explode,
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
       ),
       explode: explode,
     );
@@ -367,9 +368,9 @@ String _formEntriesToString(
 /// `Map<String, String>` values use extension methods.
 ///
 /// When [allowReserved] is true, most reserved characters in the map
-/// VALUES are kept literal (keys stay `Uri.encodeComponent`-encoded). The
-/// [ParameterEncodable] branch is intentionally not threaded — those models
-/// manage their own value encoding.
+/// VALUES are kept literal (keys stay `Uri.encodeComponent`-encoded); the flag
+/// is forwarded to the [ParameterEncodable] branch so those models honor it in
+/// their own value encoding.
 ///
 /// Note: DeepObject style only makes sense for objects, not primitives.
 List<ParameterEntry> encodeAnyToDeepObject(
@@ -390,6 +391,7 @@ List<ParameterEntry> encodeAnyToDeepObject(
       paramName,
       explode: explode,
       allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
     );
   }
   if (value is Map<String, String>) {
@@ -411,10 +413,15 @@ List<ParameterEntry> encodeAnyToDeepObject(
 /// Handles runtime type detection for values of unknown type.
 /// Generated models implementing [ParameterEncodable] encode themselves.
 /// Primitives use extension methods.
+///
+/// When [allowReserved] is true, reserved characters are kept literal except
+/// the form delimiters `& = +`; the flag is forwarded to the [UriEncodable]
+/// branch and every primitive branch.
 String encodeAnyToUri(
   Object? value, {
   required bool allowEmpty,
   bool useQueryComponent = false,
+  bool allowReserved = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -426,48 +433,56 @@ String encodeAnyToUri(
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is String) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is int) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is double) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is bool) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is DateTime) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is Uri) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   if (value is BigDecimal) {
     return value.uriEncode(
       allowEmpty: allowEmpty,
       useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
     );
   }
   throw EncodingException(

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -52,11 +52,14 @@ abstract interface class FormEncodable {
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [useQueryComponent] is true, uses '+' for spaces
   /// (application/x-www-form-urlencoded encoding).
+  /// When [allowReserved] is true, reserved characters in values are kept
+  /// literal except the form delimiters `& = +`.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   });
 }
 
@@ -67,6 +70,8 @@ abstract interface class DeepObjectEncodable {
   /// The [paramName] is the base parameter name used for nested keys.
   /// The [explode] parameter must be true; deepObject style always explodes.
   /// When [allowEmpty] is false, empty values throw an exception.
+  /// When [allowReserved] is true, reserved characters in values are kept
+  /// literal except the form delimiters `& = +`; keys stay encoded.
   ///
   /// Returns a list of parameter entries where each entry has:
   /// - name: `paramName[key]`
@@ -75,6 +80,7 @@ abstract interface class DeepObjectEncodable {
     String paramName, {
     required bool explode,
     required bool allowEmpty,
+    bool allowReserved = false,
   });
 }
 
@@ -96,7 +102,13 @@ abstract interface class UriEncodable {
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [useQueryComponent] is true, uses '+' for spaces
   /// (application/x-www-form-urlencoded encoding).
-  String uriEncode({required bool allowEmpty, bool useQueryComponent});
+  /// When [allowReserved] is true, reserved characters are kept literal except
+  /// the form delimiters `& = +`.
+  String uriEncode({
+    required bool allowEmpty,
+    bool useQueryComponent,
+    bool allowReserved,
+  });
 }
 
 /// Combined interface for types that support all standard parameter

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -47,6 +47,7 @@ class TestEncodableModel implements ParameterEncodable {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
     if (explode) {
       return [
@@ -62,6 +63,7 @@ class TestEncodableModel implements ParameterEncodable {
     String paramName, {
     required bool explode,
     required bool allowEmpty,
+    bool allowReserved = false,
   }) {
     return [
       (name: '$paramName[name]', value: name),
@@ -87,7 +89,11 @@ enum TestUriEncodableEnum implements UriEncodable {
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
+    if (allowReserved) {
+      return '$rawValue!reserved';
+    }
     return useQueryComponent
         ? Uri.encodeQueryComponent(rawValue)
         : Uri.encodeComponent(rawValue);
@@ -108,7 +114,11 @@ class QueryComponentAwareEncodable implements ParameterEncodable {
     required bool explode,
     required bool allowEmpty,
     bool useQueryComponent = false,
+    bool allowReserved = false,
   }) {
+    if (allowReserved) {
+      return [(name: paramName, value: '$rawValue!reserved')];
+    }
     return [
       (
         name: paramName,
@@ -139,7 +149,13 @@ class QueryComponentAwareEncodable implements ParameterEncodable {
     String paramName, {
     required bool explode,
     required bool allowEmpty,
-  }) => throw UnimplementedError();
+    bool allowReserved = false,
+  }) {
+    if (allowReserved) {
+      return [(name: '$paramName[k]', value: '$rawValue!reserved')];
+    }
+    throw UnimplementedError();
+  }
 
   @override
   Object? toJson() => throw UnimplementedError();
@@ -1009,6 +1025,20 @@ void main() {
         expect(withoutQuery == withQuery, isFalse);
       });
 
+      test('forwards allowReserved to ParameterEncodable.toForm', () {
+        const model = QueryComponentAwareEncodable('value');
+
+        expect(
+          encodeAnyToForm(
+            model,
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'value!reserved',
+        );
+      });
+
       test('renders bare value for empty-name entry with explode=true', () {
         const model = QueryComponentAwareEncodable('hello world');
 
@@ -1706,6 +1736,18 @@ void main() {
         expect(result[0], (name: 'obj[name]', value: 'test'));
         expect(result[1], (name: 'obj[value]', value: '42'));
       });
+
+      test('forwards allowReserved to ParameterEncodable.toDeepObject', () {
+        const model = QueryComponentAwareEncodable('value');
+        final result = encodeAnyToDeepObject(
+          model,
+          'obj',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+        expect(result, [(name: 'obj[k]', value: 'value!reserved')]);
+      });
     });
 
     group('Map<String, String>', () {
@@ -2120,6 +2162,17 @@ void main() {
           'has+space',
         );
       });
+
+      test('forwards allowReserved to UriEncodable.uriEncode', () {
+        expect(
+          encodeAnyToUri(
+            TestUriEncodableEnum.value1,
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'one!reserved',
+        );
+      });
     });
 
     group('String', () {
@@ -2166,6 +2219,18 @@ void main() {
             useQueryComponent: true,
           ),
           'hello+world',
+        );
+      });
+
+      test('keeps reserved chars literal and encodes delimiters under '
+          'allowReserved', () {
+        expect(
+          encodeAnyToUri(
+            'a/b:c&d=e+f',
+            allowEmpty: true,
+            allowReserved: true,
+          ),
+          'a/b:c%26d%3De%2Bf',
         );
       });
     });


### PR DESCRIPTION
Completes `allowReserved` support for the query surface: values serialized by a generated model (enum, object, and `allOf`/`oneOf`/`anyOf` compositions) and by the Any-to-URI path now honor `allowReserved`, alongside the scalar/list/map paths shipped earlier.

## What changed
- **Runtime (`tonik_util`):** `FormEncodable.toForm`, `DeepObjectEncodable.toDeepObject` and `UriEncodable.uriEncode` gain an optional `allowReserved` parameter; `encodeAnyToUri` gains it too, and `encodeAnyToForm` / `encodeAnyToDeepObject` now forward it into their `ParameterEncodable` branch.
- **Generator:** every generated `toForm` / `uriEncode` / `toDeepObject` (enum, object, composition, and the composite read-only guards) emits and threads the flag into each property / element value encode. The form, delimited and deepObject query builders pass `allowReserved: true` only when the spec sets it — output is byte-identical otherwise.
- **Form bodies:** because the form-entries builder is shared between query and body call sites, urlencoded body properties of these shapes honor a per-property `allowReserved` Encoding Object through the same path.

## Wire behavior
Reserved characters pass through literally, except the form-urlencoded delimiters `& = +`, which are always `%26 %3D %2B`. Query strings still force-encode `# [ ]` (Dart's `Uri` at assembly); urlencoded bodies keep `# [ ]` literal and render a space as `+`. `allowReserved: false` (the default) is byte-identical to before.

## Breaking change
The widened `tonik_util` encoding interfaces are a breaking change: types generated before this no longer satisfy them. Every generated implementer in this repository is updated in the same change. Released clients pinned to the current `tonik_util` are unaffected and only adopt the change on regeneration.

## Testing
- Full-method-body generator unit tests (with and without `allowReserved`) across all model generators and the form / uri / delimited / deepObject builders, including the flipped deferral pins.
- Runtime unit tests for the `encodeAnyToUri` / `encodeAnyToForm` / `encodeAnyToDeepObject` forwarding.
- Integration cases (Imposter): object and enum form query params, an array-of-enum form query param, an object with a list property, and a urlencoded body with an enum property — asserting the wire query / body.
- `dart analyze` clean for `packages/` and the regenerated `integration_test/`; all unit and integration suites pass.
