### PR TITLE
fix!: explode form-urlencoded body array properties by default

### DIFF
--- a/docs/uri_encoding.md
+++ b/docs/uri_encoding.md
@@ -87,11 +87,18 @@ tonik encode them.
 
 ## Form-body array properties
 
-For an `application/x-www-form-urlencoded` request body, `allowReserved` is honored on scalar,
-enum, object, composition, and **array** (list-of-simple) properties. A flagged array keeps
-reserved characters literal within each of its comma-joined elements. The array is still sent
-as a single comma-joined entry — `allowReserved` does not change that shape, so array
-**explode** (one repeated key per element) remains unaddressed for form bodies.
+For an `application/x-www-form-urlencoded` request body, an array (list-of-simple) property is
+encoded according to its `style: form` encoding:
+
+- **`explode: true` (the default)** sends one repeated key per element:
+  `tags=a&tags=b&tags=c`.
+- **`explode: false`** sends a single comma-joined entry: `tags=a,b,c`.
+- An **empty array** with the default `explode: true` is omitted entirely — no key appears on
+  the wire. With `explode: false` an empty array still emits `tags=` — the key with an empty value.
+
+`allowReserved` is honored on scalar, enum, object, composition, and array properties. On an
+array it keeps reserved characters literal within each element, regardless of whether the
+array is exploded into repeated keys or comma-joined.
 
 ## Null array elements in parameters
 

--- a/docs/uri_encoding.md
+++ b/docs/uri_encoding.md
@@ -106,8 +106,10 @@ Only the `form` style is honored for form bodies. `spaceDelimited` and `pipeDeli
 with `explode` omitted they resolve to `explode: false` and the array is comma-joined, not
 space- or pipe-joined.
 
-`additionalProperties` values are always comma-joined; dynamic keys carry no per-property
-encoding.
+Dynamic `additionalProperties` keys carry no per-property encoding, so
+`additionalProperties` never explode. Only scalar `additionalProperties` values are supported
+in form bodies; an array-valued `additionalProperties` is rejected at encode time
+("Additional properties with complex types cannot be parameter encoded").
 
 `allowReserved` is honored on scalar, enum, object, composition, and array properties. On an
 array it keeps reserved characters literal within each element, regardless of whether the

--- a/docs/uri_encoding.md
+++ b/docs/uri_encoding.md
@@ -95,6 +95,19 @@ encoded according to its `style: form` encoding:
 - **`explode: false`** sends a single comma-joined entry: `tags=a,b,c`.
 - An **empty array** with the default `explode: true` is omitted entirely — no key appears on
   the wire. With `explode: false` an empty array still emits `tags=` — the key with an empty value.
+- A **`null` (absent) nullable array property** behaves like an empty array under the exploded
+  default: it is omitted from the wire.
+- A body whose properties are **all empty exploded arrays** serializes to an empty body.
+
+The exploded default applies to **object and `allOf` form bodies**. A `oneOf`/`anyOf` form body
+does not currently receive it — its array properties stay comma-joined.
+
+Only the `form` style is honored for form bodies. `spaceDelimited` and `pipeDelimited` are not:
+with `explode` omitted they resolve to `explode: false` and the array is comma-joined, not
+space- or pipe-joined.
+
+`additionalProperties` values are always comma-joined; dynamic keys carry no per-property
+encoding.
 
 `allowReserved` is honored on scalar, enum, object, composition, and array properties. On an
 array it keeps reserved characters literal within each element, regardless of whether the

--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -51,6 +51,16 @@ switch (path) {
         }
         break
         
+    case '/form/allof-array':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=x&tags=y&label=hello'
+        }
+        break
+
     case '/form/types':
         def parts = [
             "stringValue=hello",

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -270,6 +270,30 @@ void main() {
     });
   });
 
+  group('AllOf array encoding with explode', () {
+    test('explodes an array member of an allOf body into repeated keys',
+        () async {
+      const form = AllOfArrayForm(
+        allOfArrayFormModel: AllOfArrayFormModel(label: 'hello'),
+        allOfArrayFormModel2: AllOfArrayFormModel2(tags: ['x', 'y']),
+      );
+
+      final response = await api.postAllOfArrayForm(body: form);
+
+      expect(response, isA<TonikSuccess<AllOfArrayForm>>());
+
+      final requestData = (response as TonikSuccess<AllOfArrayForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'label=hello&tags=x&tags=y');
+
+      final data = response.value;
+      expect(data.allOfArrayFormModel2.tags, ['x', 'y']);
+      expect(data.allOfArrayFormModel.label, 'hello');
+    });
+  });
+
   group('Type conversions', () {
     test('encodes various types as strings', () async {
       final dateTime = DateTime.utc(2024, 6, 20, 15, 45, 30);

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -231,7 +231,7 @@ void main() {
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
       expect(
         requestData,
-        'colors=red,green,blue&numbers=1,2,3',
+        'colors=red&colors=green&colors=blue&numbers=1&numbers=2&numbers=3',
       );
 
       final data = response.value;
@@ -248,13 +248,13 @@ void main() {
 
       final requestData =
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
-      expect(requestData, 'colors=&numbers=');
+      expect(requestData, '');
 
       final data = response.value;
       expect(data.colors, ['red', 'green', 'blue']);
     });
 
-    test('encodes single-element arrays with single key', () async {
+    test('encodes single-element arrays as a single repeated key', () async {
       const form = ArrayForm(colors: ['purple']);
 
       final response = await api.postArrayForm(body: form);
@@ -263,7 +263,7 @@ void main() {
 
       final requestData =
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
-      expect(requestData, 'colors=purple&numbers=');
+      expect(requestData, 'colors=purple');
 
       final data = response.value;
       expect(data.colors, ['red', 'green', 'blue']);
@@ -459,8 +459,8 @@ void main() {
     );
 
     test(
-      'comma-joins an array sibling into a single entry beside the flagged '
-      'scalar',
+      'comma-joins an explode=false array sibling into a single entry beside '
+      'the flagged scalar',
       () async {
         const form = AllowReservedArrayForm(
           reserved: 'a/b:c',
@@ -480,7 +480,7 @@ void main() {
     );
 
     test(
-      'keeps reserved characters literal in the comma-joined elements of a '
+      'keeps reserved characters literal in the exploded repeated entries of a '
       'flagged array property',
       () async {
         const form = AllowReservedArrayFlaggedForm(tags: ['a/b', 'c:d']);
@@ -496,7 +496,28 @@ void main() {
                 .response
                 .requestOptions
                 .data;
-        expect(requestData, 'tags=a/b,c:d');
+        expect(requestData, 'tags=a/b&tags=c:d');
+      },
+    );
+
+    test(
+      'keeps a comma inside a flagged array element literal in its own '
+      'exploded entry',
+      () async {
+        const form = AllowReservedArrayFlaggedForm(tags: ['a,b', 'c']);
+
+        final response = await api.postAllowReservedArrayFlaggedForm(
+          body: form,
+        );
+
+        expect(response, isA<TonikSuccess<AllowReservedArrayFlaggedForm>>());
+
+        final requestData =
+            (response as TonikSuccess<AllowReservedArrayFlaggedForm>)
+                .response
+                .requestOptions
+                .data;
+        expect(requestData, 'tags=a,b&tags=c');
       },
     );
 

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -268,6 +268,32 @@ void main() {
       final data = response.value;
       expect(data.colors, ['red', 'green', 'blue']);
     });
+
+    test('percent-encodes a comma inside an exploded element without '
+        'allowReserved', () async {
+      const form = ArrayForm(colors: ['a,b', 'c']);
+
+      final response = await api.postArrayForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayForm>>());
+
+      final requestData =
+          (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
+      expect(requestData, 'colors=a%2Cb&colors=c');
+    });
+
+    test('encodes a single empty-string element as one empty-value entry',
+        () async {
+      const form = ArrayForm(colors: ['']);
+
+      final response = await api.postArrayForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayForm>>());
+
+      final requestData =
+          (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
+      expect(requestData, 'colors=');
+    });
   });
 
   group('AllOf array encoding with explode', () {
@@ -500,6 +526,24 @@ void main() {
             .requestOptions
             .data;
         expect(requestData, 'reserved=a/b:c&tags=x,y,z');
+      },
+    );
+
+    test(
+      'emits an empty-value entry for an explode=false array property that is '
+      'empty',
+      () async {
+        const form = AllowReservedArrayForm(reserved: 'plain', tags: []);
+
+        final response = await api.postAllowReservedArrayForm(body: form);
+
+        expect(response, isA<TonikSuccess<AllowReservedArrayForm>>());
+
+        final requestData = (response as TonikSuccess<AllowReservedArrayForm>)
+            .response
+            .requestOptions
+            .data;
+        expect(requestData, 'reserved=plain&tags=');
       },
     );
 

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -386,9 +386,9 @@ paths:
         - form
       summary: Post form where a flagged scalar sits beside an array property
       description: >-
-        Tests that an array sibling of a flagged allowReserved scalar is
-        comma-joined into a single entry, matching the object path, rather than
-        exploded into repeated keys.
+        Tests that an explode=false array sibling of a flagged allowReserved
+        scalar is comma-joined into a single entry rather than exploded into
+        repeated keys.
       requestBody:
         required: true
         content:
@@ -398,6 +398,8 @@ paths:
             encoding:
               reserved:
                 allowReserved: true
+              tags:
+                explode: false
       responses:
         '200':
           description: Echo response with exact request body
@@ -414,8 +416,8 @@ paths:
       summary: Post form where an array property itself opts into allowReserved
       description: >-
         Tests that a flagged allowReserved array keeps reserved characters
-        literal in its comma-joined elements, unlike an unflagged array whose
-        elements are fully percent-encoded.
+        literal in its exploded repeated-key entries, unlike an unflagged array
+        whose elements are fully percent-encoded.
       requestBody:
         required: true
         content:

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -123,6 +123,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArrayForm'
 
+  /form/allof-array:
+    post:
+      operationId: postAllOfArrayForm
+      tags:
+        - form
+      summary: Post allOf form with an array member property
+      description: Tests exploded array encoding for an allOf composed body
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/AllOfArrayForm'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/AllOfArrayForm'
+
   /form/types:
     post:
       operationId: postTypesForm
@@ -585,6 +606,23 @@ components:
             type: integer
           description: Array of numbers
           example: [1, 2, 3]
+
+    AllOfArrayForm:
+      allOf:
+        - type: object
+          required:
+            - tags
+          properties:
+            tags:
+              type: array
+              items:
+                type: string
+              description: Array of tags exploded via style form
+        - type: object
+          properties:
+            label:
+              type: string
+              description: Optional label
 
     TypesForm:
       type: object

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -3,6 +3,7 @@ import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/name_utils.dart';
+import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
 import 'package:tonik_generate/src/util/additional_properties_helpers.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/composite_guard_builders.dart';
@@ -12,6 +13,7 @@ import 'package:tonik_generate/src/util/equals_method_generator.dart';
 import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
+import 'package:tonik_generate/src/util/form_exploded_values_generator.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_json_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_simple_value_expression_generator.dart';
@@ -56,28 +58,7 @@ class AllOfGenerator {
   @visibleForTesting
   List<Spec> generateClasses(AllOfModel model, [String? className]) {
     final actualClassName = className ?? nameManager.modelName(model);
-    final models = stableModelSorter.sortModels(model.models);
-
-    final pseudoProperties = models.map((m) {
-      final typeRef = typeReference(
-        m,
-        nameManager,
-        package,
-        useImmutableCollections: useImmutableCollections,
-      );
-      final isNullable = m.isEffectivelyNullable;
-      return Property(
-        name: typeRef.symbol,
-        model: m,
-        isRequired: !isNullable,
-        isNullable: isNullable,
-        isDeprecated: false,
-        examples: const [],
-        defaultValue: null,
-      );
-    }).toList();
-
-    final normalizedProperties = _normalizeModelProperties(pseudoProperties);
+    final normalizedProperties = _memberFields(model);
 
     final copyWithResult = _buildCopyWith(
       actualClassName,
@@ -117,28 +98,7 @@ class AllOfGenerator {
               )
             : publicClassName);
 
-    final models = stableModelSorter.sortModels(model.models);
-
-    final pseudoProperties = models.map((m) {
-      final typeRef = typeReference(
-        m,
-        nameManager,
-        package,
-        useImmutableCollections: useImmutableCollections,
-      );
-      final isNullable = m.isEffectivelyNullable;
-      return Property(
-        name: typeRef.symbol,
-        model: m,
-        isRequired: !isNullable,
-        isNullable: isNullable,
-        isDeprecated: false,
-        examples: const [],
-        defaultValue: null,
-      );
-    }).toList();
-
-    final normalizedProperties = _normalizeModelProperties(pseudoProperties);
+    final normalizedProperties = _memberFields(model);
     final properties = _buildPropertiesFromNormalized(
       normalizedProperties,
       model,
@@ -305,6 +265,115 @@ class AllOfGenerator {
           ),
         )
         .toList();
+  }
+
+  /// The normalized fields, one per allOf member, that back the generated
+  /// class. Shared by class generation and exploded-values access so the two
+  /// cannot drift on member field names.
+  List<({String normalizedName, Property property})> _memberFields(
+    AllOfModel model,
+  ) {
+    final pseudo = stableModelSorter.sortModels(model.models).map((m) {
+      final isNullable = m.isEffectivelyNullable;
+      return Property(
+        name: typeReference(
+          m,
+          nameManager,
+          package,
+          useImmutableCollections: useImmutableCollections,
+        ).symbol,
+        model: m,
+        isRequired: !isNullable,
+        isNullable: isNullable,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+    }).toList();
+    return _normalizeModelProperties(pseudo);
+  }
+
+  /// Collects the simple-content array properties reachable through the allOf's
+  /// object members — the exact set the request-body call site marks `explode`
+  /// via its field encodings — keeping the exploded-values channel and that
+  /// field encoding activating the same properties. Direct array members are
+  /// excluded: [_buildParameterPropertiesMethod] rejects them, so the call site
+  /// never activates them and any exploded-values entry would be dead.
+  List<FormPropertyBinding> _collectExplodedArrayBindings(
+    List<({String normalizedName, Property property})> members,
+  ) {
+    final bindings = <FormPropertyBinding>[];
+    for (final member in members) {
+      if (member.property.isReadOnly) continue;
+      final root = refer(member.normalizedName);
+      _collectArrayBindings(
+        member.property.model,
+        field: root,
+        guard: root,
+        receiverNullable: member.property.model.isEffectivelyNullable,
+        into: bindings,
+      );
+    }
+    return bindings;
+  }
+
+  /// Descends the object graph reached from an allOf member, accumulating a
+  /// force-unwrapped value access ([field]) and a parallel null-safe access
+  /// ([guard]) so a nullable link short-circuits the null test while the mapped
+  /// value stays non-nullable.
+  void _collectArrayBindings(
+    Model memberModel, {
+    required Expression field,
+    required Expression guard,
+    required bool receiverNullable,
+    required List<FormPropertyBinding> into,
+  }) {
+    ({Expression field, Expression guard}) descend(String name) {
+      if (receiverNullable) {
+        return (
+          field: field.nullChecked.property(name),
+          guard: guard.nullSafeProperty(name),
+        );
+      }
+      return (field: field.property(name), guard: guard.property(name));
+    }
+
+    switch (memberModel.resolved) {
+      case final ClassModel m:
+        for (final p in normalizeProperties(m.properties.toList())) {
+          if (p.property.isReadOnly) continue;
+          final listModel = p.property.model.resolved;
+          if (listModel is! ListModel || !listModel.hasSimpleContent) continue;
+          final access = descend(p.normalizedName);
+          final leafNullable =
+              isSchemaAwareFieldNullable(
+                p.property,
+                memberIsReadOnly: m.isReadOnly,
+              ) ||
+              listModel.isNullable;
+          final nullable = receiverNullable || leafNullable;
+          into.add((
+            field: leafNullable ? access.field.nullChecked : access.field,
+            nullGuard: nullable ? access.guard : null,
+            property: p.property,
+          ));
+        }
+      case final AllOfModel m:
+        for (final member in _memberFields(m)) {
+          final access = descend(member.normalizedName);
+          _collectArrayBindings(
+            member.property.model,
+            field: access.field,
+            guard: access.guard,
+            receiverNullable:
+                receiverNullable ||
+                member.property.model.isEffectivelyNullable,
+            into: into,
+          );
+        }
+      default:
+        break;
+    }
   }
 
   List<Field> _buildFields(
@@ -1898,6 +1967,11 @@ for (final _\$e in $apFieldName.entries) {
       return code;
     }
 
+    final explodedValues = buildFormExplodedValuesLiteral(
+      _collectExplodedArrayBindings(normalizedProperties),
+      useImmutableCollections: useImmutableCollections,
+    );
+
     final delegateToParameterProperties = refer('parameterProperties')
         .call([], {
           'allowEmpty': refer('allowEmpty'),
@@ -1910,6 +1984,8 @@ for (final _\$e in $apFieldName.entries) {
           'allowEmpty': refer('allowEmpty'),
           'alreadyEncoded': literalBool(true),
           'useQueryComponent': refer('useQueryComponent'),
+          'fieldEncodings': refer('fieldEncodings'),
+          'explodedValues': ?explodedValues,
         })
         .returned
         .statement;

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -299,16 +299,23 @@ class AllOfGenerator {
   /// field encoding activating the same properties. Direct array members are
   /// excluded: [_buildParameterPropertiesMethod] rejects them, so the call site
   /// never activates them and any exploded-values entry would be dead.
+  ///
+  /// The counterpart traversal is `_collectFormProperties` in
+  /// `to_form_value_expression_generator.dart`, which builds the request-body
+  /// field-encoding descriptors: both must walk the same property set in
+  /// lock-step or the exploded-values entries and the descriptors diverge.
   List<FormPropertyBinding> _collectExplodedArrayBindings(
     List<({String normalizedName, Property property})> members,
   ) {
     final bindings = <FormPropertyBinding>[];
     for (final member in members) {
       final root = refer(member.normalizedName);
+      final nullable = member.property.model.isEffectivelyNullable;
       _collectArrayBindings(
         member.property.model,
         field: root,
-        memberGuard: member.property.model.isEffectivelyNullable ? root : null,
+        receiverNullable: nullable,
+        memberGuard: nullable ? root : null,
         into: bindings,
       );
     }
@@ -326,14 +333,19 @@ class AllOfGenerator {
   /// leaf array property's own nullability is captured separately (as the
   /// binding's `leafGuard`) so the merge fold can tell an absent member from a
   /// present member with a null array — the two resolve to different winners.
+  ///
+  /// [receiverNullable] is the nullability of the immediate [field] receiver —
+  /// whether the link that produced it was nullable, not whether any earlier
+  /// link was. Force-unwrapping and null-aware access are decided per link from
+  /// this, so a non-nullable link nested under a nullable one emits neither an
+  /// unnecessary `!` nor a `?.` on a non-nullable receiver.
   void _collectArrayBindings(
     Model memberModel, {
     required Expression field,
+    required bool receiverNullable,
     required Expression? memberGuard,
     required List<FormPropertyBinding> into,
   }) {
-    final receiverNullable = memberGuard != null;
-
     Expression descendField(String name) => receiverNullable
         ? field.nullChecked.property(name)
         : field.property(name);
@@ -359,14 +371,15 @@ class AllOfGenerator {
         }
       case final AllOfModel m:
         for (final member in _memberFields(m)) {
-          final nestedNullable =
-              receiverNullable || member.property.model.isEffectivelyNullable;
+          final linkNullable = member.property.model.isEffectivelyNullable;
+          final nestedGuard = memberGuard != null
+              ? memberGuard.nullSafeProperty(member.normalizedName)
+              : (linkNullable ? field.property(member.normalizedName) : null);
           _collectArrayBindings(
             member.property.model,
             field: descendField(member.normalizedName),
-            memberGuard: nestedNullable
-                ? (memberGuard ?? field).nullSafeProperty(member.normalizedName)
-                : null,
+            receiverNullable: linkNullable,
+            memberGuard: nestedGuard,
             into: into,
           );
         }

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -317,10 +317,10 @@ class AllOfGenerator {
     return bindings;
   }
 
-  /// Descends the object graph reached from an allOf member, accumulating a
-  /// force-unwrapped value access ([field]) and a parallel null-safe access
-  /// ([guard]) so a nullable link short-circuits the null test while the mapped
-  /// value stays non-nullable.
+  /// Descends nested allOf members and one level of a member's ClassModel
+  /// properties, accumulating a force-unwrapped value access ([field]) and a
+  /// parallel null-safe access ([guard]) so a nullable link short-circuits the
+  /// null test while the mapped value stays non-nullable.
   void _collectArrayBindings(
     Model memberModel, {
     required Expression field,
@@ -341,9 +341,8 @@ class AllOfGenerator {
     switch (memberModel.resolved) {
       case final ClassModel m:
         for (final p in normalizeProperties(m.properties.toList())) {
-          if (p.property.isReadOnly) continue;
-          final listModel = p.property.model.resolved;
-          if (listModel is! ListModel || !listModel.hasSimpleContent) continue;
+          if (!isExplodedFormArrayProperty(p.property)) continue;
+          final listModel = p.property.model as ListModel;
           final access = descend(p.normalizedName);
           final leafNullable =
               isSchemaAwareFieldNullable(

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -304,13 +304,11 @@ class AllOfGenerator {
   ) {
     final bindings = <FormPropertyBinding>[];
     for (final member in members) {
-      if (member.property.isReadOnly) continue;
       final root = refer(member.normalizedName);
       _collectArrayBindings(
         member.property.model,
         field: root,
-        guard: root,
-        receiverNullable: member.property.model.isEffectivelyNullable,
+        memberGuard: member.property.model.isEffectivelyNullable ? root : null,
         into: bindings,
       );
     }
@@ -319,54 +317,56 @@ class AllOfGenerator {
 
   /// Descends nested allOf members and one level of a member's ClassModel
   /// properties, accumulating a force-unwrapped value access ([field]) and a
-  /// parallel null-safe access ([guard]) so a nullable link short-circuits the
-  /// null test while the mapped value stays non-nullable.
+  /// parallel null-safe access to the member ([memberGuard]) so a nullable
+  /// composition link short-circuits the null test while the mapped value stays
+  /// non-nullable.
+  ///
+  /// [memberGuard] is null-safe access to the member that owns the reached
+  /// property, or null when no composition link on the path is nullable. The
+  /// leaf array property's own nullability is captured separately (as the
+  /// binding's `leafGuard`) so the merge fold can tell an absent member from a
+  /// present member with a null array — the two resolve to different winners.
   void _collectArrayBindings(
     Model memberModel, {
     required Expression field,
-    required Expression guard,
-    required bool receiverNullable,
+    required Expression? memberGuard,
     required List<FormPropertyBinding> into,
   }) {
-    ({Expression field, Expression guard}) descend(String name) {
-      if (receiverNullable) {
-        return (
-          field: field.nullChecked.property(name),
-          guard: guard.nullSafeProperty(name),
-        );
-      }
-      return (field: field.property(name), guard: guard.property(name));
-    }
+    final receiverNullable = memberGuard != null;
+
+    Expression descendField(String name) => receiverNullable
+        ? field.nullChecked.property(name)
+        : field.property(name);
 
     switch (memberModel.resolved) {
       case final ClassModel m:
         for (final p in normalizeProperties(m.properties.toList())) {
           if (!isExplodedFormArrayProperty(p.property)) continue;
           final listModel = p.property.model as ListModel;
-          final access = descend(p.normalizedName);
+          final leafAccess = descendField(p.normalizedName);
           final leafNullable =
               isSchemaAwareFieldNullable(
                 p.property,
                 memberIsReadOnly: m.isReadOnly,
               ) ||
               listModel.isNullable;
-          final nullable = receiverNullable || leafNullable;
           into.add((
-            field: leafNullable ? access.field.nullChecked : access.field,
-            nullGuard: nullable ? access.guard : null,
+            field: leafNullable ? leafAccess.nullChecked : leafAccess,
+            memberGuard: memberGuard,
+            leafGuard: leafNullable ? leafAccess : null,
             property: p.property,
           ));
         }
       case final AllOfModel m:
         for (final member in _memberFields(m)) {
-          final access = descend(member.normalizedName);
+          final nestedNullable =
+              receiverNullable || member.property.model.isEffectivelyNullable;
           _collectArrayBindings(
             member.property.model,
-            field: access.field,
-            guard: access.guard,
-            receiverNullable:
-                receiverNullable ||
-                member.property.model.isEffectivelyNullable,
+            field: descendField(member.normalizedName),
+            memberGuard: nestedNullable
+                ? (memberGuard ?? field).nullSafeProperty(member.normalizedName)
+                : null,
             into: into,
           );
         }

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -14,6 +14,7 @@ import 'package:tonik_generate/src/util/default_resolution.dart';
 import 'package:tonik_generate/src/util/equals_method_generator.dart';
 import 'package:tonik_generate/src/util/example_doc_formatter.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/form_exploded_values_generator.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/from_form_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/from_json_value_expression_generator.dart';
@@ -266,7 +267,16 @@ class ClassGenerator {
             normalizedProperties.where((p) => !p.property.isReadOnly).toList(),
           ),
           _buildToSimpleMethod(),
-          _buildToFormMethod(),
+          _buildToFormMethod(
+            buildFormExplodedValuesLiteral(
+              [
+                for (final p in normalizedProperties)
+                  if (!p.property.isReadOnly)
+                    _explodedArrayBinding(p.normalizedName, p.property, model),
+              ],
+              useImmutableCollections: useImmutableCollections,
+            ),
+          ),
           _buildToLabelMethod(),
           _buildToMatrixMethod(),
           _buildToDeepObjectMethod(),
@@ -1120,13 +1130,31 @@ class ClassGenerator {
       property.model,
       nameManager,
       package,
-      isNullableOverride:
-          property.isNullable ||
-          !property.isRequired ||
-          property.isReadOnly ||
-          property.isWriteOnly ||
-          model.isReadOnly,
+      isNullableOverride: isSchemaAwareFieldNullable(
+        property,
+        memberIsReadOnly: model.isReadOnly,
+      ),
       useImmutableCollections: useImmutableCollections,
+    );
+  }
+
+  FormPropertyBinding _explodedArrayBinding(
+    String name,
+    Property property,
+    ClassModel model,
+  ) {
+    final listModel = property.model.resolved;
+    final nullable =
+        isSchemaAwareFieldNullable(
+          property,
+          memberIsReadOnly: model.isReadOnly,
+        ) ||
+        (listModel is ListModel && listModel.isNullable);
+    final field = refer(name);
+    return (
+      field: nullable ? field.nullChecked : field,
+      nullGuard: nullable ? field : null,
+      property: property,
     );
   }
 
@@ -1994,7 +2022,7 @@ if ($name != null) {
     return Block.of(codes);
   }
 
-  Method _buildToFormMethod() => Method(
+  Method _buildToFormMethod(Expression? explodedValues) => Method(
     (b) => b
       ..annotations.add(refer('override', 'dart:core'))
       ..name = 'toForm'
@@ -2023,6 +2051,8 @@ if ($name != null) {
                 'allowEmpty': refer('allowEmpty'),
                 'alreadyEncoded': literalBool(true),
                 'useQueryComponent': refer('useQueryComponent'),
+                'fieldEncodings': refer('fieldEncodings'),
+                'explodedValues': ?explodedValues,
               },
             )
             .returned

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1153,7 +1153,8 @@ class ClassGenerator {
     final field = refer(name);
     return (
       field: nullable ? field.nullChecked : field,
-      nullGuard: nullable ? field : null,
+      memberGuard: null,
+      leafGuard: nullable ? field : null,
       property: property,
     );
   }

--- a/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
+++ b/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
@@ -5,18 +5,32 @@ import 'package:tonik_generate/src/util/type_reference_generator.dart';
 import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 
 /// A writable form array property paired with the expression that reads its
-/// list value (`field`) and, when that read can yield null, a null-safe
-/// expression the builder tests against null before mapping (`nullGuard`).
-/// A null `nullGuard` marks a value that is always present.
+/// list value (`field`) and two independent null tests the merge fold consults.
+///
+/// `memberGuard` is null-safe access to the composition member that owns the
+/// property; when it evaluates null the member is absent from the runtime
+/// `parameterProperties` merge, so its data never reaches the wire and the fold
+/// falls through to an earlier duplicate-key candidate. A null `memberGuard`
+/// marks a member that is always present (the class path has no member, so it
+/// is always null there).
+///
+/// `leafGuard` is access to the array property read through a present member;
+/// when it evaluates null the member is present but its array value is absent.
+/// `parameterProperties` writes `''` for such a property (form bodies pass
+/// `allowEmpty: true`), so that member WINS the merge with zero elements. A
+/// null `leafGuard` marks an array value that is always present once its member
+/// is.
 typedef FormPropertyBinding = ({
   Expression field,
-  Expression? nullGuard,
+  Expression? memberGuard,
+  Expression? leafGuard,
   Property property,
 });
 
-/// Whether [property] is a writable array with simple content that form
-/// encoding emits as an exploded (`style: form, explode: true`) repeated-key
-/// property.
+/// Whether [property] is a writable array with simple content and therefore
+/// eligible for the explode machinery — the field encoding descriptor and the
+/// `explodedValues` channel. Whether it is actually exploded is decided by its
+/// encoding (explicit `explode`, or the form/absent-style default).
 ///
 /// Uses the unresolved model so it matches the class-dispatch predicate: an
 /// alias-wrapped array is not treated as an exploded form array (that routes
@@ -29,7 +43,7 @@ bool isExplodedFormArrayProperty(Property property) {
   return model is ListModel && model.hasSimpleContent;
 }
 
-/// Whether the schema-aware field generated for [property] on a member class
+/// Whether the schema-aware field generated for [property] on the owning class
 /// is typed nullable. Form null-guard emission must consult the same predicate
 /// the field type is built from, or a guard is dropped and the emission fails
 /// to compile.
@@ -44,18 +58,26 @@ bool isSchemaAwareFieldNullable(
     memberIsReadOnly;
 
 /// Builds the `Map<String, List<String>>` literal passed as `explodedValues`
-/// to an object's `toForm`, holding the individually-encoded elements of each
-/// simple-content array property keyed by raw spec name.
+/// to the `Map<String, String>.toForm` call inside the generated object's
+/// `toForm`, holding the individually-encoded elements of each simple-content
+/// array property keyed by raw spec name.
 ///
 /// Delivering elements as a list keeps their boundaries intact, so an element
 /// containing a literal comma survives `style: form, explode: true` instead of
 /// being re-split. Returns null when the object has no such array property.
 ///
 /// When several composition members expose the same raw name, the emitted
-/// elements come from whichever member's value wins the `parameterProperties`
-/// merge at runtime — last non-null wins. A later nullable member that is null
-/// falls back through a runtime-conditional chain to the earlier member's
-/// elements, so the wire never drops the merge winner's data.
+/// elements track exactly which member wins the runtime `parameterProperties`
+/// merge, so flipping `explode` cannot change which member's data is
+/// transmitted. The merge is per-member `addAll` — a later member overrides an
+/// earlier one — with two null cases distinguished:
+///
+/// - the later member is absent (its access chain is null): it never merges, so
+///   the fold falls through to the earlier candidate;
+/// - the later member is present but its array property is null:
+///   `parameterProperties` coerces that to an empty string entry (form bodies
+///   pass `allowEmpty: true`), clobbering the earlier member, so the later
+///   member wins with an empty element list (zero exploded entries).
 Expression? buildFormExplodedValuesLiteral(
   List<FormPropertyBinding> bindings, {
   required bool useImmutableCollections,
@@ -86,10 +108,11 @@ Expression? buildFormExplodedValuesLiteral(
   );
 }
 
-/// The elements of the raw-name group that wins the `parameterProperties`
-/// merge — last non-null member. Built as a left fold so each later present
-/// binding overrides the running winner, and a later null binding falls
-/// through to the earlier one, mirroring last-non-null-wins.
+/// The elements of the raw-name group emitted for the member that wins the
+/// `parameterProperties` merge. Built as a left fold so each later binding
+/// overrides the running winner; an absent member (`memberGuard` null) falls
+/// through to the earlier one, while a present member with a null array leaf
+/// (`leafGuard` null) wins with an empty list.
 Expression _mergeWinnerElements(
   List<FormPropertyBinding> group, {
   required bool useImmutableCollections,
@@ -102,25 +125,38 @@ Expression _mergeWinnerElements(
         useImmutableCollections: useImmutableCollections,
       );
 
-  final emptyList = literalConstList([], refer('String', 'dart:core'));
-
-  var winner = _guarded(group.first, elements(group.first), emptyList);
+  var winner = _guarded(group.first, elements(group.first), _emptyStringList());
   for (final binding in group.skip(1)) {
     winner = _guarded(binding, elements(binding), winner);
   }
   return winner;
 }
 
-/// [present] when [binding] is non-null at runtime, otherwise [fallback]. A
-/// non-nullable binding is always present and returns [present] directly.
+Expression _emptyStringList() =>
+    literalConstList([], refer('String', 'dart:core'));
+
+/// The value [binding] contributes to the merge fold, given [fallback] for an
+/// earlier candidate:
+///
+/// - member absent → [fallback];
+/// - member present, array leaf null → an empty element list (member wins with
+///   zero entries, matching the `''` `parameterProperties` writes);
+/// - otherwise → [present].
 Expression _guarded(
   FormPropertyBinding binding,
   Expression present,
   Expression fallback,
 ) {
-  final guard = binding.nullGuard;
-  if (guard == null) return present;
-  return guard.equalTo(literalNull).conditional(fallback, present);
+  final leafGuard = binding.leafGuard;
+  final whenMemberPresent = leafGuard == null
+      ? present
+      : leafGuard.equalTo(literalNull).conditional(_emptyStringList(), present);
+
+  final memberGuard = binding.memberGuard;
+  if (memberGuard == null) return whenMemberPresent;
+  return memberGuard
+      .equalTo(literalNull)
+      .conditional(fallback, whenMemberPresent);
 }
 
 Expression _encodedElementsExpression(

--- a/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
+++ b/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
@@ -11,13 +11,13 @@ import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 /// property; when it evaluates null the member is absent from the runtime
 /// `parameterProperties` merge, so its data never reaches the wire and the fold
 /// falls through to an earlier duplicate-key candidate. A null `memberGuard`
-/// marks a member that is always present (the class path has no member, so it
-/// is always null there).
+/// marks a member that is always present (the class path has no member, so
+/// memberGuard is always null on the class path).
 ///
 /// `leafGuard` is access to the array property read through a present member;
 /// when it evaluates null the member is present but its array value is absent.
 /// `parameterProperties` writes `''` for such a property (form bodies pass
-/// `allowEmpty: true`), so that member WINS the merge with zero elements. A
+/// `allowEmpty: true`), so that member wins the merge with zero elements. A
 /// null `leafGuard` marks an array value that is always present once its member
 /// is.
 typedef FormPropertyBinding = ({
@@ -110,9 +110,9 @@ Expression? buildFormExplodedValuesLiteral(
 
 /// The elements of the raw-name group emitted for the member that wins the
 /// `parameterProperties` merge. Built as a left fold so each later binding
-/// overrides the running winner; an absent member (`memberGuard` null) falls
-/// through to the earlier one, while a present member with a null array leaf
-/// (`leafGuard` null) wins with an empty list.
+/// overrides the running winner; an absent member (its `memberGuard` evaluates
+/// to null) falls through to the earlier one, while a present member whose
+/// `leafGuard` evaluates to null wins with an empty list.
 Expression _mergeWinnerElements(
   List<FormPropertyBinding> group, {
   required bool useImmutableCollections,

--- a/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
+++ b/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
@@ -14,6 +14,21 @@ typedef FormPropertyBinding = ({
   Property property,
 });
 
+/// Whether [property] is a writable array with simple content that form
+/// encoding emits as an exploded (`style: form, explode: true`) repeated-key
+/// property.
+///
+/// Uses the unresolved model so it matches the class-dispatch predicate: an
+/// alias-wrapped array is not treated as an exploded form array (that routes
+/// the whole class to the "contains complex types" path instead). The field
+/// encoding descriptor, the `explodedValues` channel, and the member-binding
+/// collector must all agree on this set or the wire data diverges.
+bool isExplodedFormArrayProperty(Property property) {
+  if (property.isReadOnly) return false;
+  final model = property.model;
+  return model is ListModel && model.hasSimpleContent;
+}
+
 /// Whether the schema-aware field generated for [property] on a member class
 /// is typed nullable. Form null-guard emission must consult the same predicate
 /// the field type is built from, or a guard is dropped and the emission fails
@@ -36,25 +51,19 @@ bool isSchemaAwareFieldNullable(
 /// containing a literal comma survives `style: form, explode: true` instead of
 /// being re-split. Returns null when the object has no such array property.
 ///
-/// Bindings that repeat a raw name (properties merged from several composition
-/// members) collapse to the last, matching the last-wins merge of
-/// `parameterProperties`.
+/// When several composition members expose the same raw name, the emitted
+/// elements come from whichever member's value wins the `parameterProperties`
+/// merge at runtime — last non-null wins. A later nullable member that is null
+/// falls back through a runtime-conditional chain to the earlier member's
+/// elements, so the wire never drops the merge winner's data.
 Expression? buildFormExplodedValuesLiteral(
   List<FormPropertyBinding> bindings, {
   required bool useImmutableCollections,
 }) {
-  final byName = <String, Expression>{};
+  final byName = <String, List<FormPropertyBinding>>{};
   for (final binding in bindings) {
-    final model = binding.property.model;
-    if (model is! ListModel || !model.hasSimpleContent) continue;
-
-    byName[binding.property.name] = _encodedElementsExpression(
-      binding.field,
-      binding.nullGuard,
-      binding.property.name,
-      model,
-      useImmutableCollections: useImmutableCollections,
-    );
+    if (!isExplodedFormArrayProperty(binding.property)) continue;
+    byName.putIfAbsent(binding.property.name, () => []).add(binding);
   }
 
   if (byName.isEmpty) return null;
@@ -62,7 +71,10 @@ Expression? buildFormExplodedValuesLiteral(
   return literalMap(
     {
       for (final entry in byName.entries)
-        specLiteralString(entry.key): entry.value,
+        specLiteralString(entry.key): _mergeWinnerElements(
+          entry.value,
+          useImmutableCollections: useImmutableCollections,
+        ),
     },
     refer('String', 'dart:core'),
     TypeReference(
@@ -74,11 +86,47 @@ Expression? buildFormExplodedValuesLiteral(
   );
 }
 
+/// The elements of the raw-name group that wins the `parameterProperties`
+/// merge — last non-null member. Built as a left fold so each later present
+/// binding overrides the running winner, and a later null binding falls
+/// through to the earlier one, mirroring last-non-null-wins.
+Expression _mergeWinnerElements(
+  List<FormPropertyBinding> group, {
+  required bool useImmutableCollections,
+}) {
+  Expression elements(FormPropertyBinding binding) =>
+      _encodedElementsExpression(
+        binding.field,
+        binding.property.model as ListModel,
+        binding.property.name,
+        useImmutableCollections: useImmutableCollections,
+      );
+
+  final emptyList = literalConstList([], refer('String', 'dart:core'));
+
+  var winner = _guarded(group.first, elements(group.first), emptyList);
+  for (final binding in group.skip(1)) {
+    winner = _guarded(binding, elements(binding), winner);
+  }
+  return winner;
+}
+
+/// [present] when [binding] is non-null at runtime, otherwise [fallback]. A
+/// non-nullable binding is always present and returns [present] directly.
+Expression _guarded(
+  FormPropertyBinding binding,
+  Expression present,
+  Expression fallback,
+) {
+  final guard = binding.nullGuard;
+  if (guard == null) return present;
+  return guard.equalTo(literalNull).conditional(fallback, present);
+}
+
 Expression _encodedElementsExpression(
   Expression field,
-  Expression? nullGuard,
-  String rawName,
-  ListModel model, {
+  ListModel model,
+  String rawName, {
   required bool useImmutableCollections,
 }) {
   final content = model.content;
@@ -106,17 +154,8 @@ Expression _encodedElementsExpression(
       ..body = guarded.code,
   ).closure;
 
-  Expression mapped(Expression list) {
-    final listExpr = useImmutableCollections ? list.property('unlock') : list;
-    return listExpr.property('map').call([closure]).property('toList').call([]);
-  }
-
-  if (nullGuard == null) return mapped(field);
-
-  return nullGuard
-      .equalTo(literalNull)
-      .conditional(
-        literalConstList([], refer('String', 'dart:core')),
-        mapped(field),
-      );
+  final listExpr = useImmutableCollections
+      ? field.property('unlock')
+      : field;
+  return listExpr.property('map').call([closure]).property('toList').call([]);
 }

--- a/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
+++ b/packages/tonik_generate/lib/src/util/form_exploded_values_generator.dart
@@ -1,0 +1,122 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
+import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
+
+/// A writable form array property paired with the expression that reads its
+/// list value (`field`) and, when that read can yield null, a null-safe
+/// expression the builder tests against null before mapping (`nullGuard`).
+/// A null `nullGuard` marks a value that is always present.
+typedef FormPropertyBinding = ({
+  Expression field,
+  Expression? nullGuard,
+  Property property,
+});
+
+/// Whether the schema-aware field generated for [property] on a member class
+/// is typed nullable. Form null-guard emission must consult the same predicate
+/// the field type is built from, or a guard is dropped and the emission fails
+/// to compile.
+bool isSchemaAwareFieldNullable(
+  Property property, {
+  required bool memberIsReadOnly,
+}) =>
+    property.isNullable ||
+    !property.isRequired ||
+    property.isReadOnly ||
+    property.isWriteOnly ||
+    memberIsReadOnly;
+
+/// Builds the `Map<String, List<String>>` literal passed as `explodedValues`
+/// to an object's `toForm`, holding the individually-encoded elements of each
+/// simple-content array property keyed by raw spec name.
+///
+/// Delivering elements as a list keeps their boundaries intact, so an element
+/// containing a literal comma survives `style: form, explode: true` instead of
+/// being re-split. Returns null when the object has no such array property.
+///
+/// Bindings that repeat a raw name (properties merged from several composition
+/// members) collapse to the last, matching the last-wins merge of
+/// `parameterProperties`.
+Expression? buildFormExplodedValuesLiteral(
+  List<FormPropertyBinding> bindings, {
+  required bool useImmutableCollections,
+}) {
+  final byName = <String, Expression>{};
+  for (final binding in bindings) {
+    final model = binding.property.model;
+    if (model is! ListModel || !model.hasSimpleContent) continue;
+
+    byName[binding.property.name] = _encodedElementsExpression(
+      binding.field,
+      binding.nullGuard,
+      binding.property.name,
+      model,
+      useImmutableCollections: useImmutableCollections,
+    );
+  }
+
+  if (byName.isEmpty) return null;
+
+  return literalMap(
+    {
+      for (final entry in byName.entries)
+        specLiteralString(entry.key): entry.value,
+    },
+    refer('String', 'dart:core'),
+    TypeReference(
+      (t) => t
+        ..symbol = 'List'
+        ..url = 'dart:core'
+        ..types.add(refer('String', 'dart:core')),
+    ),
+  );
+}
+
+Expression _encodedElementsExpression(
+  Expression field,
+  Expression? nullGuard,
+  String rawName,
+  ListModel model, {
+  required bool useImmutableCollections,
+}) {
+  final content = model.content;
+  final isContentNullable =
+      model.isContentNullable || content.isEffectivelyNullable;
+
+  final element = buildUriEncodeExpression(
+    refer('e'),
+    content,
+    allowEmpty: literalBool(true),
+    useQueryComponent: refer('useQueryComponent'),
+    allowReserved: CodeExpression(
+      Code(perPropertyAllowReservedValue(rawName)),
+    ),
+  ).expression;
+
+  final guarded = isContentNullable
+      ? refer('e').equalTo(literalNull).conditional(literalString(''), element)
+      : element;
+
+  final closure = Method(
+    (b) => b
+      ..lambda = true
+      ..requiredParameters.add(Parameter((p) => p..name = 'e'))
+      ..body = guarded.code,
+  ).closure;
+
+  Expression mapped(Expression list) {
+    final listExpr = useImmutableCollections ? list.property('unlock') : list;
+    return listExpr.property('map').call([closure]).property('toList').call([]);
+  }
+
+  if (nullGuard == null) return mapped(field);
+
+  return nullGuard
+      .equalTo(literalNull)
+      .conditional(
+        literalConstList([], refer('String', 'dart:core')),
+        mapped(field),
+      );
+}

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -70,10 +70,11 @@ BuiltExpression buildToFormValueExpression(
 /// call, keyed by raw spec name to match the class's own per-property lookup.
 ///
 /// Carries per-property `explode` for every writable simple-content array
-/// property — its explicit value, or defaulting to true only when the encoding
-/// omits explode and its style is form or absent; a carried `false` keeps the
-/// array comma-joined — plus `allowReserved` for any property that opts in.
-/// Returns null when no property is an array and none opts into allowReserved.
+/// property. The value is the encoding's explicit `explode`, or defaults to
+/// true only when the encoding omits explode and its style is form or absent. A
+/// carried `false` keeps the array comma-joined. Also carries `allowReserved`
+/// for any property that opts in. Returns null when no property is a writable
+/// simple-content array and none opts into allowReserved.
 Expression? _fieldEncodingsLiteral(
   Model model,
   Map<Property, FieldEncoding>? encoding,

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -3,6 +3,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
+import 'package:tonik_generate/src/util/form_exploded_values_generator.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 
 BuiltExpression buildToFormValueExpression(
@@ -69,9 +70,10 @@ BuiltExpression buildToFormValueExpression(
 /// call, keyed by raw spec name to match the class's own per-property lookup.
 ///
 /// Carries per-property `explode` for every writable simple-content array
-/// property — defaulting to true (`style: form`) when the spec omits an
-/// Encoding Object — so the runtime emits repeated keys, plus `allowReserved`
-/// for any property that opts in. Returns null when no property needs either.
+/// property — defaulting to true only when the property's encoding omits
+/// explode and its style is form or absent — so the runtime emits repeated
+/// keys, plus `allowReserved` for any property that opts in. Returns null when
+/// no property needs either.
 Expression? _fieldEncodingsLiteral(
   Model model,
   Map<Property, FieldEncoding>? encoding,
@@ -101,8 +103,8 @@ Expression? _fieldEncodingsLiteral(
 
     final fieldEncoding = byName[property.name];
     final allowReserved = fieldEncoding?.allowReserved ?? false;
-    final explode = _isSimpleContentList(property.model)
-        ? (fieldEncoding?.explode ?? true)
+    final explode = isExplodedFormArrayProperty(property)
+        ? _explodeDefault(fieldEncoding)
         : null;
 
     if (!allowReserved && explode == null) continue;
@@ -118,21 +120,31 @@ Expression? _fieldEncodingsLiteral(
   return literalMap(map, refer('String', 'dart:core'), descriptor);
 }
 
-List<Property> _collectFormProperties(Model model) {
-  switch (model.resolved) {
-    case final ClassModel m:
-      return m.properties.toList();
-    case final AllOfModel m:
-      return [
-        for (final member in m.models) ..._collectFormProperties(member),
-      ];
-    default:
-      return const [];
-  }
+/// The effective explode for a form array property: the explicit value, or
+/// per OAS the default of true only for form or absent style.
+bool _explodeDefault(FieldEncoding? fieldEncoding) {
+  final style = fieldEncoding?.style;
+  return fieldEncoding?.explode ??
+      (style == null || style == EncodingStyle.form);
 }
 
-bool _isSimpleContentList(Model model) =>
-    model is ListModel && model.hasSimpleContent;
+List<Property> _collectFormProperties(Model model) {
+  final sorter = StableModelSorter();
+  List<Property> collect(Model model) {
+    switch (model.resolved) {
+      case final ClassModel m:
+        return m.properties.toList();
+      case final AllOfModel m:
+        return [
+          for (final member in sorter.sortModels(m.models)) ...collect(member),
+        ];
+      default:
+        return const [];
+    }
+  }
+
+  return collect(model);
+}
 
 Expression _entriesToBody(Expression entries) {
   return entries

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -70,10 +70,10 @@ BuiltExpression buildToFormValueExpression(
 /// call, keyed by raw spec name to match the class's own per-property lookup.
 ///
 /// Carries per-property `explode` for every writable simple-content array
-/// property — defaulting to true only when the property's encoding omits
-/// explode and its style is form or absent — so the runtime emits repeated
-/// keys, plus `allowReserved` for any property that opts in. Returns null when
-/// no property needs either.
+/// property — its explicit value, or defaulting to true only when the encoding
+/// omits explode and its style is form or absent; a carried `false` keeps the
+/// array comma-joined — plus `allowReserved` for any property that opts in.
+/// Returns null when no property is an array and none opts into allowReserved.
 Expression? _fieldEncodingsLiteral(
   Model model,
   Map<Property, FieldEncoding>? encoding,

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -51,7 +51,7 @@ BuiltExpression buildToFormValueExpression(
     explode: literalBool(explodeLiteral),
     allowEmpty: literalBool(allowEmptyLiteral),
     useQueryComponent: useQueryComponent ? literalBool(true) : null,
-    fieldEncodings: _fieldEncodingsLiteral(encoding),
+    fieldEncodings: _fieldEncodingsLiteral(model, encoding),
   );
 
   if (entries == null) {
@@ -66,30 +66,73 @@ BuiltExpression buildToFormValueExpression(
 }
 
 /// Builds a `<String, FormFieldEncoding>` map literal for the object `toForm`
-/// call, containing only the writable properties that opt into `allowReserved`.
-/// Keyed by raw spec name to match the class's own per-property lookup. Returns
-/// null when no property opts in so the call omits the argument.
+/// call, keyed by raw spec name to match the class's own per-property lookup.
+///
+/// Carries per-property `explode` for every writable simple-content array
+/// property — defaulting to true (`style: form`) when the spec omits an
+/// Encoding Object — so the runtime emits repeated keys, plus `allowReserved`
+/// for any property that opts in. Returns null when no property needs either.
 Expression? _fieldEncodingsLiteral(
+  Model model,
   Map<Property, FieldEncoding>? encoding,
 ) {
-  if (encoding == null) return null;
+  final byName = <String, FieldEncoding>{
+    if (encoding != null)
+      for (final entry in encoding.entries) entry.key.name: entry.value,
+  };
+
+  final properties = <String, Property>{};
+  for (final property in _collectFormProperties(model)) {
+    properties[property.name] = property;
+  }
+  if (encoding != null) {
+    for (final property in encoding.keys) {
+      properties.putIfAbsent(property.name, () => property);
+    }
+  }
 
   final descriptor = refer(
     'FormFieldEncoding',
     'package:tonik_util/tonik_util.dart',
   );
-  final reserved = <Expression, Expression>{
-    for (final entry in encoding.entries)
-      if (!entry.key.isReadOnly && entry.value.allowReserved)
-        specLiteralString(entry.key.name): descriptor.constInstance([], {
-          'allowReserved': literalBool(true),
-        }),
-  };
+  final map = <Expression, Expression>{};
+  for (final property in properties.values) {
+    if (property.isReadOnly) continue;
 
-  if (reserved.isEmpty) return null;
+    final fieldEncoding = byName[property.name];
+    final allowReserved = fieldEncoding?.allowReserved ?? false;
+    final explode = _isSimpleContentList(property.model)
+        ? (fieldEncoding?.explode ?? true)
+        : null;
 
-  return literalMap(reserved, refer('String', 'dart:core'), descriptor);
+    if (!allowReserved && explode == null) continue;
+
+    map[specLiteralString(property.name)] = descriptor.constInstance([], {
+      if (allowReserved) 'allowReserved': literalBool(true),
+      if (explode != null) 'explode': literalBool(explode),
+    });
+  }
+
+  if (map.isEmpty) return null;
+
+  return literalMap(map, refer('String', 'dart:core'), descriptor);
 }
+
+List<Property> _collectFormProperties(Model model) {
+  switch (model.resolved) {
+    case final ClassModel m:
+      return m.properties.toList();
+    case final AllOfModel m:
+      return [
+        for (final member in m.models) ..._collectFormProperties(member),
+      ];
+    default:
+      return const [];
+  }
+}
+
+bool _isSimpleContentList(Model model) =>
+    model is ListModel && model.hasSimpleContent;
 
 Expression _entriesToBody(Expression entries) {
   return entries

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -244,7 +244,8 @@ String perPropertyAllowReservedArgument(String rawPropertyName) =>
     'allowReserved: ${perPropertyAllowReservedValue(rawPropertyName)}';
 
 /// A `Map<String, FormFieldEncoding> fieldEncodings = const {}` parameter that
-/// carries per-property reserved-character overrides into form encoding.
+/// carries per-property reserved-character overrides and array explode into
+/// form encoding.
 Parameter buildFieldEncodingsParameter() => Parameter(
   (b) => b
     ..name = 'fieldEncodings'

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -150,6 +150,7 @@ void main() {
             allowEmpty: allowEmpty,
             alreadyEncoded: true,
             useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
           );
         }
       ''';
@@ -240,6 +241,7 @@ void main() {
             allowEmpty: allowEmpty,
             alreadyEncoded: true,
             useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
           );
         }
       ''';
@@ -1166,6 +1168,425 @@ void main() {
     expect(
       collapseWhitespace(generated),
       contains(collapseWhitespace(expectedFromForm)),
+    );
+  });
+
+  test('generates toForm threading explodedValues for an object member with '
+      'a simple-content array property', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfObjectArray',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': meta.tags
+                  .map(
+                    (e) => e.uriEncode(
+                      allowEmpty: true,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved:
+                          fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                    ),
+                  )
+                  .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('generates toForm without explodedValues when a bare array member is '
+      'combined with an object member', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfListAndObject',
+      models: {
+        ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          properties: [
+            Property(
+              name: 'note',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('null-guards exploded array of a nullable object member without '
+      'unwrapping the member for the null test', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfNullableObject',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          isNullable: true,
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': meta?.tags == null
+                  ? const <String>[]
+                  : meta!.tags
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('collapses a duplicate exploded array key from two members to the '
+      'last-merged member', () {
+    ClassModel member(String name) => ClassModel(
+      isDeprecated: false,
+      name: name,
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfDuplicateArray',
+      models: {member('Alpha'), member('Beta')},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': beta.tags
+                  .map(
+                    (e) => e.uriEncode(
+                      allowEmpty: true,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved:
+                          fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                    ),
+                  )
+                  .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('threads an optional array property of a nested allOf member through '
+      'the composed field path', () {
+    final inner = AllOfModel(
+      isDeprecated: false,
+      name: 'Inner',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: false,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'Outer',
+      models: {inner},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': inner.meta.tags == null
+                  ? const <String>[]
+                  : inner.meta.tags!
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('null-guards a write-only required array property whose member field '
+      'the writeOnly flag widens to nullable', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfWriteOnlyArray',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              isWriteOnly: true,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': meta.tags == null
+                  ? const <String>[]
+                  : meta.tags!
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
     );
   });
 }

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -1942,8 +1942,8 @@ void main() {
     );
   });
 
-  test('emits the empty list for a duplicate array key whose scalar member '
-      'sorts last', () {
+  test("emits the sole list member's elements for a duplicate key whose "
+      'scalar member wins the merge', () {
     final listMember = ClassModel(
       isDeprecated: false,
       name: 'AListMember',
@@ -2017,6 +2017,270 @@ void main() {
                     ),
                   )
                   .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('guards a nullable class member reached through a non-nullable nested '
+      'allOf member with a plain null test, not a null-aware receiver', () {
+    final inner = AllOfModel(
+      isDeprecated: false,
+      name: 'Inner',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          isNullable: true,
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'OuterNonNullableInner',
+      models: {inner},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': inner.meta == null
+                  ? const <String>[]
+                  : inner.meta!.tags
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('unwraps only the nullable link when a non-nullable member follows a '
+      'nullable nested allOf member', () {
+    final inner = AllOfModel(
+      isDeprecated: false,
+      name: 'Inner',
+      isNullable: true,
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Mid',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'OuterNullableInner',
+      models: {inner},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': inner?.mid == null
+                  ? const <String>[]
+                  : inner!.mid.tags
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('emits the three-way merge for a duplicate array key whose later '
+      'nullable member has an optional leaf array', () {
+    final alpha = ClassModel(
+      isDeprecated: false,
+      name: 'Alpha',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final beta = ClassModel(
+      isDeprecated: false,
+      name: 'Beta',
+      isNullable: true,
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: false,
+          isNullable: true,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfNullableMemberNullableLeaf',
+      models: {alpha, beta},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': beta == null
+                  ? alpha.tags
+                        .map(
+                          (e) => e.uriEncode(
+                            allowEmpty: true,
+                            useQueryComponent: useQueryComponent,
+                            allowReserved:
+                                fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                          ),
+                        )
+                        .toList()
+                  : beta!.tags == null
+                  ? const <String>[]
+                  : beta!.tags!
+                        .map(
+                          (e) => e.uriEncode(
+                            allowEmpty: true,
+                            useQueryComponent: useQueryComponent,
+                            allowReserved:
+                                fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                          ),
+                        )
+                        .toList(),
             },
           );
         }

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -1439,6 +1439,194 @@ void main() {
     );
   });
 
+  test('agrees on the list member as merge winner for a duplicate raw name '
+      'shared by a list member and a scalar member', () {
+    final listMember = ClassModel(
+      isDeprecated: false,
+      name: 'ZListMember',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final scalarMember = ClassModel(
+      isDeprecated: false,
+      name: 'AScalarMember',
+      properties: [
+        Property(
+          name: 'tags',
+          model: StringModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfListScalarDuplicate',
+      models: {listMember, scalarMember},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': zListMember.tags
+                  .map(
+                    (e) => e.uriEncode(
+                      allowEmpty: true,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved:
+                          fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                    ),
+                  )
+                  .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('falls back to an earlier member when the later duplicate array member '
+      'is null at runtime', () {
+    final alpha = ClassModel(
+      isDeprecated: false,
+      name: 'Alpha',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final beta = ClassModel(
+      isDeprecated: false,
+      name: 'Beta',
+      isNullable: true,
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfNullableDuplicateArray',
+      models: {alpha, beta},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': beta?.tags == null
+                  ? alpha.tags
+                        .map(
+                          (e) => e.uriEncode(
+                            allowEmpty: true,
+                            useQueryComponent: useQueryComponent,
+                            allowReserved:
+                                fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                          ),
+                        )
+                        .toList()
+                  : beta!.tags
+                        .map(
+                          (e) => e.uriEncode(
+                            allowEmpty: true,
+                            useQueryComponent: useQueryComponent,
+                            allowReserved:
+                                fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                          ),
+                        )
+                        .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
   test('threads an optional array property of a nested allOf member through '
       'the composed field path', () {
     final inner = AllOfModel(

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -1347,7 +1347,7 @@ void main() {
             useQueryComponent: useQueryComponent,
             fieldEncodings: fieldEncodings,
             explodedValues: <String, List<String>>{
-              r'tags': meta?.tags == null
+              r'tags': meta == null
                   ? const <String>[]
                   : meta!.tags
                       .map(
@@ -1595,7 +1595,7 @@ void main() {
             useQueryComponent: useQueryComponent,
             fieldEncodings: fieldEncodings,
             explodedValues: <String, List<String>>{
-              r'tags': beta?.tags == null
+              r'tags': beta == null
                   ? alpha.tags
                         .map(
                           (e) => e.uriEncode(
@@ -1616,6 +1616,98 @@ void main() {
                           ),
                         )
                         .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('selects the empty list for a duplicate array key whose winning later '
+      'member is present with a null array property', () {
+    final alpha = ClassModel(
+      isDeprecated: false,
+      name: 'Alpha',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final beta = ClassModel(
+      isDeprecated: false,
+      name: 'Beta',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: false,
+          isNullable: true,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfNullLeafDuplicateArray',
+      models: {alpha, beta},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': beta.tags == null
+                  ? const <String>[]
+                  : beta.tags!
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
             },
           );
         }
@@ -1767,6 +1859,164 @@ void main() {
                         ),
                       )
                       .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('null-guards a required array property whose ListModel is itself '
+      'nullable on a member class', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfNullableListArray',
+      models: {
+        ClassModel(
+          isDeprecated: false,
+          name: 'Meta',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                isNullable: true,
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        ),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': meta.tags == null
+                  ? const <String>[]
+                  : meta.tags!
+                      .map(
+                        (e) => e.uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: useQueryComponent,
+                          allowReserved:
+                              fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                        ),
+                      )
+                      .toList(),
+            },
+          );
+        }
+      ''';
+
+    expect(
+      collapseWhitespace(generated),
+      contains(collapseWhitespace(expectedToFormMethod)),
+    );
+  });
+
+  test('emits the empty list for a duplicate array key whose scalar member '
+      'sorts last', () {
+    final listMember = ClassModel(
+      isDeprecated: false,
+      name: 'AListMember',
+      properties: [
+        Property(
+          name: 'tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final scalarMember = ClassModel(
+      isDeprecated: false,
+      name: 'ZScalarMember',
+      properties: [
+        Property(
+          name: 'tags',
+          model: StringModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfScalarLastDuplicate',
+      models: {listMember, scalarMember},
+      context: context,
+      examples: const [],
+    );
+
+    final combinedClass = generator.generateClass(model);
+    final generated = format(combinedClass.accept(emitter).toString());
+
+    const expectedToFormMethod = '''
+        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+          ).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            alreadyEncoded: true,
+            useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
+            explodedValues: <String, List<String>>{
+              r'tags': aListMember.tags
+                  .map(
+                    (e) => e.uriEncode(
+                      allowEmpty: true,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved:
+                          fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+                    ),
+                  )
+                  .toList(),
             },
           );
         }

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -1962,6 +1962,7 @@ List<ParameterEntry> toForm(
     allowEmpty: allowEmpty,
     alreadyEncoded: true,
     useQueryComponent: useQueryComponent,
+    fieldEncodings: fieldEncodings,
   );
 }
 ''';

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -1669,6 +1669,79 @@ r'tags': tags == null
       );
 
       test(
+        'toForm null-guards explodedValues for a required array property whose '
+        'ListModel is itself nullable',
+        () {
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'NullableListModel',
+            properties: [
+              Property(
+                name: 'tags',
+                model: ListModel(
+                  content: StringModel(context: context),
+                  isNullable: true,
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = generator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'tags': tags == null
+    ? const <String>[]
+    : tags!
+        .map(
+          (e) => e.uriEncode(
+            allowEmpty: true,
+            useQueryComponent: useQueryComponent,
+            allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+          ),
+        )
+        .toList(),
+},
+);
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
+          );
+        },
+      );
+
+      test(
         'toForm explodedValues maps null elements of a nullable-content array '
         'property to empty strings',
         () {

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -1149,6 +1149,86 @@ void main() {
     });
 
     group('form encoding', () {
+      test(
+        'an alias-wrapped array property routes form encoding to the contains '
+        'complex types path with no explode descriptor',
+        () {
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'ModelWithAliasedList',
+            properties: [
+              Property(
+                name: 'tags',
+                model: AliasModel(
+                  name: 'TagList',
+                  model: ListModel(
+                    content: StringModel(context: context),
+                    context: context,
+                    examples: const [],
+                  ),
+                  context: context,
+                  defaultValue: null,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = generator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedParameterPropertiesMethod = '''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) => throw EncodingException(
+  r'parameterProperties not supported for ModelWithAliasedList: contains complex types',
+);
+          ''';
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+);
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedParameterPropertiesMethod)),
+          );
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
+          );
+        },
+      );
+
       test('generates fromForm constructor for simple properties', () {
         final model = ClassModel(
           isDeprecated: false,
@@ -1415,6 +1495,101 @@ Map<String, String> parameterProperties({
             contains(collapseWhitespace(expectedToFormMethod)),
           );
 
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedParameterPropertiesMethod)),
+          );
+        },
+      );
+
+      test(
+        'array property whose raw name differs from the Dart field keys all '
+        'three maps by the raw name',
+        () {
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'RawNameListModel',
+            properties: [
+              Property(
+                name: 'user-tags',
+                model: ListModel(
+                  content: StringModel(context: context),
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = generator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'user-tags': userTags
+    .map(
+      (e) => e.uriEncode(
+        allowEmpty: true,
+        useQueryComponent: useQueryComponent,
+        allowReserved:
+            fieldEncodings[r'user-tags']?.allowReserved ?? allowReserved,
+      ),
+    )
+    .toList(),
+},
+);
+}
+          ''';
+
+          const expectedParameterPropertiesMethod = r'''
+Map<String, String> parameterProperties({
+  bool allowEmpty = true,
+  bool allowLists = true,
+  bool useQueryComponent = false,
+  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+  if (!allowLists) {
+    throw EncodingException('Lists are not supported in this encoding style');
+  }
+  final _$result = <String, String>{};
+  _$result[r'user-tags'] = userTags.uriEncode(
+    allowEmpty: allowEmpty,
+    useQueryComponent: useQueryComponent,
+    allowReserved: fieldEncodings[r'user-tags']?.allowReserved ?? allowReserved,
+  );
+  return _$result;
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
+          );
           expect(
             collapseWhitespace(generatedCode),
             contains(collapseWhitespace(expectedParameterPropertiesMethod)),

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -1369,6 +1369,18 @@ explode: explode,
 allowEmpty: allowEmpty,
 alreadyEncoded: true,
 useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'tags': tags
+    .map(
+      (e) => e.uriEncode(
+        allowEmpty: true,
+        useQueryComponent: useQueryComponent,
+        allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+      ),
+    )
+    .toList(),
+},
 );
 }
           ''';
@@ -1406,6 +1418,226 @@ Map<String, String> parameterProperties({
           expect(
             collapseWhitespace(generatedCode),
             contains(collapseWhitespace(expectedParameterPropertiesMethod)),
+          );
+        },
+      );
+
+      test(
+        'toForm null-guards explodedValues for an optional array property',
+        () {
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'OptionalListModel',
+            properties: [
+              Property(
+                name: 'tags',
+                model: ListModel(
+                  content: StringModel(context: context),
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: false,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = generator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'tags': tags == null
+    ? const <String>[]
+    : tags!
+        .map(
+          (e) => e.uriEncode(
+            allowEmpty: true,
+            useQueryComponent: useQueryComponent,
+            allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+          ),
+        )
+        .toList(),
+},
+);
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
+          );
+        },
+      );
+
+      test(
+        'toForm explodedValues maps null elements of a nullable-content array '
+        'property to empty strings',
+        () {
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'NullableElementListModel',
+            properties: [
+              Property(
+                name: 'tags',
+                model: ListModel(
+                  content: StringModel(context: context),
+                  isContentNullable: true,
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = generator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'tags': tags
+    .map(
+      (e) => e == null
+          ? ''
+          : e.uriEncode(
+              allowEmpty: true,
+              useQueryComponent: useQueryComponent,
+              allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+            ),
+    )
+    .toList(),
+},
+);
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
+          );
+        },
+      );
+
+      test(
+        'toForm explodedValues unlocks an immutable-collection array property '
+        'before mapping elements',
+        () {
+          final immutableGenerator = ClassGenerator(
+            nameManager: nameManager,
+            package: 'example',
+            useImmutableCollections: true,
+          );
+
+          final model = ClassModel(
+            isDeprecated: false,
+            name: 'ImmutableListModel',
+            properties: [
+              Property(
+                name: 'tags',
+                model: ListModel(
+                  content: StringModel(context: context),
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final result = immutableGenerator.generateClass(model);
+          final generatedCode = format(result.accept(emitter).toString());
+
+          const expectedToFormMethod = '''
+List<ParameterEntry> toForm(
+String paramName, {
+required bool explode,
+required bool allowEmpty,
+bool useQueryComponent = false,
+bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+}) {
+return parameterProperties(
+allowEmpty: allowEmpty,
+useQueryComponent: useQueryComponent,
+allowReserved: allowReserved, fieldEncodings: fieldEncodings,
+).toForm(
+paramName,
+explode: explode,
+allowEmpty: allowEmpty,
+alreadyEncoded: true,
+useQueryComponent: useQueryComponent,
+fieldEncodings: fieldEncodings,
+explodedValues: <String, List<String>>{
+r'tags': tags.unlock
+    .map(
+      (e) => e.uriEncode(
+        allowEmpty: true,
+        useQueryComponent: useQueryComponent,
+        allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
+      ),
+    )
+    .toList(),
+},
+);
+}
+          ''';
+
+          expect(
+            collapseWhitespace(generatedCode),
+            contains(collapseWhitespace(expectedToFormMethod)),
           );
         },
       );
@@ -1515,7 +1747,7 @@ Map<String, String> parameterProperties({
 
         const expectedToFormBody = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, fieldEncodings: fieldEncodings, explodedValues: <String, List<String>>{r'items': items.map((e) => e.uriEncode(allowEmpty: true, useQueryComponent: useQueryComponent, allowReserved: fieldEncodings[r'items']?.allowReserved ?? allowReserved, )).toList()}, );
           }
         ''';
 
@@ -1538,7 +1770,7 @@ Map<String, String> parameterProperties({
 
         const expectedToFormMethod = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, fieldEncodings: fieldEncodings, );
           }
         ''';
 
@@ -1786,7 +2018,7 @@ Map<String, String> parameterProperties({
 
           const expectedToFormMethod = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, fieldEncodings: fieldEncodings, );
           }
         ''';
 

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -464,6 +464,7 @@ void main() {
             allowEmpty: allowEmpty,
             alreadyEncoded: true,
             useQueryComponent: useQueryComponent,
+            fieldEncodings: fieldEncodings,
           );
         }
       ''';

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1956,6 +1956,7 @@ void main() {
                     useQueryComponent: true,
                     fieldEncodings: <String, FormFieldEncoding>{
                       r'reserved': const FormFieldEncoding(allowReserved: true),
+                      r'tags': const FormFieldEncoding(explode: true),
                     },
                   )
                   .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -377,6 +377,62 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('ClassModel body defaults an explicit form-style array property to '
+        'explode=true when the encoding omits explode', () {
+      final colors = Property(
+        name: 'colors',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [colors],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          colors: const FieldEncoding(
+            style: EncodingStyle.form,
+            explode: null,
+            allowReserved: false,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'colors': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('ClassModel body defaults a pipeDelimited array property to '
         'explode=false when the encoding omits explode', () {
       final tags = Property(
@@ -750,6 +806,54 @@ void main() {
         examples: const [],
       );
       final model = OneOfModel(
+        name: 'Form',
+        models: {(discriminatorValue: null, model: variant)},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('anyOf body yields no explode descriptors for its array properties',
+        () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final variant = ClassModel(
+        name: 'Variant',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+      final model = AnyOfModel(
         name: 'Form',
         models: {(discriminatorValue: null, model: variant)},
         context: context,

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -377,6 +377,290 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('ClassModel body defaults a pipeDelimited array property to '
+        'explode=false when the encoding omits explode', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          tags: const FieldEncoding(
+            allowReserved: false,
+            style: EncodingStyle.pipeDelimited,
+            explode: null,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: false),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body explodes a pipeDelimited array property when the '
+        'encoding sets explode=true', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          tags: const FieldEncoding(
+            allowReserved: false,
+            style: EncodingStyle.pipeDelimited,
+            explode: true,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('AllOf body flags an array member property with explode=true in '
+        'fieldEncodings', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final member = ClassModel(
+        name: 'Member',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+      final model = AllOfModel(
+        name: 'Form',
+        models: {member},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('AllOf body with a duplicate raw name across a list and a scalar '
+        'member keys the descriptor from the sorted-last member', () {
+      final listMember = ClassModel(
+        name: 'ZListMember',
+        isDeprecated: false,
+        properties: [
+          Property(
+            name: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+      final scalarMember = ClassModel(
+        name: 'AScalarMember',
+        isDeprecated: false,
+        properties: [
+          Property(
+            name: 'tags',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+      final model = AllOfModel(
+        name: 'Form',
+        models: {listMember, scalarMember},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body excludes a read-only array property from '
+        'fieldEncodings', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        isReadOnly: true,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('AnyModel body renders directly via encodeAnyToForm', () {
       final result = buildToFormValueExpression(
         'body',

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -661,6 +661,167 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('AllOf body with a duplicate raw name whose scalar member sorts last '
+        'omits the descriptor key', () {
+      final listMember = ClassModel(
+        name: 'AListMember',
+        isDeprecated: false,
+        properties: [
+          Property(
+            name: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+      final scalarMember = ClassModel(
+        name: 'ZScalarMember',
+        isDeprecated: false,
+        properties: [
+          Property(
+            name: 'tags',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+      final model = AllOfModel(
+        name: 'Form',
+        models: {listMember, scalarMember},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('oneOf body yields no explode descriptors for its array properties',
+        () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final variant = ClassModel(
+        name: 'Variant',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+      final model = OneOfModel(
+        name: 'Form',
+        models: {(discriminatorValue: null, model: variant)},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body omits the explode descriptor for an alias-wrapped '
+        'array property', () {
+      final tags = Property(
+        name: 'tags',
+        model: AliasModel(
+          name: 'Tags',
+          model: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          context: context,
+          defaultValue: null,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('AnyModel body renders directly via encodeAnyToForm', () {
       final result = buildToFormValueExpression(
         'body',

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -258,7 +258,115 @@ void main() {
                 allowEmpty: true,
                 useQueryComponent: true,
                 fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
-                  r'tags': const _i2.FormFieldEncoding(allowReserved: true),
+                  r'tags': const _i2.FormFieldEncoding(
+                    allowReserved: true,
+                    explode: true,
+                  ),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body defaults an array property to explode=true with no '
+        'encoding', () {
+      final colors = Property(
+        name: 'colors',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [colors],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'colors': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body threads explode=false for an array property that '
+        'opts out', () {
+      final colors = Property(
+        name: 'colors',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [colors],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          colors: const FieldEncoding(
+            allowReserved: false,
+            style: null,
+            explode: false,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'colors': const _i2.FormFieldEncoding(explode: false),
                 },
               )
               .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -316,8 +316,22 @@ class RequestBodyImporter {
 
       if (property == null || property.isReadOnly) continue;
 
+      final style = _mapSerializationStyle(encoding.style);
+      final isDelimitedStyle =
+          style == core.EncodingStyle.spaceDelimited ||
+          style == core.EncodingStyle.pipeDelimited;
+      if (isDelimitedStyle &&
+          encoding.explode != true &&
+          property.model.resolved is core.ListModel) {
+        log.warning(
+          'Encoding for property "${entry.key}" on the form-urlencoded schema '
+          'requests ${encoding.style} style, but only the form style is '
+          'supported for form bodies. The array will be comma-joined.',
+        );
+      }
+
       result[property] = core.FieldEncoding(
-        style: _mapSerializationStyle(encoding.style),
+        style: style,
         explode: encoding.explode,
         allowReserved: encoding.allowReserved ?? false,
       );

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -2167,6 +2167,100 @@ void main() {
       expect(idsEncoding.allowReserved, isFalse);
     });
 
+    test('spaceDelimited array with explode omitted logs a comma-join '
+        'warning', () {
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+
+      addTearDown(sub.cancel);
+
+      importFormContent(
+        formSpec(
+          properties: {
+            'ids': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+          encoding: {
+            'ids': {'style': 'spaceDelimited'},
+          },
+        ),
+      );
+
+      expect(
+        logs.any(
+          (r) =>
+              r.level == Level.WARNING &&
+              r.message.contains('"ids"') &&
+              r.message.contains('comma-joined'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('pipeDelimited array with explicit explode false logs a comma-join '
+        'warning', () {
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+
+      addTearDown(sub.cancel);
+
+      importFormContent(
+        formSpec(
+          properties: {
+            'ids': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+          encoding: {
+            'ids': {'style': 'pipeDelimited', 'explode': false},
+          },
+        ),
+      );
+
+      expect(
+        logs.any(
+          (r) =>
+              r.level == Level.WARNING &&
+              r.message.contains('"ids"') &&
+              r.message.contains('comma-joined'),
+        ),
+        isTrue,
+      );
+    });
+
+    test('spaceDelimited array with explicit explode true does not log a '
+        'comma-join warning', () {
+      final logs = <LogRecord>[];
+      final sub = Logger.root.onRecord.listen(logs.add);
+
+      addTearDown(sub.cancel);
+
+      importFormContent(
+        formSpec(
+          properties: {
+            'ids': {
+              'type': 'array',
+              'items': {'type': 'string'},
+            },
+          },
+          encoding: {
+            'ids': {'style': 'spaceDelimited', 'explode': true},
+          },
+        ),
+      );
+
+      expect(
+        logs.any(
+          (r) =>
+              r.level == Level.WARNING && r.message.contains('comma-joined'),
+        ),
+        isFalse,
+      );
+    });
+
     test('encoding key not matching any property logs warning', () {
       final logs = <LogRecord>[];
       final sub = Logger.root.onRecord.listen(logs.add);

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -56,7 +56,8 @@ abstract interface class FormEncodable {
   /// When [allowReserved] is true, reserved characters in values are kept
   /// literal except the form delimiters `& = +`.
   /// [fieldEncodings], keyed by raw property name, lets individual object
-  /// properties override [allowReserved]; other encoders ignore it.
+  /// properties override [allowReserved] and selects exploded vs comma-joined
+  /// emission for array properties; other encoders ignore it.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -56,8 +56,10 @@ abstract interface class FormEncodable {
   /// When [allowReserved] is true, reserved characters in values are kept
   /// literal except the form delimiters `& = +`.
   /// [fieldEncodings], keyed by raw property name, lets individual object
-  /// properties override [allowReserved] and selects exploded vs comma-joined
-  /// emission for array properties; other encoders ignore it.
+  /// properties override [allowReserved]. Only generated object and allOf
+  /// encoders thread it to select exploded vs comma-joined emission for array
+  /// properties; oneOf/anyOf encoders do not thread the descriptors, and other
+  /// encoders ignore it.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -248,14 +248,14 @@ extension FormStringMapEncoder on Map<String, String> {
   /// [fieldEncodings], keyed by raw property name, carries per-property array
   /// explode. When a key's descriptor has `explode == true`, its element
   /// strings are taken from [explodedValues] (keeping element boundaries that a
-  /// comma-joined value would lose) and emitted as one entry per element, so
-  /// the wire form matches `style: form, explode: true` (repeated keys). An
+  /// comma-joined value would lose) and emitted as one entry per element. An
   /// exploded empty list yields no entries; a single empty-string element
   /// yields one empty-value entry.
   ///
   /// [fieldEncodings] and [explodedValues] are ignored when [explode] is false.
-  /// The descriptors' `allowReserved` is not consulted here: values arrive
-  /// already URI-encoded upstream.
+  /// The descriptors' per-field `allowReserved` is not consulted here:
+  /// generated callers pass elements pre-encoded ([alreadyEncoded] true). With
+  /// [alreadyEncoded] false only the uniform [allowReserved] parameter applies.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
@@ -303,8 +303,9 @@ extension FormStringMapEncoder on Map<String, String> {
       if (fieldEncodings[e.key]?.explode ?? false) {
         final exploded = explodedValues[e.key];
         if (exploded == null) {
+          final owner = paramName.isEmpty ? '' : ' of "$paramName"';
           throw EncodingException(
-            'Form property "${e.key}" of "$paramName" is marked exploded but '
+            'Form property "${e.key}"$owner is marked exploded but '
             'has no exploded values. This indicates the generated code and '
             'runtime disagree (drift or version skew), not invalid input.',
           );

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -1,5 +1,6 @@
 import 'package:big_decimal/big_decimal.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
+import 'package:tonik_util/src/encoding/form_field_encoding.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
@@ -243,6 +244,14 @@ extension FormStringMapEncoder on Map<String, String> {
   /// The [alreadyEncoded] parameter indicates whether the values are already
   /// URL-encoded, in which case they are not re-encoded to prevent double
   /// encoding.
+  ///
+  /// [fieldEncodings], keyed by raw property name, carries per-property array
+  /// explode. When a key's descriptor has `explode == true`, its element
+  /// strings are taken from [explodedValues] (keeping element boundaries that a
+  /// comma-joined value would lose) and emitted as one entry per element, so
+  /// the wire form matches `style: form, explode: true` (repeated keys). An
+  /// exploded empty list yields no entries; a single empty-string element
+  /// yields one empty-value entry.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
@@ -250,6 +259,8 @@ extension FormStringMapEncoder on Map<String, String> {
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    Map<String, FormFieldEncoding> fieldEncodings = const {},
+    Map<String, List<String>> explodedValues = const {},
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -269,23 +280,37 @@ extension FormStringMapEncoder on Map<String, String> {
       ];
     }
 
-    return [
-      for (final e in entries)
-        (
-          name: _encodeValue(
-            e.key,
+    String encodeValue(String value) => alreadyEncoded
+        ? value
+        : _encodeValue(
+            value,
             useQueryComponent: useQueryComponent,
             allowReserved: allowReserved,
-          ),
-          value: alreadyEncoded
-              ? e.value
-              : _encodeValue(
-                  e.value,
-                  useQueryComponent: useQueryComponent,
-                  allowReserved: allowReserved,
-                ),
-        ),
-    ];
+          );
+
+    final result = <ParameterEntry>[];
+    for (final e in entries) {
+      final name = _encodeValue(
+        e.key,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      );
+
+      if (fieldEncodings[e.key]?.explode ?? false) {
+        final exploded = explodedValues[e.key];
+        if (exploded == null) {
+          throw EncodingException(
+            'Missing exploded values for form property "${e.key}".',
+          );
+        }
+        for (final item in exploded) {
+          result.add((name: name, value: encodeValue(item)));
+        }
+      } else {
+        result.add((name: name, value: encodeValue(e.value)));
+      }
+    }
+    return result;
   }
 }
 

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -252,6 +252,10 @@ extension FormStringMapEncoder on Map<String, String> {
   /// the wire form matches `style: form, explode: true` (repeated keys). An
   /// exploded empty list yields no entries; a single empty-string element
   /// yields one empty-value entry.
+  ///
+  /// [fieldEncodings] and [explodedValues] are ignored when [explode] is false.
+  /// The descriptors' `allowReserved` is not consulted here: values arrive
+  /// already URI-encoded upstream.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
@@ -300,7 +304,9 @@ extension FormStringMapEncoder on Map<String, String> {
         final exploded = explodedValues[e.key];
         if (exploded == null) {
           throw EncodingException(
-            'Missing exploded values for form property "${e.key}".',
+            'Form property "${e.key}" of "$paramName" is marked exploded but '
+            'has no exploded values. This indicates the generated code and '
+            'runtime disagree (drift or version skew), not invalid input.',
           );
         }
         for (final item in exploded) {

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -256,6 +256,14 @@ extension FormStringMapEncoder on Map<String, String> {
   /// The descriptors' per-field `allowReserved` is not consulted here:
   /// generated callers pass elements pre-encoded ([alreadyEncoded] true). With
   /// [alreadyEncoded] false only the uniform [allowReserved] parameter applies.
+  ///
+  /// The two channels are deliberately asymmetric: an [explodedValues] entry
+  /// whose key carries no explode descriptor is silently comma-joined by
+  /// design. Generated models bake a superset of exploded values, and callers
+  /// that thread no descriptors (oneOf/anyOf composition, explicit
+  /// `explode: false`)
+  /// rely on that tolerance. The reverse — a descriptor marked exploded with no
+  /// matching [explodedValues] entry — throws, since it signals version skew.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
@@ -305,9 +313,10 @@ extension FormStringMapEncoder on Map<String, String> {
         if (exploded == null) {
           final owner = paramName.isEmpty ? '' : ' of "$paramName"';
           throw EncodingException(
-            'Form property "${e.key}"$owner is marked exploded but '
-            'has no exploded values. This indicates the generated code and '
-            'runtime disagree (drift or version skew), not invalid input.',
+            'Form property "${e.key}"$owner is marked exploded but has no '
+            'exploded values. Either a caller-supplied FormFieldEncoding marks '
+            'a non-array property as exploded, or the generated code and this '
+            'runtime disagree (version skew).',
           );
         }
         for (final item in exploded) {

--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -16,8 +16,7 @@ class FormFieldEncoding {
   /// Per-property array explode. When true, a list property emits one repeated
   /// `name=value` entry per element, which requires a matching entry in the
   /// `explodedValues` map passed to `Map<String, String>.toForm`; when false it
-  /// stays a single comma-joined entry. Null when the property is not an array;
-  /// false when the array stays a single comma-joined entry.
+  /// stays a single comma-joined entry. Null when the property is not an array.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -1,7 +1,9 @@
 import 'package:meta/meta.dart';
 
-/// Per-property encoding options threaded into a form-style `toForm` call so
-/// individual object properties can opt into reserved-character preservation.
+/// Per-property encoding options threaded into a form-style `toForm` call:
+/// whether an object property opts into reserved-character preservation and,
+/// for array properties, whether it explodes into repeated `name=value`
+/// entries.
 @immutable
 class FormFieldEncoding {
   /// Creates a descriptor; [allowReserved] defaults to false.
@@ -11,7 +13,9 @@ class FormFieldEncoding {
   /// except the form delimiters `& = +`.
   final bool allowReserved;
 
-  /// Reserved for per-property array explode; not yet consumed by `toForm`.
+  /// Per-property array explode. When true, a list property emits one repeated
+  /// `name=value` entry per element; when false it stays a single comma-joined
+  /// entry. Null for non-list properties.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -16,8 +16,8 @@ class FormFieldEncoding {
   /// Per-property array explode. When true, a list property emits one repeated
   /// `name=value` entry per element, which requires a matching entry in the
   /// `explodedValues` map passed to `Map<String, String>.toForm`; when false it
-  /// stays a single comma-joined entry. Null when the property is not an
-  /// exploded array.
+  /// stays a single comma-joined entry. Null when the property is not an array;
+  /// false when the array stays a single comma-joined entry.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -14,8 +14,10 @@ class FormFieldEncoding {
   final bool allowReserved;
 
   /// Per-property array explode. When true, a list property emits one repeated
-  /// `name=value` entry per element; when false it stays a single comma-joined
-  /// entry. Null for non-list properties.
+  /// `name=value` entry per element, which requires a matching entry in the
+  /// `explodedValues` map passed to `Map<String, String>.toForm`; when false it
+  /// stays a single comma-joined entry. Null when the property is not an
+  /// exploded array.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -536,8 +536,8 @@ void main() {
       );
     });
 
-    test('explode=true throws naming the property when explodedValues lacks '
-        'the exploded key', () {
+    test('explode=true throws naming the property and paramName when '
+        'explodedValues lacks the exploded key', () {
       expect(
         () => {'colors': 'red,green,blue'}.toForm(
           'p',
@@ -552,7 +552,32 @@ void main() {
           isA<EncodingException>().having(
             (e) => e.message,
             'message',
-            allOf(contains('colors'), contains('"p"')),
+            allOf(contains('"colors"'), contains('of "p"')),
+          ),
+        ),
+      );
+    });
+
+    test('explode=true omits the paramName segment from the drift message when '
+        'paramName is empty', () {
+      expect(
+        () => {'colors': 'red,green,blue'}.toForm(
+          '',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'colors': FormFieldEncoding(explode: true),
+          },
+        ),
+        throwsA(
+          isA<EncodingException>().having(
+            (e) => e.message,
+            'message',
+            allOf(
+              contains('"colors" is marked exploded'),
+              isNot(contains(' of ')),
+            ),
           ),
         ),
       );

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -2,6 +2,7 @@ import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/form_encoder_extensions.dart';
+import 'package:tonik_util/src/encoding/form_field_encoding.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
 
 void main() {
@@ -462,6 +463,224 @@ void main() {
         const <ParameterEntry>[
           (name: 'email', value: 'albert%40example.com'),
           (name: 'name', value: 'John%20Doe'),
+        ],
+      );
+    });
+
+    test(
+      'explode=true emits one entry per element from explodedValues',
+      () {
+        expect(
+          {
+            'colors': 'red,green,blue',
+            'name': 'John',
+          }.toForm(
+            'p',
+            explode: true,
+            allowEmpty: true,
+            alreadyEncoded: true,
+            fieldEncodings: const {
+              'colors': FormFieldEncoding(explode: true),
+            },
+            explodedValues: const {
+              'colors': ['red', 'green', 'blue'],
+            },
+          ),
+          const <ParameterEntry>[
+            (name: 'colors', value: 'red'),
+            (name: 'colors', value: 'green'),
+            (name: 'colors', value: 'blue'),
+            (name: 'name', value: 'John'),
+          ],
+        );
+      },
+    );
+
+    test(
+      'explode=false keeps a list value as a single comma-joined entry',
+      () {
+        expect(
+          {'colors': 'red,green,blue'}.toForm(
+            'p',
+            explode: true,
+            allowEmpty: true,
+            alreadyEncoded: true,
+            fieldEncodings: const {
+              'colors': FormFieldEncoding(),
+            },
+            explodedValues: const {
+              'colors': ['red', 'green', 'blue'],
+            },
+          ),
+          const <ParameterEntry>[(name: 'colors', value: 'red,green,blue')],
+        );
+      },
+    );
+
+    test('explode=true with an empty list emits no entry', () {
+      expect(
+        {
+          'colors': '',
+          'name': 'John',
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'colors': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {'colors': <String>[]},
+        ),
+        const <ParameterEntry>[(name: 'name', value: 'John')],
+      );
+    });
+
+    test('explode=true throws when explodedValues lacks the exploded key', () {
+      expect(
+        () => {'colors': 'red,green,blue'}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'colors': FormFieldEncoding(explode: true),
+          },
+        ),
+        throwsA(isA<EncodingException>()),
+      );
+    });
+
+    test('explode=true with a single empty-string element emits one empty '
+        'entry', () {
+      expect(
+        {'tags': ''}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'tags': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {
+            'tags': [''],
+          },
+        ),
+        const <ParameterEntry>[(name: 'tags', value: '')],
+      );
+    });
+
+    test(
+      'explode=true encodes each element with allowReserved false, percent '
+      'encoding a comma-containing element',
+      () {
+        expect(
+          {'tags': ''}.toForm(
+            'p',
+            explode: true,
+            allowEmpty: true,
+            fieldEncodings: const {
+              'tags': FormFieldEncoding(explode: true),
+            },
+            explodedValues: const {
+              'tags': ['a,b', 'c'],
+            },
+          ),
+          const <ParameterEntry>[
+            (name: 'tags', value: 'a%2Cb'),
+            (name: 'tags', value: 'c'),
+          ],
+        );
+      },
+    );
+
+    test(
+      'explode=true with allowReserved keeps a comma-containing element '
+      'literal as a single entry',
+      () {
+        expect(
+          {'tags': ''}.toForm(
+            'p',
+            explode: true,
+            allowEmpty: true,
+            allowReserved: true,
+            fieldEncodings: const {
+              'tags': FormFieldEncoding(explode: true),
+            },
+            explodedValues: const {
+              'tags': ['a,b', 'c'],
+            },
+          ),
+          const <ParameterEntry>[
+            (name: 'tags', value: 'a,b'),
+            (name: 'tags', value: 'c'),
+          ],
+        );
+      },
+    );
+
+    test('explode=true percent-encodes reserved characters in elements', () {
+      expect(
+        {'tags': ''}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {
+            'tags': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {
+            'tags': ['a/b', 'c d'],
+          },
+        ),
+        const <ParameterEntry>[
+          (name: 'tags', value: 'a%2Fb'),
+          (name: 'tags', value: 'c%20d'),
+        ],
+      );
+    });
+
+    test('explode=true keeps already-encoded elements verbatim', () {
+      expect(
+        {'tags': ''}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'tags': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {
+            'tags': ['a%2Fb', 'c%3Ad'],
+          },
+        ),
+        const <ParameterEntry>[
+          (name: 'tags', value: 'a%2Fb'),
+          (name: 'tags', value: 'c%3Ad'),
+        ],
+      );
+    });
+
+    test('scalar entries without a descriptor stay a single entry', () {
+      expect(
+        {
+          'note': 'a,b,c',
+          'colors': '',
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'colors': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {
+            'colors': ['red', 'green'],
+          },
+        ),
+        const <ParameterEntry>[
+          (name: 'note', value: 'a,b,c'),
+          (name: 'colors', value: 'red'),
+          (name: 'colors', value: 'green'),
         ],
       );
     });

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -552,7 +552,10 @@ void main() {
           isA<EncodingException>().having(
             (e) => e.message,
             'message',
-            allOf(contains('"colors"'), contains('of "p"')),
+            'Form property "colors" of "p" is marked exploded but has no '
+                'exploded values. Either a caller-supplied FormFieldEncoding '
+                'marks a non-array property as exploded, or the generated code '
+                'and this runtime disagree (version skew).',
           ),
         ),
       );
@@ -574,10 +577,10 @@ void main() {
           isA<EncodingException>().having(
             (e) => e.message,
             'message',
-            allOf(
-              contains('"colors" is marked exploded'),
-              isNot(contains(' of ')),
-            ),
+            'Form property "colors" is marked exploded but has no exploded '
+                'values. Either a caller-supplied FormFieldEncoding marks a '
+                'non-array property as exploded, or the generated code and '
+                'this runtime disagree (version skew).',
           ),
         ),
       );

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -536,7 +536,8 @@ void main() {
       );
     });
 
-    test('explode=true throws when explodedValues lacks the exploded key', () {
+    test('explode=true throws naming the property when explodedValues lacks '
+        'the exploded key', () {
       expect(
         () => {'colors': 'red,green,blue'}.toForm(
           'p',
@@ -547,7 +548,30 @@ void main() {
             'colors': FormFieldEncoding(explode: true),
           },
         ),
-        throwsA(isA<EncodingException>()),
+        throwsA(
+          isA<EncodingException>().having(
+            (e) => e.message,
+            'message',
+            allOf(contains('colors'), contains('"p"')),
+          ),
+        ),
+      );
+    });
+
+    test('explode=false ignores fieldEncodings and explodedValues, collapsing '
+        'the map into a single entry', () {
+      expect(
+        {'colors': ''}.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          alreadyEncoded: true,
+          fieldEncodings: const {
+            'colors': FormFieldEncoding(explode: true),
+          },
+          explodedValues: const {'colors': <String>[]},
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'colors,')],
       );
     });
 


### PR DESCRIPTION
## Problem

For an `application/x-www-form-urlencoded` request body whose object schema has an array property, the generated client always sent the comma-joined form:

```
q=hello&tags=urgent,open
```

OAS 3.x defines per-property serialization for urlencoded bodies via the Encoding Object, which follows query-parameter defaults: `style: form`, `explode: true`. RFC 6570 form expansion (`{?tags*}`) serializes that as repeated keys:

```
q=hello&tags=urgent&tags=open
```

The comma-joined output is the `explode: false` form, so a conformant server parsed the array as a single element. Additionally, an explicit per-property `explode` in the spec's Encoding Object was parsed but silently ignored.

## Fix

- Generated object/allOf `toForm` now delivers array elements with boundaries intact (a `Map<String, List<String>>` alongside the existing property map) instead of pre-flattening them, and the runtime form encoder emits one `name=value` entry per element when the property's effective explode is true.
- Per-property `explode` from the Encoding Object is threaded through (`FormFieldEncoding`); absent an Encoding Object the OAS default `true` applies. An explicit `explode: false` keeps the comma-joined single entry.
- Element boundaries stay lossless in combination with `allowReserved`, where element values may contain literal commas (`tags=a,b&tags=c` remains two entries).
- Empty arrays are omitted from the exploded output per RFC 6570; a single-empty-string element emits one `tags=` entry. If the runtime is asked to explode a property without element data (an encoder invariant violation), it throws an `EncodingException` naming the property instead of silently dropping the field.
- Nullability of nested allOf member fields (including write-only/read-only widening) is derived from the same predicate used for field type generation, so guarded access is emitted wherever the field type is nullable.
- Decoding needed no changes: the object decoder already merges repeated keys for list properties.
- `docs/uri_encoding.md` updated to describe the new default behavior.

## Breaking change

The wire format of form-urlencoded bodies with array properties changes from `tags=a,b` to `tags=a&tags=b` unless the spec explicitly sets `explode: false`. This matches the OAS default; specs relying on the previous behavior should declare `explode: false` in the Encoding Object.

## Tests

- `tonik_util`: repeated-entry explode, explode=false comma-join, empty list vs `['']`, element percent-encoding, `allowReserved` with comma-containing elements, missing-element-data throw — all with literal expected values.
- `tonik_generate`: full-body emission tests for the class path (required, optional null-guarded, nullable-element, immutable-collection) and the allOf path (object member with array property, direct list member, nullable member, duplicate-key last-wins, write-only null-guard).
- `integration_test/form_urlencoded`: repeated-key wire assertions, explicit `explode: false` scenario, comma-in-element `allowReserved` scenario, round-trip.
