### PR TITLE
fix: throw InvalidFormatException on offset-path parse errors and report original input

### DIFF
--- a/integration_test/defaulted/defaulted_test/test/defaulted_test.dart
+++ b/integration_test/defaulted/defaulted_test/test/defaulted_test.dart
@@ -569,10 +569,7 @@ void main() {
   });
 
   group('BadlyDefaulted — runtime fallback validates on access', () {
-    // OffsetDateTime.parse rewrites the first space to T before reporting,
-    // so the spec literal `"not a date"` reaches InvalidFormatException.value
-    // as `"notTa date"`.
-    const offendingValue = 'notTa date';
+    const offendingValue = 'not a date';
 
     test(
       'the static getter throws an InvalidFormatException whose structured '

--- a/packages/tonik_util/lib/src/offset_date_time.dart
+++ b/packages/tonik_util/lib/src/offset_date_time.dart
@@ -35,8 +35,9 @@ class OffsetDateTime implements DateTime {
   /// Parses a datetime string with timezone offset.
   factory OffsetDateTime._parseWithTimezoneOffset(
     String input,
-    RegExpMatch timezoneMatch,
-  ) {
+    RegExpMatch timezoneMatch, {
+    required String originalInput,
+  }) {
     final offsetString = timezoneMatch.group(0)!;
     final datetimeString = input.substring(
       0,
@@ -46,7 +47,15 @@ class OffsetDateTime implements DateTime {
     final offset = _parseTimezoneOffset(offsetString);
 
     // Parse the datetime part (without timezone) as local time
-    final localDateTime = DateTime.parse(datetimeString);
+    final DateTime localDateTime;
+    try {
+      localDateTime = DateTime.parse(datetimeString);
+    } on FormatException {
+      throw InvalidFormatException(
+        value: originalInput,
+        format: 'ISO8601 datetime format',
+      );
+    }
 
     // Create OffsetDateTime from the local time and offset
     return OffsetDateTime.from(
@@ -94,6 +103,7 @@ class OffsetDateTime implements DateTime {
       return OffsetDateTime._parseWithTimezoneOffset(
         normalizedInput,
         timezoneMatch,
+        originalInput: input,
       );
     }
 
@@ -111,7 +121,7 @@ class OffsetDateTime implements DateTime {
       }
     } on FormatException {
       throw InvalidFormatException(
-        value: normalizedInput,
+        value: input,
         format: 'ISO8601 datetime format',
       );
     }

--- a/packages/tonik_util/test/src/offset_date_time_test.dart
+++ b/packages/tonik_util/test/src/offset_date_time_test.dart
@@ -989,15 +989,59 @@ void main() {
         );
       });
 
-      test('should not replace a non-separator lowercase t in malformed '
-          'input', () {
+      test('should throw InvalidFormatException for malformed datetime '
+          'with valid timezone offset', () {
+        expect(
+          () => OffsetDateTime.parse('garbage+05:30'),
+          throwsA(isA<InvalidFormatException>()),
+        );
+      });
+
+      test('should throw InvalidFormatException for malformed time part '
+          'with compact timezone offset', () {
+        expect(
+          () => OffsetDateTime.parse('2024-01-15txx:30:00+0530'),
+          throwsA(isA<InvalidFormatException>()),
+        );
+      });
+
+      test('should report the original input for malformed input '
+          'containing a space', () {
         expect(
           () => OffsetDateTime.parse('not a date'),
           throwsA(
             isA<InvalidFormatException>().having(
               (e) => e.value,
               'value',
-              'notTa date',
+              'not a date',
+            ),
+          ),
+        );
+      });
+
+      test('should report the original input for malformed input '
+          'containing a digit-flanked lowercase t', () {
+        expect(
+          () => OffsetDateTime.parse('12t34'),
+          throwsA(
+            isA<InvalidFormatException>().having(
+              (e) => e.value,
+              'value',
+              '12t34',
+            ),
+          ),
+        );
+      });
+
+      test('should report the original input for malformed input '
+          'with a valid timezone offset', () {
+        expect(
+          () => OffsetDateTime.parse('not a date+05:30'),
+          throwsA(
+            isA<InvalidFormatException>().having(
+              (e) => e.value,
+              'value',
+              'not a date+05:30',
             ),
           ),
         );


### PR DESCRIPTION
## Summary

`OffsetDateTime.parse` — the shared root of every generated `format: date-time` decoder (`decodeJsonDateTime`, `decodeSimpleDateTime`, `decodeFormDateTime`) — had two error-handling gaps, both fixed here:

### 1. Offset path leaked a raw `FormatException`

The method documents that invalid input throws a `DecodingException`, and the UTC/local branch honors that by mapping Dart's `FormatException` to `InvalidFormatException`. The numeric-offset branch did not: `_parseWithTimezoneOffset` called `DateTime.parse` unguarded, so a malformed datetime body with a valid trailing offset (e.g. `garbage+05:30`, `2024-01-15txx:30:00+0530`) escaped as a raw `dart:core` `FormatException` — bypassing generated `fromJson`/`fromSimple`/`fromForm` code that only catches `DecodingException`. The offset branch now uses the same mapping as the UTC/local branch.

### 2. Errors reported the normalized string, not the caller's input

`parse` rewrites the input before validating (first space → `T`, digit-flanked lowercase `t` → `T`) and then reported that mutated string in `InvalidFormatException.value`. A caller sending `not a date` got an error quoting `notTa date` — a value that never appeared on the wire, so log/Sentry searches for the real payload find nothing. Both branches now report the original input; normalization stays an implementation detail.

Offset-specific errors (e.g. `+25:00`) still report just the offset substring — the offset regex matches only digits, `+`/`-`, and `:`, which normalization never touches, so no fidelity leak is possible there.

## Tests

- Added unit tests (failing first) for both gaps: malformed datetime with `±HH:MM` and `±HHMM` offsets throws `InvalidFormatException`, and the reported value is the original input for space-normalized, `t`-normalized, and offset-path inputs.
- The old test pinning the leaked `notTa date` value is re-expressed as an original-value assertion; the non-clobbering property it guarded (digit-bounded `t` regex) remains covered by the existing positive lowercase-`t` acceptance tests.
- Updated the `defaulted` integration suite expectation from the normalized `notTa date` to the spec literal `not a date`.
- Full `tonik_util` suite (1219 tests) and full `defaulted` integration suite (90 tests) pass; analysis clean.
