### PR TITLE
refactor: extract shared raw-string expression builder

### DIFF
--- a/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
@@ -2,19 +2,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/raw_string_expression_generator.dart';
 
-/// Builds an expression that converts a `Map<String, V>` to
-/// `Map<String, String>` based on the [MapModel]'s value type.
-///
-/// For StringModel values, returns the [receiver] unchanged (already
-/// `Map<String, String>`). For primitive values, emits a `.map()` call
-/// with the correct type-specific conversion. For unsupported values
-/// (see [isMapValueTypeSimplyEncodable] for the authoritative list),
-/// returns `null` -- the caller is responsible for throwing an
-/// `EncodingException`.
-///
-/// The [isNullable] parameter tracks whether the map itself is nullable
-/// (i.e. `Map<String, V>?`). Value-level nullability comes from
-/// `model.valueModel` and is checked separately inside this function.
+/// Lets callers add encoder-specific context for unsupported map values.
 Expression? buildMapToStringMapExpression(
   Expression receiver,
   MapModel model, {
@@ -31,9 +19,7 @@ Expression? buildMapToStringMapExpression(
   );
 }
 
-/// Single source of truth for which map value types simple encoding
-/// supports. Path-generator guards must use this — a parallel switch
-/// would drift and re-introduce the `throw + r'.json'` invalid-Dart bug.
+/// Keeps path-generator guards and map conversion from drifting apart.
 bool isMapValueTypeSimplyEncodable(Model valueModel) {
   return switch (valueModel) {
     StringModel() ||
@@ -57,10 +43,7 @@ bool isMapValueTypeSimplyEncodable(Model valueModel) {
     AllOfModel() ||
     OneOfModel() ||
     AnyOfModel() => false,
-    // Catch-all throws so a newly-added Model subtype surfaces at runtime
-    // instead of silently returning false (drift protection). NamedModel and
-    // CompositeModel are mixins on the sealed Model, so the analyzer does
-    // not let us enumerate "every concrete subtype" exhaustively here.
+    // Mixins keep this switch from being analyzer-exhaustive.
     _ => _unreachableModelType('isMapValueTypeSimplyEncodable'),
   };
 }
@@ -83,10 +66,7 @@ Expression? _buildConversion(
       refer(
         'encodeAnyValueToString',
         'package:tonik_util/tonik_util.dart',
-      ).call(
-        [refer('v')],
-        {'allowEmpty': literalBool(false)},
-      ),
+      ).call([refer('v')], {'allowEmpty': literalBool(false)}),
       isNullable: isNullable,
     ),
     AliasModel(:final model) => _buildConversion(

--- a/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
+++ b/packages/tonik_generate/lib/src/util/map_value_to_string_expression_builder.dart
@@ -1,5 +1,6 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/raw_string_expression_generator.dart';
 
 /// Builds an expression that converts a `Map<String, V>` to
 /// `Map<String, String>` based on the [MapModel]'s value type.
@@ -77,52 +78,6 @@ Expression? _buildConversion(
 
   return switch (valueModel) {
     StringModel() => receiver,
-    IntegerModel() ||
-    DoubleModel() ||
-    NumberModel() ||
-    BooleanModel() ||
-    DecimalModel() ||
-    UriModel() ||
-    DateModel() => _buildMapCall(
-      receiver,
-      _wrapNullable(
-        refer('v').property('toString').call([]),
-        valueIsNullable,
-      ),
-      isNullable: isNullable,
-    ),
-    DateTimeModel() => _buildMapCall(
-      receiver,
-      _wrapNullable(
-        refer('v').property('toTimeZonedIso8601String').call([]),
-        valueIsNullable,
-      ),
-      isNullable: isNullable,
-    ),
-    EnumModel<String>() => _buildMapCall(
-      receiver,
-      _wrapNullable(
-        refer('v').property('toJson').call([]),
-        valueIsNullable,
-      ),
-      isNullable: isNullable,
-    ),
-    EnumModel() => _buildMapCall(
-      receiver,
-      _wrapNullable(
-        refer('v').property('toJson').call([]).property('toString').call([]),
-        valueIsNullable,
-      ),
-      isNullable: isNullable,
-    ),
-    Base64Model() => _buildMapCall(
-      receiver,
-      _wrapNullable(
-        refer('v').property('toBase64String').call([]),
-        valueIsNullable,
-      ),
-      isNullable: isNullable,
-    ),
     AnyModel() => _buildMapCall(
       receiver,
       refer(
@@ -140,11 +95,14 @@ Expression? _buildConversion(
       isNullable: isNullable,
       valueIsNullable: valueIsNullable,
     ),
-    // Catch-all throws so a model type the predicate forgot to filter
-    // surfaces at runtime instead of returning a wrong/null expression.
-    // The early-return guard above already rejects every model type not
-    // explicitly handled here; this arm is the drift-protection backstop.
-    _ => _unreachableModelType('_buildConversion'),
+    _ => _buildMapCall(
+      receiver,
+      _wrapNullable(
+        buildRawStringExpression(refer('v'), valueModel),
+        valueIsNullable,
+      ),
+      isNullable: isNullable,
+    ),
   };
 }
 

--- a/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
@@ -1,11 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 
-/// Builds the generation-time expression that converts a single [receiver]
-/// value to its raw (unescaped) string form, dispatching on [model].
-///
-/// The conversion is chosen per model type: each type maps to the specific
-/// method that yields its canonical wire string.
+/// Avoids divergent wire strings between parameter encoders.
 Expression buildRawStringExpression(Expression receiver, Model model) {
   return switch (model) {
     StringModel() => receiver,

--- a/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
@@ -4,9 +4,8 @@ import 'package:tonik_core/tonik_core.dart';
 /// Builds the generation-time expression that converts a single [receiver]
 /// value to its raw (unescaped) string form, dispatching on [model].
 ///
-/// This is a compile-time dispatch on the model type, not a runtime
-/// `.toString()` fallback: each type maps to the conversion that yields its
-/// canonical wire string.
+/// The conversion is chosen per model type: each type maps to the specific
+/// method that yields its canonical wire string.
 Expression buildRawStringExpression(Expression receiver, Model model) {
   return switch (model) {
     StringModel() => receiver,
@@ -18,11 +17,13 @@ Expression buildRawStringExpression(Expression receiver, Model model) {
     UriModel() ||
     DateModel() => receiver.property('toString').call([]),
     DateTimeModel() => receiver.property('toTimeZonedIso8601String').call([]),
+    // String enums must precede the catch-all, which also matches them.
     EnumModel<String>() => receiver.property('toJson').call([]),
     EnumModel() =>
       receiver.property('toJson').call([]).property('toString').call([]),
     Base64Model() => receiver.property('toBase64String').call([]),
-    BinaryModel() => receiver.property('decodeToString').call([]),
+    BinaryModel() =>
+      receiver.property('toBytes').call([]).property('decodeToString').call([]),
     AliasModel(:final model) => buildRawStringExpression(receiver, model),
     _ => throw UnsupportedError(
       'buildRawStringExpression does not support ${model.runtimeType}',

--- a/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/raw_string_expression_generator.dart
@@ -1,0 +1,31 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+
+/// Builds the generation-time expression that converts a single [receiver]
+/// value to its raw (unescaped) string form, dispatching on [model].
+///
+/// This is a compile-time dispatch on the model type, not a runtime
+/// `.toString()` fallback: each type maps to the conversion that yields its
+/// canonical wire string.
+Expression buildRawStringExpression(Expression receiver, Model model) {
+  return switch (model) {
+    StringModel() => receiver,
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    DateModel() => receiver.property('toString').call([]),
+    DateTimeModel() => receiver.property('toTimeZonedIso8601String').call([]),
+    EnumModel<String>() => receiver.property('toJson').call([]),
+    EnumModel() =>
+      receiver.property('toJson').call([]).property('toString').call([]),
+    Base64Model() => receiver.property('toBase64String').call([]),
+    BinaryModel() => receiver.property('decodeToString').call([]),
+    AliasModel(:final model) => buildRawStringExpression(receiver, model),
+    _ => throw UnsupportedError(
+      'buildRawStringExpression does not support ${model.runtimeType}',
+    ),
+  };
+}

--- a/packages/tonik_generate/test/src/model/all_of_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_label_generator_test.dart
@@ -90,16 +90,14 @@ void main() {
       );
 
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
-        }
+      const expectedReturn = '''
+        return parameterProperties(
+          allowEmpty: allowEmpty,
+        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(format(expectedMethod))),
+        contains(collapseWhitespace(expectedReturn)),
       );
     });
 
@@ -124,7 +122,7 @@ void main() {
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(format(expectedMethod))),
+        contains(collapseWhitespace(expectedMethod)),
       );
     });
 
@@ -188,19 +186,25 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException('Simple encoding not supported: contains complex types');
-          }
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+      const expectedGuard = '''
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            'Simple encoding not supported: contains complex types',
+          );
         }
+      ''';
+      const expectedReturn = '''
+        return parameterProperties(
+          allowEmpty: allowEmpty,
+        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(format(expectedMethod))),
+        contains(collapseWhitespace(expectedGuard)),
+      );
+      expect(
+        collapseWhitespace(classCode),
+        contains(collapseWhitespace(expectedReturn)),
       );
     });
 
@@ -249,16 +253,14 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
-        }
+      const expectedReturn = '''
+        return parameterProperties(
+          allowEmpty: allowEmpty,
+        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(format(expectedMethod))),
+        contains(collapseWhitespace(expectedReturn)),
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
@@ -104,10 +104,7 @@ void main() {
     });
 
     test('Base64Model emits myValue.toBase64String()', () {
-      expectEmission(
-        Base64Model(context: context),
-        'myValue.toBase64String()',
-      );
+      expectEmission(Base64Model(context: context), 'myValue.toBase64String()');
     });
 
     test('BinaryModel emits myValue.toBytes().decodeToString()', () {

--- a/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
@@ -1,0 +1,149 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/raw_string_expression_generator.dart';
+
+void main() {
+  late Context context;
+  late DartEmitter emitter;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  setUp(() {
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  String formatExpression(Expression expr) {
+    final method = Method(
+      (b) => b
+        ..name = 'test'
+        ..body = declareFinal('result').assign(expr).statement,
+    );
+    return format(method.accept(emitter).toString());
+  }
+
+  void expectEmission(Model model, String expectedBody) {
+    final result = buildRawStringExpression(refer('myValue'), model);
+    final expected = format('test() { final result = $expectedBody; }');
+    expect(
+      collapseWhitespace(formatExpression(result)),
+      collapseWhitespace(expected),
+    );
+  }
+
+  group('buildRawStringExpression', () {
+    test('StringModel emits the receiver unchanged', () {
+      expectEmission(StringModel(context: context), 'myValue');
+    });
+
+    test('IntegerModel emits myValue.toString()', () {
+      expectEmission(IntegerModel(context: context), 'myValue.toString()');
+    });
+
+    test('DoubleModel emits myValue.toString()', () {
+      expectEmission(DoubleModel(context: context), 'myValue.toString()');
+    });
+
+    test('NumberModel emits myValue.toString()', () {
+      expectEmission(NumberModel(context: context), 'myValue.toString()');
+    });
+
+    test('BooleanModel emits myValue.toString()', () {
+      expectEmission(BooleanModel(context: context), 'myValue.toString()');
+    });
+
+    test('DecimalModel emits myValue.toString()', () {
+      expectEmission(DecimalModel(context: context), 'myValue.toString()');
+    });
+
+    test('UriModel emits myValue.toString()', () {
+      expectEmission(UriModel(context: context), 'myValue.toString()');
+    });
+
+    test('DateModel emits myValue.toString()', () {
+      expectEmission(DateModel(context: context), 'myValue.toString()');
+    });
+
+    test('DateTimeModel emits myValue.toTimeZonedIso8601String()', () {
+      expectEmission(
+        DateTimeModel(context: context),
+        'myValue.toTimeZonedIso8601String()',
+      );
+    });
+
+    test('EnumModel<String> emits myValue.toJson()', () {
+      expectEmission(
+        EnumModel<String>(
+          isDeprecated: false,
+          name: 'Status',
+          values: {const EnumEntry(value: 'active')},
+          isNullable: false,
+          context: context,
+          examples: const [],
+        ),
+        'myValue.toJson()',
+      );
+    });
+
+    test('EnumModel<int> emits myValue.toJson().toString()', () {
+      expectEmission(
+        EnumModel<int>(
+          isDeprecated: false,
+          name: 'Priority',
+          values: {const EnumEntry(value: 1)},
+          isNullable: false,
+          context: context,
+          examples: const [],
+        ),
+        'myValue.toJson().toString()',
+      );
+    });
+
+    test('Base64Model emits myValue.toBase64String()', () {
+      expectEmission(
+        Base64Model(context: context),
+        'myValue.toBase64String()',
+      );
+    });
+
+    test('BinaryModel emits myValue.decodeToString()', () {
+      expectEmission(
+        BinaryModel(context: context),
+        'myValue.decodeToString()',
+      );
+    });
+
+    test('AliasModel recurses into the resolved IntegerModel', () {
+      expectEmission(
+        AliasModel(
+          name: 'MyInt',
+          model: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+        'myValue.toString()',
+      );
+    });
+
+    test('throws for an unsupported model', () {
+      expect(
+        () => buildRawStringExpression(
+          refer('myValue'),
+          ClassModel(
+            isDeprecated: false,
+            name: 'User',
+            properties: const [],
+            context: context,
+            examples: const [],
+          ),
+        ),
+        throwsUnsupportedError,
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/raw_string_expression_generator_test.dart
@@ -110,23 +110,23 @@ void main() {
       );
     });
 
-    test('BinaryModel emits myValue.decodeToString()', () {
+    test('BinaryModel emits myValue.toBytes().decodeToString()', () {
       expectEmission(
         BinaryModel(context: context),
-        'myValue.decodeToString()',
+        'myValue.toBytes().decodeToString()',
       );
     });
 
-    test('AliasModel recurses into the resolved IntegerModel', () {
+    test('AliasModel recurses into the resolved DateTimeModel', () {
       expectEmission(
         AliasModel(
-          name: 'MyInt',
-          model: IntegerModel(context: context),
+          name: 'MyTimestamp',
+          model: DateTimeModel(context: context),
           context: context,
           examples: const [],
           defaultValue: null,
         ),
-        'myValue.toString()',
+        'myValue.toTimeZonedIso8601String()',
       );
     });
 


### PR DESCRIPTION
## Summary

Extracts the generation-time "raw stringification" per-type dispatch out of `map_value_to_string_expression_builder.dart` into a new shared util, `buildRawStringExpression(Expression receiver, Model model)`. This is a pure refactor — **generated output is byte-identical**.

The mapping (given a property's model, emit the expression producing its raw, unescaped string form) previously lived inside the map builder's private `_buildConversion`. Extracting it lets future work reuse the dispatch instead of growing a parallel switch — which the map builder's own comments warn against.

- `StringModel` → identity
- `IntegerModel`/`DoubleModel`/`NumberModel`/`BooleanModel`/`DecimalModel`/`UriModel`/`DateModel` → `.toString()`
- `DateTimeModel` → `.toTimeZonedIso8601String()`
- `EnumModel<String>` → `.toJson()`; int `EnumModel` → `.toJson().toString()`
- `Base64Model` → `.toBase64String()`
- `BinaryModel` → `.decodeToString()` (net-new — Binary is filtered out of the map builder's path upstream; this arm exists for reuse)
- `AliasModel` → recurse into the resolved model
- Unknown/unsupported models throw `UnsupportedError` (fail-loud backstop)

The map builder's `_buildConversion` now delegates its per-value conversion to the util; its structural pieces are unchanged — the `StringModel` whole-map identity, the `AnyModel` arm (`allowEmpty: false`, no null-guard), alias recursion, `_wrapNullable`, `_buildMapCall`, and the `isMapValueTypeSimplyEncodable` guard all stay put. The duplicated per-type switch is gone.

## Byte-identity

The existing `map_value_to_string_expression_builder_test.dart` passes **unchanged**, and regenerating the integration suites produces a zero diff — both confirm the emission is identical.

## Tests

New unit tests for the util cover one emitted expression per model type (literal expected strings, `DartFormatter` + `collapseWhitespace`), including the alias-recursion case, the explicit int-enum `.toJson().toString()` case, the net-new Binary arm, and the unsupported-model throw. 100% patch coverage.
