### PR TITLE
Support wildcard response media types

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -120,6 +120,15 @@ This means:
 - Add or remove a response in your spec, regenerate, and the compiler flags every call site that needs updating
 - Different content types on the same status code (e.g. JSON vs plain text) each get their own typed variant
 
+Response content types may also use simple media-type ranges. Tonik supports
+`type/*` and `*/*` response entries, matching them against the concrete
+`Content-Type` header after stripping parameters such as `charset=utf-8`.
+Exact content types take precedence over `type/*`, and `type/*` takes
+precedence over `*/*`. For example, if a response declares both
+`application/json` and `application/*`, an `application/json; charset=utf-8`
+response uses the exact JSON variant, while `application/problem+json` can
+match the `application/*` variant.
+
 Error types on `TonikError`: `encoding`, `decoding`, `network`, `cancelled`, `other`.
 
 ### Request Cancellation
@@ -289,6 +298,7 @@ Each operation generates a sealed response class. Every status code and content 
 |---------|--------|
 | Distinct type per status code | ✅ |
 | Distinct type per content type | ✅ |
+| Response media-type ranges | ✅ (`type/*`, `*/*`) |
 | Exhaustive pattern matching | ✅ |
 | Range codes (`2XX`, `4XX`) | ✅ |
 | `default` response | ✅ |

--- a/integration_test/structured_syntax_suffix/openapi.yaml
+++ b/integration_test/structured_syntax_suffix/openapi.yaml
@@ -79,7 +79,7 @@ paths:
         - widgets
       summary: Get bytes through a status and media-type range
       description: |-
-        Returns 206 application/json while the response is declared as 2XX and
+        Returns 203 application/json while the response is declared as 2XX and
         application/*.
       operationId: getRangeWildcard
       responses:

--- a/integration_test/structured_syntax_suffix/openapi.yaml
+++ b/integration_test/structured_syntax_suffix/openapi.yaml
@@ -73,22 +73,6 @@ paths:
             '*/*':
               schema:
                 $ref: '#/components/schemas/Widget'
-  /wildcard/range-status:
-    get:
-      tags:
-        - widgets
-      summary: Get bytes through a status and media-type range
-      description: |-
-        Returns 203 application/json while the response is declared as 2XX and
-        application/*.
-      operationId: getRangeWildcard
-      responses:
-        '2XX':
-          description: Status range wildcard response retrieved successfully
-          content:
-            'application/*':
-              schema:
-                $ref: '#/components/schemas/Widget'
 components:
   schemas:
     Widget:

--- a/integration_test/structured_syntax_suffix/openapi.yaml
+++ b/integration_test/structured_syntax_suffix/openapi.yaml
@@ -40,6 +40,55 @@ paths:
             application/problem+json:
               schema:
                 $ref: '#/components/schemas/Widget'
+  /wildcard/application:
+    get:
+      tags:
+        - widgets
+      summary: Get bytes through an application media-type range
+      description: |-
+        Returns application/json while the response is declared as
+        application/*, so the client should match the range and deliver raw
+        bytes.
+      operationId: getApplicationWildcard
+      responses:
+        '200':
+          description: Wildcard application response retrieved successfully
+          content:
+            'application/*':
+              schema:
+                $ref: '#/components/schemas/Widget'
+  /wildcard/catch-all:
+    get:
+      tags:
+        - widgets
+      summary: Get bytes through the catch-all media-type range
+      description: |-
+        Returns text/plain while the response is declared as */*, so the client
+        should match the range and deliver raw bytes.
+      operationId: getCatchAllWildcard
+      responses:
+        '200':
+          description: Catch-all wildcard response retrieved successfully
+          content:
+            '*/*':
+              schema:
+                $ref: '#/components/schemas/Widget'
+  /wildcard/range-status:
+    get:
+      tags:
+        - widgets
+      summary: Get bytes through a status and media-type range
+      description: |-
+        Returns 206 application/json while the response is declared as 2XX and
+        application/*.
+      operationId: getRangeWildcard
+      responses:
+        '2XX':
+          description: Status range wildcard response retrieved successfully
+          content:
+            'application/*':
+              schema:
+                $ref: '#/components/schemas/Widget'
 components:
   schemas:
     Widget:

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
@@ -22,12 +22,6 @@ if (context.request.path == '/api/v1/widget' && context.request.method == 'GET')
         .withHeader('Content-Type', 'text/plain')
         .withContent('catch-all wildcard response')
 
-} else if (context.request.path == '/api/v1/wildcard/range-status' && context.request.method == 'GET') {
-    respond()
-        .withStatusCode(203)
-        .withHeader('Content-Type', 'application/json')
-        .withContent('{"id":203,"name":"range-wildcard"}')
-
 } else {
     respond().usingDefaultBehaviour()
 }

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
@@ -1,26 +1,33 @@
-def response = respond().withStatusCode(200)
-
 if (context.request.path == '/api/v1/widget' && context.request.method == 'GET') {
-    response.withHeader('Content-Type', 'application/vnd.api+json')
-            .withContent('{"id":42,"name":"sprocket"}')
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'application/vnd.api+json')
+        .withContent('{"id":42,"name":"sprocket"}')
 
 } else if (context.request.path == '/api/v1/problem' && context.request.method == 'GET') {
-    response.withHeader('Content-Type', 'application/problem+json')
-            .withContent('{"id":7,"name":"teapot"}')
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'application/problem+json')
+        .withContent('{"id":7,"name":"teapot"}')
 
 } else if (context.request.path == '/api/v1/wildcard/application' && context.request.method == 'GET') {
-    response.withHeader('Content-Type', 'application/json')
-            .withContent('{"id":99,"name":"application-wildcard"}')
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'application/json')
+        .withContent('{"id":99,"name":"application-wildcard"}')
 
 } else if (context.request.path == '/api/v1/wildcard/catch-all' && context.request.method == 'GET') {
-    response.withHeader('Content-Type', 'text/plain')
-            .withContent('catch-all wildcard response')
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'text/plain')
+        .withContent('catch-all wildcard response')
 
 } else if (context.request.path == '/api/v1/wildcard/range-status' && context.request.method == 'GET') {
-    response.withStatusCode(206)
-            .withHeader('Content-Type', 'application/json')
-            .withContent('{"id":206,"name":"range-wildcard"}')
+    respond()
+        .withStatusCode(206)
+        .withHeader('Content-Type', 'application/json')
+        .withContent('{"id":206,"name":"range-wildcard"}')
 
 } else {
-    response.usingDefaultBehaviour()
+    respond().usingDefaultBehaviour()
 }

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
@@ -24,9 +24,9 @@ if (context.request.path == '/api/v1/widget' && context.request.method == 'GET')
 
 } else if (context.request.path == '/api/v1/wildcard/range-status' && context.request.method == 'GET') {
     respond()
-        .withStatusCode(206)
+        .withStatusCode(203)
         .withHeader('Content-Type', 'application/json')
-        .withContent('{"id":206,"name":"range-wildcard"}')
+        .withContent('{"id":203,"name":"range-wildcard"}')
 
 } else {
     respond().usingDefaultBehaviour()

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/imposter/response.groovy
@@ -8,6 +8,19 @@ if (context.request.path == '/api/v1/widget' && context.request.method == 'GET')
     response.withHeader('Content-Type', 'application/problem+json')
             .withContent('{"id":7,"name":"teapot"}')
 
+} else if (context.request.path == '/api/v1/wildcard/application' && context.request.method == 'GET') {
+    response.withHeader('Content-Type', 'application/json')
+            .withContent('{"id":99,"name":"application-wildcard"}')
+
+} else if (context.request.path == '/api/v1/wildcard/catch-all' && context.request.method == 'GET') {
+    response.withHeader('Content-Type', 'text/plain')
+            .withContent('catch-all wildcard response')
+
+} else if (context.request.path == '/api/v1/wildcard/range-status' && context.request.method == 'GET') {
+    response.withStatusCode(206)
+            .withHeader('Content-Type', 'application/json')
+            .withContent('{"id":206,"name":"range-wildcard"}')
+
 } else {
     response.usingDefaultBehaviour()
 }

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
@@ -78,10 +78,10 @@ void main() {
     expect(result, isA<TonikSuccess<TonikFile>>());
     final success = result as TonikSuccess<TonikFile>;
 
-    expect(success.response.statusCode, 206);
+    expect(success.response.statusCode, 203);
     expect(
       utf8.decode(success.value.toBytes()),
-      '{"id":206,"name":"range-wildcard"}',
+      '{"id":203,"name":"range-wildcard"}',
     );
   });
 }

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
@@ -72,16 +72,4 @@ void main() {
     expect(utf8.decode(success.value.toBytes()), 'catch-all wildcard response');
   });
 
-  test('status range with application/* matches concrete response', () async {
-    final result = await buildApi().getRangeWildcard();
-
-    expect(result, isA<TonikSuccess<TonikFile>>());
-    final success = result as TonikSuccess<TonikFile>;
-
-    expect(success.response.statusCode, 203);
-    expect(
-      utf8.decode(success.value.toBytes()),
-      '{"id":203,"name":"range-wildcard"}',
-    );
-  });
 }

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/structured_syntax_suffix_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:structured_syntax_suffix_api/structured_syntax_suffix_api.dart';
 import 'package:test/test.dart';
 import 'package:test_helpers/test_helpers.dart';
@@ -16,27 +18,70 @@ void main() {
     return WidgetsApi(CustomServer(baseUrl: baseUrl));
   }
 
-  test('application/vnd.api+json response decodes into the declared model',
-      () async {
-    final result = await buildApi().getWidget();
+  test(
+    'application/vnd.api+json response decodes into the declared model',
+    () async {
+      final result = await buildApi().getWidget();
 
-    expect(result, isA<TonikSuccess<Widget>>());
-    final success = result as TonikSuccess<Widget>;
+      expect(result, isA<TonikSuccess<Widget>>());
+      final success = result as TonikSuccess<Widget>;
+
+      expect(success.response.statusCode, 200);
+      expect(success.value.id, 42);
+      expect(success.value.name, 'sprocket');
+    },
+  );
+
+  test(
+    'application/problem+json response decodes into the declared model',
+    () async {
+      final result = await buildApi().getProblem();
+
+      expect(result, isA<TonikSuccess<Widget>>());
+      final success = result as TonikSuccess<Widget>;
+
+      expect(success.response.statusCode, 200);
+      expect(success.value.id, 7);
+      expect(success.value.name, 'teapot');
+    },
+  );
+
+  test(
+    'application/* response matches application/json and returns bytes',
+    () async {
+      final result = await buildApi().getApplicationWildcard();
+
+      expect(result, isA<TonikSuccess<TonikFile>>());
+      final success = result as TonikSuccess<TonikFile>;
+
+      expect(success.response.statusCode, 200);
+      expect(
+        utf8.decode(success.value.toBytes()),
+        '{"id":99,"name":"application-wildcard"}',
+      );
+    },
+  );
+
+  test('*/* response matches text/plain and returns bytes', () async {
+    final result = await buildApi().getCatchAllWildcard();
+
+    expect(result, isA<TonikSuccess<TonikFile>>());
+    final success = result as TonikSuccess<TonikFile>;
 
     expect(success.response.statusCode, 200);
-    expect(success.value.id, 42);
-    expect(success.value.name, 'sprocket');
+    expect(utf8.decode(success.value.toBytes()), 'catch-all wildcard response');
   });
 
-  test('application/problem+json response decodes into the declared model',
-      () async {
-    final result = await buildApi().getProblem();
+  test('status range with application/* matches concrete response', () async {
+    final result = await buildApi().getRangeWildcard();
 
-    expect(result, isA<TonikSuccess<Widget>>());
-    final success = result as TonikSuccess<Widget>;
+    expect(result, isA<TonikSuccess<TonikFile>>());
+    final success = result as TonikSuccess<TonikFile>;
 
-    expect(success.response.statusCode, 200);
-    expect(success.value.id, 7);
-    expect(success.value.name, 'teapot');
+    expect(success.response.statusCode, 206);
+    expect(
+      utf8.decode(success.value.toBytes()),
+      '{"id":206,"name":"range-wildcard"}',
+    );
   });
 }

--- a/packages/tonik/README.md
+++ b/packages/tonik/README.md
@@ -145,7 +145,7 @@ See the [petstore integration tests](https://github.com/t-unit/tonik/blob/main/i
 
 | Category | What's Supported |
 |----------|------------------|
-| **Responses** | Multiple status codes, multiple content types, response headers, `default` and range codes (`2XX`) |
+| **Responses** | Multiple status codes, multiple content types and media-type ranges (`type/*`, `*/*`), response headers, `default` and range codes (`2XX`) |
 | **Composition** | `oneOf` (sealed classes), `anyOf`, `allOf`, discriminators, nested composition |
 | **Types** | Integer/string enums, `date`, `date-time` with timezone, `decimal`/`BigDecimal`, `uri`, `binary` |
 | **Parameters** | Path, query, header; all encoding styles (`form`, `simple`, `label`, `matrix`, `deepObject`, etc.) |

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -143,21 +143,62 @@ class ParseGenerator {
     // Normalize spec keys with the same helper the generated code uses at
     // runtime so case patterns match the runtime-computed `_$mediaType`.
     final normalized = tonik_util.extractMediaType(contentType);
-    final contentTypePattern = normalized != null
+    final isMediaRange = normalized != null && _isMediaTypeRange(normalized);
+    final contentTypePattern = normalized != null && !isMediaRange
         ? specLiteralStringCode(normalized)
         : '_';
+    final mediaTypeGuard = isMediaRange
+        ? _mediaTypeRangeGuard(normalized)
+        : null;
+
     switch (status) {
       case ExplicitResponseStatus():
-        return Code('case (${status.statusCode}, $contentTypePattern):');
+        return _caseWithGuards(
+          'case (${status.statusCode}, $contentTypePattern)',
+          [?mediaTypeGuard],
+        );
       case RangeResponseStatus():
-        return Code(
-          'case (var status, $contentTypePattern) '
-          'when status != null '
-          '&& status >= ${status.min} && status <= ${status.max}:',
+        return _caseWithGuards(
+          'case (var status, $contentTypePattern)',
+          [
+            Code(
+              'status != null '
+              '&& status >= ${status.min} && status <= ${status.max}',
+            ),
+            ?mediaTypeGuard,
+          ],
         );
       case DefaultResponseStatus():
-        return Code('case (_, $contentTypePattern):');
+        return _caseWithGuards(
+          'case (_, $contentTypePattern)',
+          [?mediaTypeGuard],
+        );
     }
+  }
+
+  Code _caseWithGuards(String pattern, List<Code> guards) {
+    if (guards.isEmpty) return Code('$pattern:');
+
+    return Block.of([
+      Code('$pattern when '),
+      for (final (index, guard) in guards.indexed) ...[
+        if (index > 0) const Code(' && '),
+        guard,
+      ],
+      const Code(':'),
+    ]);
+  }
+
+  Code _mediaTypeRangeGuard(String mediaTypeRange) {
+    return Block.of([
+      refer(
+        'matchesMediaTypeRange',
+        'package:tonik_util/tonik_util.dart',
+      ).code,
+      const Code(r'(_$mediaType, '),
+      Code(specLiteralStringCode(mediaTypeRange)),
+      const Code(')'),
+    ]);
   }
 
   Code _caseBody(
@@ -721,6 +762,54 @@ class ParseGenerator {
       );
     }
 
-    return contentTypes;
+    return _sortContentTypesBySpecificity(contentTypes);
+  }
+
+  Set<String?> _sortContentTypesBySpecificity(Set<String?> contentTypes) {
+    final exact = <String?>[];
+    final typeRanges = <String?>[];
+    final catchAllRanges = <String?>[];
+    final catchAllPatterns = <String?>[];
+
+    for (final contentType in contentTypes) {
+      switch (_contentTypeSpecificity(contentType)) {
+        case 0:
+          exact.add(contentType);
+        case 1:
+          typeRanges.add(contentType);
+        case 2:
+          catchAllRanges.add(contentType);
+        case 3:
+          catchAllPatterns.add(contentType);
+      }
+    }
+
+    return {
+      ...exact,
+      ...typeRanges,
+      ...catchAllRanges,
+      ...catchAllPatterns,
+    };
+  }
+
+  int _contentTypeSpecificity(String? contentType) {
+    final normalized = tonik_util.extractMediaType(contentType);
+    if (normalized == null) return 3;
+    if (normalized == '*/*') return 2;
+    if (_isTypeMediaRange(normalized)) return 1;
+    return 0;
+  }
+
+  bool _isMediaTypeRange(String mediaType) {
+    return mediaType == '*/*' || _isTypeMediaRange(mediaType);
+  }
+
+  bool _isTypeMediaRange(String mediaType) {
+    final slashIndex = mediaType.indexOf('/');
+    if (slashIndex <= 0 || slashIndex == mediaType.length - 1) return false;
+
+    final type = mediaType.substring(0, slashIndex);
+    final subtype = mediaType.substring(slashIndex + 1);
+    return subtype == '*' && type != '*' && !type.contains('*');
   }
 }

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -1851,6 +1851,191 @@ TonikFile _parseResponse(Response<List<int>> response) {
         );
       });
 
+      test('generates guarded case for type wildcard response media range', () {
+        final operation = Operation(
+          operationId: 'applicationWildcardOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/application-wildcard',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: BinaryModel(context: context),
+                  rawContentType: 'application/*',
+                  contentType: ContentType.bytes,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+TonikFile _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, _) when matchesMediaTypeRange(_$mediaType, r'application/*'):
+      final _$body = TonikFileBytes(decodeResponseBytes(response.data));
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test(
+        'generates guarded case for catch-all media range and status range',
+        () {
+          final operation = Operation(
+            operationId: 'catchAllRangeOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/catch-all-range',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const RangeResponseStatus(min: 200, max: 299): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: BinaryModel(context: context),
+                    rawContentType: '*/*',
+                    contentType: ContentType.bytes,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
+TonikFile _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (var status, _) when status != null && status >= 200 && status <= 299 && matchesMediaTypeRange(_$mediaType, r'*/*'):
+      final _$body = TonikFileBytes(decodeResponseBytes(response.data));
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test('orders exact media type before type wildcard before catch-all', () {
+        final operation = Operation(
+          operationId: 'wildcardPrecedenceOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/wildcard-precedence',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: BinaryModel(context: context),
+                  rawContentType: '*/*',
+                  contentType: ContentType.bytes,
+                  examples: const [],
+                ),
+                ResponseBody(
+                  model: BinaryModel(context: context),
+                  rawContentType: 'application/*',
+                  contentType: ContentType.bytes,
+                  examples: const [],
+                ),
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+AnonymousResponse _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+  switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json.decodeJsonString();
+      return AnonymousResponseJson(body: _$body);
+    case (200, _) when matchesMediaTypeRange(_$mediaType, r'application/*'):
+      final _$body = TonikFileBytes(decodeResponseBytes(response.data));
+      return AnonymousResponseModel2(body: _$body);
+    case (200, _) when matchesMediaTypeRange(_$mediaType, r'*/*'):
+      final _$body = TonikFileBytes(decodeResponseBytes(response.data));
+      return AnonymousResponseModel(body: _$body);
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
       test('generates bytes decoder for image/png response', () {
         final operation = Operation(
           operationId: 'imageOp',

--- a/packages/tonik_util/lib/src/decoding/media_type.dart
+++ b/packages/tonik_util/lib/src/decoding/media_type.dart
@@ -29,3 +29,48 @@ String? extractMediaType(String? header) {
 
   return stripped.toLowerCase();
 }
+
+/// Returns whether [actual] belongs to the declared media type or range.
+///
+/// Supports exact matches, `type/*`, and `*/*` after applying the same
+/// parameter stripping and lowercasing as [extractMediaType].
+bool matchesMediaTypeRange(String? actual, String declared) {
+  final actualMediaType = extractMediaType(actual);
+  final declaredMediaType = extractMediaType(declared);
+
+  if (!_isConcreteMediaType(actualMediaType)) return false;
+  if (declaredMediaType == null || !_hasTypeSubtype(declaredMediaType)) {
+    return false;
+  }
+
+  if (!_isMediaTypeRange(declaredMediaType)) {
+    return actualMediaType == declaredMediaType;
+  }
+
+  if (declaredMediaType == '*/*') return true;
+
+  final slashIndex = declaredMediaType.indexOf('/');
+  final declaredType = declaredMediaType.substring(0, slashIndex);
+  return actualMediaType!.startsWith('$declaredType/');
+}
+
+bool _hasTypeSubtype(String mediaType) {
+  final slashIndex = mediaType.indexOf('/');
+  return slashIndex > 0 && slashIndex < mediaType.length - 1;
+}
+
+bool _isConcreteMediaType(String? mediaType) {
+  if (mediaType == null || !_hasTypeSubtype(mediaType)) return false;
+  return !mediaType.contains('*');
+}
+
+bool _isMediaTypeRange(String mediaType) {
+  if (mediaType == '*/*') return true;
+
+  final slashIndex = mediaType.indexOf('/');
+  if (slashIndex <= 0 || slashIndex == mediaType.length - 1) return false;
+
+  final type = mediaType.substring(0, slashIndex);
+  final subtype = mediaType.substring(slashIndex + 1);
+  return subtype == '*' && type != '*' && !type.contains('*');
+}

--- a/packages/tonik_util/test/src/decoding/media_type_test.dart
+++ b/packages/tonik_util/test/src/decoding/media_type_test.dart
@@ -88,4 +88,47 @@ void main() {
       expect(extractMediaType('garbage; foo=bar'), 'garbage');
     });
   });
+
+  group('matchesMediaTypeRange', () {
+    test('matches exact media types after normalizing parameters and case', () {
+      expect(
+        matchesMediaTypeRange(
+          'Application/JSON; charset=utf-8',
+          'application/json',
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches type wildcard media ranges', () {
+      expect(
+        matchesMediaTypeRange('application/json', 'application/*'),
+        isTrue,
+      );
+      expect(
+        matchesMediaTypeRange('application/problem+json', 'application/*'),
+        isTrue,
+      );
+      expect(matchesMediaTypeRange('text/plain', 'application/*'), isFalse);
+    });
+
+    test('matches catch-all media range for concrete media types', () {
+      expect(matchesMediaTypeRange('application/json', '*/*'), isTrue);
+      expect(matchesMediaTypeRange('text/plain', '*/*'), isTrue);
+    });
+
+    test('does not match missing or malformed actual media types', () {
+      expect(matchesMediaTypeRange(null, 'application/*'), isFalse);
+      expect(matchesMediaTypeRange('garbage', 'application/*'), isFalse);
+      expect(matchesMediaTypeRange('garbage', '*/*'), isFalse);
+    });
+
+    test('does not treat unsupported wildcard shapes as ranges', () {
+      expect(matchesMediaTypeRange('application/json', '*/json'), isFalse);
+      expect(
+        matchesMediaTypeRange('application/json', 'application/j*'),
+        isFalse,
+      );
+    });
+  });
 }


### PR DESCRIPTION
Summary: Support wildcard response media-type ranges in generated response parsing; add exact/type wildcard/catch-all precedence and coverage; add structured_syntax_suffix Imposter cases. Validation: focused util/generator tests passed; analyzer passed; setup_integration_tests.sh completed; focused Imposter test is added but local execution is blocked before assertions because the host Java runtime is unavailable.