### PR TITLE
fix!: percent-encode object property keys in form explode:false encoding

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
@@ -61,6 +61,23 @@ void main() {
       final success = result as TonikSuccess;
       expect(success.response.statusCode, 200);
     });
+
+    test('getQueryAnyNoExplode percent-encodes object keys, commas literal',
+        () async {
+      final api = buildApi();
+      final result = await api.getQueryAnyNoExplode(
+        anyValue: <String, dynamic>{
+          'first name': 'Jane',
+          'a,b': 'v1',
+          'c&d': 'v2',
+        },
+      );
+      final success = result as TonikSuccess;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=first%20name,Jane,a%2Cb,v1,c%26d,v2',
+      );
+    });
   });
 
   group('Query parameters - spaceDelimited style', () {

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -122,6 +122,12 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/Class'
+        - name: reservedKeys
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/ReservedKeys'
         - name: classNested
           in: query
           style: form
@@ -1753,6 +1759,25 @@ components:
           type: string
         age:
           type: integer
+    ReservedKeys:
+      type: object
+      required:
+        - first name
+        - last name
+        - a,b
+        - c&d
+        - p%20q
+      properties:
+        first name:
+          type: string
+        last name:
+          type: string
+        a,b:
+          type: string
+        c&d:
+          type: string
+        p%20q:
+          type: string
     ClassNested:
       type: object
       required:

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -141,6 +141,28 @@ void main() {
       );
     });
 
+    test('reservedKeys percent-encodes property keys, commas stay literal',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormComplex(
+        reservedKeys: const ReservedKeys(
+          firstName: 'Jane',
+          lastName: 'Doe',
+          ab: 'v1',
+          cAmpersandD: 'v2',
+          pPercentQ20: 'v3',
+        ),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'reservedKeys=first%20name,Jane,last%20name,Doe,a%2Cb,v1,c%26d,v2,'
+        'p%2520q,v3',
+      );
+    });
+
     test('classNested', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormComplex(

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -262,7 +262,6 @@ extension FormStringMapEncoder on Map<String, String> {
           value: uriEncode(
             allowEmpty: allowEmpty,
             alreadyEncoded: alreadyEncoded,
-            encodeKeys: false,
             useQueryComponent: useQueryComponent,
             allowReserved: allowReserved,
           ),

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -219,7 +219,6 @@ extension StringMapUriEncoder on Map<String, String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
-    bool encodeKeys = true,
     bool allowReserved = false,
   }) {
     if (isEmpty && !allowEmpty) {
@@ -239,7 +238,7 @@ extension StringMapUriEncoder on Map<String, String> {
     return entries
         .expand(
           (e) => [
-            if (encodeKeys) encode(e.key) else e.key,
+            encode(e.key),
             if (alreadyEncoded) e.value else encode(e.value),
           ],
         )

--- a/packages/tonik_util/test/form_encoder_decoder_round_trip_test.dart
+++ b/packages/tonik_util/test/form_encoder_decoder_round_trip_test.dart
@@ -374,19 +374,14 @@ void main() {
         expect(parts, containsAll(['name', 'John', 'age', '25']));
       });
 
-      test('map with special characters', () {
+      test('map with special characters encodes keys and values', () {
         const original = {'key=name': 'value&data', 'other+key': 'more data'};
         final encoded = original
             .toForm('p', explode: false, allowEmpty: true)
             .single
             .value;
 
-        // Verify that values are properly encoded (keys are not encoded in
-        // explode=false)
-        expect(encoded, contains('key=name'));
-        expect(encoded, contains('value%26data'));
-        expect(encoded, contains('other+key'));
-        expect(encoded, contains('more%20data'));
+        expect(encoded, 'key%3Dname,value%26data,other%2Bkey,more%20data');
       });
     });
 

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1296,6 +1296,22 @@ void main() {
         );
       });
 
+      test('explode=false percent-encodes reserved-char keys, commas stay '
+          'literal', () {
+        expect(
+          encodeAnyToForm(
+            <String, dynamic>{
+              'first name': 'Jane',
+              'a,b': 'v1',
+              'c&d': 'v2',
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'first%20name,Jane,a%2Cb,v1,c%26d,v2',
+        );
+      });
+
       test('uses + for spaces with useQueryComponent=true', () {
         expect(
           encodeAnyToForm(

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -386,6 +386,64 @@ void main() {
       );
     });
 
+    test('explode=false percent-encodes reserved-char keys, commas stay '
+        'literal', () {
+      expect(
+        {
+          'first name': 'Jane',
+          'last name': 'Doe',
+          'a,b': 'v1',
+          'c&d': 'v2',
+          'p%20q': 'v3',
+        }.toForm('p', explode: false, allowEmpty: true),
+        const <ParameterEntry>[
+          (
+            name: 'p',
+            value: 'first%20name,Jane,last%20name,Doe,a%2Cb,v1,c%26d,v2,'
+                'p%2520q,v3',
+          ),
+        ],
+      );
+    });
+
+    test('explode=false encodes reserved-char keys with + when '
+        'useQueryComponent=true', () {
+      expect(
+        {
+          'first name': 'Jane',
+          'a,b': 'v1',
+        }.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: 'first+name,Jane,a%2Cb,v1'),
+        ],
+      );
+    });
+
+    test('explode=false keeps reserved chars in keys literal except & = + '
+        'when allowReserved=true', () {
+      expect(
+        {
+          'a&b': 'v1',
+          'c=d': 'v2',
+          'e:f': 'v3',
+          'g+h': 'v4',
+        }.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[
+          (name: 'p', value: 'a%26b,v1,c%3Dd,v2,e:f,v3,g%2Bh,v4'),
+        ],
+      );
+    });
+
     test('does not re-encode values when alreadyEncoded=true', () {
       expect(
         {
@@ -721,16 +779,16 @@ void main() {
       );
     });
 
-    test('map explode=false keeps reserved literal in values, keys '
-        'untouched', () {
+    test('map explode=false keeps reserved literal in keys and values, encodes '
+        '& = +', () {
       expect(
-        {'a:b': 'c=d'}.toForm(
+        {'a:b': 'c=d', 'e&f': 'g:h'}.toForm(
           'p',
           explode: false,
           allowEmpty: true,
           allowReserved: true,
         ),
-        const <ParameterEntry>[(name: 'p', value: 'a:b,c%3Dd')],
+        const <ParameterEntry>[(name: 'p', value: 'a:b,c%3Dd,e%26f,g:h')],
       );
     });
 
@@ -752,7 +810,12 @@ void main() {
           (
             name: 'p',
             value: map.entries
-                .expand((e) => [e.key, Uri.encodeComponent(e.value)])
+                .expand(
+                  (e) => [
+                    Uri.encodeComponent(e.key),
+                    Uri.encodeComponent(e.value),
+                  ],
+                )
                 .join(','),
           ),
         ],

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -420,17 +420,6 @@ void main() {
       );
     });
 
-    test('map encodeKeys false leaves keys untouched under allowReserved', () {
-      expect(
-        {'a&b': 'c=d'}.uriEncode(
-          allowEmpty: true,
-          allowReserved: true,
-          encodeKeys: false,
-        ),
-        'a&b,c%3Dd',
-      );
-    });
-
     test('map default is byte-identical to encodeComponent per key/value', () {
       const map = {'a&b': 'c:d', 'e=f': 'g+h'};
       expect(


### PR DESCRIPTION
## Summary

For a form-style, `explode: false` object parameter, the RFC 6570 expansion is `key,value,key,value`, and §3.2.1 requires **both** names and values to be encoded the same way as simple strings. The generated client percent-encoded the property **values** but emitted the property **keys** verbatim. Because `toForm` output is the final wire encoding (passed straight to `Uri.replace(query:)`, which is a no-op on valid escapes), raw keys reached the wire unencoded — so a key containing a reserved character broke the request:

- a key with `&` or `=` split the query into a second, bogus parameter;
- a key with `,` dissolved into the pair delimiters, shifting the name/value pairing;
- a key that looked like a percent-escape (`p%20q`) was silently decoded to a different name by the server.

The fix encodes keys in the `explode: false` map path (the `explode: true` branch and the `toSimple`/`toLabel`/`toMatrix` object paths already encoded keys) and removes the now-dead `encodeKeys` parameter from `StringMapUriEncoder.uriEncode`. This is a runtime-only change in `tonik_util`; generated code is unchanged.

Example wire output for spec property names `first name`, `last name`, `a,b`, `c&d`, `p%20q`:

```
before: filter=first%20name,Jane,last%20name,Doe,a,b,v1,c&d,v2,p%20q,v3
after:  filter=first%20name,Jane,last%20name,Doe,a%2Cb,v1,c%26d,v2,p%2520q,v3
```

## Standard

- RFC 6570 §3.2.1 — associative arrays: "Both name and value strings are encoded in the same way as simple string values."
- RFC 6570 §3.2.8 / RFC 3986 §3.4 — the query component permits only the unreserved set literally; everything else is percent-encoded. OpenAPI `form` style defers serialization to RFC 6570.

## Testing

- Unit (`tonik_util`): `explode: false` object encoding with reserved-character keys, asserting full `ParameterEntry` output — covering the query mode (`%20`), the urlencoded-body mode (`useQueryComponent: true`, `+`), and a direct `allowReserved: true` case. The special-characters round-trip test now decodes back to the original map instead of asserting fragments.
- Integration (`query_parameters`): a `form`/`explode: false` object query parameter whose schema has reserved-character property names, asserting the exact encoded wire query; plus a freeform-object (`Any`) query parameter exercising the same map path (`boolean_schemas`).

## Notes

- **`allowReserved` on keys (follow-up):** property keys are always percent-encoded regardless of the parameter's `allowReserved` setting. Threading `allowReserved` through to key encoding is cross-cutting across every composite object path (class/allOf/oneOf/anyOf) and is deferred to a dedicated change; over-encoding a key is safe because it round-trips.
- **Urlencoded body coverage:** an `explode: false` object cannot currently be produced inside an `application/x-www-form-urlencoded` body (nested-object body properties are unsupported, and a whole-body freeform object is always `explode: true`), so the body runtime path is covered by unit tests rather than an end-to-end integration test.
