### PR TITLE
refactor: resolve form and multipart body encoding by property identity

### DIFF
--- a/packages/tonik_core/lib/src/model/property_encoding.dart
+++ b/packages/tonik_core/lib/src/model/property_encoding.dart
@@ -21,13 +21,8 @@ class FieldEncoding {
     required this.explode,
   });
 
-  /// Whether reserved characters are allowed without encoding.
   final bool allowReserved;
-
-  /// Serialization style for this property.
   final EncodingStyle? style;
-
-  /// Whether arrays/objects generate separate values.
   final bool? explode;
 
   @override
@@ -61,29 +56,14 @@ class PartEncoding {
     required this.allowReserved,
   });
 
-  /// Typed content type for this property's part.
   final ContentType? contentType;
-
-  /// Raw content type string for this property's part (e.g. 'application/json').
   final String? rawContentType;
-
-  /// Per-part headers, resolved from encoding header refs.
   final Map<String, ResponseHeader>? headers;
-
-  /// Serialization style for this property.
   final EncodingStyle? style;
-
-  /// Whether arrays/objects generate separate values.
   final bool? explode;
-
-  /// Whether reserved characters are allowed without encoding.
   final bool? allowReserved;
 
-  /// Whether this encoding uses style-based serialization mode.
-  ///
-  /// True when any of [style], [explode], or [allowReserved] is non-null,
-  /// meaning the OAS spec explicitly specified at least one of these fields.
-  /// When false, serialization is content-based (determined by [contentType]).
+  /// When false, serialization is content-based, driven by [contentType].
   bool get isStyleBased =>
       style != null || explode != null || allowReserved != null;
 

--- a/packages/tonik_core/lib/src/model/property_encoding.dart
+++ b/packages/tonik_core/lib/src/model/property_encoding.dart
@@ -11,17 +11,54 @@ enum EncodingStyle {
   deepObject,
 }
 
-/// Encoding metadata for a single property in a multipart/form-data or
+/// Encoding metadata for a single property in an
 /// application/x-www-form-urlencoded request body.
 @immutable
-class PropertyEncoding {
-  const PropertyEncoding({
-    this.contentType,
-    this.rawContentType,
-    this.headers,
-    this.style,
-    this.explode,
-    this.allowReserved,
+class FieldEncoding {
+  const FieldEncoding({
+    required this.allowReserved,
+    required this.style,
+    required this.explode,
+  });
+
+  /// Whether reserved characters are allowed without encoding.
+  final bool allowReserved;
+
+  /// Serialization style for this property.
+  final EncodingStyle? style;
+
+  /// Whether arrays/objects generate separate values.
+  final bool? explode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is FieldEncoding &&
+          runtimeType == other.runtimeType &&
+          allowReserved == other.allowReserved &&
+          style == other.style &&
+          explode == other.explode;
+
+  @override
+  int get hashCode => Object.hash(allowReserved, style, explode);
+
+  @override
+  String toString() =>
+      'FieldEncoding(allowReserved: $allowReserved, '
+      'style: $style, explode: $explode)';
+}
+
+/// Encoding metadata for a single property in a multipart/form-data
+/// request body.
+@immutable
+class PartEncoding {
+  const PartEncoding({
+    required this.contentType,
+    required this.rawContentType,
+    required this.headers,
+    required this.style,
+    required this.explode,
+    required this.allowReserved,
   });
 
   /// Typed content type for this property's part.
@@ -53,7 +90,7 @@ class PropertyEncoding {
   @override
   bool operator ==(Object other) =>
       identical(this, other) ||
-      other is PropertyEncoding &&
+      other is PartEncoding &&
           runtimeType == other.runtimeType &&
           contentType == other.contentType &&
           rawContentType == other.rawContentType &&
@@ -74,7 +111,7 @@ class PropertyEncoding {
 
   @override
   String toString() =>
-      'PropertyEncoding(contentType: $contentType, '
+      'PartEncoding(contentType: $contentType, '
       'rawContentType: $rawContentType, '
       'headers: $headers, style: $style, explode: $explode, '
       'allowReserved: $allowReserved)';

--- a/packages/tonik_core/lib/src/model/request_body.dart
+++ b/packages/tonik_core/lib/src/model/request_body.dart
@@ -128,11 +128,19 @@ class RequestContent {
   /// Per-property encoding metadata for application/x-www-form-urlencoded
   /// request bodies, keyed by the [Property] it describes.
   /// Null for all other content types.
+  ///
+  /// Keys are the exact [Property] instances in [model]'s resolved properties,
+  /// matched by identity. Transformers must mutate those properties in place;
+  /// rebuilding them makes these lookups silently miss.
   Map<Property, FieldEncoding>? formEncoding;
 
   /// Per-property encoding metadata for multipart/form-data request bodies,
   /// keyed by the [Property] it describes.
   /// Null for all other content types.
+  ///
+  /// Keys are the exact [Property] instances in [model]'s resolved properties,
+  /// matched by identity. Transformers must mutate those properties in place;
+  /// rebuilding them makes these lookups silently miss.
   Map<Property, PartEncoding>? multipartEncoding;
 
   @override

--- a/packages/tonik_core/lib/src/model/request_body.dart
+++ b/packages/tonik_core/lib/src/model/request_body.dart
@@ -116,7 +116,8 @@ class RequestContent {
     required this.contentType,
     required this.rawContentType,
     required this.examples,
-    this.encoding,
+    this.formEncoding,
+    this.multipartEncoding,
   });
 
   Model model;
@@ -124,10 +125,15 @@ class RequestContent {
   String rawContentType;
   List<Example> examples;
 
-  /// Per-property encoding metadata for multipart/form-data and
-  /// application/x-www-form-urlencoded request bodies.
+  /// Per-property encoding metadata for application/x-www-form-urlencoded
+  /// request bodies, keyed by the [Property] it describes.
   /// Null for all other content types.
-  Map<String, PropertyEncoding>? encoding;
+  Map<Property, FieldEncoding>? formEncoding;
+
+  /// Per-property encoding metadata for multipart/form-data request bodies,
+  /// keyed by the [Property] it describes.
+  /// Null for all other content types.
+  Map<Property, PartEncoding>? multipartEncoding;
 
   @override
   String toString() =>

--- a/packages/tonik_core/lib/src/model/request_body.dart
+++ b/packages/tonik_core/lib/src/model/request_body.dart
@@ -125,22 +125,14 @@ class RequestContent {
   String rawContentType;
   List<Example> examples;
 
-  /// Per-property encoding metadata for application/x-www-form-urlencoded
-  /// request bodies, keyed by the [Property] it describes.
-  /// Null for all other content types.
-  ///
-  /// Keys are the exact [Property] instances in [model]'s resolved properties,
-  /// matched by identity. Transformers must mutate those properties in place;
-  /// rebuilding them makes these lookups silently miss.
+  /// Per-property encoding for application/x-www-form-urlencoded bodies, keyed
+  /// by identity on [model]'s resolved [Property] instances — transformers must
+  /// mutate those in place, never rebuild, or lookups silently miss.
   Map<Property, FieldEncoding>? formEncoding;
 
-  /// Per-property encoding metadata for multipart/form-data request bodies,
-  /// keyed by the [Property] it describes.
-  /// Null for all other content types.
-  ///
-  /// Keys are the exact [Property] instances in [model]'s resolved properties,
-  /// matched by identity. Transformers must mutate those properties in place;
-  /// rebuilding them makes these lookups silently miss.
+  /// Per-property encoding for multipart/form-data bodies, keyed by identity on
+  /// [model]'s resolved [Property] instances — transformers must mutate those
+  /// in place, never rebuild, or lookups silently miss.
   Map<Property, PartEncoding>? multipartEncoding;
 
   @override

--- a/packages/tonik_core/lib/src/transformer/content_type_normalizer.dart
+++ b/packages/tonik_core/lib/src/transformer/content_type_normalizer.dart
@@ -238,7 +238,8 @@ class ContentTypeNormalizer {
       model: normalizedModel,
       contentType: content.contentType,
       rawContentType: content.rawContentType,
-      encoding: content.encoding,
+      formEncoding: content.formEncoding,
+      multipartEncoding: content.multipartEncoding,
       examples: content.examples,
     );
   }

--- a/packages/tonik_core/test/model/property_encoding_test.dart
+++ b/packages/tonik_core/test/model/property_encoding_test.dart
@@ -2,43 +2,160 @@ import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 
 void main() {
-  group('PropertyEncoding', () {
+  group('FieldEncoding', () {
+    group('equality', () {
+      test('two encodings with same fields are equal', () {
+        const a = FieldEncoding(
+          allowReserved: true,
+          style: EncodingStyle.form,
+          explode: true,
+        );
+        const b = FieldEncoding(
+          allowReserved: true,
+          style: EncodingStyle.form,
+          explode: true,
+        );
+        expect(a, b);
+        expect(a.hashCode, b.hashCode);
+      });
+
+      test('encodings with different allowReserved are not equal', () {
+        const a = FieldEncoding(
+          allowReserved: true,
+          style: null,
+          explode: null,
+        );
+        const b = FieldEncoding(
+          allowReserved: false,
+          style: null,
+          explode: null,
+        );
+        expect(a, isNot(b));
+      });
+
+      test('encodings with different style are not equal', () {
+        const a = FieldEncoding(
+          allowReserved: false,
+          style: EncodingStyle.form,
+          explode: null,
+        );
+        const b = FieldEncoding(
+          allowReserved: false,
+          style: EncodingStyle.pipeDelimited,
+          explode: null,
+        );
+        expect(a, isNot(b));
+      });
+
+      test('encodings with different explode are not equal', () {
+        const a = FieldEncoding(
+          allowReserved: false,
+          style: null,
+          explode: true,
+        );
+        const b = FieldEncoding(
+          allowReserved: false,
+          style: null,
+          explode: false,
+        );
+        expect(a, isNot(b));
+      });
+
+      test('encoding is not equal to non-encoding object', () {
+        const a = FieldEncoding(
+          allowReserved: false,
+          style: null,
+          explode: null,
+        );
+        expect(a, isNot('not an encoding'));
+      });
+
+      test('encoding is equal to itself', () {
+        const a = FieldEncoding(
+          allowReserved: true,
+          style: EncodingStyle.deepObject,
+          explode: null,
+        );
+        expect(a, a);
+      });
+    });
+
+    group('toString', () {
+      test('includes all fields', () {
+        const encoding = FieldEncoding(
+          allowReserved: true,
+          style: EncodingStyle.form,
+          explode: false,
+        );
+        final str = encoding.toString();
+        expect(str, contains('FieldEncoding'));
+        expect(str, contains('allowReserved: true'));
+        expect(str, contains('EncodingStyle.form'));
+        expect(str, contains('explode: false'));
+      });
+    });
+  });
+
+  group('PartEncoding', () {
     group('isStyleBased', () {
       test('is false when all style fields are null', () {
-        const encoding = PropertyEncoding();
+        const encoding = PartEncoding(
+          contentType: null,
+          rawContentType: null,
+          headers: null,
+          style: null,
+          explode: null,
+          allowReserved: null,
+        );
         expect(encoding.isStyleBased, isFalse);
       });
 
       test('is true when style is set', () {
-        const encoding = PropertyEncoding(
+        const encoding = PartEncoding(
+          contentType: null,
+          rawContentType: null,
+          headers: null,
           style: EncodingStyle.form,
+          explode: null,
+          allowReserved: null,
         );
         expect(encoding.isStyleBased, isTrue);
       });
 
       test('is true when explode is set to false', () {
-        const encoding = PropertyEncoding(explode: false);
+        const encoding = PartEncoding(
+          contentType: null,
+          rawContentType: null,
+          headers: null,
+          style: null,
+          explode: false,
+          allowReserved: null,
+        );
         expect(encoding.isStyleBased, isTrue);
       });
 
-      test(
-        'is true when explode is set to true (default value still triggers)',
-        () {
-          const encoding = PropertyEncoding(explode: true);
-          expect(encoding.isStyleBased, isTrue);
-        },
-      );
-
       test('is true when allowReserved is set', () {
-        const encoding = PropertyEncoding(allowReserved: true);
+        const encoding = PartEncoding(
+          contentType: null,
+          rawContentType: null,
+          headers: null,
+          style: null,
+          explode: null,
+          allowReserved: true,
+        );
         expect(encoding.isStyleBased, isTrue);
       });
 
       test(
         'is false when only contentType is set (style fields still null)',
         () {
-          const encoding = PropertyEncoding(
+          const encoding = PartEncoding(
+            contentType: null,
             rawContentType: 'application/json',
+            headers: null,
+            style: null,
+            explode: null,
+            allowReserved: null,
           );
           expect(encoding.isStyleBased, isFalse);
         },
@@ -47,98 +164,75 @@ void main() {
 
     group('equality', () {
       test('two encodings with same fields are equal', () {
-        const a = PropertyEncoding(
+        const a = PartEncoding(
           contentType: ContentType.json,
           rawContentType: 'application/json',
+          headers: null,
           style: EncodingStyle.form,
           explode: true,
           allowReserved: false,
         );
-        const b = PropertyEncoding(
+        const b = PartEncoding(
           contentType: ContentType.json,
           rawContentType: 'application/json',
+          headers: null,
           style: EncodingStyle.form,
           explode: true,
           allowReserved: false,
         );
         expect(a, b);
         expect(a.hashCode, b.hashCode);
-      });
-
-      test('two empty encodings are equal', () {
-        const a = PropertyEncoding();
-        const b = PropertyEncoding();
-        expect(a, b);
-        expect(a.hashCode, b.hashCode);
-      });
-
-      test('encodings with different style are not equal', () {
-        const a = PropertyEncoding(
-          style: EncodingStyle.form,
-        );
-        const b = PropertyEncoding(
-          style: EncodingStyle.pipeDelimited,
-        );
-        expect(a, isNot(b));
-      });
-
-      test('encodings with different explode are not equal', () {
-        const a = PropertyEncoding(explode: true);
-        const b = PropertyEncoding(explode: false);
-        expect(a, isNot(b));
       });
 
       test('encodings with different rawContentType are not equal', () {
-        const a = PropertyEncoding(
+        const a = PartEncoding(
+          contentType: null,
           rawContentType: 'application/json',
+          headers: null,
+          style: null,
+          explode: null,
+          allowReserved: null,
         );
-        const b = PropertyEncoding(rawContentType: 'text/plain');
-        expect(a, isNot(b));
-      });
-
-      test('encodings with different allowReserved are not equal', () {
-        const a = PropertyEncoding(allowReserved: true);
-        const b = PropertyEncoding(allowReserved: false);
+        const b = PartEncoding(
+          contentType: null,
+          rawContentType: 'text/plain',
+          headers: null,
+          style: null,
+          explode: null,
+          allowReserved: null,
+        );
         expect(a, isNot(b));
       });
 
       test('encoding is not equal to non-encoding object', () {
-        const a = PropertyEncoding();
-        expect(a, isNot('not an encoding'));
-      });
-
-      test('encoding is equal to itself', () {
-        const a = PropertyEncoding(
-          style: EncodingStyle.deepObject,
+        const a = PartEncoding(
+          contentType: null,
+          rawContentType: null,
+          headers: null,
+          style: null,
+          explode: null,
+          allowReserved: null,
         );
-        expect(a, a);
+        expect(a, isNot('not an encoding'));
       });
     });
 
     group('toString', () {
       test('includes all fields', () {
-        const encoding = PropertyEncoding(
+        const encoding = PartEncoding(
           contentType: ContentType.json,
           rawContentType: 'application/json',
+          headers: null,
           style: EncodingStyle.form,
           explode: true,
           allowReserved: false,
         );
         final str = encoding.toString();
-        expect(str, contains('PropertyEncoding'));
+        expect(str, contains('PartEncoding'));
         expect(str, contains('application/json'));
         expect(str, contains('EncodingStyle.form'));
         expect(str, contains('explode: true'));
         expect(str, contains('allowReserved: false'));
-      });
-
-      test('includes null fields', () {
-        const encoding = PropertyEncoding();
-        final str = encoding.toString();
-        expect(str, contains('contentType: null'));
-        expect(str, contains('style: null'));
-        expect(str, contains('explode: null'));
-        expect(str, contains('allowReserved: null'));
       });
     });
   });

--- a/packages/tonik_core/test/src/transformer/content_type_normalizer_test.dart
+++ b/packages/tonik_core/test/src/transformer/content_type_normalizer_test.dart
@@ -1045,6 +1045,72 @@ void main() {
 
         expect(content.multipartEncoding, isNotNull);
         expect(content.multipartEncoding, equals(encoding));
+        expect(content.multipartEncoding!.keys.single, same(fileProperty));
+      });
+
+      test('preserves encoding when normalizing form request content', () {
+        final nameProperty = Property(
+          name: 'name',
+          model: StringModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        );
+        final encoding = {
+          nameProperty: const FieldEncoding(
+            allowReserved: true,
+            style: EncodingStyle.form,
+            explode: true,
+          ),
+        };
+
+        final requestBody = RequestBodyObject(
+          name: 'FilterForm',
+          context: context,
+          description: 'Form with encoding',
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'FilterData',
+                properties: [nameProperty],
+                context: context,
+                isDeprecated: false,
+                examples: const [],
+              ),
+              rawContentType: 'application/x-www-form-urlencoded',
+              contentType: ContentType.form,
+              formEncoding: encoding,
+              examples: const [],
+            ),
+          },
+        );
+
+        final document = ApiDocument(
+          title: 'Test API',
+          version: '1.0.0',
+          models: const {},
+          responseHeaders: const {},
+          requestHeaders: const {},
+          servers: const {},
+          operations: const {},
+          responses: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          requestBodies: {requestBody},
+        );
+
+        final transformed = normalizer.apply(document);
+        final transformedBody =
+            transformed.requestBodies.first as RequestBodyObject;
+        final content = transformedBody.content.first;
+
+        expect(content.formEncoding, isNotNull);
+        expect(content.formEncoding, equals(encoding));
+        expect(content.formEncoding!.keys.single, same(nameProperty));
       });
 
       test('logs warning when replacing model for text content type', () {

--- a/packages/tonik_core/test/src/transformer/content_type_normalizer_test.dart
+++ b/packages/tonik_core/test/src/transformer/content_type_normalizer_test.dart
@@ -981,12 +981,23 @@ void main() {
       });
 
       test('preserves encoding when normalizing multipart request content', () {
+        final fileProperty = Property(
+          name: 'file',
+          model: BinaryModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        );
         final encoding = {
-          'file': const PropertyEncoding(
+          fileProperty: const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
+            headers: null,
             style: EncodingStyle.form,
             explode: true,
+            allowReserved: null,
           ),
         };
 
@@ -999,14 +1010,14 @@ void main() {
             RequestContent(
               model: ClassModel(
                 name: 'UploadData',
-                properties: const [],
+                properties: [fileProperty],
                 context: context,
                 isDeprecated: false,
                 examples: const [],
               ),
               rawContentType: 'multipart/form-data',
               contentType: ContentType.multipart,
-              encoding: encoding,
+              multipartEncoding: encoding,
               examples: const [],
             ),
           },
@@ -1032,8 +1043,8 @@ void main() {
             transformed.requestBodies.first as RequestBodyObject;
         final content = transformedBody.content.first;
 
-        expect(content.encoding, isNotNull);
-        expect(content.encoding, equals(encoding));
+        expect(content.multipartEncoding, isNotNull);
+        expect(content.multipartEncoding, equals(encoding));
       });
 
       test('logs warning when replacing model for text content type', () {

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -131,7 +131,7 @@ class DataGenerator {
             final formModel = c.model.resolved;
             final perProperty =
                 formModel is ClassModel &&
-                formBodyHasAllowReserved(c.encoding, formModel);
+                formBodyHasAllowReserved(c.formEncoding, formModel);
             switchCases
               ..add(Code(perProperty ? ' value => ' : ' value => value.'))
               ..add(
@@ -140,7 +140,7 @@ class DataGenerator {
                   c.model,
                   useQueryComponent: true,
                   useImmutableCollections: useImmutableCollections,
-                  encoding: perProperty ? c.encoding : null,
+                  encoding: perProperty ? c.formEncoding : null,
                 ).code,
               )
               ..add(const Code(','));
@@ -291,7 +291,7 @@ class DataGenerator {
           model,
           useQueryComponent: true,
           useImmutableCollections: useImmutableCollections,
-          encoding: content.first.encoding,
+          encoding: content.first.formEncoding,
         );
         bodyCode
           ..clear()

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -110,10 +110,8 @@ Expression? buildFormEntriesValueExpression(
   }
 }
 
-/// Gates the per-property form-body path, which only an `allowReserved` flag
-/// needs. It stays on the byte-identical object-level `body.toForm()` path
-/// unless a writable, emitted property of [model] carries the flag — a flag on
-/// a read-only property has no emitted effect.
+/// True when a writable, emitted property of [model] carries `allowReserved` —
+/// the only case that needs the per-property form-body path.
 bool formBodyHasAllowReserved(
   Map<Property, FieldEncoding>? encoding,
   ClassModel model,

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -115,16 +115,13 @@ Expression? buildFormEntriesValueExpression(
 /// unless a writable, emitted property of [model] carries the flag — a flag on
 /// a read-only property or an unmatched key has no emitted effect.
 bool formBodyHasAllowReserved(
-  Map<String, PropertyEncoding>? encoding,
+  Map<Property, FieldEncoding>? encoding,
   ClassModel model,
 ) {
   if (encoding == null) return false;
-  final emittedNames = {
-    for (final property in model.properties)
-      if (!property.isReadOnly) property.name,
-  };
-  return encoding.entries.any(
-    (e) => (e.value.allowReserved ?? false) && emittedNames.contains(e.key),
+  return model.properties.any(
+    (property) =>
+        !property.isReadOnly && (encoding[property]?.allowReserved ?? false),
   );
 }
 
@@ -139,7 +136,7 @@ bool formBodyHasAllowReserved(
 buildClassFormEntriesExpression(
   Expression receiver,
   ClassModel model,
-  Map<String, PropertyEncoding>? encoding, {
+  Map<Property, FieldEncoding>? encoding, {
   bool useImmutableCollections = false,
 }) {
   final normalizedProps = normalizeProperties(model.properties.toList())
@@ -151,7 +148,7 @@ buildClassFormEntriesExpression(
     final entryCodes = _buildPropertyFormEntry(
       receiver.property(normalizedName),
       property,
-      encoding?[property.name]?.allowReserved ?? false,
+      encoding?[property]?.allowReserved ?? false,
       useImmutableCollections: useImmutableCollections,
     );
     if (entryCodes == null) {

--- a/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/form_entries_expression_builder.dart
@@ -113,7 +113,7 @@ Expression? buildFormEntriesValueExpression(
 /// Gates the per-property form-body path, which only an `allowReserved` flag
 /// needs. It stays on the byte-identical object-level `body.toForm()` path
 /// unless a writable, emitted property of [model] carries the flag — a flag on
-/// a read-only property or an unmatched key has no emitted effect.
+/// a read-only property has no emitted effect.
 bool formBodyHasAllowReserved(
   Map<Property, FieldEncoding>? encoding,
   ClassModel model,

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -235,7 +235,7 @@ void _addMultipartHeaderParameters({
   for (final content in requestBody.resolvedContent) {
     if (content.contentType != ContentType.multipart) continue;
 
-    final encoding = content.encoding;
+    final encoding = content.multipartEncoding;
     if (encoding == null) continue;
 
     // Resolve the model to get properties.
@@ -248,7 +248,7 @@ void _addMultipartHeaderParameters({
     final normalizedProps = normalizeProperties(writeProperties);
 
     for (final (:normalizedName, :property) in normalizedProps) {
-      final propertyEncoding = encoding[property.name];
+      final propertyEncoding = encoding[property];
       final headers = propertyEncoding?.headers;
       if (headers == null || headers.isEmpty) continue;
 

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -11,7 +11,7 @@ BuiltExpression buildToFormValueExpression(
   bool explodeLiteral = true,
   bool allowEmptyLiteral = true,
   bool useImmutableCollections = false,
-  Map<String, PropertyEncoding>? encoding,
+  Map<Property, FieldEncoding>? encoding,
 }) {
   final receiver = refer(valueExpression);
   final resolved = model.resolved;

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -95,7 +95,7 @@ List<Code> _buildMultipartFields(
       bodyAccessor,
       normalizedName,
       isNullable,
-      encoding: content.encoding,
+      encoding: content.multipartEncoding?[property],
     );
 
     if (fieldCode == null) continue;
@@ -121,12 +121,11 @@ Code? _buildFieldCode(
   String bodyAccessor,
   String normalizedName,
   bool isNullable, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? encoding,
 }) {
   final accessor = '$bodyAccessor.$normalizedName${isNullable ? '!' : ''}';
-  final propertyEncoding = encoding?[rawName];
-  final contentType = propertyEncoding?.contentType;
-  final rawContentType = propertyEncoding?.rawContentType;
+  final contentType = encoding?.contentType;
+  final rawContentType = encoding?.rawContentType;
   final effectiveRawContentType =
       rawContentType ??
       'text/plain'; // style-based primitives serialise as plain strings
@@ -134,7 +133,7 @@ Code? _buildFieldCode(
   // Build per-part header statements and variable name (if any).
   final headerResult = _buildHeaderMapStatements(
     normalizedName,
-    propertyEncoding,
+    encoding,
     isPropertyOptional: isNullable,
   );
 
@@ -221,7 +220,7 @@ Code? _buildFieldCode(
     MapModel() => _buildMapModelFileAddition(
       rawName,
       accessor,
-      encoding: encoding,
+      propertyEncoding: encoding,
       headerVarName: headerVarName,
     ),
 
@@ -231,7 +230,7 @@ Code? _buildFieldCode(
     AnyOfModel() => _buildComplexObjectFileAddition(
       rawName,
       accessor,
-      encoding: encoding,
+      propertyEncoding: encoding,
       headerVarName: headerVarName,
     ),
 
@@ -239,7 +238,7 @@ Code? _buildFieldCode(
       rawName,
       accessor,
       resolved,
-      encoding: encoding,
+      propertyEncoding: encoding,
       headerVarName: headerVarName,
     ),
 
@@ -277,7 +276,7 @@ class _HeaderMapResult {
 /// Returns `null` if there are no non-Content-Type headers.
 _HeaderMapResult? _buildHeaderMapStatements(
   String normalizedPropertyName,
-  PropertyEncoding? encoding, {
+  PartEncoding? encoding, {
   bool isPropertyOptional = false,
 }) {
   final headers = encoding?.headers;
@@ -506,10 +505,10 @@ Code _buildAnyModelFileAddition(
 Code _buildBinaryFileAddition(
   String rawName,
   String accessor, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? encoding,
   String? headerVarName,
 }) {
-  final rawContentType = encoding?[rawName]?.rawContentType;
+  final rawContentType = encoding?.rawContentType;
   final isDefaultContentType =
       rawContentType == null || rawContentType == 'application/octet-stream';
 
@@ -582,10 +581,9 @@ Code _buildListFieldAddition(
   String rawName,
   String accessor,
   ListModel listModel, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? propertyEncoding,
   String? headerVarName,
 }) {
-  final propertyEncoding = encoding?[rawName];
   final style = propertyEncoding?.style;
   final contentType = propertyEncoding?.contentType;
 
@@ -636,7 +634,7 @@ Code _buildListFieldAddition(
       refer(accessor),
       _complexItemExpr(
         rawName,
-        encoding: encoding,
+        encoding: propertyEncoding,
         headerVarName: headerVarName,
       ),
       isFile: true,
@@ -719,7 +717,7 @@ Code _buildContentBasedListAddition(
   String rawName,
   String accessor,
   Model contentModel, {
-  PropertyEncoding? propertyEncoding,
+  PartEncoding? propertyEncoding,
   String? headerVarName,
 }) {
   // Array-of-arrays is not supported: the spec recurses into items but there
@@ -952,11 +950,10 @@ switch (item) {
 /// Returns an [Expression] for a complex object item in a for-loop.
 Expression _complexItemExpr(
   String rawName, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? encoding,
   String? headerVarName,
 }) {
-  final rawContentType =
-      encoding?[rawName]?.rawContentType ?? 'application/json';
+  final rawContentType = encoding?.rawContentType ?? 'application/json';
   final namedArgs = <String, Expression>{
     'contentType': refer(
       'DioMediaType',
@@ -1090,11 +1087,9 @@ Code _buildDeepObjectFileAddition(
 Code _buildMapModelFileAddition(
   String rawName,
   String accessor, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? propertyEncoding,
   String? headerVarName,
 }) {
-  final propertyEncoding = encoding?[rawName];
-
   // deepObject is not supported for plain maps.
   if (propertyEncoding?.style == EncodingStyle.deepObject) {
     return generateEncodingExceptionExpression(
@@ -1240,11 +1235,9 @@ Code _buildUrlEncodedMapFileAddition(
 Code _buildComplexObjectFileAddition(
   String rawName,
   String accessor, {
-  Map<String, PropertyEncoding>? encoding,
+  PartEncoding? propertyEncoding,
   String? headerVarName,
 }) {
-  final propertyEncoding = encoding?[rawName];
-
   if (propertyEncoding?.style == EncodingStyle.deepObject) {
     return _buildDeepObjectFileAddition(
       rawName,
@@ -1405,7 +1398,7 @@ typedef MultipartHeaderParamInfo = ({
 List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
   RequestContent content,
 ) {
-  final encoding = content.encoding;
+  final encoding = content.multipartEncoding;
   if (encoding == null) return const [];
 
   final model = content.model.resolved;
@@ -1417,7 +1410,7 @@ List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
   final result = <MultipartHeaderParamInfo>[];
 
   for (final (:normalizedName, :property) in normalizedProps) {
-    final propertyEncoding = encoding[property.name];
+    final propertyEncoding = encoding[property];
     final headers = propertyEncoding?.headers;
     if (headers == null || headers.isEmpty) continue;
 

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1172,10 +1172,10 @@ void main() {
                   contentType: ContentType.form,
                   rawContentType: 'application/x-www-form-urlencoded',
                   examples: const [],
-                  encoding: {
-                    'reserved': const PropertyEncoding(allowReserved: true),
-                    'notReserved': const PropertyEncoding(allowReserved: false),
-                  },
+                  formEncoding: _formEncodingByName(formModel, {
+                    'reserved': _reserved(true),
+                    'notReserved': _reserved(false),
+                  }),
                 ),
               },
             ),
@@ -1263,9 +1263,9 @@ void main() {
                   contentType: ContentType.form,
                   rawContentType: 'application/x-www-form-urlencoded',
                   examples: const [],
-                  encoding: {
-                    'reserved': const PropertyEncoding(allowReserved: true),
-                  },
+                  formEncoding: _formEncodingByName(formModel, {
+                    'reserved': _reserved(true),
+                  }),
                 ),
               },
             ),
@@ -1340,9 +1340,9 @@ void main() {
                   contentType: ContentType.form,
                   rawContentType: 'application/x-www-form-urlencoded',
                   examples: const [],
-                  encoding: {
-                    'name': const PropertyEncoding(allowReserved: false),
-                  },
+                  formEncoding: _formEncodingByName(formModel, {
+                    'name': _reserved(false),
+                  }),
                 ),
               },
             ),
@@ -1411,7 +1411,7 @@ void main() {
             operationId: 'postSecret',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -1482,7 +1482,7 @@ void main() {
             operationId: 'postMeta',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -1562,7 +1562,7 @@ void main() {
             operationId: 'postBad',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -1653,9 +1653,9 @@ void main() {
             operationId: 'postCombo',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
-              'status': const PropertyEncoding(allowReserved: true),
-              'choice': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
+              'status': _reserved(true),
+              'choice': _reserved(true),
             },
             context: testContext,
           );
@@ -1742,7 +1742,7 @@ void main() {
             operationId: 'postEnumOnly',
             model: formModel,
             encoding: {
-              'status': const PropertyEncoding(allowReserved: true),
+              'status': _reserved(true),
             },
             context: testContext,
           );
@@ -1826,7 +1826,7 @@ void main() {
             operationId: 'postCompositionOnly',
             model: formModel,
             encoding: {
-              'choice': const PropertyEncoding(allowReserved: true),
+              'choice': _reserved(true),
             },
             context: testContext,
           );
@@ -1895,7 +1895,7 @@ void main() {
             operationId: 'postSpaced',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -1967,7 +1967,7 @@ void main() {
             operationId: 'postList',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -2037,7 +2037,7 @@ void main() {
             operationId: 'postMap',
             model: formModel,
             encoding: {
-              'reserved': const PropertyEncoding(allowReserved: true),
+              'reserved': _reserved(true),
             },
             context: testContext,
           );
@@ -2094,7 +2094,7 @@ void main() {
             operationId: 'postAnyOnly',
             model: formModel,
             encoding: {
-              'metadata': const PropertyEncoding(allowReserved: true),
+              'metadata': _reserved(true),
             },
             context: testContext,
           );
@@ -2164,7 +2164,7 @@ void main() {
             operationId: 'postReadOnly',
             model: formModel,
             encoding: {
-              'hidden': const PropertyEncoding(allowReserved: true),
+              'hidden': _reserved(true),
             },
             context: testContext,
           );
@@ -2223,7 +2223,7 @@ void main() {
             operationId: 'postCollision',
             model: formModel,
             encoding: {
-              'user_name': const PropertyEncoding(allowReserved: true),
+              'user_name': _reserved(true),
             },
             context: testContext,
           );
@@ -2296,22 +2296,24 @@ void main() {
                 model: userModel,
                 contentType: ContentType.multipart,
                 rawContentType: 'multipart/form-data',
-                encoding: {
-                  'name': const PropertyEncoding(
+                multipartEncoding: _multipartEncodingByName(userModel, {
+                  'name': const PartEncoding(
                     contentType: ContentType.text,
                     rawContentType: 'text/plain',
+                    headers: null,
                     style: EncodingStyle.form,
                     explode: true,
                     allowReserved: false,
                   ),
-                  'nickname': const PropertyEncoding(
+                  'nickname': const PartEncoding(
                     contentType: ContentType.text,
                     rawContentType: 'text/plain',
+                    headers: null,
                     style: EncodingStyle.form,
                     explode: true,
                     allowReserved: false,
                   ),
-                },
+                }),
                 examples: const [],
               ),
             },
@@ -2381,10 +2383,13 @@ void main() {
                   model: uploadModel,
                   contentType: ContentType.multipart,
                   rawContentType: 'multipart/form-data',
-                  encoding: {
-                    'file': PropertyEncoding(
+                  multipartEncoding: _multipartEncodingByName(uploadModel, {
+                    'file': PartEncoding(
                       contentType: ContentType.bytes,
                       rawContentType: 'application/octet-stream',
+                      style: null,
+                      explode: null,
+                      allowReserved: null,
                       headers: {
                         'X-Rate-Limit': ResponseHeaderObject(
                           name: 'X-Rate-Limit',
@@ -2399,7 +2404,7 @@ void main() {
                         ),
                       },
                     ),
-                  },
+                  }),
                   examples: const [],
                 ),
               },
@@ -2487,15 +2492,16 @@ void main() {
                 model: formModel,
                 contentType: ContentType.multipart,
                 rawContentType: 'multipart/form-data',
-                encoding: {
-                  'name': const PropertyEncoding(
+                multipartEncoding: _multipartEncodingByName(formModel, {
+                  'name': const PartEncoding(
                     contentType: ContentType.text,
                     rawContentType: 'text/plain',
+                    headers: null,
                     style: EncodingStyle.form,
                     explode: true,
                     allowReserved: false,
                   ),
-                },
+                }),
                 examples: const [],
               ),
             },
@@ -2749,10 +2755,10 @@ void main() {
                   contentType: ContentType.form,
                   rawContentType: 'application/x-www-form-urlencoded',
                   examples: const [],
-                  encoding: {
-                    'reserved': const PropertyEncoding(allowReserved: true),
-                    'plain': const PropertyEncoding(allowReserved: false),
-                  },
+                  formEncoding: _formEncodingByName(formModel, {
+                    'reserved': _reserved(true),
+                    'plain': _reserved(false),
+                  }),
                 ),
               },
             ),
@@ -2834,15 +2840,16 @@ void main() {
                   model: userModel,
                   contentType: ContentType.multipart,
                   rawContentType: 'multipart/form-data',
-                  encoding: {
-                    'name': const PropertyEncoding(
+                  multipartEncoding: _multipartEncodingByName(userModel, {
+                    'name': const PartEncoding(
                       contentType: ContentType.text,
                       rawContentType: 'text/plain',
+                      headers: null,
                       style: EncodingStyle.form,
                       explode: true,
                       allowReserved: false,
                     ),
-                  },
+                  }),
                   examples: const [],
                 ),
               },
@@ -2925,10 +2932,13 @@ void main() {
                   model: uploadModel,
                   contentType: ContentType.multipart,
                   rawContentType: 'multipart/form-data',
-                  encoding: {
-                    'file': PropertyEncoding(
+                  multipartEncoding: _multipartEncodingByName(uploadModel, {
+                    'file': PartEncoding(
                       contentType: ContentType.bytes,
                       rawContentType: 'application/octet-stream',
+                      style: null,
+                      explode: null,
+                      allowReserved: null,
                       headers: {
                         'X-Checksum': ResponseHeaderObject(
                           name: 'X-Checksum',
@@ -2943,7 +2953,7 @@ void main() {
                         ),
                       },
                     ),
-                  },
+                  }),
                   examples: const [],
                 ),
               },
@@ -3241,10 +3251,33 @@ void main() {
   });
 }
 
+FieldEncoding _reserved(bool allowReserved) =>
+    FieldEncoding(allowReserved: allowReserved, style: null, explode: null);
+
+Map<Property, FieldEncoding> _formEncodingByName(
+  ClassModel model,
+  Map<String, FieldEncoding> byName,
+) {
+  return {
+    for (final entry in byName.entries)
+      model.properties.firstWhere((p) => p.name == entry.key): entry.value,
+  };
+}
+
+Map<Property, PartEncoding> _multipartEncodingByName(
+  ClassModel model,
+  Map<String, PartEncoding> byName,
+) {
+  return {
+    for (final entry in byName.entries)
+      model.properties.firstWhere((p) => p.name == entry.key): entry.value,
+  };
+}
+
 Operation _formOperation({
   required String operationId,
   required ClassModel model,
-  required Map<String, PropertyEncoding> encoding,
+  required Map<String, FieldEncoding> encoding,
   required Context context,
 }) {
   return Operation(
@@ -3262,7 +3295,7 @@ Operation _formOperation({
           contentType: ContentType.form,
           rawContentType: 'application/x-www-form-urlencoded',
           examples: const [],
-          encoding: encoding,
+          formEncoding: _formEncodingByName(model, encoding),
         ),
       },
     ),

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -873,15 +873,16 @@ Future<TonikResult<void>> call({
                 model: multipartModel,
                 contentType: ContentType.multipart,
                 rawContentType: 'multipart/form-data',
-                encoding: {
-                  'name': const PropertyEncoding(
+                multipartEncoding: _multipartEncoding(multipartModel, {
+                  'name': const PartEncoding(
                     contentType: ContentType.text,
                     rawContentType: 'text/plain',
+                    headers: null,
                     style: EncodingStyle.form,
                     explode: true,
                     allowReserved: false,
                   ),
-                },
+                }),
                 examples: const [],
               ),
             },
@@ -3126,6 +3127,24 @@ Future<TonikResult<void>> call({
             defaultValue: 'static-trace-id',
           );
 
+          final uploadModel = ClassModel(
+            name: 'UploadForm',
+            properties: [
+              Property(
+                name: 'file',
+                model: BinaryModel(context: context),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            isDeprecated: false,
+            examples: const [],
+          );
+
           final requestBody = RequestBodyObject(
             name: 'uploadBody',
             context: context,
@@ -3133,29 +3152,16 @@ Future<TonikResult<void>> call({
             isRequired: true,
             content: {
               RequestContent(
-                model: ClassModel(
-                  name: 'UploadForm',
-                  properties: [
-                    Property(
-                      name: 'file',
-                      model: BinaryModel(context: context),
-                      isRequired: true,
-                      isNullable: false,
-                      isDeprecated: false,
-                      examples: const [],
-                      defaultValue: null,
-                    ),
-                  ],
-                  context: context,
-                  isDeprecated: false,
-                  examples: const [],
-                ),
+                model: uploadModel,
                 contentType: ContentType.multipart,
                 rawContentType: 'multipart/form-data',
-                encoding: {
-                  'file': PropertyEncoding(
+                multipartEncoding: _multipartEncoding(uploadModel, {
+                  'file': PartEncoding(
                     contentType: ContentType.bytes,
                     rawContentType: 'application/octet-stream',
+                    style: null,
+                    explode: null,
+                    allowReserved: null,
                     headers: {
                       'X-Trace-Id': ResponseHeaderObject(
                         name: 'X-Trace-Id',
@@ -3170,7 +3176,7 @@ Future<TonikResult<void>> call({
                       ),
                     },
                   ),
-                },
+                }),
                 examples: const [],
               ),
             },
@@ -3562,4 +3568,14 @@ Future<TonikResult<void>> call({
       );
     });
   });
+}
+
+Map<Property, PartEncoding> _multipartEncoding(
+  ClassModel model,
+  Map<String, PartEncoding> byName,
+) {
+  return {
+    for (final entry in byName.entries)
+      model.properties.firstWhere((p) => p.name == entry.key): entry.value,
+  };
 }

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -443,14 +443,7 @@ void main() {
 
   group('multipart per-part header parameters', () {
     test('generates parameter for property with one header', () {
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel1 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -466,11 +459,19 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel1,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel1, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -486,8 +487,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -526,14 +530,7 @@ void main() {
     });
 
     test('generates multiple header parameters for multiple headers', () {
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel2 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -549,11 +546,19 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel2,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel2, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -580,8 +585,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -628,14 +636,7 @@ void main() {
     test(
       'optional property with required header produces optional parameter',
       () {
-        final requestBody = RequestBodyObject(
-          name: 'uploadBody',
-          context: context,
-          description: null,
-          isRequired: true,
-          content: {
-            RequestContent(
-              model: ClassModel(
+        final partModel3 = ClassModel(
                 name: 'UploadForm',
                 properties: [
                   Property(
@@ -651,11 +652,19 @@ void main() {
                 context: context,
                 isDeprecated: false,
                 examples: const [],
-              ),
+              );
+        final requestBody = RequestBodyObject(
+          name: 'uploadBody',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: partModel3,
               contentType: ContentType.multipart,
               rawContentType: 'multipart/form-data',
-              encoding: {
-                'avatar': PropertyEncoding(
+              multipartEncoding: _multipartEncoding(partModel3, {
+                'avatar': PartEncoding(
                   contentType: ContentType.bytes,
                   rawContentType: 'application/octet-stream',
                   headers: {
@@ -671,8 +680,11 @@ void main() {
                       examples: const [],
                     ),
                   },
+                  style: null,
+                  explode: null,
+                  allowReserved: null,
                 ),
-              },
+              }),
               examples: const [],
             ),
           },
@@ -710,14 +722,7 @@ void main() {
     );
 
     test('does not filter out Content-Type header', () {
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel4 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -733,11 +738,19 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel4,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel4, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -764,8 +777,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -802,14 +818,7 @@ void main() {
     });
 
     test('no extra parameters for property without headers', () {
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel5 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -825,15 +834,27 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel5,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'name': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel5, {
+              'name': const PartEncoding(
                 contentType: ContentType.text,
                 rawContentType: 'text/plain',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -871,14 +892,7 @@ void main() {
       // Query param "file_custom" normalizes to "fileCustom".
       // Multipart header "X-Custom" on property "file" also normalizes to
       // "fileCustom". We need unique names.
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel6 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -894,11 +908,19 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel6,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel6, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -914,8 +936,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -972,14 +997,7 @@ void main() {
     });
 
     test('generates deprecated annotation for deprecated multipart header', () {
-      final requestBody = RequestBodyObject(
-        name: 'uploadBody',
-        context: context,
-        description: null,
-        isRequired: true,
-        content: {
-          RequestContent(
-            model: ClassModel(
+      final partModel7 = ClassModel(
               name: 'UploadForm',
               properties: [
                 Property(
@@ -995,11 +1013,19 @@ void main() {
               context: context,
               isDeprecated: false,
               examples: const [],
-            ),
+            );
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: partModel7,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(partModel7, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -1015,8 +1041,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -1093,8 +1122,8 @@ void main() {
             model: bodyModel,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'file': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(bodyModel, {
+              'file': PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
                 headers: {
@@ -1104,8 +1133,11 @@ void main() {
                     header: underlyingHeader,
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           ),
         },
@@ -1159,14 +1191,7 @@ void main() {
           defaultValue: 'static-trace-id',
         );
 
-        final requestBody = RequestBodyObject(
-          name: 'uploadBody',
-          context: context,
-          description: null,
-          isRequired: true,
-          content: {
-            RequestContent(
-              model: ClassModel(
+        final partModel8 = ClassModel(
                 name: 'UploadForm',
                 properties: [
                   Property(
@@ -1182,11 +1207,19 @@ void main() {
                 context: context,
                 isDeprecated: false,
                 examples: const [],
-              ),
+              );
+        final requestBody = RequestBodyObject(
+          name: 'uploadBody',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: partModel8,
               contentType: ContentType.multipart,
               rawContentType: 'multipart/form-data',
-              encoding: {
-                'file': PropertyEncoding(
+              multipartEncoding: _multipartEncoding(partModel8, {
+                'file': PartEncoding(
                   contentType: ContentType.bytes,
                   rawContentType: 'application/octet-stream',
                   headers: {
@@ -1202,8 +1235,11 @@ void main() {
                       examples: const [],
                     ),
                   },
+                  style: null,
+                  explode: null,
+                  allowReserved: null,
                 ),
-              },
+              }),
               examples: const [],
             ),
           },
@@ -2163,4 +2199,14 @@ void main() {
     );
 
   });
+}
+
+Map<Property, PartEncoding> _multipartEncoding(
+  ClassModel model,
+  Map<String, PartEncoding> byName,
+) {
+  return {
+    for (final entry in byName.entries)
+      model.properties.firstWhere((p) => p.name == entry.key): entry.value,
+  };
 }

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -75,15 +75,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'name': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'name': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -132,15 +133,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'name': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'name': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -191,15 +193,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'nickname': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'nickname': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -250,15 +253,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'bio': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'bio': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -299,7 +303,7 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: const {},
+        multipartEncoding: const {},
         examples: const [],
       );
 
@@ -420,15 +424,16 @@ void main() {
         ),
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'title': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(classModel, {
+          'title': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -487,15 +492,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'name': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'name': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -545,15 +551,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'password': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'password': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -602,15 +609,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'data': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'data': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -659,15 +667,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'impossible': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'impossible': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -720,15 +729,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            r'$total': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            r'$total': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -782,15 +792,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'age': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'age': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -839,15 +850,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'score': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'score': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -896,15 +908,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'value': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'value': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -953,15 +966,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'active': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'active': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1010,15 +1024,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'birth_date': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'birth_date': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1067,15 +1082,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'amount': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'amount': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1124,15 +1140,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'website': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'website': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1183,15 +1200,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'created_at': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'created_at': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1243,15 +1261,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1304,15 +1323,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'age': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'age': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1362,15 +1382,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'createdAt': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'createdAt': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1420,15 +1441,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'active': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'active': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1478,15 +1500,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'score': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'score': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -1541,12 +1564,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'name': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'name': const PartEncoding(
               style: EncodingStyle.form,
               explode: true,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1598,12 +1625,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': const PartEncoding(
               style: EncodingStyle.form,
               explode: true,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1655,11 +1686,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'active': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'active': const PartEncoding(
               allowReserved: true,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              style: null,
+              explode: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1711,12 +1747,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'createdAt': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'createdAt': const PartEncoding(
               style: EncodingStyle.form,
               explode: false,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1768,12 +1808,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'value': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'value': const PartEncoding(
               style: EncodingStyle.form,
               explode: true,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1837,12 +1881,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'status': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'status': const PartEncoding(
               style: EncodingStyle.form,
               explode: true,
+              contentType: null,
+              rawContentType: null,
+              headers: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1908,15 +1956,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'status': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'status': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -1980,15 +2029,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -2052,15 +2102,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'status': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'status': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -2124,15 +2175,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -2194,15 +2246,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'status': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'status': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2265,15 +2318,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'status': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'status': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2326,15 +2380,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'avatar': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'avatar': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2394,15 +2449,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'document': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'document': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2464,15 +2520,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'photo': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'photo': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2534,15 +2591,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'image': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'image': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'image/png',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2610,15 +2668,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2680,12 +2739,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'avatar': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'avatar': const PartEncoding(
               contentType: ContentType.bytes,
               rawContentType: 'application/octet-stream',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -2758,15 +2821,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -2832,15 +2896,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2905,15 +2970,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -2978,15 +3044,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -3049,15 +3116,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -3122,15 +3190,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -3195,15 +3264,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/xml',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -3268,15 +3338,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -3339,15 +3410,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -3414,15 +3486,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -3490,15 +3563,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -3566,15 +3640,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -3643,15 +3718,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -3717,13 +3793,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'address': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'address': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
-                // No style/explode/allowReserved → content-based mode
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -3807,12 +3886,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'address': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'address': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -3897,12 +3980,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              "it's-form": const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              "it's-form": const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -3987,12 +4074,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              r'path\form': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              r'path\form': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -4078,12 +4169,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              r'$total': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              r'$total': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -4165,12 +4260,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'address': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'address': const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4255,16 +4354,17 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'address': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'address': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
                 // style/explode present → style-based mode, contentType ignored
                 style: EncodingStyle.form,
                 explode: true,
                 allowReserved: false,
+                headers: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -4333,8 +4433,8 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'address': PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'address': PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
                 headers: {
@@ -4350,8 +4450,11 @@ void main() {
                     examples: const [],
                   ),
                 },
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -4441,15 +4544,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4513,15 +4617,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4650,15 +4755,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4719,15 +4825,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            "it's-meta": const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            "it's-meta": const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.deepObject,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4787,12 +4894,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4874,12 +4985,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -4964,12 +5079,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            "it's-meta": const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            "it's-meta": const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -5052,12 +5171,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            r'path\to': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            r'path\to': const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -5140,12 +5263,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            r'$total': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            r'$total': const PartEncoding(
               contentType: ContentType.form,
               rawContentType: 'application/x-www-form-urlencoded',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -5235,15 +5362,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'metadata': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'metadata': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -5307,15 +5435,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5370,15 +5499,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.spaceDelimited,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5433,15 +5563,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5496,15 +5627,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.spaceDelimited,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5559,15 +5691,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.pipeDelimited,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5623,15 +5756,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.deepObject,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5689,15 +5823,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            "it's-tags": const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            "it's-tags": const PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.deepObject,
               explode: false,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -5767,15 +5902,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'statuses': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'statuses': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5842,15 +5978,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'codes': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'codes': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5907,15 +6044,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'scores': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'scores': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -5970,15 +6108,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'scores': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'scores': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6033,15 +6172,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'scores': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'scores': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6096,15 +6236,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'dates': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'dates': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6159,15 +6300,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'dates': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'dates': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6224,15 +6366,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'files': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'files': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6292,15 +6435,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'files': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'files': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
             explode: false,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6370,15 +6514,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'addresses': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'addresses': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6441,15 +6586,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'addresses': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'addresses': const PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/xml',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6506,15 +6652,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6571,15 +6718,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -6637,12 +6785,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'tags': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'tags': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -6695,12 +6847,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'scores': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'scores': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -6818,12 +6974,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'addresses': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'addresses': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -6876,12 +7036,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'dates': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'dates': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -6934,12 +7098,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'tags': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'tags': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -7000,13 +7168,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'tags': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'tags': const PartEncoding(
                 contentType: ContentType.text,
                 rawContentType: 'text/plain',
-                // No style/explode/allowReserved → falls through to explode: true
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7064,13 +7235,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'scores': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'scores': const PartEncoding(
                 contentType: ContentType.text,
                 rawContentType: 'text/plain',
-                // No style/explode/allowReserved → repeated parts
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7128,13 +7302,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'dates': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'dates': const PartEncoding(
                 contentType: ContentType.text,
                 rawContentType: 'text/plain',
-                // No style/explode/allowReserved → repeated parts
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7204,13 +7381,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'priorities': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'priorities': const PartEncoding(
                 contentType: ContentType.text,
                 rawContentType: 'text/plain',
-                // No style/explode/allowReserved → repeated parts
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7337,13 +7517,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'priorities': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'priorities': const PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
-              // No style fields → content-based mode
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -7402,13 +7585,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'files': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'files': const PartEncoding(
                 contentType: ContentType.bytes,
                 rawContentType: 'application/octet-stream',
-                // No style/explode/allowReserved → content-based mode
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7476,13 +7662,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'matrix': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'matrix': const PartEncoding(
                 contentType: ContentType.json,
                 rawContentType: 'application/json',
-                // No style fields → content-based mode
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7545,12 +7734,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              r'$matrix': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              r'$matrix': const PartEncoding(
                 contentType: ContentType.json,
                 rawContentType: 'application/json',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7609,13 +7802,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              'items': const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              'items': const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
-                // No style fields → content-based mode
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7674,12 +7870,16 @@ void main() {
             model: model,
             contentType: ContentType.multipart,
             rawContentType: 'multipart/form-data',
-            encoding: {
-              "it's-items": const PropertyEncoding(
+            multipartEncoding: _multipartEncoding(model, {
+              "it's-items": const PartEncoding(
                 contentType: ContentType.form,
                 rawContentType: 'application/x-www-form-urlencoded',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
               ),
-            },
+            }),
             examples: const [],
           );
 
@@ -7734,15 +7934,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'name': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'name': const PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
             explode: true,
             allowReserved: false,
+            headers: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -7828,8 +8029,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
@@ -7849,7 +8050,7 @@ void main() {
               ),
             },
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -7911,8 +8112,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             headers: {
@@ -7928,8 +8129,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8001,8 +8205,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'address': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'address': PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             headers: {
@@ -8018,8 +8222,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8077,8 +8284,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'description': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'description': PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             headers: {
@@ -8094,8 +8301,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8151,8 +8361,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               headers: {
@@ -8168,8 +8378,11 @@ void main() {
                   examples: const [],
                 ),
               },
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -8236,8 +8449,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'status': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'status': PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             headers: {
@@ -8253,8 +8466,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8308,8 +8524,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             headers: {
@@ -8325,8 +8541,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8387,8 +8606,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             headers: {
@@ -8415,8 +8634,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8481,12 +8703,16 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': const PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': const PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
+            headers: null,
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8551,8 +8777,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
@@ -8570,8 +8796,9 @@ void main() {
                 examples: const [],
               ),
             },
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8629,8 +8856,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'tags': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'tags': PartEncoding(
             contentType: ContentType.text,
             rawContentType: 'text/plain',
             style: EncodingStyle.form,
@@ -8648,8 +8875,9 @@ void main() {
                 examples: const [],
               ),
             },
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8707,8 +8935,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'files': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'files': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             style: EncodingStyle.form,
@@ -8726,8 +8954,9 @@ void main() {
                 examples: const [],
               ),
             },
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8798,8 +9027,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'addresses': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'addresses': PartEncoding(
             contentType: ContentType.json,
             rawContentType: 'application/json',
             style: EncodingStyle.form,
@@ -8817,8 +9046,9 @@ void main() {
                 examples: const [],
               ),
             },
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8871,8 +9101,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'file': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'file': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             headers: {
@@ -8888,8 +9118,11 @@ void main() {
                 examples: const [],
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -8957,8 +9190,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'file': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'file': PartEncoding(
               contentType: ContentType.bytes,
               rawContentType: 'application/octet-stream',
               headers: {
@@ -8974,8 +9207,11 @@ void main() {
                   examples: const [],
                 ),
               },
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9042,8 +9278,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'data': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'data': PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               headers: {
@@ -9059,8 +9295,11 @@ void main() {
                   examples: const [],
                 ),
               },
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9118,8 +9357,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'count': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'count': PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               headers: {
@@ -9135,8 +9374,11 @@ void main() {
                   examples: const [],
                 ),
               },
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9194,8 +9436,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'createdAt': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'createdAt': PartEncoding(
               contentType: ContentType.json,
               rawContentType: 'application/json',
               headers: {
@@ -9211,8 +9453,11 @@ void main() {
                   examples: const [],
                 ),
               },
+              style: null,
+              explode: null,
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9274,8 +9519,8 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'dates': PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'dates': PartEncoding(
               contentType: ContentType.text,
               rawContentType: 'text/plain',
               style: EncodingStyle.form,
@@ -9293,8 +9538,9 @@ void main() {
                   examples: const [],
                 ),
               },
+              allowReserved: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9361,8 +9607,8 @@ void main() {
         model: model,
         contentType: ContentType.multipart,
         rawContentType: 'multipart/form-data',
-        encoding: {
-          'document': PropertyEncoding(
+        multipartEncoding: _multipartEncoding(model, {
+          'document': PartEncoding(
             contentType: ContentType.bytes,
             rawContentType: 'application/octet-stream',
             headers: {
@@ -9372,8 +9618,11 @@ void main() {
                 header: underlyingHeader,
               ),
             },
+            style: null,
+            explode: null,
+            allowReserved: null,
           ),
-        },
+        }),
         examples: const [],
       );
 
@@ -9440,15 +9689,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            'name': const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            'name': const PartEncoding(
               contentType: ContentType.text,
               rawContentType: "text/it's-plain",
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9500,15 +9750,16 @@ void main() {
           model: model,
           contentType: ContentType.multipart,
           rawContentType: 'multipart/form-data',
-          encoding: {
-            "it's-field": const PropertyEncoding(
+          multipartEncoding: _multipartEncoding(model, {
+            "it's-field": const PartEncoding(
               contentType: ContentType.bytes,
               rawContentType: 'application/octet-stream',
               style: EncodingStyle.form,
               explode: true,
               allowReserved: false,
+              headers: null,
             ),
-          },
+          }),
           examples: const [],
         );
 
@@ -9546,4 +9797,14 @@ void main() {
       },
     );
   });
+}
+
+Map<Property, PartEncoding> _multipartEncoding(
+  ClassModel model,
+  Map<String, PartEncoding> byName,
+) {
+  return {
+    for (final entry in byName.entries)
+      model.properties.firstWhere((p) => p.name == entry.key): entry.value,
+  };
 }

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -297,6 +297,15 @@ class RequestBodyImporter {
         ? {for (final p in resolved.properties) p.name: p}
         : null;
 
+    if (propertiesByName == null && encodingMap.isNotEmpty) {
+      log.warning(
+        'Form-urlencoded body has a non-object schema '
+        '(${resolved.runtimeType}). Its encoding block '
+        '(${encodingMap.keys.join(', ')}) has no fields to describe and '
+        'is ignored.',
+      );
+    }
+
     final result = <core.Property, core.FieldEncoding>{};
     for (final entry in encodingMap.entries) {
       final encoding = entry.value;

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -124,25 +124,26 @@ class RequestBodyImporter {
               context.push('body'),
             );
 
-            final encoding = switch (contentType) {
-              core.ContentType.multipart => _populateMultipartDefaults(
-                name: name,
-                model: model,
-                explicitEncoding: explicitEncoding,
-              ),
-              core.ContentType.form when hasEncoding => _importFormEncoding(
-                mediaType.encoding!,
-                model,
-              ),
-              _ => null,
-            };
+            final formEncoding =
+                contentType == core.ContentType.form && hasEncoding
+                ? _importFormEncoding(mediaType.encoding!, model)
+                : null;
+            final multipartEncoding =
+                contentType == core.ContentType.multipart
+                ? _populateMultipartDefaults(
+                    name: name,
+                    model: model,
+                    explicitEncoding: explicitEncoding,
+                  )
+                : null;
 
             content.add(
               core.RequestContent(
                 model: model,
                 rawContentType: rawContentType,
                 contentType: contentType,
-                encoding: encoding,
+                formEncoding: formEncoding,
+                multipartEncoding: multipartEncoding,
                 examples: exampleImporter.fromMediaType(mediaType),
               ),
             );
@@ -189,10 +190,10 @@ class RequestBodyImporter {
     }
   }
 
-  Map<String, core.PropertyEncoding>? _populateMultipartDefaults({
+  Map<core.Property, core.PartEncoding>? _populateMultipartDefaults({
     required String? name,
     required core.Model model,
-    required Map<String, core.PropertyEncoding>? explicitEncoding,
+    required Map<String, core.PartEncoding>? explicitEncoding,
   }) {
     // Resolve through aliases to find the underlying model
     final resolved = model.resolved;
@@ -222,9 +223,12 @@ class RequestBodyImporter {
       }
     }
 
-    final result = <String, core.PropertyEncoding>{};
+    final result = <core.Property, core.PartEncoding>{};
 
     for (final property in resolved.properties) {
+      // Encoding on a read-only property is meaningless; it is not sent.
+      if (property.isReadOnly) continue;
+
       final existing = explicitEncoding?[property.name];
       final defaultContentType = _resolveDefaultContentType(property.model);
       final defaultRawContentType = _resolveDefaultRawContentType(
@@ -232,7 +236,7 @@ class RequestBodyImporter {
       );
 
       final isStyleBased = existing?.isStyleBased ?? false;
-      result[property.name] = core.PropertyEncoding(
+      result[property] = core.PartEncoding(
         contentType: isStyleBased
             ? null
             : (existing?.contentType ?? defaultContentType),
@@ -281,27 +285,34 @@ class RequestBodyImporter {
 
   /// Unlike the multipart path, no per-property content-type default is
   /// applied, and allowReserved is captured regardless of OpenAPI version.
-  Map<String, core.PropertyEncoding> _importFormEncoding(
+  ///
+  /// Keys that match no property, and read-only properties, are dropped: the
+  /// former have no field to describe, the latter are never sent.
+  Map<core.Property, core.FieldEncoding>? _importFormEncoding(
     Map<String, Encoding> encodingMap,
     core.Model model,
   ) {
     final resolved = model.resolved;
-    final propertyNames = resolved is core.ClassModel
-        ? resolved.properties.map((p) => p.name).toSet()
+    final propertiesByName = resolved is core.ClassModel
+        ? {for (final p in resolved.properties) p.name: p}
         : null;
 
-    final result = <String, core.PropertyEncoding>{};
+    final result = <core.Property, core.FieldEncoding>{};
     for (final entry in encodingMap.entries) {
       final encoding = entry.value;
+      final property = propertiesByName?[entry.key];
 
-      if (propertyNames != null && !propertyNames.contains(entry.key)) {
+      if (propertiesByName != null && property == null) {
         log.warning(
           'Encoding key "${entry.key}" does not match any property '
           'on the form-urlencoded schema. Ignoring.',
         );
+        continue;
       }
 
-      result[entry.key] = core.PropertyEncoding(
+      if (property == null || property.isReadOnly) continue;
+
+      result[property] = core.FieldEncoding(
         style: _mapSerializationStyle(encoding.style),
         explode: encoding.explode,
         allowReserved: encoding.allowReserved ?? false,
@@ -329,11 +340,11 @@ class RequestBodyImporter {
     return headers;
   }
 
-  Map<String, core.PropertyEncoding> _importEncoding(
+  Map<String, core.PartEncoding> _importEncoding(
     Map<String, Encoding> encodingMap,
     core.Context context,
   ) {
-    final result = <String, core.PropertyEncoding>{};
+    final result = <String, core.PartEncoding>{};
     final isOas30 = openApiObject.openapi.startsWith('3.0');
     for (final entry in encodingMap.entries) {
       final propertyName = entry.key;
@@ -361,7 +372,7 @@ class RequestBodyImporter {
                 core.EncodingStyle.form)
           : null;
 
-      result[propertyName] = core.PropertyEncoding(
+      result[propertyName] = core.PartEncoding(
         contentType: useStyleMode ? null : resolvedContentType,
         rawContentType: useStyleMode ? null : encoding.contentType,
         headers: headers,

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -283,11 +283,9 @@ class RequestBodyImporter {
     };
   }
 
-  /// Unlike the multipart path, no per-property content-type default is
-  /// applied, and allowReserved is captured regardless of OpenAPI version.
-  ///
-  /// Keys that match no property, and read-only properties, are dropped: the
-  /// former have no field to describe, the latter are never sent.
+  /// Unmatched keys and read-only properties are dropped: the former have no
+  /// field to describe, the latter are never sent. No per-property content-type
+  /// default is applied, unlike the multipart path.
   Map<core.Property, core.FieldEncoding>? _importFormEncoding(
     Map<String, Encoding> encodingMap,
     core.Model model,

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -2150,7 +2150,12 @@ void main() {
 
       expect(content.contentType, ContentType.form);
       expect(fieldEncodingFor(content, 'name'), isNotNull);
+      expect(content.formEncoding, hasLength(1));
       expect(_propertyNamed(content, 'nonExistent'), isNull);
+      expect(
+        content.formEncoding!.keys.any((p) => p.name == 'nonExistent'),
+        isFalse,
+      );
       expect(
         logs.any(
           (r) =>
@@ -2188,7 +2193,7 @@ void main() {
       );
     });
 
-    test('non-object schema drops encoding without unmatched-key warning', () {
+    test('non-object schema with an encoding block logs a warning', () {
       final logs = <LogRecord>[];
       final sub = Logger.root.onRecord.listen(logs.add);
 
@@ -2219,16 +2224,14 @@ void main() {
         },
       });
 
-      // A non-object schema has no properties to key the descriptor by, so
-      // the encoding map is empty — and no unmatched-key warning fires.
       expect(content.formEncoding, isEmpty);
       expect(
         logs.any(
           (r) =>
               r.level == Level.WARNING &&
-              r.message.contains('form-urlencoded schema'),
+              r.message.contains('non-object schema'),
         ),
-        isFalse,
+        isTrue,
       );
     });
 
@@ -2285,7 +2288,13 @@ void main() {
       expect(content.formEncoding![nameProperty]!.allowReserved, isTrue);
     });
 
-    test('read-only form property is dropped from the encoding map', () {
+    test('read-only form property is dropped from the encoding map '
+        'without a warning', () {
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+
+      addTearDown(sub.cancel);
+
       final content = importFormContent(
         formSpec(
           properties: {
@@ -2302,6 +2311,10 @@ void main() {
       expect(content.formEncoding, hasLength(1));
       expect(fieldEncodingFor(content, 'id'), isNull);
       expect(fieldEncodingFor(content, 'name'), isNotNull);
+      expect(
+        logs.any((r) => r.level == Level.WARNING),
+        isFalse,
+      );
     });
 
     test('form encoding on an alias-chain property keys by declared '

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -877,14 +877,14 @@ void main() {
       expect(content.model, isA<ClassModel>());
 
       // Default encoding should be populated for all properties
-      expect(content.encoding, isNotNull);
-      expect(content.encoding, hasLength(2));
+      expect(content.multipartEncoding, isNotNull);
+      expect(content.multipartEncoding, hasLength(2));
 
-      final fileEncoding = content.encoding!['file']!;
+      final fileEncoding = partEncodingFor(content, 'file')!;
       expect(fileEncoding.contentType, ContentType.bytes);
       expect(fileEncoding.rawContentType, 'application/octet-stream');
 
-      final descriptionEncoding = content.encoding!['description']!;
+      final descriptionEncoding = partEncodingFor(content, 'description')!;
       expect(descriptionEncoding.contentType, ContentType.text);
       expect(descriptionEncoding.rawContentType, 'text/plain');
     });
@@ -925,16 +925,16 @@ void main() {
                 as RequestBodyObject;
 
         final content = body.content.first;
-        expect(content.encoding, isNotNull);
-        expect(content.encoding, hasLength(2));
+        expect(content.multipartEncoding, isNotNull);
+        expect(content.multipartEncoding, hasLength(2));
 
         // format: byte → Base64Model → application/octet-stream (spec-correct)
-        final dataEncoding = content.encoding!['data']!;
+        final dataEncoding = partEncodingFor(content, 'data')!;
         expect(dataEncoding.contentType, ContentType.bytes);
         expect(dataEncoding.rawContentType, 'application/octet-stream');
 
         // plain string → text/plain
-        final nameEncoding = content.encoding!['name']!;
+        final nameEncoding = partEncodingFor(content, 'name')!;
         expect(nameEncoding.contentType, ContentType.text);
         expect(nameEncoding.rawContentType, 'text/plain');
       },
@@ -999,10 +999,10 @@ void main() {
               as RequestBodyObject;
 
       final content = body.content.first;
-      expect(content.encoding, isNotNull);
-      expect(content.encoding, hasLength(3));
+      expect(content.multipartEncoding, isNotNull);
+      expect(content.multipartEncoding, hasLength(3));
 
-      final idEncoding = content.encoding!['id']!;
+      final idEncoding = partEncodingFor(content, 'id')!;
       // OAS 3.1: contentType SHALL be ignored when style fields are present
       expect(idEncoding.contentType, isNull);
       expect(idEncoding.rawContentType, isNull);
@@ -1010,7 +1010,7 @@ void main() {
       expect(idEncoding.explode, isTrue);
       expect(idEncoding.allowReserved, isFalse);
 
-      final addressEncoding = content.encoding!['address']!;
+      final addressEncoding = partEncodingFor(content, 'address')!;
       // OAS 3.1: contentType SHALL be ignored when style fields are present
       expect(addressEncoding.contentType, isNull);
       expect(addressEncoding.rawContentType, isNull);
@@ -1018,7 +1018,7 @@ void main() {
       expect(addressEncoding.explode, isTrue);
       expect(addressEncoding.allowReserved, isFalse);
 
-      final imageEncoding = content.encoding!['profileImage']!;
+      final imageEncoding = partEncodingFor(content, 'profileImage')!;
       expect(imageEncoding.rawContentType, 'image/png');
       expect(imageEncoding.style, isNull);
       expect(imageEncoding.explode, isNull);
@@ -1073,9 +1073,9 @@ void main() {
               as RequestBodyObject;
 
       final content = body.content.first;
-      expect(content.encoding, isNotNull);
+      expect(content.multipartEncoding, isNotNull);
 
-      final fileEncoding = content.encoding!['file']!;
+      final fileEncoding = partEncodingFor(content, 'file')!;
       expect(fileEncoding.contentType, ContentType.bytes);
       expect(fileEncoding.rawContentType, 'application/octet-stream');
       expect(fileEncoding.style, isNull);
@@ -1120,10 +1120,10 @@ void main() {
 
       final content = body.content.first;
       expect(content.contentType, ContentType.multipart);
-      expect(content.encoding, isNotNull);
-      expect(content.encoding, hasLength(1));
+      expect(content.multipartEncoding, isNotNull);
+      expect(content.multipartEncoding, hasLength(1));
 
-      final nameEncoding = content.encoding!['name']!;
+      final nameEncoding = partEncodingFor(content, 'name')!;
       expect(nameEncoding.contentType, ContentType.text);
       expect(nameEncoding.rawContentType, 'text/plain');
       expect(nameEncoding.style, isNull);
@@ -1188,10 +1188,10 @@ void main() {
           ),
         );
 
-        expect(content.encoding, isNotNull);
-        expect(content.encoding, hasLength(1));
+        expect(content.multipartEncoding, isNotNull);
+        expect(content.multipartEncoding, hasLength(1));
 
-        final encoding = content.encoding!['name']!;
+        final encoding = partEncodingFor(content, 'name')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
         expect(encoding.style, isNull);
@@ -1208,7 +1208,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['count']!;
+        final encoding = partEncodingFor(content, 'count')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
         expect(encoding.style, isNull);
@@ -1225,7 +1225,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['active']!;
+        final encoding = partEncodingFor(content, 'active')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1239,7 +1239,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['file']!;
+        final encoding = partEncodingFor(content, 'file')!;
         expect(encoding.contentType, ContentType.bytes);
         expect(encoding.rawContentType, 'application/octet-stream');
         expect(encoding.style, isNull);
@@ -1261,7 +1261,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['address']!;
+        final encoding = partEncodingFor(content, 'address')!;
         expect(encoding.contentType, ContentType.json);
         expect(encoding.rawContentType, 'application/json');
       });
@@ -1281,7 +1281,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         expect(encoding.contentType, ContentType.json);
         expect(encoding.rawContentType, 'application/json');
       });
@@ -1303,7 +1303,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['items']!;
+        final encoding = partEncodingFor(content, 'items')!;
         expect(encoding.contentType, ContentType.json);
         expect(encoding.rawContentType, 'application/json');
       });
@@ -1320,7 +1320,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['tags']!;
+        final encoding = partEncodingFor(content, 'tags')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1340,7 +1340,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['matrix']!;
+        final encoding = partEncodingFor(content, 'matrix')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1361,7 +1361,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['values']!;
+        final encoding = partEncodingFor(content, 'values')!;
         expect(encoding.contentType, ContentType.json);
         expect(encoding.rawContentType, 'application/json');
       });
@@ -1378,7 +1378,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['label']!;
+        final encoding = partEncodingFor(content, 'label')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1395,7 +1395,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['status']!;
+        final encoding = partEncodingFor(content, 'status')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1422,7 +1422,7 @@ void main() {
             ),
           );
 
-          final encoding = content.encoding!['data']!;
+          final encoding = partEncodingFor(content, 'data')!;
           // OAS 3.1: when style fields are present, contentType SHALL be
           // ignored
           expect(encoding.rawContentType, isNull);
@@ -1457,7 +1457,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // contentType is preserved (not affected by version)
         expect(encoding.rawContentType, 'application/xml');
         // OAS 3.0 always uses content-based mode: style fields are null
@@ -1485,7 +1485,7 @@ void main() {
             ),
           );
 
-          final encoding = content.encoding!['data']!;
+          final encoding = partEncodingFor(content, 'data')!;
           expect(encoding.rawContentType, 'application/xml');
           // No style fields set → content-based mode
           expect(encoding.style, isNull);
@@ -1511,7 +1511,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // explode explicitly set → style-based mode with defaults filled
         expect(encoding.style, EncodingStyle.form);
         expect(encoding.explode, isFalse);
@@ -1535,7 +1535,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // explode explicitly set to true (even though it's the form default)
         // still triggers style-based mode
         expect(encoding.style, EncodingStyle.form);
@@ -1560,7 +1560,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // allowReserved explicitly set → style-based mode with defaults filled
         expect(encoding.style, EncodingStyle.form);
         expect(encoding.explode, isTrue);
@@ -1585,7 +1585,7 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // form style → explode defaults to true per OAS spec
         expect(encoding.style, EncodingStyle.form);
         expect(encoding.explode, isTrue);
@@ -1610,11 +1610,49 @@ void main() {
           ),
         );
 
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         // non-form style → explode defaults to false per OAS spec
         expect(encoding.style, EncodingStyle.deepObject);
         expect(encoding.explode, isFalse);
         expect(encoding.allowReserved, isFalse);
+      });
+
+      test('multipart encoding map is keyed by the declared Property '
+          'instance', () {
+        final content = importMultipartContent(
+          multipartSpec(
+            properties: {
+              'name': {'type': 'string'},
+            },
+          ),
+        );
+
+        final classModel = content.model.resolved as ClassModel;
+        final nameProperty = classModel.properties.single;
+        expect(content.multipartEncoding!.keys.single, same(nameProperty));
+      });
+
+      test('multipart encoding on an alias-chain property keys by declared '
+          'Property', () {
+        final content = importMultipartContent(
+          multipartSpec(
+            properties: {
+              'label': {r'$ref': '#/components/schemas/MyString'},
+            },
+            schemas: {
+              'MyString': {'type': 'string'},
+            },
+          ),
+        );
+
+        final classModel = content.model.resolved as ClassModel;
+        final labelProperty = classModel.properties.single;
+        expect(labelProperty.model, isA<AliasModel>());
+        expect(content.multipartEncoding!.keys.single, same(labelProperty));
+        expect(
+          content.multipartEncoding![labelProperty]!.contentType,
+          ContentType.text,
+        );
       });
 
       test('mixed map: style-based property and content-based property '
@@ -1637,21 +1675,21 @@ void main() {
         );
 
         // 'styled' has explicit style → style-based mode
-        final styledEncoding = content.encoding!['styled']!;
+        final styledEncoding = partEncodingFor(content, 'styled')!;
         expect(styledEncoding.style, EncodingStyle.deepObject);
         expect(styledEncoding.explode, isFalse);
         expect(styledEncoding.allowReserved, isFalse);
         expect(styledEncoding.isStyleBased, isTrue);
 
         // 'plain' has no explicit encoding → content-based mode
-        final plainEncoding = content.encoding!['plain']!;
+        final plainEncoding = partEncodingFor(content, 'plain')!;
         expect(plainEncoding.style, isNull);
         expect(plainEncoding.explode, isNull);
         expect(plainEncoding.allowReserved, isNull);
         expect(plainEncoding.isStyleBased, isFalse);
       });
 
-      test('readOnly properties are included in encoding map', () {
+      test('readOnly properties are dropped from encoding map', () {
         final content = importMultipartContent(
           multipartSpec(
             properties: {
@@ -1664,9 +1702,9 @@ void main() {
           ),
         );
 
-        expect(content.encoding, hasLength(2));
-        expect(content.encoding!['id'], isNotNull);
-        expect(content.encoding!['name'], isNotNull);
+        expect(content.multipartEncoding, hasLength(1));
+        expect(partEncodingFor(content, 'id'), isNull);
+        expect(partEncodingFor(content, 'name'), isNotNull);
       });
 
       test('writeOnly properties are included in encoding map', () {
@@ -1681,16 +1719,10 @@ void main() {
           ),
         );
 
-        expect(content.encoding, hasLength(1));
-        expect(content.encoding!['password'], isNotNull);
-        expect(
-          content.encoding!['password']!.contentType,
-          ContentType.text,
-        );
-        expect(
-          content.encoding!['password']!.rawContentType,
-          'text/plain',
-        );
+        expect(content.multipartEncoding, hasLength(1));
+        final password = partEncodingFor(content, 'password')!;
+        expect(password.contentType, ContentType.text);
+        expect(password.rawContentType, 'text/plain');
       });
 
       test(
@@ -1704,7 +1736,7 @@ void main() {
             ),
           );
 
-          final encoding = content.encoding!['encoded']!;
+          final encoding = partEncodingFor(content, 'encoded')!;
           expect(encoding.contentType, ContentType.bytes);
           expect(encoding.rawContentType, 'application/octet-stream');
         },
@@ -1721,7 +1753,7 @@ void main() {
             },
           ),
         );
-        final encoding = content.encoding!['data']!;
+        final encoding = partEncodingFor(content, 'data')!;
         expect(encoding.contentType, ContentType.text);
         expect(encoding.rawContentType, 'text/plain');
       });
@@ -1739,7 +1771,7 @@ void main() {
               },
             ),
           );
-          final encoding = content.encoding!['data']!;
+          final encoding = partEncodingFor(content, 'data')!;
           expect(encoding.contentType, ContentType.bytes);
           expect(encoding.rawContentType, 'application/octet-stream');
         },
@@ -1779,7 +1811,7 @@ void main() {
 
         final content = body.content.first;
         expect(content.contentType, ContentType.form);
-        expect(content.encoding, isNull);
+        expect(content.formEncoding, isNull);
       });
 
       test('encoding keys not matching any property log warning '
@@ -1801,9 +1833,9 @@ void main() {
           ),
         );
 
-        expect(content.encoding, hasLength(1));
-        expect(content.encoding!['name'], isNotNull);
-        expect(content.encoding!.containsKey('nonExistent'), isFalse);
+        expect(content.multipartEncoding, hasLength(1));
+        expect(partEncodingFor(content, 'name'), isNotNull);
+        expect(_propertyNamed(content, 'nonExistent'), isNull);
         expect(
           logs.any(
             (r) =>
@@ -1830,15 +1862,15 @@ void main() {
           ),
         );
 
-        expect(content.encoding, hasLength(4));
-        expect(content.encoding!['name']!.contentType, ContentType.text);
-        expect(content.encoding!['age']!.contentType, ContentType.text);
+        expect(content.multipartEncoding, hasLength(4));
+        expect(partEncodingFor(content, 'name')!.contentType, ContentType.text);
+        expect(partEncodingFor(content, 'age')!.contentType, ContentType.text);
         expect(
-          content.encoding!['photo']!.contentType,
+          partEncodingFor(content, 'photo')!.contentType,
           ContentType.bytes,
         );
         expect(
-          content.encoding!['metadata']!.contentType,
+          partEncodingFor(content, 'metadata')!.contentType,
           ContentType.json,
         );
       });
@@ -1877,7 +1909,7 @@ void main() {
                 as RequestBodyObject;
 
         final content = body.content.first;
-        expect(content.encoding, isNull);
+        expect(content.multipartEncoding, isNull);
         expect(
           logs.any(
             (r) =>
@@ -1982,13 +2014,12 @@ void main() {
       );
 
       expect(content.contentType, ContentType.form);
-      expect(content.encoding, isNotNull);
-      expect(content.encoding, hasLength(1));
-      final filterEncoding = content.encoding!['filter']!;
+      expect(content.formEncoding, isNotNull);
+      expect(content.formEncoding, hasLength(1));
+      final filterEncoding = fieldEncodingFor(content, 'filter')!;
       expect(filterEncoding.allowReserved, isTrue);
       expect(filterEncoding.style, isNull);
       expect(filterEncoding.explode, isNull);
-      expect(filterEncoding.headers, isNull);
     });
 
     test('encoding is null when no encoding object is present', () {
@@ -2001,7 +2032,7 @@ void main() {
       );
 
       expect(content.contentType, ContentType.form);
-      expect(content.encoding, isNull);
+      expect(content.formEncoding, isNull);
     });
 
     test(
@@ -2018,7 +2049,7 @@ void main() {
           ),
         );
 
-        expect(content.encoding!['name']!.allowReserved, isFalse);
+        expect(fieldEncodingFor(content, 'name')!.allowReserved, isFalse);
       },
     );
 
@@ -2035,7 +2066,7 @@ void main() {
         ),
       );
 
-      expect(content.encoding!['filter']!.allowReserved, isTrue);
+      expect(fieldEncodingFor(content, 'filter')!.allowReserved, isTrue);
     });
 
     test('captures allowReserved true under OAS 3.1', () {
@@ -2050,7 +2081,7 @@ void main() {
         ),
       );
 
-      expect(content.encoding!['filter']!.allowReserved, isTrue);
+      expect(fieldEncodingFor(content, 'filter')!.allowReserved, isTrue);
     });
 
     test('does not apply multipart per-property content type defaults', () {
@@ -2071,11 +2102,11 @@ void main() {
         ),
       );
 
-      expect(content.encoding, hasLength(1));
-      final nameEncoding = content.encoding!['name']!;
-      expect(nameEncoding.contentType, isNull);
-      expect(nameEncoding.rawContentType, isNull);
-      expect(content.encoding!.containsKey('meta'), isFalse);
+      expect(content.formEncoding, hasLength(1));
+      expect(fieldEncodingFor(content, 'name'), isNotNull);
+      final metaProperty = _propertyNamed(content, 'meta');
+      expect(metaProperty, isNotNull);
+      expect(content.formEncoding!.containsKey(metaProperty), isFalse);
     });
 
     test('captures style and explode from encoding object', () {
@@ -2093,7 +2124,7 @@ void main() {
         ),
       );
 
-      final idsEncoding = content.encoding!['ids']!;
+      final idsEncoding = fieldEncodingFor(content, 'ids')!;
       expect(idsEncoding.style, EncodingStyle.spaceDelimited);
       expect(idsEncoding.explode, isFalse);
       expect(idsEncoding.allowReserved, isFalse);
@@ -2118,7 +2149,8 @@ void main() {
       );
 
       expect(content.contentType, ContentType.form);
-      expect(content.encoding!['name'], isNotNull);
+      expect(fieldEncodingFor(content, 'name'), isNotNull);
+      expect(_propertyNamed(content, 'nonExistent'), isNull);
       expect(
         logs.any(
           (r) =>
@@ -2145,7 +2177,7 @@ void main() {
         ),
       );
 
-      expect(content.encoding!['name']!.allowReserved, isTrue);
+      expect(fieldEncodingFor(content, 'name')!.allowReserved, isTrue);
       expect(
         logs.any(
           (r) =>
@@ -2156,33 +2188,7 @@ void main() {
       );
     });
 
-    test('form-urlencoded ignores encoding object headers', () {
-      final content = importFormContent(
-        formSpec(
-          properties: {
-            'name': {'type': 'string'},
-          },
-          encoding: {
-            'name': {
-              'headers': {
-                'X-Custom': {r'$ref': '#/components/headers/X-Custom'},
-              },
-            },
-          },
-          headers: {
-            'X-Custom': {
-              'description': 'A custom header',
-              'schema': {'type': 'string'},
-            },
-          },
-        ),
-      );
-
-      expect(content.encoding!['name']!.headers, isNull);
-    });
-
-    test('non-object schema captures encoding without unmatched-key warning',
-        () {
+    test('non-object schema drops encoding without unmatched-key warning', () {
       final logs = <LogRecord>[];
       final sub = Logger.root.onRecord.listen(logs.add);
 
@@ -2213,8 +2219,9 @@ void main() {
         },
       });
 
-      expect(content.encoding!['ids'], isNotNull);
-      expect(content.encoding!['ids']!.allowReserved, isTrue);
+      // A non-object schema has no properties to key the descriptor by, so
+      // the encoding map is empty — and no unmatched-key warning fires.
+      expect(content.formEncoding, isEmpty);
       expect(
         logs.any(
           (r) =>
@@ -2237,12 +2244,12 @@ void main() {
         ),
       );
 
-      expect(content.encoding, hasLength(1));
-      final nameEncoding = content.encoding!['name']!;
+      expect(content.formEncoding, hasLength(1));
+      final nameEncoding = fieldEncodingFor(content, 'name')!;
       expect(nameEncoding.style, isNull);
     });
 
-    test('explicit contentType is not captured on the form path', () {
+    test('form encoding captures the property with default field values', () {
       final content = importFormContent(
         formSpec(
           properties: {
@@ -2254,9 +2261,104 @@ void main() {
         ),
       );
 
-      final nameEncoding = content.encoding!['name']!;
-      expect(nameEncoding.contentType, isNull);
-      expect(nameEncoding.rawContentType, isNull);
+      final nameEncoding = fieldEncodingFor(content, 'name')!;
+      expect(nameEncoding.allowReserved, isFalse);
+      expect(nameEncoding.style, isNull);
+      expect(nameEncoding.explode, isNull);
+    });
+
+    test('form encoding map is keyed by the declared Property instance', () {
+      final content = importFormContent(
+        formSpec(
+          properties: {
+            'name': {'type': 'string'},
+          },
+          encoding: {
+            'name': {'allowReserved': true},
+          },
+        ),
+      );
+
+      final classModel = content.model.resolved as ClassModel;
+      final nameProperty = classModel.properties.single;
+      expect(content.formEncoding!.keys.single, same(nameProperty));
+      expect(content.formEncoding![nameProperty]!.allowReserved, isTrue);
+    });
+
+    test('read-only form property is dropped from the encoding map', () {
+      final content = importFormContent(
+        formSpec(
+          properties: {
+            'id': {'type': 'string', 'readOnly': true},
+            'name': {'type': 'string'},
+          },
+          encoding: {
+            'id': {'allowReserved': true},
+            'name': {'allowReserved': true},
+          },
+        ),
+      );
+
+      expect(content.formEncoding, hasLength(1));
+      expect(fieldEncodingFor(content, 'id'), isNull);
+      expect(fieldEncodingFor(content, 'name'), isNotNull);
+    });
+
+    test('form encoding on an alias-chain property keys by declared '
+        'Property', () {
+      final content = importFormContent({
+        'openapi': '3.1.0',
+        'info': {'title': 'Test', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'MyString': {'type': 'string'},
+          },
+          'requestBodies': {
+            'FormBody': {
+              'description': 'Form body',
+              'required': true,
+              'content': {
+                'application/x-www-form-urlencoded': {
+                  'schema': {
+                    'type': 'object',
+                    'properties': {
+                      'label': {r'$ref': '#/components/schemas/MyString'},
+                    },
+                  },
+                  'encoding': {
+                    'label': {'allowReserved': true},
+                  },
+                },
+              },
+            },
+          },
+        },
+      });
+
+      final classModel = content.model.resolved as ClassModel;
+      final labelProperty = classModel.properties.single;
+      expect(labelProperty.model, isA<AliasModel>());
+      expect(content.formEncoding!.keys.single, same(labelProperty));
+      expect(content.formEncoding![labelProperty]!.allowReserved, isTrue);
     });
   });
+}
+
+Property? _propertyNamed(RequestContent content, String name) {
+  final resolved = content.model.resolved;
+  if (resolved is! ClassModel) return null;
+  return resolved.properties.firstWhereOrNull((p) => p.name == name);
+}
+
+PartEncoding? partEncodingFor(RequestContent content, String name) {
+  final property = _propertyNamed(content, name);
+  if (property == null) return null;
+  return content.multipartEncoding?[property];
+}
+
+FieldEncoding? fieldEncodingFor(RequestContent content, String name) {
+  final property = _propertyNamed(content, name);
+  if (property == null) return null;
+  return content.formEncoding?[property];
 }


### PR DESCRIPTION
## What

Replace the string-keyed `RequestContent.encoding` side-map (`Map<String, PropertyEncoding>?`) with two identity-keyed, consumer-shaped descriptors resolved once in the parser:

- `Map<Property, FieldEncoding>? formEncoding` — form bodies (lean: `allowReserved` / `style` / `explode`)
- `Map<Property, PartEncoding>? multipartEncoding` — multipart (`contentType` / `headers` / style)

`PropertyEncoding` is split into these two types.

## Why

The old map was keyed by raw property-name strings, disconnected from the `ClassModel.properties` it describes. Generators were forced to re-derive the association — string-matching encoding keys to properties and re-deciding read-only filtering — which is brittle and easy to drift. Now the parser resolves each Encoding Object key to its `Property` once (warning and dropping unmatched keys, dropping read-only properties, keeping `additionalProperties` a first-class decision), and every consumer looks up by `Property` identity.

## Scope

Pure data-contract reshape. **No wire-behavior change** — generated output and integration-test request bodies are byte-identical (integration regeneration produced no diff). Runtime interfaces and package versions are untouched.

## Verification

- `dart analyze` (packages + integration_test): clean
- Unit tests: 5110 passed across all five packages
- Integration: regeneration byte-identical; all 78 suites pass (incl. form_urlencoded + multipart)
- Patch coverage: 100%
