### PR TITLE
feat: add tagged-map simple/label/matrix/deepObject encoders

### DIFF
--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -3,29 +3,28 @@ import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/property_value.dart';
 import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 
-String _encodeValue(PropertyValue value, {required bool allowReserved}) =>
-    switch (value) {
-      ScalarPropertyValue(:final value) => encodeUriValue(
-        value,
-        allowReserved: allowReserved,
-        useQueryComponent: false,
-      ),
-      ArrayPropertyValue(:final values) => values
-          .map(
-            (element) => encodeUriValue(
-              element,
-              allowReserved: allowReserved,
-              useQueryComponent: false,
-            ),
-          )
-          .join(','),
-    };
+String _encodeValue(PropertyValue value) => switch (value) {
+  ScalarPropertyValue(:final value) => encodeUriValue(
+    value,
+    allowReserved: false,
+    useQueryComponent: false,
+  ),
+  ArrayPropertyValue(:final values) => values
+      .map(
+        (element) => encodeUriValue(
+          element,
+          allowReserved: false,
+          useQueryComponent: false,
+        ),
+      )
+      .join(','),
+};
 
 String _collapsedPairs(Map<String, PropertyValue> map) => map.entries
     .expand(
       (e) => [
         Uri.encodeComponent(e.key),
-        _encodeValue(e.value, allowReserved: false),
+        _encodeValue(e.value),
       ],
     )
     .join(',');
@@ -51,11 +50,16 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
 /// Simple/label/matrix/deepObject encoders over `Map<String, PropertyValue>`
 /// whose values are raw (unescaped).
 ///
-/// Each is byte-identical to encoding every value with
+/// For non-empty values each is byte-identical to encoding every value with
 /// [encodeUriValue] (`useQueryComponent: false`) and then assembling the
 /// resulting `Map<String, String>` through the matching string-map encoder with
 /// `alreadyEncoded: true`. Array values contribute their percent-encoded
 /// elements comma-joined; the comma separators between elements stay literal.
+///
+/// The equivalence does not extend to empty values: an empty scalar
+/// (`scalar('')`) or empty array (`array([])`) throws [EmptyValueException]
+/// under `allowEmpty: false`, whereas the string-map siblings render `k,` and
+/// never throw. Do not delete these empty-value guards to "restore parity".
 extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Encodes this property map using simple style encoding.
   ///
@@ -71,7 +75,7 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
           .map(
             (e) =>
                 '${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value, allowReserved: false)}',
+                '${_encodeValue(e.value)}',
           )
           .join(',');
     }
@@ -93,7 +97,7 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
           .map(
             (e) =>
                 '.${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value, allowReserved: false)}',
+                '${_encodeValue(e.value)}',
           )
           .join();
     }
@@ -119,7 +123,7 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
           .map(
             (e) =>
                 ';${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value, allowReserved: false)}',
+                '${_encodeValue(e.value)}',
           )
           .join();
     }

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -50,11 +50,14 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
 /// Simple/label/matrix/deepObject encoders over `Map<String, PropertyValue>`
 /// whose values are raw (unescaped).
 ///
-/// For non-empty values each is byte-identical to encoding every value with
-/// [encodeUriValue] (`useQueryComponent: false`) and then assembling the
-/// resulting `Map<String, String>` through the matching string-map encoder with
+/// For the simple, label and matrix encoders, for non-empty values each is
+/// byte-identical to encoding every value with [encodeUriValue]
+/// (`useQueryComponent: false`) and then assembling the resulting
+/// `Map<String, String>` through the matching string-map encoder with
 /// `alreadyEncoded: true`. Array values contribute their percent-encoded
 /// elements comma-joined; the comma separators between elements stay literal.
+/// deepObject differs: it returns parameter entries and rejects array values
+/// (see its own method doc).
 ///
 /// The equivalence does not extend to empty values: for the simple, label and
 /// matrix encoders, an empty scalar (`scalar('')`) or empty array (`array([])`)

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -1,0 +1,172 @@
+import 'package:tonik_util/src/encoding/encoding_exception.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/property_value.dart';
+import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
+
+String _encodeValue(PropertyValue value, {required bool allowReserved}) =>
+    switch (value) {
+      ScalarPropertyValue(:final value) => encodeUriValue(
+        value,
+        allowReserved: allowReserved,
+        useQueryComponent: false,
+      ),
+      ArrayPropertyValue(:final values) => values
+          .map(
+            (element) => encodeUriValue(
+              element,
+              allowReserved: allowReserved,
+              useQueryComponent: false,
+            ),
+          )
+          .join(','),
+    };
+
+String _collapsedPairs(Map<String, PropertyValue> map) => map.entries
+    .expand(
+      (e) => [
+        Uri.encodeComponent(e.key),
+        _encodeValue(e.value, allowReserved: false),
+      ],
+    )
+    .join(',');
+
+void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
+  if (map.isEmpty && !allowEmpty) {
+    throw const EmptyValueException();
+  }
+  if (allowEmpty) {
+    return;
+  }
+  for (final value in map.values) {
+    final isValueEmpty = switch (value) {
+      ScalarPropertyValue(:final value) => value.isEmpty,
+      ArrayPropertyValue(:final values) => values.isEmpty,
+    };
+    if (isValueEmpty) {
+      throw const EmptyValueException();
+    }
+  }
+}
+
+/// Simple/label/matrix/deepObject encoders over `Map<String, PropertyValue>`
+/// whose values are raw (unescaped).
+///
+/// Each is byte-identical to encoding every value with
+/// [encodeUriValue] (`useQueryComponent: false`) and then assembling the
+/// resulting `Map<String, String>` through the matching string-map encoder with
+/// `alreadyEncoded: true`. Array values contribute their percent-encoded
+/// elements comma-joined; the comma separators between elements stay literal.
+extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
+  /// Encodes this property map using simple style encoding.
+  ///
+  /// With [explode] false the result is `key,value,key2,value2`; with [explode]
+  /// true it is `key=value,key2=value2`.
+  String toSimple({required bool explode, required bool allowEmpty}) {
+    _guardEmpty(this, allowEmpty: allowEmpty);
+    if (isEmpty) {
+      return '';
+    }
+    if (explode) {
+      return entries
+          .map(
+            (e) =>
+                '${Uri.encodeComponent(e.key)}='
+                '${_encodeValue(e.value, allowReserved: false)}',
+          )
+          .join(',');
+    }
+    return _collapsedPairs(this);
+  }
+
+  /// Encodes this property map using label style encoding.
+  ///
+  /// With [explode] false the result is `.key,value,key2,value2`; with
+  /// [explode] true it is `.key=value.key2=value2`. An empty map renders
+  /// as `.`.
+  String toLabel({required bool explode, required bool allowEmpty}) {
+    _guardEmpty(this, allowEmpty: allowEmpty);
+    if (isEmpty) {
+      return '.';
+    }
+    if (explode) {
+      return entries
+          .map(
+            (e) =>
+                '.${Uri.encodeComponent(e.key)}='
+                '${_encodeValue(e.value, allowReserved: false)}',
+          )
+          .join();
+    }
+    return '.${_collapsedPairs(this)}';
+  }
+
+  /// Encodes this property map using matrix style encoding.
+  ///
+  /// With [explode] false the result is `;paramName=key,value,key2,value2`;
+  /// with [explode] true it is `;key=value;key2=value2`. An empty map renders
+  /// as `;paramName`.
+  String toMatrix(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) {
+    _guardEmpty(this, allowEmpty: allowEmpty);
+    if (isEmpty) {
+      return ';$paramName';
+    }
+    if (explode) {
+      return entries
+          .map(
+            (e) =>
+                ';${Uri.encodeComponent(e.key)}='
+                '${_encodeValue(e.value, allowReserved: false)}',
+          )
+          .join();
+    }
+    return ';$paramName=${_collapsedPairs(this)}';
+  }
+
+  /// Encodes this property map using deepObject style encoding.
+  ///
+  /// Returns entries of the form `(name: 'paramName[key]', value: value)`.
+  /// [allowReserved] threads into value encoding only; keys are always
+  /// component-encoded. An empty map renders as an empty list.
+  ///
+  /// Throws [EncodingException] when [explode] is false, and when any value is
+  /// an array (deepObject does not support lists).
+  List<ParameterEntry> toDeepObject(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    if (!explode) {
+      throw const EncodingException('deepObject style requires explode=true');
+    }
+    if (isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final result = <ParameterEntry>[];
+    for (final entry in entries) {
+      switch (entry.value) {
+        case ArrayPropertyValue():
+          throw const EncodingException(
+            'Lists are not supported in this encoding style',
+          );
+        case ScalarPropertyValue(:final value):
+          if (value.isEmpty && !allowEmpty) {
+            throw const EmptyValueException();
+          }
+          result.add((
+            name: '$paramName[${Uri.encodeComponent(entry.key)}]',
+            value: encodeUriValue(
+              value,
+              allowReserved: allowReserved,
+              useQueryComponent: false,
+            ),
+          ));
+      }
+    }
+    return result;
+  }
+}

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -56,10 +56,11 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
 /// `alreadyEncoded: true`. Array values contribute their percent-encoded
 /// elements comma-joined; the comma separators between elements stay literal.
 ///
-/// The equivalence does not extend to empty values: an empty scalar
-/// (`scalar('')`) or empty array (`array([])`) throws [EmptyValueException]
-/// under `allowEmpty: false`, whereas the string-map siblings render `k,` and
-/// never throw. Do not delete these empty-value guards to "restore parity".
+/// The equivalence does not extend to empty values: for the simple, label and
+/// matrix encoders, an empty scalar (`scalar('')`) or empty array (`array([])`)
+/// throws [EmptyValueException] under `allowEmpty: false`, whereas the
+/// string-map siblings render `k,` and never throw. Do not delete these
+/// empty-value guards to "restore parity".
 extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Encodes this property map using simple style encoding.
   ///
@@ -134,10 +135,13 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   ///
   /// Returns entries of the form `(name: 'paramName[key]', value: value)`.
   /// [allowReserved] threads into value encoding only; keys are always
-  /// component-encoded. An empty map renders as an empty list.
+  /// component-encoded. An empty map renders as an empty list when [allowEmpty]
+  /// is true.
   ///
   /// Throws [EncodingException] when [explode] is false, and when any value is
-  /// an array (deepObject does not support lists).
+  /// an array (deepObject does not support lists). Throws [EmptyValueException]
+  /// under `allowEmpty: false` when the map is empty or a scalar value is
+  /// empty.
   List<ParameterEntry> toDeepObject(
     String paramName, {
     required bool explode,

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -47,28 +47,14 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
   }
 }
 
-/// Simple/label/matrix/deepObject encoders over `Map<String, PropertyValue>`
-/// whose values are raw (unescaped).
+/// Style encoders over `Map<String, PropertyValue>` with raw (unescaped)
+/// values, matching the string-map encoders' wire output.
 ///
-/// For the simple, label and matrix encoders, for non-empty values each is
-/// byte-identical to encoding every value with [encodeUriValue]
-/// (`useQueryComponent: false`) and then assembling the resulting
-/// `Map<String, String>` through the matching string-map encoder with
-/// `alreadyEncoded: true`. Array values contribute their percent-encoded
-/// elements comma-joined; the comma separators between elements stay literal.
-/// deepObject differs: it returns parameter entries and rejects array values
-/// (see its own method doc).
-///
-/// The equivalence does not extend to empty values: for the simple, label and
-/// matrix encoders, an empty scalar (`scalar('')`) or empty array (`array([])`)
-/// throws [EmptyValueException] under `allowEmpty: false`, whereas the
-/// string-map siblings render `k,` and never throw. Do not delete these
-/// empty-value guards to "restore parity".
+/// Unlike those siblings, an empty scalar or array throws [EmptyValueException]
+/// under `allowEmpty: false` instead of rendering `k,` — a deliberate guard,
+/// not a parity gap to "fix".
 extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Encodes this property map using simple style encoding.
-  ///
-  /// With [explode] false the result is `key,value,key2,value2`; with [explode]
-  /// true it is `key=value,key2=value2`.
   String toSimple({required bool explode, required bool allowEmpty}) {
     _guardEmpty(this, allowEmpty: allowEmpty);
     if (isEmpty) {
@@ -87,10 +73,6 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   }
 
   /// Encodes this property map using label style encoding.
-  ///
-  /// With [explode] false the result is `.key,value,key2,value2`; with
-  /// [explode] true it is `.key=value.key2=value2`. An empty map renders
-  /// as `.`.
   String toLabel({required bool explode, required bool allowEmpty}) {
     _guardEmpty(this, allowEmpty: allowEmpty);
     if (isEmpty) {
@@ -109,10 +91,6 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   }
 
   /// Encodes this property map using matrix style encoding.
-  ///
-  /// With [explode] false the result is `;paramName=key,value,key2,value2`;
-  /// with [explode] true it is `;key=value;key2=value2`. An empty map renders
-  /// as `;paramName`.
   String toMatrix(
     String paramName, {
     required bool explode,
@@ -136,15 +114,9 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
 
   /// Encodes this property map using deepObject style encoding.
   ///
-  /// Returns entries of the form `(name: 'paramName[key]', value: value)`.
-  /// [allowReserved] threads into value encoding only; keys are always
-  /// component-encoded. An empty map renders as an empty list when [allowEmpty]
-  /// is true.
-  ///
-  /// Throws [EncodingException] when [explode] is false, and when any value is
-  /// an array (deepObject does not support lists). Throws [EmptyValueException]
-  /// under `allowEmpty: false` when the map is empty or a scalar value is
-  /// empty.
+  /// [allowReserved] applies to values only; keys are always component-encoded.
+  /// Throws [EncodingException] for a non-explode call or an array value, and
+  /// [EmptyValueException] on an empty map or value under `allowEmpty: false`.
   List<ParameterEntry> toDeepObject(
     String paramName, {
     required bool explode,

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -2,39 +2,7 @@ import 'package:big_decimal/big_decimal.dart';
 import 'package:tonik_util/src/encoding/binary_extensions.dart';
 import 'package:tonik_util/src/encoding/datetime_extension.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
-
-/// With [allowReserved] false the result is byte-identical to
-/// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
-/// this. With [allowReserved] true reserved chars including `[ ]` pass through
-/// literally; the form delimiters `& =`, along with `+`, `%`, and non-ASCII,
-/// stay encoded, and a space becomes `%20` (or `+` under [useQueryComponent]).
-String _encodeUriValue(
-  String value, {
-  required bool allowReserved,
-  required bool useQueryComponent,
-}) {
-  if (!allowReserved) {
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(value)
-        : Uri.encodeComponent(value);
-  }
-
-  // Uri.encodeFull keeps reserved chars literal, but & and = are data here,
-  // not delimiters, so they must stay encoded. A literal + must become %2B
-  // before a space is rendered as +, otherwise a data + and a space would be
-  // indistinguishable. encodeFull predates RFC 3986 treating [ ] as reserved
-  // and still percent-encodes them, so restore those to literal.
-  var encoded = Uri.encodeFull(value)
-      .replaceAll('+', '%2B')
-      .replaceAll('&', '%26')
-      .replaceAll('=', '%3D')
-      .replaceAll('%5B', '[')
-      .replaceAll('%5D', ']');
-  if (useQueryComponent) {
-    encoded = encoded.replaceAll('%20', '+');
-  }
-  return encoded;
-}
+import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 
 /// Extension for URI encoding Uri values.
 extension UriEncoder on Uri {
@@ -43,7 +11,7 @@ extension UriEncoder on Uri {
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => _encodeUriValue(
+  }) => encodeUriValue(
     toString(),
     allowReserved: allowReserved,
     useQueryComponent: useQueryComponent,
@@ -61,7 +29,7 @@ extension StringUriEncoder on String {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
-    return _encodeUriValue(
+    return encodeUriValue(
       this,
       allowReserved: allowReserved,
       useQueryComponent: useQueryComponent,
@@ -90,7 +58,7 @@ extension DoubleUriEncoder on double {
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => _encodeUriValue(
+  }) => encodeUriValue(
     toString(),
     allowReserved: allowReserved,
     useQueryComponent: useQueryComponent,
@@ -132,7 +100,7 @@ extension DateTimeUriEncoder on DateTime {
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => _encodeUriValue(
+  }) => encodeUriValue(
     toTimeZonedIso8601String(),
     allowReserved: allowReserved,
     useQueryComponent: useQueryComponent,
@@ -169,7 +137,7 @@ extension BinaryUriEncoder on List<int> {
     if (isEmpty) {
       return '';
     }
-    return _encodeUriValue(
+    return encodeUriValue(
       decodeToString(),
       allowReserved: allowReserved,
       useQueryComponent: useQueryComponent,
@@ -203,7 +171,7 @@ extension StringListUriEncoder on List<String> {
     }
 
     return map(
-      (item) => _encodeUriValue(
+      (item) => encodeUriValue(
         item,
         allowReserved: allowReserved,
         useQueryComponent: useQueryComponent,
@@ -229,7 +197,7 @@ extension StringMapUriEncoder on Map<String, String> {
       return '';
     }
 
-    String encode(String value) => _encodeUriValue(
+    String encode(String value) => encodeUriValue(
       value,
       allowReserved: allowReserved,
       useQueryComponent: useQueryComponent,

--- a/packages/tonik_util/lib/src/encoding/uri_value_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_value_encoder.dart
@@ -1,0 +1,32 @@
+/// With [allowReserved] false the result is byte-identical to
+/// [Uri.encodeQueryComponent] / [Uri.encodeComponent] — call sites rely on
+/// this. With [allowReserved] true reserved chars including `[ ]` pass through
+/// literally; the form delimiters `& =`, along with `+`, `%`, and non-ASCII,
+/// stay encoded, and a space becomes `%20` (or `+` under [useQueryComponent]).
+String encodeUriValue(
+  String value, {
+  required bool allowReserved,
+  required bool useQueryComponent,
+}) {
+  if (!allowReserved) {
+    return useQueryComponent
+        ? Uri.encodeQueryComponent(value)
+        : Uri.encodeComponent(value);
+  }
+
+  // Uri.encodeFull keeps reserved chars literal, but & and = are data here,
+  // not delimiters, so they must stay encoded. A literal + must become %2B
+  // before a space is rendered as +, otherwise a data + and a space would be
+  // indistinguishable. encodeFull predates RFC 3986 treating [ ] as reserved
+  // and still percent-encodes them, so restore those to literal.
+  var encoded = Uri.encodeFull(value)
+      .replaceAll('+', '%2B')
+      .replaceAll('&', '%26')
+      .replaceAll('=', '%3D')
+      .replaceAll('%5B', '[')
+      .replaceAll('%5D', ']');
+  if (useQueryComponent) {
+    encoded = encoded.replaceAll('%20', '+');
+  }
+  return encoded;
+}

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -24,6 +24,7 @@ export 'src/encoding/parameter_entry.dart';
 export 'src/encoding/pipe_delimited_encoder_extensions.dart';
 export 'src/encoding/property_value.dart';
 export 'src/encoding/property_value_form_encoder.dart';
+export 'src/encoding/property_value_style_encoders.dart';
 export 'src/encoding/simple_encoder_extensions.dart';
 export 'src/encoding/space_delimited_encoder_extensions.dart';
 export 'src/encoding/uri_encoder_extensions.dart';

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -35,6 +35,14 @@ void main() {
       );
     });
 
+    test('reserved characters in keys are percent-encoded', () {
+      const value = {'a/b': PropertyValue.scalar('v')};
+      expect(
+        value.toSimple(explode: false, allowEmpty: false),
+        'a%2Fb,v',
+      );
+    });
+
     test('array beside a scalar comma-joins with explode=false', () {
       const value = {
         'a': PropertyValue.scalar('x'),
@@ -151,6 +159,14 @@ void main() {
       expect(
         value.toLabel(explode: true, allowEmpty: true),
         '.street=123%20Main%20St.city=New%20York',
+      );
+    });
+
+    test('reserved characters in keys are percent-encoded', () {
+      const value = {'a/b': PropertyValue.scalar('v')};
+      expect(
+        value.toLabel(explode: false, allowEmpty: false),
+        '.a%2Fb,v',
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -414,6 +414,21 @@ void main() {
       );
     });
 
+    test('empty array throws the list-unsupported message, not empty-value',
+        () {
+      const value = {'k': PropertyValue.array(<String>[])};
+      expect(
+        () => value.toDeepObject('p', explode: true, allowEmpty: false),
+        throwsA(
+          isA<EncodingException>().having(
+            (e) => e.message,
+            'message',
+            'Lists are not supported in this encoding style',
+          ),
+        ),
+      );
+    });
+
     test('explode=false throws', () {
       const value = {'x': PropertyValue.scalar('1')};
       expect(

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -1,0 +1,463 @@
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('PropertyValueStyleEncoders.toSimple', () {
+    test('scalar object with explode=false matches the string-map counterpart',
+        () {
+      const value = {
+        'color': PropertyValue.scalar('blue'),
+        'size': PropertyValue.scalar('large'),
+      };
+      expect(
+        value.toSimple(explode: false, allowEmpty: true),
+        'color,blue,size,large',
+      );
+    });
+
+    test('scalar object with explode=true matches the string-map counterpart',
+        () {
+      const value = {
+        'color': PropertyValue.scalar('blue'),
+        'size': PropertyValue.scalar('large'),
+      };
+      expect(
+        value.toSimple(explode: true, allowEmpty: true),
+        'color=blue,size=large',
+      );
+    });
+
+    test('reserved characters in scalar values are percent-encoded', () {
+      const value = {'formula': PropertyValue.scalar('x=y+z')};
+      expect(
+        value.toSimple(explode: true, allowEmpty: true),
+        'formula=x%3Dy%2Bz',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=false', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        value.toSimple(explode: false, allowEmpty: true),
+        'a,x,tags,t1,t2',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=true', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        value.toSimple(explode: true, allowEmpty: true),
+        'a=x,tags=t1,t2',
+      );
+    });
+
+    test('comma inside an element is percent-encoded, separator stays literal',
+        () {
+      const value = {
+        'k': PropertyValue.array(['a,b', 'c']),
+      };
+      expect(
+        value.toSimple(explode: true, allowEmpty: true),
+        'k=a%2Cb,c',
+      );
+    });
+
+    test('empty map renders empty string with allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(value.toSimple(explode: false, allowEmpty: true), '');
+      expect(value.toSimple(explode: true, allowEmpty: true), '');
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toSimple(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+      expect(
+        () => value.toSimple(explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty scalar renders with allowEmpty=true', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(value.toSimple(explode: false, allowEmpty: true), 'k,');
+      expect(value.toSimple(explode: true, allowEmpty: true), 'k=');
+    });
+
+    test('empty scalar throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(
+        () => value.toSimple(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty array throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.array(<String>[])};
+      expect(
+        () => value.toSimple(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty array renders empty value with allowEmpty=true', () {
+      const value = {'k': PropertyValue.array(<String>[])};
+      expect(value.toSimple(explode: false, allowEmpty: true), 'k,');
+      expect(value.toSimple(explode: true, allowEmpty: true), 'k=');
+    });
+
+    test('single empty-string element is not an empty array and never throws',
+        () {
+      const value = {
+        'k': PropertyValue.array(['']),
+      };
+      expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
+    });
+  });
+
+  group('PropertyValueStyleEncoders.toLabel', () {
+    test('scalar object with explode=false matches the string-map counterpart',
+        () {
+      const value = {
+        'x': PropertyValue.scalar('1'),
+        'y': PropertyValue.scalar('2'),
+      };
+      expect(value.toLabel(explode: false, allowEmpty: true), '.x,1,y,2');
+    });
+
+    test('scalar object with explode=true matches the string-map counterpart',
+        () {
+      const value = {
+        'x': PropertyValue.scalar('1'),
+        'y': PropertyValue.scalar('2'),
+      };
+      expect(value.toLabel(explode: true, allowEmpty: true), '.x=1.y=2');
+    });
+
+    test('reserved characters in scalar values are percent-encoded', () {
+      const value = {
+        'street': PropertyValue.scalar('123 Main St'),
+        'city': PropertyValue.scalar('New York'),
+      };
+      expect(
+        value.toLabel(explode: true, allowEmpty: true),
+        '.street=123%20Main%20St.city=New%20York',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=false', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        value.toLabel(explode: false, allowEmpty: true),
+        '.a,x,tags,t1,t2',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=true', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(value.toLabel(explode: true, allowEmpty: true), '.a=x.tags=t1,t2');
+    });
+
+    test('comma inside an element is percent-encoded, separator stays literal',
+        () {
+      const value = {
+        'k': PropertyValue.array(['a,b', 'c']),
+      };
+      expect(value.toLabel(explode: true, allowEmpty: true), '.k=a%2Cb,c');
+    });
+
+    test('empty map renders . with allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(value.toLabel(explode: false, allowEmpty: true), '.');
+      expect(value.toLabel(explode: true, allowEmpty: true), '.');
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toLabel(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+      expect(
+        () => value.toLabel(explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty scalar renders with allowEmpty=true', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(value.toLabel(explode: false, allowEmpty: true), '.k,');
+      expect(value.toLabel(explode: true, allowEmpty: true), '.k=');
+    });
+
+    test('empty scalar throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(
+        () => value.toLabel(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty array throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.array(<String>[])};
+      expect(
+        () => value.toLabel(explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('single empty-string element is not an empty array and never throws',
+        () {
+      const value = {
+        'k': PropertyValue.array(['']),
+      };
+      expect(value.toLabel(explode: false, allowEmpty: false), '.k,');
+      expect(value.toLabel(explode: true, allowEmpty: false), '.k=');
+    });
+  });
+
+  group('PropertyValueStyleEncoders.toMatrix', () {
+    test('scalar object with explode=false matches the string-map counterpart',
+        () {
+      const value = {
+        'x': PropertyValue.scalar('1'),
+        'y': PropertyValue.scalar('2'),
+      };
+      expect(
+        value.toMatrix('point', explode: false, allowEmpty: true),
+        ';point=x,1,y,2',
+      );
+    });
+
+    test('scalar object with explode=true matches the string-map counterpart',
+        () {
+      const value = {
+        'x': PropertyValue.scalar('1'),
+        'y': PropertyValue.scalar('2'),
+      };
+      expect(
+        value.toMatrix('point', explode: true, allowEmpty: true),
+        ';x=1;y=2',
+      );
+    });
+
+    test('reserved characters in keys and values are percent-encoded', () {
+      const value = {
+        'key & name': PropertyValue.scalar('value,test'),
+        'other': PropertyValue.scalar('normal'),
+      };
+      expect(
+        value.toMatrix('data', explode: true, allowEmpty: true),
+        ';key%20%26%20name=value%2Ctest;other=normal',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=false', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        value.toMatrix('p', explode: false, allowEmpty: true),
+        ';p=a,x,tags,t1,t2',
+      );
+    });
+
+    test('array beside a scalar comma-joins with explode=true', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        value.toMatrix('p', explode: true, allowEmpty: true),
+        ';a=x;tags=t1,t2',
+      );
+    });
+
+    test('comma inside an element is percent-encoded, separator stays literal',
+        () {
+      const value = {
+        'k': PropertyValue.array(['a,b', 'c']),
+      };
+      expect(
+        value.toMatrix('p', explode: true, allowEmpty: true),
+        ';k=a%2Cb,c',
+      );
+    });
+
+    test('empty map renders ;paramName with allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(value.toMatrix('point', explode: false, allowEmpty: true),
+          ';point');
+      expect(
+          value.toMatrix('point', explode: true, allowEmpty: true), ';point');
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toMatrix('point', explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+      expect(
+        () => value.toMatrix('point', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty scalar renders with allowEmpty=true', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(value.toMatrix('p', explode: false, allowEmpty: true), ';p=k,');
+      expect(value.toMatrix('p', explode: true, allowEmpty: true), ';k=');
+    });
+
+    test('empty scalar throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(
+        () => value.toMatrix('p', explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty array throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.array(<String>[])};
+      expect(
+        () => value.toMatrix('p', explode: false, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('single empty-string element is not an empty array and never throws',
+        () {
+      const value = {
+        'k': PropertyValue.array(['']),
+      };
+      expect(value.toMatrix('p', explode: false, allowEmpty: false), ';p=k,');
+      expect(value.toMatrix('p', explode: true, allowEmpty: false), ';k=');
+    });
+  });
+
+  group('PropertyValueStyleEncoders.toDeepObject', () {
+    test('scalar object produces bracketed name entries', () {
+      const value = {
+        'x': PropertyValue.scalar('1'),
+        'y': PropertyValue.scalar('2'),
+      };
+      expect(
+        value.toDeepObject('point', explode: true, allowEmpty: true),
+        [
+          (name: 'point[x]', value: '1'),
+          (name: 'point[y]', value: '2'),
+        ],
+      );
+    });
+
+    test('keys are component-encoded, brackets stay literal', () {
+      const value = {'a b': PropertyValue.scalar('v')};
+      expect(
+        value.toDeepObject('f', explode: true, allowEmpty: true),
+        [(name: 'f[a%20b]', value: 'v')],
+      );
+    });
+
+    test('reserved characters in values are percent-encoded without '
+        'allowReserved', () {
+      const value = {'path': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toDeepObject('filter', explode: true, allowEmpty: true),
+        [(name: 'filter[path]', value: 'a%2Fb%3Ac')],
+      );
+    });
+
+    test('reserved characters in values stay literal with allowReserved', () {
+      const value = {'path': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toDeepObject(
+          'filter',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        [(name: 'filter[path]', value: 'a/b:c')],
+      );
+    });
+
+    test('array value throws with the list-unsupported message', () {
+      const value = {
+        'a': PropertyValue.scalar('x'),
+        'tags': PropertyValue.array(['t1', 't2']),
+      };
+      expect(
+        () => value.toDeepObject('p', explode: true, allowEmpty: true),
+        throwsA(
+          isA<EncodingException>().having(
+            (e) => e.message,
+            'message',
+            'Lists are not supported in this encoding style',
+          ),
+        ),
+      );
+    });
+
+    test('explode=false throws', () {
+      const value = {'x': PropertyValue.scalar('1')};
+      expect(
+        () => value.toDeepObject('p', explode: false, allowEmpty: true),
+        throwsA(
+          isA<EncodingException>().having(
+            (e) => e.message,
+            'message',
+            'deepObject style requires explode=true',
+          ),
+        ),
+      );
+    });
+
+    test('empty map renders empty list with allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        value.toDeepObject('p', explode: true, allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toDeepObject('p', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty scalar renders empty value with allowEmpty=true', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(
+        value.toDeepObject('p', explode: true, allowEmpty: true),
+        [(name: 'p[k]', value: '')],
+      );
+    });
+
+    test('empty scalar throws with allowEmpty=false', () {
+      const value = {'k': PropertyValue.scalar('')};
+      expect(
+        () => value.toDeepObject('p', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
+}

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -413,6 +413,20 @@ void main() {
       );
     });
 
+    test('reserved characters in keys stay component-encoded with '
+        'allowReserved', () {
+      const value = {'a/b': PropertyValue.scalar('x/y')};
+      expect(
+        value.toDeepObject(
+          'p',
+          explode: true,
+          allowEmpty: false,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'p[a%2Fb]', value: 'x/y')],
+      );
+    });
+
     test('array value throws with the list-unsupported message', () {
       const value = {
         'a': PropertyValue.scalar('x'),


### PR DESCRIPTION
## Summary

Adds form-neutral encoders over `Map<String, PropertyValue>` for the remaining parameter styles — simple, label, matrix, and deepObject — mirroring the existing `Map<String, String>` encoders but taking raw (unescaped) values. This is additive and ships dark: nothing calls the new code yet, so there is no wire behavior change.

Each new encoder is byte-parity with the prior pipeline (where generated code percent-encoded values via `.uriEncode` and the string-map encoder assembled them with `alreadyEncoded: true`):

- **simple / label / matrix** — scalar and pair assembly matches each string-map sibling exactly; an array value contributes its percent-encoded elements comma-joined (a comma inside an element is `%2C`, the separator between elements is a literal `,`). These styles have no per-property explode concept for nested arrays — comma-join is permanent.
- **deepObject** — returns `paramName[key]=value` entries; keys are component-encoded with literal brackets, and `allowReserved` threads into values. Any array value throws `EncodingException('Lists are not supported in this encoding style')` — the same message the collection guard produces today, relocated into the encoder (it now fires when the array is encountered during encoding).

Each encoder owns its empty-value checks: it mirrors the string-map counterpart's empty-map and empty rendering, plus the empty-scalar rule (`scalar('')` with `allowEmpty: false` throws) that previously lived in the generated `.uriEncode` calls.

## Shared helper

The percent-encoding helper (previously file-private in `uri_encoder_extensions.dart`) is relocated into a package-private `uri_value_encoder.dart` so both the URI encoders and the new style encoders share one copy. It is intentionally not barrel-exported — it stays off the package's public API.

## Tests

Unit tests in `tonik_util` cover, per style: explode true/false scalar shapes with literals lifted side-by-side from the string-map sibling tests, an array beside a scalar, a comma inside an element, reserved characters, and the empty-map / empty-scalar / single-empty-element cases under both `allowEmpty` settings; deepObject additionally covers key component-encoding, `allowReserved` with and without, and the array/`explode:false` throws. Expected values are literal strings. 100% patch coverage.
