### PR TITLE
feat: add PropertyValue tagged type and form encoder

### DIFF
--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -13,7 +13,8 @@ class FormFieldEncoding {
 
   /// When true, an array property is exploded into repeated keys by the
   /// `Map<String, PropertyValue>` form encoder; when false or null the array
-  /// is comma-joined into a single entry.
+  /// is comma-joined into a single entry. Only consulted when the containing
+  /// object is exploded; in collapse mode arrays are always comma-joined.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/form_field_encoding.dart
@@ -11,7 +11,9 @@ class FormFieldEncoding {
   /// except the form delimiters `& = +`.
   final bool allowReserved;
 
-  /// Reserved for per-property array explode; not yet consumed by `toForm`.
+  /// When true, an array property is exploded into repeated keys by the
+  /// `Map<String, PropertyValue>` form encoder; when false or null the array
+  /// is comma-joined into a single entry.
   final bool? explode;
 
   @override

--- a/packages/tonik_util/lib/src/encoding/property_value.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value.dart
@@ -1,0 +1,33 @@
+/// A style-neutral property value carrying whether it originated as a single
+/// scalar or as an array, so the distinction survives until encode time.
+///
+/// A plain `Map<String, List<String>>` cannot tell `scalar('')` from
+/// `array([])`, and an array's element boundaries must be preserved so an
+/// encoder can choose between repeated keys and a comma-joined value.
+sealed class PropertyValue {
+  const PropertyValue();
+
+  /// A single raw (unescaped) value.
+  const factory PropertyValue.scalar(String value) = ScalarPropertyValue;
+
+  /// Raw (unescaped) array elements whose boundaries survive until encode time.
+  const factory PropertyValue.array(List<String> values) = ArrayPropertyValue;
+}
+
+/// A [PropertyValue] holding a single raw value.
+final class ScalarPropertyValue extends PropertyValue {
+  /// Creates a scalar property value from a raw (unescaped) [value].
+  const ScalarPropertyValue(this.value);
+
+  /// The raw (unescaped) value.
+  final String value;
+}
+
+/// A [PropertyValue] holding raw array elements.
+final class ArrayPropertyValue extends PropertyValue {
+  /// Creates an array property value from raw (unescaped) [values].
+  const ArrayPropertyValue(this.values);
+
+  /// The raw (unescaped) elements.
+  final List<String> values;
+}

--- a/packages/tonik_util/lib/src/encoding/property_value.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value.dart
@@ -1,8 +1,10 @@
+import 'package:meta/meta.dart';
+
 /// A style-neutral property value carrying whether it originated as a single
 /// scalar or as an array, so the distinction survives until encode time.
 ///
-/// A plain `Map<String, List<String>>` cannot tell `scalar('')` from
-/// `array([])`, and an array's element boundaries must be preserved so an
+/// A plain `Map<String, List<String>>` cannot tell `scalar('x')` from
+/// `array(['x'])`, and an array's element boundaries must be preserved so an
 /// encoder can choose between repeated keys and a comma-joined value.
 sealed class PropertyValue {
   const PropertyValue();
@@ -15,6 +17,7 @@ sealed class PropertyValue {
 }
 
 /// A [PropertyValue] holding a single raw value.
+@immutable
 final class ScalarPropertyValue extends PropertyValue {
   /// Creates a scalar property value from a raw (unescaped) [value].
   const ScalarPropertyValue(this.value);
@@ -24,6 +27,7 @@ final class ScalarPropertyValue extends PropertyValue {
 }
 
 /// A [PropertyValue] holding raw array elements.
+@immutable
 final class ArrayPropertyValue extends PropertyValue {
   /// Creates an array property value from raw (unescaped) [values].
   const ArrayPropertyValue(this.values);

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -30,8 +30,8 @@ String _joinEncoded(
 
 /// Extension for encoding a tagged property map using form style encoding.
 ///
-/// Keys are raw property names and values are raw (unescaped); this is the
-/// single form percent-encoding site for objects.
+/// This is the percent-encoding boundary for `Map<String, PropertyValue>` form
+/// encoding: keys are raw property names and values are raw (unescaped).
 extension PropertyValueFormEncoder on Map<String, PropertyValue> {
   /// Encodes this property map using form style encoding.
   ///
@@ -79,6 +79,8 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
         allowReserved: false,
       );
       final encoding = fieldEncodings[name];
+      // A present descriptor always carries a concrete allowReserved, so the
+      // object-level value is only a fallback for properties without one.
       final valueAllowReserved = encoding?.allowReserved ?? allowReserved;
 
       switch (entry.value) {

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -35,9 +35,11 @@ String _joinEncoded(
 extension PropertyValueFormEncoder on Map<String, PropertyValue> {
   /// Encodes this property map using form style encoding.
   ///
-  /// Per-property [FormFieldEncoding.explode] controls array assembly and
-  /// [FormFieldEncoding.allowReserved] applies to values only; keys are always
-  /// component-encoded.
+  /// When the map is exploded, per-property [FormFieldEncoding.explode]
+  /// controls array assembly and [FormFieldEncoding.allowReserved] applies to
+  /// values only; keys are always component-encoded. In collapse mode
+  /// (object-level `explode` false) [fieldEncodings] is ignored and arrays are
+  /// always comma-joined.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -1,0 +1,153 @@
+import 'package:tonik_util/src/encoding/encoding_exception.dart';
+import 'package:tonik_util/src/encoding/form_field_encoding.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/property_value.dart';
+import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
+
+String _encode(
+  String value, {
+  required bool useQueryComponent,
+  required bool allowReserved,
+}) => value.uriEncode(
+  allowEmpty: true,
+  useQueryComponent: useQueryComponent,
+  allowReserved: allowReserved,
+);
+
+String _joinEncoded(
+  List<String> values, {
+  required bool useQueryComponent,
+  required bool allowReserved,
+}) => values
+    .map(
+      (element) => _encode(
+        element,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
+    )
+    .join(',');
+
+/// Extension for encoding a tagged property map using form style encoding.
+///
+/// Keys are raw property names and values are raw (unescaped); this is the
+/// single form percent-encoding site for objects.
+extension PropertyValueFormEncoder on Map<String, PropertyValue> {
+  /// Encodes this property map using form style encoding.
+  ///
+  /// Per-property [FormFieldEncoding.explode] controls array assembly and
+  /// [FormFieldEncoding.allowReserved] applies to values only; keys are always
+  /// component-encoded.
+  List<ParameterEntry> toForm(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+    Map<String, FormFieldEncoding> fieldEncodings = const {},
+  }) {
+    if (isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+
+    if (!allowEmpty) {
+      for (final value in values) {
+        final isValueEmpty = switch (value) {
+          ScalarPropertyValue(:final value) => value.isEmpty,
+          ArrayPropertyValue(:final values) => values.isEmpty,
+        };
+        if (isValueEmpty) {
+          throw const EmptyValueException();
+        }
+      }
+    }
+
+    if (!explode) {
+      return _collapse(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      );
+    }
+
+    final result = <ParameterEntry>[];
+    for (final entry in entries) {
+      final name = entry.key;
+      final encodedKey = _encode(
+        name,
+        useQueryComponent: useQueryComponent,
+        allowReserved: false,
+      );
+      final encoding = fieldEncodings[name];
+      final valueAllowReserved = encoding?.allowReserved ?? allowReserved;
+
+      switch (entry.value) {
+        case ScalarPropertyValue(:final value):
+          result.add((
+            name: encodedKey,
+            value: _encode(
+              value,
+              useQueryComponent: useQueryComponent,
+              allowReserved: valueAllowReserved,
+            ),
+          ));
+        case ArrayPropertyValue(:final values):
+          if (encoding?.explode ?? false) {
+            for (final element in values) {
+              result.add((
+                name: encodedKey,
+                value: _encode(
+                  element,
+                  useQueryComponent: useQueryComponent,
+                  allowReserved: valueAllowReserved,
+                ),
+              ));
+            }
+          } else {
+            result.add((
+              name: encodedKey,
+              value: _joinEncoded(
+                values,
+                useQueryComponent: useQueryComponent,
+                allowReserved: valueAllowReserved,
+              ),
+            ));
+          }
+      }
+    }
+    return result;
+  }
+
+  List<ParameterEntry> _collapse(
+    String paramName, {
+    required bool useQueryComponent,
+    required bool allowReserved,
+  }) {
+    final parts = <String>[];
+    for (final entry in entries) {
+      parts
+        ..add(
+          _encode(
+            entry.key,
+            useQueryComponent: useQueryComponent,
+            allowReserved: false,
+          ),
+        )
+        ..add(
+          switch (entry.value) {
+            ScalarPropertyValue(:final value) => _encode(
+              value,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+            ),
+            ArrayPropertyValue(:final values) => _joinEncoded(
+              values,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+            ),
+          },
+        );
+    }
+    return [(name: paramName, value: parts.join(','))];
+  }
+}

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -22,6 +22,8 @@ export 'src/encoding/label_encoder_extensions.dart';
 export 'src/encoding/matrix_encoder_extensions.dart';
 export 'src/encoding/parameter_entry.dart';
 export 'src/encoding/pipe_delimited_encoder_extensions.dart';
+export 'src/encoding/property_value.dart';
+export 'src/encoding/property_value_form_encoder.dart';
 export 'src/encoding/simple_encoder_extensions.dart';
 export 'src/encoding/space_delimited_encoder_extensions.dart';
 export 'src/encoding/uri_encoder_extensions.dart';

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -224,6 +224,32 @@ void main() {
         const <ParameterEntry>[(name: 'p', value: 'k%2F1,a/b')],
       );
     });
+
+    test("a descriptor's default allowReserved wins over the object-level "
+        'flag', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['a/b']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[(name: 'tags', value: 'a%2Fb')],
+      );
+    });
+
+    test('keeps element reserved chars literal joined by literal commas for a '
+        'non-exploded array', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['a/b', 'c/d']),
+        }.toForm('p', explode: true, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'tags', value: 'a/b,c/d')],
+      );
+    });
   });
 
   group('useQueryComponent space rendering', () {

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -1,0 +1,314 @@
+import 'package:test/test.dart';
+import 'package:tonik_util/src/encoding/encoding_exception.dart';
+import 'package:tonik_util/src/encoding/form_field_encoding.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/property_value.dart';
+import 'package:tonik_util/src/encoding/property_value_form_encoder.dart';
+
+void main() {
+  group('object-level explode=true', () {
+    test('explodes a flagged array beside a scalar sibling into repeated '
+        'keys', () {
+      expect(
+        <String, PropertyValue>{
+          'q': const PropertyValue.scalar('hello'),
+          'tags': const PropertyValue.array(['urgent', 'open']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[
+          (name: 'q', value: 'hello'),
+          (name: 'tags', value: 'urgent'),
+          (name: 'tags', value: 'open'),
+        ],
+      );
+    });
+
+    test('explodes a flagged array into repeated keys beside a scalar', () {
+      expect(
+        <String, PropertyValue>{
+          'name': const PropertyValue.scalar('John'),
+          'colors': const PropertyValue.array(['red', 'green', 'blue']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'colors': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[
+          (name: 'name', value: 'John'),
+          (name: 'colors', value: 'red'),
+          (name: 'colors', value: 'green'),
+          (name: 'colors', value: 'blue'),
+        ],
+      );
+    });
+
+    test('comma-joins an array with no descriptor beside a scalar', () {
+      expect(
+        <String, PropertyValue>{
+          'q': const PropertyValue.scalar('hello'),
+          'tags': const PropertyValue.array(['urgent', 'open']),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[
+          (name: 'q', value: 'hello'),
+          (name: 'tags', value: 'urgent,open'),
+        ],
+      );
+    });
+
+    test('comma-joins an array with an explicit explode=false descriptor', () {
+      expect(
+        <String, PropertyValue>{
+          'colors': const PropertyValue.array(['red', 'green', 'blue']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'colors': FormFieldEncoding()},
+        ),
+        const <ParameterEntry>[(name: 'colors', value: 'red,green,blue')],
+      );
+    });
+  });
+
+  group('object-level explode=true empty distinction', () {
+    test('omits an exploded empty array entirely', () {
+      expect(
+        <String, PropertyValue>{
+          'name': const PropertyValue.scalar('John'),
+          'tags': const PropertyValue.array([]),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[(name: 'name', value: 'John')],
+      );
+    });
+
+    test('emits one empty-value entry for an exploded single empty-string '
+        'element', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[(name: 'tags', value: '')],
+      );
+    });
+
+    test('emits one empty-value entry for a non-exploded empty array', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array([]),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'tags', value: '')],
+      );
+    });
+
+    test('emits an empty-value entry for a scalar empty string', () {
+      expect(
+        <String, PropertyValue>{
+          'key': const PropertyValue.scalar(''),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'key', value: '')],
+      );
+    });
+  });
+
+  group('object-level explode=true comma inside element', () {
+    test('percent-encodes an element comma when exploded without '
+        'allowReserved', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['a,b', 'c']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[
+          (name: 'tags', value: 'a%2Cb'),
+          (name: 'tags', value: 'c'),
+        ],
+      );
+    });
+
+    test('keeps an element comma literal when exploded with allowReserved', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['a,b', 'c']),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {
+            'tags': FormFieldEncoding(explode: true, allowReserved: true),
+          },
+        ),
+        const <ParameterEntry>[
+          (name: 'tags', value: 'a,b'),
+          (name: 'tags', value: 'c'),
+        ],
+      );
+    });
+
+    test('percent-encodes element commas but keeps separators literal when '
+        'non-exploded without allowReserved', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['a,b', 'c']),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'tags', value: 'a%2Cb,c')],
+      );
+    });
+  });
+
+  group('object-level explode=false collapse', () {
+    test('collapses scalars and an array into a single comma-joined entry', () {
+      expect(
+        <String, PropertyValue>{
+          'a': const PropertyValue.scalar('1'),
+          'colors': const PropertyValue.array(['red', 'green', 'blue']),
+        }.toForm('p', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'p', value: 'a,1,colors,red,green,blue')],
+      );
+    });
+
+    test('ignores fieldEncodings when collapsing', () {
+      expect(
+        <String, PropertyValue>{
+          'a': const PropertyValue.scalar('1'),
+          'colors': const PropertyValue.array(['red', 'green', 'blue']),
+        }.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          fieldEncodings: const {'colors': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'a,1,colors,red,green,blue')],
+      );
+    });
+
+    test('collapses an empty array into an empty value segment', () {
+      expect(
+        <String, PropertyValue>{
+          'colors': const PropertyValue.array([]),
+        }.toForm('p', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'p', value: 'colors,')],
+      );
+    });
+  });
+
+  group('allowReserved', () {
+    test('applies a per-property override to values and component-encodes '
+        'keys', () {
+      expect(
+        <String, PropertyValue>{
+          'a/1': const PropertyValue.scalar('x/y'),
+          'b/2': const PropertyValue.scalar('p/q'),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'a/1': FormFieldEncoding(allowReserved: true)},
+        ),
+        const <ParameterEntry>[
+          (name: 'a%2F1', value: 'x/y'),
+          (name: 'b%2F2', value: 'p%2Fq'),
+        ],
+      );
+    });
+  });
+
+  group('useQueryComponent space rendering', () {
+    test('renders a space as + when useQueryComponent is true', () {
+      expect(
+        <String, PropertyValue>{
+          'q': const PropertyValue.scalar('a b'),
+        }.toForm('p', explode: true, allowEmpty: true, useQueryComponent: true),
+        const <ParameterEntry>[(name: 'q', value: 'a+b')],
+      );
+    });
+
+    test('renders a space as %20 when useQueryComponent is false', () {
+      expect(
+        <String, PropertyValue>{
+          'q': const PropertyValue.scalar('a b'),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'q', value: 'a%20b')],
+      );
+    });
+  });
+
+  group('EmptyValueException', () {
+    test('throws on an empty map when allowEmpty is false', () {
+      expect(
+        () => <String, PropertyValue>{}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: false,
+        ),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('does not throw on an empty map when allowEmpty is true', () {
+      expect(
+        <String, PropertyValue>{}.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[],
+      );
+    });
+
+    test('throws on a scalar empty string when allowEmpty is false', () {
+      expect(
+        () => <String, PropertyValue>{
+          'key': const PropertyValue.scalar(''),
+        }.toForm('p', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('does not throw on a scalar empty string when allowEmpty is true', () {
+      expect(
+        <String, PropertyValue>{
+          'key': const PropertyValue.scalar(''),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'key', value: '')],
+      );
+    });
+
+    test('throws on an empty array when allowEmpty is false', () {
+      expect(
+        () => <String, PropertyValue>{
+          'tags': const PropertyValue.array([]),
+        }.toForm('p', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('does not throw on an empty array when allowEmpty is true', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array([]),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[],
+      );
+    });
+  });
+}

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -171,6 +171,20 @@ void main() {
       );
     });
 
+    test('ignores a per-property allowReserved when collapsing', () {
+      expect(
+        <String, PropertyValue>{
+          'k/1': const PropertyValue.scalar('a/b'),
+        }.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+          fieldEncodings: const {'k/1': FormFieldEncoding(allowReserved: true)},
+        ),
+        const <ParameterEntry>[(name: 'p', value: 'k%2F1,a%2Fb')],
+      );
+    });
+
     test('collapses an empty array into an empty value segment', () {
       expect(
         <String, PropertyValue>{

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -7,26 +7,6 @@ import 'package:tonik_util/src/encoding/property_value_form_encoder.dart';
 
 void main() {
   group('object-level explode=true', () {
-    test('explodes a flagged array beside a scalar sibling into repeated '
-        'keys', () {
-      expect(
-        <String, PropertyValue>{
-          'q': const PropertyValue.scalar('hello'),
-          'tags': const PropertyValue.array(['urgent', 'open']),
-        }.toForm(
-          'p',
-          explode: true,
-          allowEmpty: true,
-          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
-        ),
-        const <ParameterEntry>[
-          (name: 'q', value: 'hello'),
-          (name: 'tags', value: 'urgent'),
-          (name: 'tags', value: 'open'),
-        ],
-      );
-    });
-
     test('explodes a flagged array into repeated keys beside a scalar', () {
       expect(
         <String, PropertyValue>{
@@ -112,15 +92,6 @@ void main() {
           'tags': const PropertyValue.array([]),
         }.toForm('p', explode: true, allowEmpty: true),
         const <ParameterEntry>[(name: 'tags', value: '')],
-      );
-    });
-
-    test('emits an empty-value entry for a scalar empty string', () {
-      expect(
-        <String, PropertyValue>{
-          'key': const PropertyValue.scalar(''),
-        }.toForm('p', explode: true, allowEmpty: true),
-        const <ParameterEntry>[(name: 'key', value: '')],
       );
     });
   });
@@ -229,6 +200,30 @@ void main() {
         ],
       );
     });
+
+    test('applies an object-level override to values while component-encoding '
+        'keys when exploded', () {
+      expect(
+        <String, PropertyValue>{
+          'a/1': const PropertyValue.scalar('a/b'),
+          'tags': const PropertyValue.array(['a/b']),
+        }.toForm('p', explode: true, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[
+          (name: 'a%2F1', value: 'a/b'),
+          (name: 'tags', value: 'a/b'),
+        ],
+      );
+    });
+
+    test('applies an object-level override to values while component-encoding '
+        'keys when collapsed', () {
+      expect(
+        <String, PropertyValue>{
+          'k/1': const PropertyValue.scalar('a/b'),
+        }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: 'k%2F1,a/b')],
+      );
+    });
   });
 
   group('useQueryComponent space rendering', () {
@@ -308,6 +303,21 @@ void main() {
           fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
         ),
         const <ParameterEntry>[],
+      );
+    });
+
+    test('throws on an empty exploded array descriptor when allowEmpty is '
+        'false', () {
+      expect(
+        () => <String, PropertyValue>{
+          'tags': const PropertyValue.array([]),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: false,
+          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+        ),
+        throwsA(isA<EmptyValueException>()),
       );
     });
   });


### PR DESCRIPTION
## Summary

Adds a tagged runtime value type and a form encoder over it in `tonik_util`. This is additive and ships dark — nothing calls the new code yet, so there is no wire behavior change.

- **`PropertyValue`** — a sealed type with two variants, `PropertyValue.scalar(String)` and `PropertyValue.array(List<String>)`, each holding raw (unescaped) strings. The tag lets the map distinguish a scalar from a single-element array (`scalar('x')` and `array(['x'])` both flatten to `['x']` under a plain `Map<String, List<String>>`) and separates a scalar empty string (`key=`) from an omitted exploded empty array from a non-exploded empty array — distinctions the flat map cannot carry.
- **Form encoder** — an extension `Map<String, PropertyValue>.toForm(...)` that performs all object form percent-encoding in one place via `String.uriEncode`. It consults per-property `explode` (from `FormFieldEncoding`) only when the winning value is an array; a descriptor-less array comma-joins, preserving today's wire output. The encoder owns all form value-emptiness checks (`EmptyValueException` for an empty map, empty scalar, or empty array when `allowEmpty` is false).

## Behavior

- Object `explode: true` → one entry per property; an exploded array yields repeated keys, an empty exploded array is omitted, and `['']` yields a single empty-value entry.
- Object `explode: false` → a single collapsed `k1,v1,k2,v2` entry, byte-identical to the existing map form encoder at `allowReserved: false`; `fieldEncodings` is ignored in this mode.
- Per-property `allowReserved` applies to values only; keys are always component-encoded. A present per-property descriptor is the complete source of truth for that property, so its `allowReserved` (non-nullable, default false) takes precedence over the object-level flag.

## Tests

Unit tests in `tonik_util` cover repeated-key explode, the three-way empty-array distinction, comma-in-element encoding with and without `allowReserved`, the collapse byte-parity case, per-property overrides and precedence, `useQueryComponent` space rendering, and all three `EmptyValueException` cases plus their non-throwing counterparts. Expected wire values are literal strings. 100% patch coverage.

## Design notes

`PropertyValue` deliberately omits `==`/`hashCode` and a defensive list copy, following the in-package `TonikResult` sealed-ADT precedent: it is consumed only by an exhaustive switch and is never compared as an instance — tests assert on the resulting `ParameterEntry` records, which have value equality. This differs from the sibling `FormFieldEncoding`, which implements equality because it is a descriptor looked up by key and compared. Both can be revisited if a future consumer starts comparing or retaining these values.
