### PR TITLE
refactor: reshape parameterProperties to a tagged raw-value map

### DIFF
--- a/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
@@ -50,10 +50,9 @@ void main() {
         label: 'release',
       );
 
-      final encoded = filter.parameterProperties();
+      final encoded = filter.toForm('filter', explode: true, allowEmpty: true);
       final wire = [
-        for (final entry in encoded.entries)
-          '${entry.key}=${entry.value}',
+        for (final entry in encoded) '${entry.name}=${entry.value}',
       ].join('&');
 
       final decoded = Filter.fromForm(wire, explode: true);

--- a/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
+++ b/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
@@ -260,7 +260,10 @@ void main() {
       final params = user.parameterProperties();
 
       expect(params.containsKey('email'), isTrue);
-      expect(params['email'], 'test%40example.com');
+      expect(
+        (params['email']! as ScalarPropertyValue).value,
+        'test@example.com',
+      );
     });
 
     test('parameterProperties includes writeOnly fields', () {
@@ -269,7 +272,7 @@ void main() {
 
       expect(params.containsKey('name'), isTrue);
       expect(params.containsKey('password'), isTrue);
-      expect(params['password'], 'pass');
+      expect((params['password']! as ScalarPropertyValue).value, 'pass');
     });
   });
 
@@ -458,8 +461,8 @@ void main() {
         confirmPassword: 'def',
       );
       final params = change.parameterProperties();
-      expect(params['newPassword'], 'abc');
-      expect(params['confirmPassword'], 'def');
+      expect((params['newPassword']! as ScalarPropertyValue).value, 'abc');
+      expect((params['confirmPassword']! as ScalarPropertyValue).value, 'def');
     });
   });
 
@@ -782,8 +785,8 @@ void main() {
         commandBody: CommandBody(action: 'create'),
       );
       final params = command.parameterProperties();
-      expect(params['token'], 'abc123');
-      expect(params['action'], 'create');
+      expect((params['token']! as ScalarPropertyValue).value, 'abc123');
+      expect((params['action']! as ScalarPropertyValue).value, 'create');
     });
 
     test('POST /bulk-command sends writeOnly allOf command', () async {
@@ -975,8 +978,8 @@ void main() {
         ),
       );
       final params = command.parameterProperties();
-      expect(params['deviceId'], 'dev-001');
-      expect(params['force'], 'true');
+      expect((params['deviceId']! as ScalarPropertyValue).value, 'dev-001');
+      expect((params['force']! as ScalarPropertyValue).value, 'true');
     });
 
     test('POST /device-command sends writeOnly anyOf command', () async {

--- a/packages/tonik/pubspec.yaml
+++ b/packages/tonik/pubspec.yaml
@@ -36,7 +36,7 @@ dependencies:
   yaml: ^3.1.3
 
 dev_dependencies:
-  dart_style: ^3.1.9
+  dart_style: ^3.1.11
   path: ^1.9.1
   test: ^1.26.3
   very_good_analysis: ^10.2.0

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -18,6 +18,7 @@ import 'package:tonik_generate/src/util/from_simple_value_expression_generator.d
 import 'package:tonik_generate/src/util/hash_code_generator.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
 import 'package:tonik_generate/src/util/known_keys_collector.dart';
+import 'package:tonik_generate/src/util/property_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_label_parameter_expression_generator.dart';
@@ -1281,9 +1282,9 @@ class AllOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
-          ..body = buildEmptyMapStringString().returned.statement,
+          ..body = buildEmptyMapStringPropertyValue().returned.statement,
       );
     }
 
@@ -1307,7 +1308,7 @@ class AllOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..lambda = true
           ..body = generateEncodingExceptionExpression(message, raw: true).code,
@@ -1323,7 +1324,7 @@ class AllOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..lambda = true
           ..body = generateEncodingExceptionExpression(
@@ -1338,7 +1339,7 @@ class AllOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
@@ -1351,7 +1352,7 @@ class AllOfGenerator {
     final propertyMergingLines = [
       declareFinal(
         r'_$mergedProperties',
-      ).assign(buildEmptyMapStringString()).statement,
+      ).assign(buildEmptyMapStringPropertyValue()).statement,
     ];
 
     for (final normalized in normalizedProperties) {
@@ -1364,15 +1365,7 @@ class AllOfGenerator {
                 .property(
                   'parameterProperties',
                 )
-                .call(
-                  [],
-                  {
-                    'allowEmpty': refer('allowEmpty'),
-                    'allowLists': refer('allowLists'),
-                    'allowReserved': refer('allowReserved'),
-                    'fieldEncodings': refer('fieldEncodings'),
-                  },
-                ),
+                .call([], {'allowEmpty': refer('allowEmpty')}),
           ]).statement,
           const Code('}'),
         ]);
@@ -1383,15 +1376,7 @@ class AllOfGenerator {
                 .property(
                   'parameterProperties',
                 )
-                .call(
-                  [],
-                  {
-                    'allowEmpty': refer('allowEmpty'),
-                    'allowLists': refer('allowLists'),
-                    'allowReserved': refer('allowReserved'),
-                    'fieldEncodings': refer('fieldEncodings'),
-                  },
-                ),
+                .call([], {'allowEmpty': refer('allowEmpty')}),
           ]).statement,
         );
       }
@@ -1408,7 +1393,7 @@ class AllOfGenerator {
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..body = Block.of(propertyMergingLines),
     );
@@ -1428,25 +1413,37 @@ class AllOfGenerator {
 
     if (ap is TypedAdditionalProperties &&
         ap.valueModel.encodingShape == EncodingShape.simple) {
-      final uriEncodeCall = ap.valueModel.isEffectivelyNullable
-          ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
-                '.uriEncode(allowEmpty: allowEmpty, '
-                "allowReserved: allowReserved) ?? ''"
-          : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
-                '.uriEncode(allowEmpty: allowEmpty, '
-                'allowReserved: allowReserved)';
       return [
-        Code('''
-for (final _\$e in $apFieldName.entries) {
-  _\$mergedProperties[_\$e.key] = $uriEncodeCall;
-}'''),
+        Code('for (final _\$e in $apFieldName.entries) {'),
+        refer(r'_$mergedProperties')
+            .index(refer(r'_$e').property('key'))
+            .assign(
+              propertyValueScalar(
+                additionalPropertyRawScalar(
+                  refer(r'_$e').property('value'),
+                  ap.valueModel,
+                ),
+              ),
+            )
+            .statement,
+        const Code('}'),
       ];
     } else if (ap is UnrestrictedAdditionalProperties) {
       return [
-        Code(
-          'for (final _\$e in $apFieldName.entries) { '
-          r"_$mergedProperties[_$e.key] = _$e.value?.toString() ?? ''; }",
-        ),
+        Code('for (final _\$e in $apFieldName.entries) {'),
+        refer(r'_$mergedProperties')
+            .index(refer(r'_$e').property('key'))
+            .assign(
+              propertyValueScalar(
+                refer(r'_$e')
+                    .property('value')
+                    .nullSafeProperty('toString')
+                    .call([])
+                    .ifNullThen(literalString('')),
+              ),
+            )
+            .statement,
+        const Code('}'),
       ];
     } else {
       // Typed with complex value model — throw
@@ -1492,7 +1489,7 @@ for (final _\$e in $apFieldName.entries) {
         const Code('allowEmpty: allowEmpty,'),
         const Code(
           ').toSimple('
-          'explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);',
+          'explode: explode, allowEmpty: allowEmpty);',
         ),
       ];
 
@@ -1547,7 +1544,6 @@ for (final _\$e in $apFieldName.entries) {
             .call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
-              'alreadyEncoded': literalBool(true),
             })
             .returned
             .statement,
@@ -1671,7 +1667,6 @@ for (final _\$e in $apFieldName.entries) {
                 .call([], {
                   'explode': refer('explode'),
                   'allowEmpty': refer('allowEmpty'),
-                  'alreadyEncoded': literalBool(true),
                 })
                 .returned
                 .statement,
@@ -1906,19 +1901,16 @@ for (final _\$e in $apFieldName.entries) {
     }
 
     final delegateToParameterProperties = refer('parameterProperties')
-        .call([], {
-          'allowEmpty': refer('allowEmpty'),
-          'allowReserved': refer('allowReserved'),
-          'fieldEncodings': refer('fieldEncodings'),
-        })
+        .call([], {'allowEmpty': refer('allowEmpty')})
         .property('toForm')
         .call(
           [refer('paramName')],
           {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
-            'alreadyEncoded': literalBool(true),
             'useQueryComponent': refer('useQueryComponent'),
+            'allowReserved': refer('allowReserved'),
+            'fieldEncodings': refer('fieldEncodings'),
           },
         )
         .returned
@@ -2024,7 +2016,7 @@ for (final _\$e in $apFieldName.entries) {
         const Code('allowEmpty: allowEmpty,'),
         const Code(
           ').toLabel('
-          'explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);',
+          'explode: explode, allowEmpty: allowEmpty);',
         ),
       ];
 
@@ -2209,7 +2201,6 @@ for (final _\$e in $apFieldName.entries) {
               .call([], {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
               })
               .returned
               .statement,
@@ -2307,7 +2298,6 @@ for (final _\$e in $apFieldName.entries) {
               {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
               },
             )
             .returned
@@ -2464,7 +2454,6 @@ for (final _\$e in $apFieldName.entries) {
                 {
                   'explode': refer('explode'),
                   'allowEmpty': refer('allowEmpty'),
-                  'alreadyEncoded': literalBool(true),
                 },
               )
               .returned

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -16,6 +16,7 @@ import 'package:tonik_generate/src/util/from_json_value_expression_generator.dar
 import 'package:tonik_generate/src/util/from_simple_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/hash_code_generator.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
+import 'package:tonik_generate/src/util/property_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
@@ -979,7 +980,7 @@ class AnyOfGenerator {
       body.add(
         declareFinal(
           r'_$mapValues',
-        ).assign(literalList([], buildMapStringStringType())).statement,
+        ).assign(literalList([], buildMapStringPropertyValueType())).statement,
       );
     }
 
@@ -1028,7 +1029,7 @@ class AnyOfGenerator {
 
     final mergeBlocks = <Code>[
       const Code(r'final _$map = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
     ];
 
     if (needsMapValues) {
@@ -1046,7 +1047,7 @@ class AnyOfGenerator {
           r'_$map.putIfAbsent('
           '${specLiteralStringCode(model.discriminator!)}, () => ',
         ),
-        const Code(r'_$discValue'),
+        propertyValueScalar(refer(r'_$discValue')).code,
         const Code(');'),
         const Code(' }'),
       ]);
@@ -1055,8 +1056,7 @@ class AnyOfGenerator {
       ..add(const Code(r'return _$map.toSimple('))
       ..addAll([
         const Code('explode: explode, '),
-        const Code('allowEmpty: allowEmpty, '),
-        const Code('alreadyEncoded: true'),
+        const Code('allowEmpty: allowEmpty'),
         const Code(');'),
       ]);
 
@@ -1165,7 +1165,7 @@ class AnyOfGenerator {
       body.add(
         declareFinal(
           r'_$mapValues',
-        ).assign(literalList([], buildMapStringStringType())).statement,
+        ).assign(literalList([], buildMapStringPropertyValueType())).statement,
       );
     }
 
@@ -1211,7 +1211,7 @@ class AnyOfGenerator {
 
     final mergeBlocks = <Code>[
       const Code(r'final _$map = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
     ];
 
     if (needsMapValues) {
@@ -1229,7 +1229,7 @@ class AnyOfGenerator {
           r'_$map.putIfAbsent('
           '${specLiteralStringCode(model.discriminator!)}, () => ',
         ),
-        const Code(r'_$discValue'),
+        propertyValueScalar(refer(r'_$discValue')).code,
         const Code(');'),
         const Code(' }'),
       ]);
@@ -1240,8 +1240,9 @@ class AnyOfGenerator {
         const Code('paramName, '),
         const Code('explode: explode, '),
         const Code('allowEmpty: allowEmpty, '),
-        const Code('alreadyEncoded: true, '),
-        const Code('useQueryComponent: useQueryComponent'),
+        const Code('useQueryComponent: useQueryComponent, '),
+        const Code('allowReserved: allowReserved, '),
+        const Code('fieldEncodings: fieldEncodings'),
         const Code(');'),
       ]);
 
@@ -1424,8 +1425,7 @@ class AnyOfGenerator {
         codes.add(
           Code(
             'final _\$${fieldName}Form = '
-            '$fieldName!.parameterProperties('
-            'allowEmpty: allowEmpty, allowReserved: allowReserved);',
+            '$fieldName!.parameterProperties(allowEmpty: allowEmpty);',
           ),
         );
         if (needsMapValues) {
@@ -1472,8 +1472,7 @@ class AnyOfGenerator {
         ..add(
           Code(
             'final _\$${fieldName}Form = '
-            '$fieldName!.parameterProperties('
-            'allowEmpty: allowEmpty, allowReserved: allowReserved);',
+            '$fieldName!.parameterProperties(allowEmpty: allowEmpty);',
           ),
         );
       if (needsMapValues) {
@@ -1710,7 +1709,7 @@ class AnyOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
@@ -1739,7 +1738,7 @@ class AnyOfGenerator {
     if (needsMapValues) {
       body.addAll([
         const Code(r'final _$mapValues = <'),
-        buildMapStringStringType().code,
+        buildMapStringPropertyValueType().code,
         const Code('>[];'),
       ]);
     }
@@ -1799,13 +1798,6 @@ class AnyOfGenerator {
       } else if (fieldModel is ListModel) {
         body
           ..add(Code('if ($name != null) {'))
-          ..add(const Code('if (!allowLists) {'))
-          ..add(
-            generateEncodingExceptionExpression(
-              'Lists are not supported in this encoding style',
-            ).statement,
-          )
-          ..add(const Code('}'))
           ..add(
             generateEncodingExceptionExpression(
               'Lists are not supported in parameterProperties',
@@ -1837,7 +1829,7 @@ class AnyOfGenerator {
 
     final mergeBlocks = <Code>[
       const Code(r'final _$map = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
     ];
 
     if (needsMapValues) {
@@ -1854,7 +1846,7 @@ class AnyOfGenerator {
           r'_$map.putIfAbsent('
           '${specLiteralStringCode(model.discriminator!)}, () => ',
         ),
-        const Code(r'_$discValue'),
+        propertyValueScalar(refer(r'_$discValue')).code,
         const Code(');'),
         const Code(' }'),
       ]);
@@ -1865,13 +1857,13 @@ class AnyOfGenerator {
     if (needsMapValues || hasSimpleTypes) {
       body.addAll(mergeBlocks);
     } else {
-      body.add(buildEmptyMapStringString().returned.statement);
+      body.add(buildEmptyMapStringPropertyValue().returned.statement);
     }
 
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..lambda = false
         ..body = Block.of(body),
@@ -1889,24 +1881,16 @@ class AnyOfGenerator {
     if (fieldModel.encodingShape == EncodingShape.complex) {
       // Lists cannot use parameterProperties
       if (fieldModel is ListModel) {
-        codes
-          ..add(const Code('if (!allowLists) {'))
-          ..add(
-            generateEncodingExceptionExpression(
-              'Lists are not supported in this encoding style',
-            ).statement,
-          )
-          ..add(const Code('}'))
-          ..add(
-            refer('EncodingException', 'package:tonik_util/tonik_util.dart')
-                .call([
-                  literalString(
-                    'Lists are not supported in parameterProperties',
-                  ),
-                ])
-                .thrown
-                .statement,
-          );
+        codes.add(
+          refer('EncodingException', 'package:tonik_util/tonik_util.dart')
+              .call([
+                literalString(
+                  'Lists are not supported in parameterProperties',
+                ),
+              ])
+              .thrown
+              .statement,
+        );
       } else if (fieldModel is MapModel) {
         // Map types cannot use parameterProperties
         codes.add(
@@ -1918,9 +1902,7 @@ class AnyOfGenerator {
         codes.add(
           Code(
             r'_$mapValues.add('
-            '$fieldName!.parameterProperties(allowEmpty: allowEmpty, '
-            'allowLists: allowLists, allowReserved: allowReserved, '
-            'fieldEncodings: fieldEncodings));',
+            '$fieldName!.parameterProperties(allowEmpty: allowEmpty));',
           ),
         );
 
@@ -1951,9 +1933,7 @@ class AnyOfGenerator {
         const Code(':'),
         Code(
           r'_$mapValues.add('
-          '$fieldName!.parameterProperties(allowEmpty: allowEmpty, '
-          'allowLists: allowLists, allowReserved: allowReserved, '
-          'fieldEncodings: fieldEncodings));',
+          '$fieldName!.parameterProperties(allowEmpty: allowEmpty));',
         ),
       ];
 
@@ -2027,7 +2007,7 @@ class AnyOfGenerator {
       body.add(
         declareFinal(
           r'_$mapValues',
-        ).assign(literalList([], buildMapStringStringType())).statement,
+        ).assign(literalList([], buildMapStringPropertyValueType())).statement,
       );
     }
 
@@ -2068,7 +2048,7 @@ class AnyOfGenerator {
 
     final mergeBlocks = <Code>[
       const Code(r'final _$map = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
     ];
 
     if (needsMapValues) {
@@ -2087,7 +2067,7 @@ class AnyOfGenerator {
           r'_$map.putIfAbsent('
           '${specLiteralStringCode(model.discriminator!)}, () => ',
         ),
-        const Code(r'_$discValue'),
+        propertyValueScalar(refer(r'_$discValue')).code,
         const Code(');'),
         const Code(' }'),
       ]);
@@ -2096,8 +2076,7 @@ class AnyOfGenerator {
       ..add(const Code(r'return _$map.toLabel('))
       ..addAll([
         const Code('explode: explode, '),
-        const Code('allowEmpty: allowEmpty, '),
-        const Code('alreadyEncoded: true'),
+        const Code('allowEmpty: allowEmpty'),
         const Code(');'),
       ]);
 
@@ -2199,7 +2178,7 @@ class AnyOfGenerator {
       body.add(
         declareFinal(
           r'_$mapValues',
-        ).assign(literalList([], buildMapStringStringType())).statement,
+        ).assign(literalList([], buildMapStringPropertyValueType())).statement,
       );
     }
 
@@ -2240,7 +2219,7 @@ class AnyOfGenerator {
 
     final mergeBlocks = <Code>[
       const Code(r'final _$map = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
     ];
 
     if (needsMapValues) {
@@ -2259,7 +2238,7 @@ class AnyOfGenerator {
           r'_$map.putIfAbsent('
           '${specLiteralStringCode(model.discriminator!)}, () => ',
         ),
-        const Code(r'_$discValue'),
+        propertyValueScalar(refer(r'_$discValue')).code,
         const Code(');'),
         const Code(' }'),
       ]);
@@ -2269,8 +2248,7 @@ class AnyOfGenerator {
       ..addAll([
         const Code('paramName, '),
         const Code('explode: explode, '),
-        const Code('allowEmpty: allowEmpty, '),
-        const Code('alreadyEncoded: true'),
+        const Code('allowEmpty: allowEmpty'),
         const Code(');'),
       ]);
 

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -20,10 +20,11 @@ import 'package:tonik_generate/src/util/from_json_value_expression_generator.dar
 import 'package:tonik_generate/src/util/from_simple_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/hash_code_generator.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
+import 'package:tonik_generate/src/util/property_value_expression_generator.dart';
+import 'package:tonik_generate/src/util/raw_string_expression_generator.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
-import 'package:tonik_generate/src/util/uri_encode_expression_generator.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 final Logger _classGeneratorLog = Logger('ClassGenerator');
@@ -1157,7 +1158,7 @@ class ClassGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(_buildParameterPropertiesParameters())
           ..lambda = true
           ..body = generateEncodingExceptionExpression(
@@ -1221,27 +1222,37 @@ class ClassGenerator {
 
     if (ap is TypedAdditionalProperties &&
         ap.valueModel.encodingShape == EncodingShape.simple) {
-      final uriEncodeCall = ap.valueModel.isEffectivelyNullable
-          ? '${uriEncodeReceiver(ap.valueModel, r'_$e.value?')}'
-                '.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent, '
-                "allowReserved: allowReserved) ?? ''"
-          : '${uriEncodeReceiver(ap.valueModel, r'_$e.value')}'
-                '.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent, '
-                'allowReserved: allowReserved)';
       return [
-        Code('''
-for (final _\$e in $apFieldName.entries) {
-  _\$result[_\$e.key] = $uriEncodeCall;
-}'''),
+        Code('for (final _\$e in $apFieldName.entries) {'),
+        refer(r'_$result')
+            .index(refer(r'_$e').property('key'))
+            .assign(
+              propertyValueScalar(
+                additionalPropertyRawScalar(
+                  refer(r'_$e').property('value'),
+                  ap.valueModel,
+                ),
+              ),
+            )
+            .statement,
+        const Code('}'),
       ];
     } else if (ap is UnrestrictedAdditionalProperties) {
       return [
-        Code(
-          'for (final _\$e in $apFieldName.entries) { '
-          r"_$result[_$e.key] = _$e.value?.toString() ?? ''; }",
-        ),
+        Code('for (final _\$e in $apFieldName.entries) {'),
+        refer(r'_$result')
+            .index(refer(r'_$e').property('key'))
+            .assign(
+              propertyValueScalar(
+                refer(r'_$e')
+                    .property('value')
+                    .nullSafeProperty('toString')
+                    .call([])
+                    .ifNullThen(literalString('')),
+              ),
+            )
+            .statement,
+        const Code('}'),
       ];
     } else {
       // Typed with complex value model — throw
@@ -1259,34 +1270,67 @@ for (final _\$e in $apFieldName.entries) {
     }
   }
 
-  List<Parameter> _buildParameterPropertiesParameters() {
+  List<Parameter> _buildParameterPropertiesParameters() =>
+      buildParameterPropertiesParameters();
+
+  Code _scalarPropertyAssignment(String propertyName, Expression raw) =>
+      refer(r'_$result')
+          .index(specLiteralString(propertyName))
+          .assign(propertyValueScalar(raw))
+          .statement;
+
+  Expression _rawScalarExpression(Expression receiver, Model model) {
+    return switch (model.resolved) {
+      OneOfModel() || AnyOfModel() || AllOfModel() =>
+        refer(
+          'encodeAnyValueToString',
+          'package:tonik_util/tonik_util.dart',
+        ).call(
+          [receiver.property('toJson').call([])],
+          {
+            'allowEmpty': refer('allowEmpty'),
+          },
+        ),
+      _ => buildRawStringExpression(receiver, model),
+    };
+  }
+
+  List<Code> _buildScalarPropertyAssignment({
+    required String name,
+    required String propertyName,
+    required bool isRequired,
+    required bool isNullable,
+    required bool isFieldNullable,
+    required Model model,
+  }) {
+    Code assign(Expression receiver) => _scalarPropertyAssignment(
+      propertyName,
+      _rawScalarExpression(receiver, model),
+    );
+
+    if (isRequired && !isNullable && !isFieldNullable) {
+      return [assign(refer(name))];
+    }
+
+    final checked = refer(name).nullChecked;
+    if (isRequired && !isNullable) {
+      return [
+        Code('if ($name == null) {'),
+        generateEncodingExceptionExpression(
+          'Required property $propertyName is null.',
+          raw: true,
+        ).statement,
+        const Code('}'),
+        assign(checked),
+      ];
+    }
+
     return [
-      Parameter(
-        (b) => b
-          ..name = 'allowEmpty'
-          ..type = refer('bool', 'dart:core')
-          ..named = true
-          ..required = false
-          ..defaultTo = literalTrue.code,
-      ),
-      Parameter(
-        (b) => b
-          ..name = 'allowLists'
-          ..type = refer('bool', 'dart:core')
-          ..named = true
-          ..required = false
-          ..defaultTo = literalTrue.code,
-      ),
-      Parameter(
-        (b) => b
-          ..name = 'useQueryComponent'
-          ..type = refer('bool', 'dart:core')
-          ..named = true
-          ..required = false
-          ..defaultTo = literalFalse.code,
-      ),
-      buildBoolParameter('allowReserved'),
-      buildFieldEncodingsParameter(),
+      Code('if ($name != null) {'),
+      assign(checked),
+      const Code('} else if (allowEmpty) {'),
+      _scalarPropertyAssignment(propertyName, literalString('')),
+      const Code('}'),
     ];
   }
 
@@ -1299,9 +1343,9 @@ for (final _\$e in $apFieldName.entries) {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(_buildParameterPropertiesParameters())
-          ..body = buildEmptyMapStringString().returned.statement,
+          ..body = buildEmptyMapStringPropertyValue().returned.statement,
       );
     }
 
@@ -1318,63 +1362,31 @@ for (final _\$e in $apFieldName.entries) {
       final resolvedModel = model.resolved;
 
       if (resolvedModel is NeverModel) {
-        propertyAssignments.addAll([
+        propertyAssignments.add(
           generateEncodingExceptionExpression(
             'Cannot encode NeverModel property $propertyName: '
             'this type does not permit any value',
             raw: true,
           ).statement,
-        ]);
+        );
         continue;
       }
 
-      final reservedArg = perPropertyAllowReservedArgument(propertyName);
-      if (isRequired && !isNullable && !isFieldNullable) {
-        propertyAssignments.add(
-          Code(
-            '_\$result[${specLiteralStringCode(propertyName)}] = '
-            '${uriEncodeReceiver(model, name)}.uriEncode('
-            'allowEmpty: allowEmpty, '
-            'useQueryComponent: useQueryComponent, '
-            '$reservedArg);',
-          ),
-        );
-      } else {
-        final checkedReceiver = uriEncodeReceiver(model, '$name!');
-        if (isRequired && !isNullable) {
-          propertyAssignments
-            ..add(Code('if ($name == null) {'))
-            ..add(
-              generateEncodingExceptionExpression(
-                'Required property $propertyName is null.',
-                raw: true,
-              ).statement,
-            )
-            ..add(const Code('}'))
-            ..add(
-              Code(
-                '_\$result[${specLiteralStringCode(propertyName)}] = '
-                '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                'useQueryComponent: useQueryComponent, '
-                '$reservedArg);',
-              ),
-            );
-        } else {
-          propertyAssignments.add(
-            Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, $reservedArg);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-          );
-        }
-      }
+      propertyAssignments.addAll(
+        _buildScalarPropertyAssignment(
+          name: name,
+          propertyName: propertyName,
+          isRequired: isRequired,
+          isNullable: isNullable,
+          isFieldNullable: isFieldNullable,
+          model: model,
+        ),
+      );
     }
 
     final methodBody = [
       const Code(r'final _$result = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
       ...propertyAssignments,
       ..._buildAdditionalPropertiesParameterLoop(model),
       const Code(r'return _$result;'),
@@ -1383,7 +1395,7 @@ if ($name != null) {
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
         ..body = Block.of(methodBody),
     );
@@ -1394,34 +1406,6 @@ if ($name != null) {
     List<({String normalizedName, Property property})> properties,
     ClassModel model,
   ) {
-    final listProperties = properties
-        .where(
-          (p) =>
-              p.property.model is ListModel &&
-              (p.property.model as ListModel).hasSimpleContent,
-        )
-        .toList();
-
-    final hasRequiredNonNullableLists = listProperties.any(
-      (p) =>
-          p.property.isRequired &&
-          !p.property.isReadOnly &&
-          !p.property.isNullable &&
-          !p.property.model.isEffectivelyNullable,
-    );
-
-    final methodBody = <Code>[];
-
-    if (hasRequiredNonNullableLists) {
-      methodBody.addAll([
-        const Code('if (!allowLists) {'),
-        generateEncodingExceptionExpression(
-          'Lists are not supported in this encoding style',
-        ).statement,
-        const Code('}'),
-      ]);
-    }
-
     final propertyAssignments = <Code>[];
 
     for (final prop in properties) {
@@ -1433,71 +1417,33 @@ if ($name != null) {
           prop.property.isNullable || fieldModel.isEffectivelyNullable;
       final isFieldNullable = isNullable || prop.property.isWriteOnly;
 
-      final reservedArg = perPropertyAllowReservedArgument(propertyName);
       if (fieldModel.encodingShape == EncodingShape.simple) {
-        if (isRequired && !isNullable && !isFieldNullable) {
-          propertyAssignments.add(
-            Code(
-              '_\$result[${specLiteralStringCode(propertyName)}] = '
-              '${uriEncodeReceiver(fieldModel, name)}.uriEncode('
-              'allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent, '
-              '$reservedArg);',
-            ),
-          );
-        } else {
-          final checkedReceiver = uriEncodeReceiver(fieldModel, '$name!');
-          if (isRequired && !isNullable) {
-            propertyAssignments
-              ..add(Code('if ($name == null) {'))
-              ..add(
-                generateEncodingExceptionExpression(
-                  'Required property $propertyName is null.',
-                  raw: true,
-                ).statement,
-              )
-              ..add(const Code('}'))
-              ..add(
-                Code(
-                  '_\$result[${specLiteralStringCode(propertyName)}] = '
-                  '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                  'useQueryComponent: useQueryComponent, '
-                  '$reservedArg);',
-                ),
-              );
-          } else {
-            propertyAssignments.add(
-              Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, $reservedArg);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-            );
-          }
-        }
+        propertyAssignments.addAll(
+          _buildScalarPropertyAssignment(
+            name: name,
+            propertyName: propertyName,
+            isRequired: isRequired,
+            isNullable: isNullable,
+            isFieldNullable: isFieldNullable,
+            model: fieldModel,
+          ),
+        );
       } else if (fieldModel is ListModel && fieldModel.hasSimpleContent) {
         final valueRef = (isRequired && !isNullable)
             ? (isFieldNullable ? refer(name).nullChecked : refer(name))
             : refer(name).nullChecked;
-        final encodeExpr = buildUriEncodeExpression(
+        final rawList = buildRawStringListExpression(
           valueRef,
-          fieldModel,
-          allowEmpty: refer('allowEmpty'),
-          useQueryComponent: refer('useQueryComponent'),
+          fieldModel.content,
+          isContentNullable:
+              fieldModel.isContentNullable ||
+              fieldModel.content.isEffectivelyNullable,
           useImmutableCollections: useImmutableCollections,
-          allowReserved: CodeExpression(
-            Code(
-              perPropertyAllowReservedValue(
-                propertyName,
-              ),
-            ),
-          ),
         );
 
-        final assignmentExpr = refer(
-          r'_$result',
-        ).index(specLiteralString(propertyName)).assign(encodeExpr.expression);
+        final assignmentExpr = refer(r'_$result')
+            .index(specLiteralString(propertyName))
+            .assign(propertyValueArray(rawList));
 
         if (isRequired && !isNullable) {
           if (isFieldNullable) {
@@ -1513,44 +1459,28 @@ if ($name != null) {
           }
           propertyAssignments.add(assignmentExpr.statement);
         } else {
-          methodBody
-            ..add(
-              Code('if (!allowLists && $name != null) {'),
-            )
-            ..add(
-              generateEncodingExceptionExpression(
-                'Lists are not supported in this encoding style',
-              ).statement,
-            )
-            ..add(const Code('}'));
-
           propertyAssignments
-            ..add(
-              Code('if ($name != null) {'),
-            )
+            ..add(Code('if ($name != null) {'))
             ..add(assignmentExpr.statement)
-            ..add(
-              Code('''
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-            );
+            ..add(const Code('} else if (allowEmpty) {'))
+            ..add(_scalarPropertyAssignment(propertyName, literalString('')))
+            ..add(const Code('}'));
         }
       }
     }
 
-    methodBody.addAll([
+    final methodBody = <Code>[
       const Code(r'final _$result = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
       ...propertyAssignments,
       ..._buildAdditionalPropertiesParameterLoop(model),
       const Code(r'return _$result;'),
-    ]);
+    ];
 
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
         ..body = Block.of(methodBody),
     );
@@ -1563,7 +1493,7 @@ if ($name != null) {
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
         ..body = generateEncodingExceptionExpression(
           'parameterProperties not supported for $className: '
@@ -1592,68 +1522,39 @@ if ($name != null) {
 
       if (resolvedModel is AnyModel) {
         propertyAssignments.add(
-          Code(
-            '_\$result[${specLiteralStringCode(propertyName)}] = '
-            "$name?.toString() ?? '';",
+          _scalarPropertyAssignment(
+            propertyName,
+            refer(name)
+                .nullSafeProperty('toString')
+                .call([])
+                .ifNullThen(literalString('')),
           ),
         );
         continue;
       }
 
       if (resolvedModel is NeverModel) {
-        propertyAssignments.addAll([
+        propertyAssignments.add(
           generateEncodingExceptionExpression(
             'Cannot encode NeverModel property $propertyName: '
             'this type does not permit any value',
             raw: true,
           ).statement,
-        ]);
+        );
         continue;
       }
 
       if (model.encodingShape == .simple) {
-        final reservedArg = perPropertyAllowReservedArgument(propertyName);
-        if (isRequired && !isNullable && !isFieldNullable) {
-          propertyAssignments.add(
-            Code(
-              '_\$result[${specLiteralStringCode(propertyName)}] = '
-              '${uriEncodeReceiver(model, name)}.uriEncode('
-              'allowEmpty: allowEmpty, '
-              'useQueryComponent: useQueryComponent, '
-              '$reservedArg);',
-            ),
-          );
-        } else {
-          final checkedReceiver = uriEncodeReceiver(model, '$name!');
-          if (isRequired && !isNullable) {
-            propertyAssignments
-              ..add(Code('if ($name == null) {'))
-              ..add(
-                generateEncodingExceptionExpression(
-                  'Required property $propertyName is null.',
-                  raw: true,
-                ).statement,
-              )
-              ..add(const Code('}'))
-              ..add(
-                Code(
-                  '_\$result[${specLiteralStringCode(propertyName)}] = '
-                  '$checkedReceiver.uriEncode(allowEmpty: allowEmpty, '
-                  'useQueryComponent: useQueryComponent, '
-                  '$reservedArg);',
-                ),
-              );
-          } else {
-            propertyAssignments.add(
-              Code('''
-if ($name != null) {
-  _\$result[${specLiteralStringCode(propertyName)}] = $checkedReceiver.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, $reservedArg);
-} else if (allowEmpty) {
-  _\$result[${specLiteralStringCode(propertyName)}] = '';
-}'''),
-            );
-          }
-        }
+        propertyAssignments.addAll(
+          _buildScalarPropertyAssignment(
+            name: name,
+            propertyName: propertyName,
+            isRequired: isRequired,
+            isNullable: isNullable,
+            isFieldNullable: isFieldNullable,
+            model: model,
+          ),
+        );
       } else {
         final isFieldNullable = isNullable || !isRequired;
         final encodingShapeRef = refer(
@@ -1661,16 +1562,27 @@ if ($name != null) {
           'package:tonik_util/tonik_util.dart',
         );
 
+        Code mixedScalarAssign(Expression receiver) =>
+            _scalarPropertyAssignment(
+              propertyName,
+              refer(
+                'encodeAnyValueToString',
+                'package:tonik_util/tonik_util.dart',
+              ).call(
+                [receiver.property('toJson').call([])],
+                {
+                  'allowEmpty': refer('allowEmpty'),
+                },
+              ),
+            );
+
         if (isFieldNullable) {
           propertyAssignments.addAll([
             Code('if ($name != null) {'),
             Code('  if ($name!.currentEncodingShape == '),
             encodingShapeRef.property('simple').code,
             const Code(') {'),
-            Code(
-              '    _\$result[${specLiteralStringCode(propertyName)}] = '
-              '$name!.toSimple(explode: false, allowEmpty: allowEmpty);',
-            ),
+            mixedScalarAssign(refer(name).nullChecked),
             const Code('} else {'),
             generateEncodingExceptionExpression(
               'parameterProperties not supported for $className: '
@@ -1684,10 +1596,7 @@ if ($name != null) {
             Code('if ($name.currentEncodingShape == '),
             encodingShapeRef.property('simple').code,
             const Code(') {'),
-            Code(
-              '  _\$result[${specLiteralStringCode(propertyName)}] = '
-              '$name.toSimple(explode: false, allowEmpty: allowEmpty);',
-            ),
+            mixedScalarAssign(refer(name)),
             const Code('} else {'),
             generateEncodingExceptionExpression(
               'parameterProperties not supported for $className: '
@@ -1702,7 +1611,7 @@ if ($name != null) {
 
     final methodBody = [
       const Code(r'final _$result = '),
-      buildEmptyMapStringString().statement,
+      buildEmptyMapStringPropertyValue().statement,
       ...propertyAssignments,
       ..._buildAdditionalPropertiesParameterLoop(model),
       const Code(r'return _$result;'),
@@ -1711,7 +1620,7 @@ if ($name != null) {
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
         ..body = Block.of(methodBody),
     );
@@ -1730,7 +1639,6 @@ if ($name != null) {
             .call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
-              'alreadyEncoded': literalBool(true),
             })
             .returned
             .statement,
@@ -2009,20 +1917,16 @@ if ($name != null) {
       ..optionalParameters.addAll(buildFormEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
-            .call([], {
-              'allowEmpty': refer('allowEmpty'),
-              'useQueryComponent': refer('useQueryComponent'),
-              'allowReserved': refer('allowReserved'),
-              'fieldEncodings': refer('fieldEncodings'),
-            })
+            .call([], {'allowEmpty': refer('allowEmpty')})
             .property('toForm')
             .call(
               [refer('paramName')],
               {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
                 'useQueryComponent': refer('useQueryComponent'),
+                'allowReserved': refer('allowReserved'),
+                'fieldEncodings': refer('fieldEncodings'),
               },
             )
             .returned
@@ -2043,7 +1947,6 @@ if ($name != null) {
             .call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
-              'alreadyEncoded': literalBool(true),
             })
             .returned
             .statement,
@@ -2072,7 +1975,6 @@ if ($name != null) {
               {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
               },
             )
             .returned
@@ -2105,18 +2007,14 @@ if ($name != null) {
       ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
-            .call([], {
-              'allowEmpty': refer('allowEmpty'),
-              'allowLists': literalBool(false),
-              'allowReserved': refer('allowReserved'),
-            })
+            .call([], {'allowEmpty': refer('allowEmpty')})
             .property('toDeepObject')
             .call(
               [refer('paramName')],
               {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
+                'allowReserved': refer('allowReserved'),
               },
             )
             .returned

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -14,6 +14,7 @@ import 'package:tonik_generate/src/util/from_json_value_expression_generator.dar
 import 'package:tonik_generate/src/util/from_simple_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/hash_code_generator.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
+import 'package:tonik_generate/src/util/property_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
@@ -931,14 +932,12 @@ class OneOfGenerator {
               'allowEmpty': refer('allowEmpty'),
             }).code,
             const Code(','),
-            Code(
-              '${specLiteralStringCode(model.discriminator!)}: '
-              '${specLiteralStringCode(discriminatorValue)},',
-            ),
+            Code('${specLiteralStringCode(model.discriminator!)}: '),
+            propertyValueScalar(specLiteralString(discriminatorValue)).code,
+            const Code(','),
             const Code('}'),
             const Code(
-              '.toSimple(explode: explode, allowEmpty: allowEmpty, '
-              'alreadyEncoded: true) : ',
+              '.toSimple(explode: explode, allowEmpty: allowEmpty) : ',
             ),
             refer('value').property('toSimple').call([], {
               'explode': refer('explode'),
@@ -966,14 +965,12 @@ class OneOfGenerator {
               'allowEmpty': refer('allowEmpty'),
             }).code,
             const Code(','),
-            Code(
-              '${specLiteralStringCode(model.discriminator!)}: '
-              '${specLiteralStringCode(discriminatorValue)},',
-            ),
+            Code('${specLiteralStringCode(model.discriminator!)}: '),
+            propertyValueScalar(specLiteralString(discriminatorValue)).code,
+            const Code(','),
             const Code('}'),
             const Code(
-              '.toSimple(explode: '
-              'explode, allowEmpty: allowEmpty, alreadyEncoded: true),',
+              '.toSimple(explode: explode, allowEmpty: allowEmpty),',
             ),
           ]);
         }
@@ -1169,17 +1166,16 @@ class OneOfGenerator {
           const Code('...'),
           refer('value').property('parameterProperties').call([], {
             'allowEmpty': refer('allowEmpty'),
-            'allowReserved': refer('allowReserved'),
           }).code,
           const Code(','),
-          Code(
-            '${specLiteralStringCode(model.discriminator!)}: '
-            '${specLiteralStringCode(discriminatorValue)},',
-          ),
+          Code('${specLiteralStringCode(model.discriminator!)}: '),
+          propertyValueScalar(specLiteralString(discriminatorValue)).code,
+          const Code(','),
           const Code('}'),
           const Code(
             '.toForm(paramName, explode: explode, allowEmpty: allowEmpty, '
-            'alreadyEncoded: true, useQueryComponent: useQueryComponent)',
+            'useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved, fieldEncodings: fieldEncodings)',
           ),
         ];
 
@@ -1357,7 +1353,7 @@ class OneOfGenerator {
       return Method(
         (b) => b
           ..name = 'parameterProperties'
-          ..returns = buildMapStringStringType()
+          ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(buildParameterPropertiesParameters())
           ..body = generateEncodingExceptionExpression(
             'parameterProperties not supported for $className: '
@@ -1402,7 +1398,7 @@ class OneOfGenerator {
         if (isNullable) {
           caseCodes.addAll([
             const Code('value == null ? '),
-            buildEmptyMapStringString().code,
+            buildEmptyMapStringPropertyValue().code,
             const Code(' : '),
           ]);
         }
@@ -1418,15 +1414,11 @@ class OneOfGenerator {
             const Code('...'),
             refer('value').property('parameterProperties').call([], {
               'allowEmpty': refer('allowEmpty'),
-              'allowLists': refer('allowLists'),
-              'allowReserved': refer('allowReserved'),
-              'fieldEncodings': refer('fieldEncodings'),
             }).code,
             const Code(','),
-            Code(
-              '${specLiteralStringCode(model.discriminator!)}: '
-              '${specLiteralStringCode(discriminatorValue)},',
-            ),
+            Code('${specLiteralStringCode(model.discriminator!)}: '),
+            propertyValueScalar(specLiteralString(discriminatorValue)).code,
+            const Code(','),
             const Code('} : '),
             generateEncodingExceptionExpression(
               'parameterProperties not supported for $className: '
@@ -1444,9 +1436,6 @@ class OneOfGenerator {
             const Code('? '),
             refer('value').property('parameterProperties').call([], {
               'allowEmpty': refer('allowEmpty'),
-              'allowLists': refer('allowLists'),
-              'allowReserved': refer('allowReserved'),
-              'fieldEncodings': refer('fieldEncodings'),
             }).code,
             const Code(': '),
             generateEncodingExceptionExpression(
@@ -1481,7 +1470,7 @@ class OneOfGenerator {
           if (isNullable) {
             caseCodes.addAll([
               const Code('value == null ? '),
-              buildEmptyMapStringString().code,
+              buildEmptyMapStringPropertyValue().code,
               const Code(' : '),
             ]);
           }
@@ -1492,24 +1481,17 @@ class OneOfGenerator {
               const Code('...'),
               refer('value').property('parameterProperties').call([], {
                 'allowEmpty': refer('allowEmpty'),
-                'allowLists': refer('allowLists'),
-                'allowReserved': refer('allowReserved'),
-                'fieldEncodings': refer('fieldEncodings'),
               }).code,
               const Code(','),
-              Code(
-                '${specLiteralStringCode(model.discriminator!)}: '
-                '${specLiteralStringCode(discriminatorValue)},',
-              ),
+              Code('${specLiteralStringCode(model.discriminator!)}: '),
+              propertyValueScalar(specLiteralString(discriminatorValue)).code,
+              const Code(','),
               const Code('}'),
             ]);
           } else {
             caseCodes.add(
               refer('value').property('parameterProperties').call([], {
                 'allowEmpty': refer('allowEmpty'),
-                'allowLists': refer('allowLists'),
-                'allowReserved': refer('allowReserved'),
-                'fieldEncodings': refer('fieldEncodings'),
               }).code,
             );
           }
@@ -1527,7 +1509,7 @@ class OneOfGenerator {
     return Method(
       (b) => b
         ..name = 'parameterProperties'
-        ..returns = buildMapStringStringType()
+        ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(buildParameterPropertiesParameters())
         ..lambda = false
         ..body = body,
@@ -1590,14 +1572,12 @@ class OneOfGenerator {
               'allowEmpty': refer('allowEmpty'),
             }).code,
             const Code(','),
-            Code(
-              '${specLiteralStringCode(model.discriminator!)}: '
-              '${specLiteralStringCode(discriminatorValue)},',
-            ),
+            Code('${specLiteralStringCode(model.discriminator!)}: '),
+            propertyValueScalar(specLiteralString(discriminatorValue)).code,
+            const Code(','),
             const Code('}'),
             const Code(
-              '.toLabel(explode: explode, allowEmpty: allowEmpty, '
-              'alreadyEncoded: true) : ',
+              '.toLabel(explode: explode, allowEmpty: allowEmpty) : ',
             ),
             refer('value').property('toLabel').call([], {
               'explode': refer('explode'),
@@ -1624,14 +1604,12 @@ class OneOfGenerator {
               'allowEmpty': refer('allowEmpty'),
             }).code,
             const Code(','),
-            Code(
-              '${specLiteralStringCode(model.discriminator!)}: '
-              '${specLiteralStringCode(discriminatorValue)},',
-            ),
+            Code('${specLiteralStringCode(model.discriminator!)}: '),
+            propertyValueScalar(specLiteralString(discriminatorValue)).code,
+            const Code(','),
             const Code('}'),
             const Code(
-              '.toLabel(explode: explode, allowEmpty: allowEmpty, '
-              'alreadyEncoded: true),',
+              '.toLabel(explode: explode, allowEmpty: allowEmpty),',
             ),
           ]);
         }

--- a/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
+++ b/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
@@ -25,7 +25,7 @@ Method buildReadOnlyParameterPropertiesMethod(Code exceptionBody) {
   return Method(
     (b) => b
       ..name = 'parameterProperties'
-      ..returns = buildMapStringStringType()
+      ..returns = buildMapStringPropertyValueType()
       ..optionalParameters.addAll(buildParameterPropertiesParameters())
       ..lambda = true
       ..body = exceptionBody,
@@ -249,18 +249,14 @@ Method buildToDeepObjectMethod() {
       ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
-            .call([], {
-              'allowEmpty': refer('allowEmpty'),
-              'allowLists': literalBool(false),
-              'allowReserved': refer('allowReserved'),
-            })
+            .call([], {'allowEmpty': refer('allowEmpty')})
             .property('toDeepObject')
             .call(
               [refer('paramName')],
               {
                 'explode': refer('explode'),
                 'allowEmpty': refer('allowEmpty'),
-                'alreadyEncoded': literalBool(true),
+                'allowReserved': refer('allowReserved'),
               },
             )
             .returned

--- a/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
@@ -14,7 +14,7 @@ Expression propertyValueArray(Expression rawList) =>
     refer('PropertyValue', _tonikUtilUrl).property('array').call([rawList]);
 
 /// The raw scalar for an additional-property [value] of [valueModel], applying
-/// the null-collection policy (null → empty string) when the value is nullable.
+/// the null → empty-string policy when the value is nullable.
 Expression additionalPropertyRawScalar(Expression value, Model valueModel) {
   if (valueModel.isEffectivelyNullable) {
     return value
@@ -27,12 +27,15 @@ Expression additionalPropertyRawScalar(Expression value, Model valueModel) {
   return buildRawStringExpression(value, valueModel);
 }
 
-/// Builds a `List<String>` of raw (unescaped) elements for a simple-content
-/// list whose element type is [contentModel].
+/// Builds a `List<String>` of per-element strings for a simple-content list
+/// whose element type is [contentModel].
 ///
-/// Mirrors the URI-encode list traversal minus the per-element percent-encoding
-/// so the element boundaries reach the form encoder intact: `.unlock` for
-/// immutable collections and a null-element to `''` guard for nullable content.
+/// For scalar content these are raw (unescaped): the traversal mirrors the
+/// URI-encode list handling minus the per-element percent-encoding, so element
+/// boundaries reach the form encoder intact (`.unlock` for immutable
+/// collections, a null-element to `''` guard for nullable content). Composite
+/// content is instead pre-encoded here, so it is double-encoded once the form
+/// encoder runs.
 Expression buildRawStringListExpression(
   Expression valueExpression,
   Model contentModel, {

--- a/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
@@ -1,0 +1,102 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/raw_string_expression_generator.dart';
+
+const _tonikUtilUrl = 'package:tonik_util/tonik_util.dart';
+
+/// `PropertyValue.scalar(<raw>)`.
+Expression propertyValueScalar(Expression raw) =>
+    refer('PropertyValue', _tonikUtilUrl).property('scalar').call([raw]);
+
+/// `PropertyValue.array(<rawList>)`.
+Expression propertyValueArray(Expression rawList) =>
+    refer('PropertyValue', _tonikUtilUrl).property('array').call([rawList]);
+
+/// The raw scalar for an additional-property [value] of [valueModel], applying
+/// the null-collection policy (null → empty string) when the value is nullable.
+Expression additionalPropertyRawScalar(Expression value, Model valueModel) {
+  if (valueModel.isEffectivelyNullable) {
+    return value
+        .equalTo(literalNull)
+        .conditional(
+          literalString(''),
+          buildRawStringExpression(value.nullChecked, valueModel),
+        );
+  }
+  return buildRawStringExpression(value, valueModel);
+}
+
+/// Builds a `List<String>` of raw (unescaped) elements for a simple-content
+/// list whose element type is [contentModel].
+///
+/// Mirrors the URI-encode list traversal minus the per-element percent-encoding
+/// so the element boundaries reach the form encoder intact: `.unlock` for
+/// immutable collections and a null-element to `''` guard for nullable content.
+Expression buildRawStringListExpression(
+  Expression valueExpression,
+  Model contentModel, {
+  required bool isContentNullable,
+  bool useImmutableCollections = false,
+}) {
+  final listExpr = useImmutableCollections
+      ? valueExpression.property('unlock')
+      : valueExpression;
+
+  Expression nullGuard(Expression raw) => isContentNullable
+      ? refer('e').equalTo(literalNull).conditional(literalString(''), raw)
+      : raw;
+
+  Expression mapToRaw(Expression body) => listExpr
+      .property('map')
+      .call([
+        Method(
+          (b) => b
+            ..requiredParameters.add(Parameter((p) => p..name = 'e'))
+            ..body = body.code,
+        ).closure,
+      ])
+      .property('toList')
+      .call([]);
+
+  return switch (contentModel) {
+    StringModel() when isContentNullable => mapToRaw(
+      refer('e').ifNullThen(literalString('')),
+    ),
+    StringModel() => listExpr,
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DateTimeModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    DateModel() ||
+    BinaryModel() ||
+    Base64Model() ||
+    EnumModel() => mapToRaw(
+      nullGuard(buildRawStringExpression(refer('e'), contentModel)),
+    ),
+    // Elements are percent-encoded here, then again by the form encoder, so
+    // composite content stays double-encoded on the wire as it was before.
+    AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() => mapToRaw(
+      nullGuard(
+        refer('encodeAnyToUri', _tonikUtilUrl).call(
+          [
+            refer('e'),
+          ],
+          {'allowEmpty': refer('allowEmpty')},
+        ),
+      ),
+    ),
+    AliasModel(:final model) => buildRawStringListExpression(
+      valueExpression,
+      model,
+      isContentNullable: isContentNullable,
+      useImmutableCollections: useImmutableCollections,
+    ),
+    _ => generateEncodingExceptionExpression(
+      'Unsupported list content type for URI encoding.',
+    ),
+  };
+}

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -167,22 +167,14 @@ TypeReference buildMapStringObjectType() => TypeReference(
     ]),
 );
 
-/// Returns a TypeReference for [Map<String, String>].
-TypeReference buildMapStringStringType() => TypeReference(
+/// Returns a TypeReference for `Map<String, PropertyValue>`.
+TypeReference buildMapStringPropertyValueType() => TypeReference(
   (b) => b
     ..symbol = 'Map'
     ..url = 'dart:core'
     ..types.addAll([
-      TypeReference(
-        (b) => b
-          ..symbol = 'String'
-          ..url = 'dart:core',
-      ),
-      TypeReference(
-        (b) => b
-          ..symbol = 'String'
-          ..url = 'dart:core',
-      ),
+      refer('String', 'dart:core'),
+      refer('PropertyValue', 'package:tonik_util/tonik_util.dart'),
     ]),
 );
 
@@ -231,18 +223,6 @@ List<Parameter> buildEncodingParameters() => [
   buildBoolParameter('allowEmpty', required: true),
 ];
 
-/// The per-property `allowReserved` value expression: prefers the descriptor's
-/// flag, keyed by the raw spec name, and falls back to the uniform
-/// `allowReserved` so query-param objects (which carry no descriptor) keep
-/// their behavior.
-String perPropertyAllowReservedValue(String rawPropertyName) =>
-    'fieldEncodings[${specLiteralStringCode(rawPropertyName)}]'
-    '?.allowReserved ?? allowReserved';
-
-/// The `allowReserved:` argument built from [perPropertyAllowReservedValue].
-String perPropertyAllowReservedArgument(String rawPropertyName) =>
-    'allowReserved: ${perPropertyAllowReservedValue(rawPropertyName)}';
-
 /// A `Map<String, FormFieldEncoding> fieldEncodings = const {}` parameter that
 /// carries per-property reserved-character overrides into form encoding.
 Parameter buildFieldEncodingsParameter() => Parameter(
@@ -272,9 +252,6 @@ List<Parameter> buildFormEncodingParameters() => [
 /// Shared parameters for every composite `parameterProperties` method.
 List<Parameter> buildParameterPropertiesParameters() => [
   buildBoolParameter('allowEmpty', defaultValue: true),
-  buildBoolParameter('allowLists', defaultValue: true),
-  buildBoolParameter('allowReserved'),
-  buildFieldEncodingsParameter(),
 ];
 
 /// Encoding parameters for `toDeepObject`, kept separate from
@@ -291,11 +268,8 @@ List<Parameter> buildUriEncodeParameters() => [
   buildBoolParameter('allowReserved'),
 ];
 
-/// Returns a LiteralMapExpression for an empty [Map<String, String>] literal.
-///
-/// This can be used with Code.scope to create properly
-/// qualified empty map literals in generated code.
-LiteralMapExpression buildEmptyMapStringString() => literalMap(
+/// Returns a `<String, PropertyValue>{}` literal.
+LiteralMapExpression buildEmptyMapStringPropertyValue() => literalMap(
   {},
   TypeReference(
     (b) => b
@@ -304,8 +278,8 @@ LiteralMapExpression buildEmptyMapStringString() => literalMap(
   ),
   TypeReference(
     (b) => b
-      ..symbol = 'String'
-      ..url = 'dart:core',
+      ..symbol = 'PropertyValue'
+      ..url = 'package:tonik_util/tonik_util.dart',
   ),
 );
 

--- a/packages/tonik_generate/pubspec.yaml
+++ b/packages/tonik_generate/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   change_case: ^2.2.0
   code_builder: ^4.11.0
   collection: ^1.19.1
-  dart_style: ^3.1.2
+  dart_style: ^3.1.11
   logging: ^1.3.0
   meta: ^1.17.0
   path: ^1.9.1

--- a/packages/tonik_generate/test/src/model/all_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_deep_object_generator_test.dart
@@ -80,7 +80,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -139,7 +139,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -163,7 +163,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -174,7 +174,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes allowLists=false to parameterProperties', () {
+    test('toDeepObject delegates to the parameterProperties encoder', () {
       final model = AllOfModel(
         isDeprecated: false,
         name: 'AllOfWithAllowLists',
@@ -190,7 +190,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -201,7 +201,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes alreadyEncoded=true', () {
+    test('toDeepObject forwards allowReserved to the encoder', () {
       final model = AllOfModel(
         isDeprecated: false,
         name: 'AllOfEncoded',
@@ -216,7 +216,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -140,19 +140,8 @@ void main() {
       final combinedClass = generator.generateClass(model);
 
       const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-          ).toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-            useQueryComponent: useQueryComponent,
-          );
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
       expect(
         collapseWhitespace(format(combinedClass.accept(emitter).toString())),
@@ -225,24 +214,8 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException(
-              r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
-            );
-          }
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-          ).toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-            useQueryComponent: useQueryComponent,
-          );
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { if (currentEncodingShape == EncodingShape.mixed) { throw EncodingException( r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported', ); } return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
     expect(
       collapseWhitespace(generated),
@@ -923,34 +896,8 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$listForm = list
-              .map(
-                (e) => e.uriEncode(
-                  allowEmpty: allowEmpty,
-                  useQueryComponent: useQueryComponent,
-                ),
-              )
-              .toList()
-              .toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                alreadyEncoded: true,
-              );
-          _$entryLists.add(_$listForm);
-          _$values.add(_$listForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$listForm = list .map( (e) => e.uriEncode( allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } return _$entryLists.first; }
+''';
 
     expect(
       collapseWhitespace(generated),
@@ -977,34 +924,8 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$listForm = list
-              .map(
-                (e) => e.uriEncode(
-                  allowEmpty: allowEmpty,
-                  useQueryComponent: useQueryComponent,
-                ),
-              )
-              .toList()
-              .toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                alreadyEncoded: true,
-              );
-          _$entryLists.add(_$listForm);
-          _$values.add(_$listForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$listForm = list .map( (e) => e.uriEncode( allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } return _$entryLists.first; }
+''';
 
     expect(
       collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1659,7 +1659,7 @@ Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => t
       ''';
 
       const expectedParameterProperties = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListClass: allOf mixing arrays with other types is not supported', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListClass: allOf mixing arrays with other types is not supported', );
 ''';
 
       expect(
@@ -1699,7 +1699,7 @@ Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => t
       ''';
 
       const expectedParameterProperties = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListPrimitive: allOf mixing arrays with other types is not supported', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListPrimitive: allOf mixing arrays with other types is not supported', );
 ''';
 
       expect(
@@ -1861,7 +1861,7 @@ Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => t
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfWithList: contains array types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for AllOfWithList: contains array types', );
 ''';
 
         expect(
@@ -1943,7 +1943,7 @@ Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => t
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedMapClass: contains map types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for AllOfMixedMapClass: contains map types', );
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1328,8 +1328,7 @@ void main() {
           .toList()
           .toLabel(
             explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
+            allowEmpty: allowEmpty, alreadyEncoded: true,
           );
       ''';
 
@@ -1358,30 +1357,8 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToMatrix = r'''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          final _$values = <String>{};
-          final _$listMatrix = list
-            .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-            .toList()
-            .toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          _$values.add(_$listMatrix);
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf matrix encoding for AllOfDateTimeList: all values must encode to the same result',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfDateTimeList: all values must encode to the same result', ); } return _$values.first; }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1409,33 +1386,9 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToSimple = r'''
-        @override
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          if (list != null) {
-            final _$listSimple = list!
-                .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty))
-                .toList()
-                .toSimple(
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                );
-            _$values.add(_$listSimple);
-          }
-          if (_$values.length > 1) {
-            throw EncodingException(
-              'Inconsistent allOf simple encoding: all values must encode to the same result',
-            );
-          }
-          if (_$values.isEmpty) {
-            throw EncodingException(
-              'Cannot encode to simple: all properties are null',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+@override
+String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; if (list != null) { final _$listSimple = list! .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); } if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( 'Cannot encode to simple: all properties are null', ); } return _$values.first; }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1463,48 +1416,9 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToForm = r'''
-        @override
-        List<ParameterEntry> toForm(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool useQueryComponent = false,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          if (list != null) {
-            final _$listForm = list!
-                .map(
-                  (e) => e.uriEncode(
-                    allowEmpty: allowEmpty,
-                    useQueryComponent: useQueryComponent,
-                  ),
-                )
-                .toList()
-                .toForm(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  useQueryComponent: useQueryComponent,
-                  alreadyEncoded: true,
-                );
-            _$entryLists.add(_$listForm);
-            _$values.add(_$listForm.map((e) => e.value).join(','));
-          }
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding: all values must encode to the same result',
-            );
-          }
-          if (_$entryLists.isEmpty) {
-            throw EncodingException(
-              r'Cannot encode AllOfNullableList to encoding: all properties are null',
-            );
-          }
-          return _$entryLists.first;
-        }
-      ''';
+@override
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; if (list != null) { final _$listForm = list! .map( (e) => e.uriEncode( allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); } if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } if (_$entryLists.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$entryLists.first; }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1532,33 +1446,9 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToLabel = r'''
-        @override
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          if (list != null) {
-            final _$listLabel = list!
-                .map((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toLabel(
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                );
-            _$values.add(_$listLabel);
-          }
-          if (_$values.length > 1) {
-            throw EncodingException(
-              'Inconsistent allOf label encoding: all values must encode to the same result',
-            );
-          }
-          if (_$values.isEmpty) {
-            throw EncodingException(
-              r'Cannot encode AllOfNullableList to encoding: all properties are null',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+@override
+String toLabel({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; if (list != null) { final _$listLabel = list! .map((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toLabel( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listLabel); } if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf label encoding: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$values.first; }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1586,38 +1476,9 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToMatrix = r'''
-        @override
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          final _$values = <String>{};
-          if (list != null) {
-            final _$listMatrix = list!
-                .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toMatrix(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                );
-            _$values.add(_$listMatrix);
-          }
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf matrix encoding for AllOfNullableList: all values must encode to the same result',
-            );
-          }
-          if (_$values.isEmpty) {
-            throw EncodingException(
-              r'Cannot encode AllOfNullableList to encoding: all properties are null',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+@override
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfNullableList: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$values.first; }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1744,15 +1605,8 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedParameterProperties = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) =>
-          throw EncodingException(
-            r'parameterProperties not supported for AllOfIntList: contains array types',
-          );
-      ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfIntList: contains array types', );
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1805,15 +1659,8 @@ void main() {
       ''';
 
       const expectedParameterProperties = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) =>
-          throw EncodingException(
-            r'parameterProperties not supported for AllOfMixedListClass: allOf mixing arrays with other types is not supported',
-          );
-      ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListClass: allOf mixing arrays with other types is not supported', );
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1852,15 +1699,8 @@ void main() {
       ''';
 
       const expectedParameterProperties = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) =>
-          throw EncodingException(
-            r'parameterProperties not supported for AllOfMixedListPrimitive: allOf mixing arrays with other types is not supported',
-          );
-      ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedListPrimitive: allOf mixing arrays with other types is not supported', );
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -1928,8 +1768,7 @@ void main() {
     });
 
     test(
-      'generates parameterProperties with allowLists parameter for '
-      'complex allOf',
+      'generates parameterProperties merging members for complex allOf',
       () {
         final classModel1 = ClassModel(
           isDeprecated: false,
@@ -1982,25 +1821,13 @@ void main() {
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = r'''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            final _$mergedProperties = <String, String>{};
+          Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+            final _$mergedProperties = <String, PropertyValue>{};
             _$mergedProperties.addAll(
-              testClass1.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowLists: allowLists,
-                allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-              ),
+              testClass1.parameterProperties(allowEmpty: allowEmpty),
             );
             _$mergedProperties.addAll(
-              testClass2.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowLists: allowLists,
-                allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-              ),
+              testClass2.parameterProperties(allowEmpty: allowEmpty),
             );
             return _$mergedProperties;
           }
@@ -2034,15 +1861,8 @@ void main() {
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = '''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) =>
-            throw EncodingException(
-              r'parameterProperties not supported for AllOfWithList: contains array types',
-            );
-        ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfWithList: contains array types', );
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -2072,15 +1892,8 @@ void main() {
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = '''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) =>
-            throw EncodingException(
-              r'parameterProperties not supported for AllOfWithMap: contains map types',
-            );
-        ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfWithMap: contains map types', );
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -2130,15 +1943,8 @@ void main() {
         final generated = format(combinedClass.accept(emitter).toString());
 
         const expectedParameterProperties = '''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) =>
-            throw EncodingException(
-              r'parameterProperties not supported for AllOfMixedMapClass: contains map types',
-            );
-        ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for AllOfMixedMapClass: contains map types', );
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -4229,24 +4035,8 @@ class Holder {
         );
 
         const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$mergedProperties = <String, String>{};
-    _$mergedProperties.addAll(
-      $base.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$mergedProperties[_$e.key] = _$e.value?.toString() ?? '';
-    }
-    return _$mergedProperties;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mergedProperties = <String, PropertyValue>{}; _$mergedProperties.addAll( $base.parameterProperties(allowEmpty: allowEmpty), ); for (final _$e in additionalProperties.entries) { _$mergedProperties[_$e.key] = PropertyValue.scalar( _$e.value?.toString() ?? '', ); } return _$mergedProperties; }
+''';
 
         final combinedClass = generator.generateClass(model);
         expect(
@@ -4290,27 +4080,8 @@ class Holder {
           );
 
           const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$mergedProperties = <String, String>{};
-    _$mergedProperties.addAll(
-      $base.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$mergedProperties[_$e.key] = _$e.value.uriEncode(
-        allowEmpty: allowEmpty,
-        allowReserved: allowReserved,
-      );
-    }
-    return _$mergedProperties;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mergedProperties = <String, PropertyValue>{}; _$mergedProperties.addAll( $base.parameterProperties(allowEmpty: allowEmpty), ); for (final _$e in additionalProperties.entries) { _$mergedProperties[_$e.key] = PropertyValue.scalar(_$e.value); } return _$mergedProperties; }
+''';
 
           final combinedClass = generator.generateClass(model);
           expect(
@@ -4356,27 +4127,8 @@ class Holder {
           );
 
           const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$mergedProperties = <String, String>{};
-    _$mergedProperties.addAll(
-      $base.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$mergedProperties[_$e.key] = _$e.value.toBase64String().uriEncode(
-        allowEmpty: allowEmpty,
-        allowReserved: allowReserved,
-      );
-    }
-    return _$mergedProperties;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mergedProperties = <String, PropertyValue>{}; _$mergedProperties.addAll( $base.parameterProperties(allowEmpty: allowEmpty), ); for (final _$e in additionalProperties.entries) { _$mergedProperties[_$e.key] = PropertyValue.scalar( _$e.value.toBase64String(), ); } return _$mergedProperties; }
+''';
 
           final combinedClass = generator.generateClass(model);
           expect(
@@ -4439,29 +4191,8 @@ class Holder {
           );
 
           const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$mergedProperties = <String, String>{};
-    _$mergedProperties.addAll(
-      $base.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$mergedProperties[_$e.key] =
-          _$e.value?.toBase64String().uriEncode(
-            allowEmpty: allowEmpty,
-            allowReserved: allowReserved,
-          ) ??
-          '';
-    }
-    return _$mergedProperties;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mergedProperties = <String, PropertyValue>{}; _$mergedProperties.addAll( $base.parameterProperties(allowEmpty: allowEmpty), ); for (final _$e in additionalProperties.entries) { _$mergedProperties[_$e.key] = PropertyValue.scalar( _$e.value == null ? '' : _$e.value!.toBase64String(), ); } return _$mergedProperties; }
+''';
 
           final combinedClass = generator.generateClass(model);
           expect(
@@ -4512,18 +4243,10 @@ class Holder {
           );
 
           const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$mergedProperties = <String, String>{};
+  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+    final _$mergedProperties = <String, PropertyValue>{};
     _$mergedProperties.addAll(
-      $base.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
+      $base.parameterProperties(allowEmpty: allowEmpty),
     );
     if (additionalProperties.isNotEmpty) {
       throw EncodingException(

--- a/packages/tonik_generate/test/src/model/all_of_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_label_generator_test.dart
@@ -90,14 +90,16 @@ void main() {
       );
 
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedReturn = '''
-        return parameterProperties(
-          allowEmpty: allowEmpty,
-        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+      const expectedMethod = '''
+        String toLabel({required bool explode, required bool allowEmpty}) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+        }
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedReturn)),
+        contains(collapseWhitespace(format(expectedMethod))),
       );
     });
 
@@ -122,7 +124,7 @@ void main() {
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        contains(collapseWhitespace(format(expectedMethod))),
       );
     });
 
@@ -186,25 +188,19 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedGuard = '''
-        if (currentEncodingShape == EncodingShape.mixed) {
-          throw EncodingException(
-            'Simple encoding not supported: contains complex types',
-          );
+      const expectedMethod = '''
+        String toLabel({required bool explode, required bool allowEmpty}) {
+          if (currentEncodingShape == EncodingShape.mixed) {
+            throw EncodingException('Simple encoding not supported: contains complex types');
+          }
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
-      const expectedReturn = '''
-        return parameterProperties(
-          allowEmpty: allowEmpty,
-        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
-      ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedGuard)),
-      );
-      expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedReturn)),
+        contains(collapseWhitespace(format(expectedMethod))),
       );
     });
 
@@ -253,14 +249,16 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedReturn = '''
-        return parameterProperties(
-          allowEmpty: allowEmpty,
-        ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+      const expectedMethod = '''
+        String toLabel({required bool explode, required bool allowEmpty}) {
+          return parameterProperties(
+            allowEmpty: allowEmpty,
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+        }
       ''';
       expect(
         collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedReturn)),
+        contains(collapseWhitespace(format(expectedMethod))),
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
@@ -114,7 +114,7 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties(allowEmpty: allowEmpty) .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
 ''';
 
       expect(
@@ -573,7 +573,7 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
           final classCode = format(generatedClass.accept(emitter).toString());
 
           const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties(allowEmpty: allowEmpty) .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
 ''';
           expect(
             collapseWhitespace(classCode),
@@ -603,7 +603,7 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
           final classCode = format(generatedClass.accept(emitter).toString());
 
           const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties(allowEmpty: allowEmpty) .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
 ''';
           expect(
             collapseWhitespace(classCode),

--- a/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
@@ -114,19 +114,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -259,7 +248,6 @@ void main() {
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
-            alreadyEncoded: true,
           );
         }
       ''';
@@ -465,19 +453,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -550,30 +527,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-          String toMatrix(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-          }) {
-            final _$values = <String>{};
-            final _$listMatrix = list
-                .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toMatrix(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                );
-            _$values.add(_$listMatrix);
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Inconsistent allOf matrix encoding for AllOfIntList: all values must encode to the same result',
-              );
-            }
-            return _$values.first;
-          }
-        ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfIntList: all values must encode to the same result', ); } return _$values.first; }
+''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),
@@ -618,19 +573,8 @@ void main() {
           final classCode = format(generatedClass.accept(emitter).toString());
 
           const expectedMethod = '''
-            String toMatrix(
-              String paramName, {
-              required bool explode,
-              required bool allowEmpty,
-            }) {
-              return parameterProperties(allowEmpty: allowEmpty).toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-              );
-            }
-          ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
           expect(
             collapseWhitespace(classCode),
             contains(collapseWhitespace(expectedMethod)),
@@ -659,19 +603,8 @@ void main() {
           final classCode = format(generatedClass.accept(emitter).toString());
 
           const expectedMethod = '''
-            String toMatrix(
-              String paramName, {
-              required bool explode,
-              required bool allowEmpty,
-            }) {
-              return parameterProperties(allowEmpty: allowEmpty).toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-              );
-            }
-          ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
           expect(
             collapseWhitespace(classCode),
             contains(collapseWhitespace(expectedMethod)),
@@ -703,36 +636,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-          String toMatrix(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-          }) {
-            final _$values = <String>{};
-            final _$listMatrix = list
-                .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toMatrix(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                );
-            _$values.add(_$listMatrix);
-            final _$list2Matrix = list2.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            );
-            _$values.add(_$list2Matrix);
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Inconsistent allOf matrix encoding for AllOfMultipleLists: all values must encode to the same result',
-              );
-            }
-            return _$values.first;
-          }
-        ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); final _$list2Matrix = list2.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$list2Matrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfMultipleLists: all values must encode to the same result', ); } return _$values.first; }
+''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/model/all_of_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_parameter_encoding_test.dart
@@ -53,17 +53,12 @@ void main() {
       expect(method.name, 'parameterProperties');
       expect(
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
-        'Map<String,String>',
+        'Map<String,PropertyValue>',
       );
-      expect(method.optionalParameters.length, 4);
+      expect(method.optionalParameters.length, 1);
       expect(
         method.optionalParameters.map((p) => p.name),
-        containsAll([
-          'allowEmpty',
-          'allowLists',
-          'allowReserved',
-          'fieldEncodings',
-        ]),
+        containsAll(['allowEmpty']),
       );
     });
 
@@ -82,11 +77,7 @@ void main() {
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   throw EncodingException(
     r'parameterProperties not supported for Combined: contains primitive types',
   );
@@ -120,18 +111,10 @@ Map<String, String> parameterProperties({
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mergedProperties = <String, String>{};
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mergedProperties = <String, PropertyValue>{};
   _$mergedProperties.addAll(
-    $base.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowLists: allowLists,
-      allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-    ),
+    $base.parameterProperties(allowEmpty: allowEmpty),
   );
   return _$mergedProperties;
 }
@@ -165,11 +148,7 @@ Map<String, String> parameterProperties({
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   throw EncodingException(
     r'parameterProperties not supported for Mixed: contains primitive types',
   );
@@ -210,25 +189,13 @@ Map<String, String> parameterProperties({
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mergedProperties = <String, String>{};
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mergedProperties = <String, PropertyValue>{};
   _$mergedProperties.addAll(
-    firstModel.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowLists: allowLists,
-      allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-    ),
+    firstModel.parameterProperties(allowEmpty: allowEmpty),
   );
   _$mergedProperties.addAll(
-    secondModel.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowLists: allowLists,
-      allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-    ),
+    secondModel.parameterProperties(allowEmpty: allowEmpty),
   );
   return _$mergedProperties;
 }
@@ -239,6 +206,80 @@ Map<String, String> parameterProperties({
         contains(collapseWhitespace(expectedMethod)),
       );
     });
+
+    test(
+      'merges a duplicate property that is an array in one member and a scalar '
+      'in another as a plain last-member-wins overwrite',
+      () {
+        final model = AllOfModel(
+          isDeprecated: false,
+          name: 'DuplicateShapeAllOf',
+          models: {
+            ClassModel(
+              isDeprecated: false,
+              name: 'ArrayMember',
+              properties: [
+                Property(
+                  name: 'value',
+                  model: ListModel(
+                    content: StringModel(context: context),
+                    context: context,
+                    examples: const [],
+                  ),
+                  isRequired: true,
+                  isNullable: false,
+                  isDeprecated: false,
+                  examples: const [],
+                  defaultValue: null,
+                ),
+              ],
+              context: context,
+              examples: const [],
+            ),
+            ClassModel(
+              isDeprecated: false,
+              name: 'ScalarMember',
+              properties: [
+                Property(
+                  name: 'value',
+                  model: StringModel(context: context),
+                  isRequired: true,
+                  isNullable: false,
+                  isDeprecated: false,
+                  examples: const [],
+                  defaultValue: null,
+                ),
+              ],
+              context: context,
+              examples: const [],
+            ),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final combinedClass = generator.generateClass(model);
+        final classCode = format(combinedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mergedProperties = <String, PropertyValue>{};
+  _$mergedProperties.addAll(
+    arrayMember.parameterProperties(allowEmpty: allowEmpty),
+  );
+  _$mergedProperties.addAll(
+    scalarMember.parameterProperties(allowEmpty: allowEmpty),
+  );
+  return _$mergedProperties;
+}
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
 
     test(
       'runtime check for allOf with complex class and mixed encoding anyOf',
@@ -304,25 +345,13 @@ Map<String, String> parameterProperties({
         final classCode = format(combinedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mergedProperties = <String, String>{};
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mergedProperties = <String, PropertyValue>{};
   _$mergedProperties.addAll(
-    stringOrComplex.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowLists: allowLists,
-      allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-    ),
+    stringOrComplex.parameterProperties(allowEmpty: allowEmpty),
   );
   _$mergedProperties.addAll(
-    simpleModel.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowLists: allowLists,
-      allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-    ),
+    simpleModel.parameterProperties(allowEmpty: allowEmpty),
   );
   return _$mergedProperties;
 }
@@ -348,13 +377,7 @@ Map<String, String> parameterProperties({
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  return <String, String>{};
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return <String, PropertyValue>{}; }
 ''';
 
       expect(

--- a/packages/tonik_generate/test/src/model/all_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_schema_level_read_write_only_test.dart
@@ -156,11 +156,7 @@ void main() {
       final classCode = format(combinedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) => throw EncodingException(
+        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
       ''';

--- a/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
@@ -51,21 +51,8 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToSimple = r'''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          final _$listSimple = list
-            .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty))
-            .toList()
-            .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
-          _$values.add(_$listSimple);
-          if (_$values.length > 1) {
-            throw EncodingException(
-              'Inconsistent allOf simple encoding: all values must encode to the same result',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$listSimple = list .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
+''';
 
     expect(
       collapseWhitespace(generated),
@@ -108,26 +95,8 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToSimple = r'''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          final _$listSimple = list
-            .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty))
-            .toList()
-            .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
-          _$values.add(_$listSimple);
-          final _$list2Simple = list2
-            .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty))
-            .toList()
-            .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
-          _$values.add(_$list2Simple);
-          if (_$values.length > 1) {
-            throw EncodingException(
-              'Inconsistent allOf simple encoding: all values must encode to the same result',
-            );
-          }
-          return _$values.first;
-        }
-      ''';
+String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$listSimple = list .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); final _$list2Simple = list2 .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$list2Simple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
+''';
 
     expect(
       collapseWhitespace(generated),
@@ -185,7 +154,7 @@ void main() {
         String toSimple({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -401,7 +370,7 @@ void main() {
           }
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
@@ -152,9 +152,8 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
 
     const expectedToSimpleMethod = '''
         String toSimple({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -368,9 +367,8 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
               'Simple encoding not supported: contains complex types',
             );
           }
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/any_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_deep_object_generator_test.dart
@@ -81,7 +81,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -146,7 +146,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -156,7 +156,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes allowLists=false to parameterProperties', () {
+    test('toDeepObject delegates to the parameterProperties encoder', () {
       final model = AnyOfModel(
         isDeprecated: false,
         name: 'AnyOfWithAllowLists',
@@ -173,7 +173,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -183,7 +183,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes alreadyEncoded=true', () {
+    test('toDeepObject forwards allowReserved to the encoder', () {
       final model = AnyOfModel(
         isDeprecated: false,
         name: 'AnyOfEncoded',
@@ -199,7 +199,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -265,7 +265,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -662,28 +662,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          final _$mapValues = <Map<String, String>>[];
-          if (a != null) {
-            final _$aForm = a!.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowReserved: allowReserved,
-            );
-            _$mapValues.add(_$aForm);
-          }
-          final _$map = <String, String>{};
-          for (final _$m in _$mapValues) {
-            _$map.addAll(_$m);
-          }
-          return _$map.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-            useQueryComponent: useQueryComponent,
-          );
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$mapValues = <Map<String, PropertyValue>>[]; if (a != null) { final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aForm); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -744,42 +724,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-          if (a != null) {
-            final _$aForm = a!.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowReserved: allowReserved,
-            );
-            _$mapValues.add(_$aForm);
-            _$discriminatorValue ??= r'a';
-          }
-          if (b != null) {
-            final _$bForm = b!.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowReserved: allowReserved,
-            );
-            _$mapValues.add(_$bForm);
-            _$discriminatorValue ??= r'b';
-          }
-          final _$map = <String, String>{};
-          for (final _$m in _$mapValues) {
-            _$map.addAll(_$m);
-          }
-          final _$discValue = _$discriminatorValue;
-          if (_$discValue != null) {
-            _$map.putIfAbsent(r'type', () => _$discValue);
-          }
-          return _$map.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-            useQueryComponent: useQueryComponent,
-          );
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (a != null) { final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aForm); _$discriminatorValue ??= r'a'; } if (b != null) { final _$bForm = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bForm); _$discriminatorValue ??= r'b'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -821,58 +767,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          if (data != null) {
-            final _$dataForm = data!.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowReserved: allowReserved,
-            );
-            _$mapValues.add(_$dataForm);
-          }
-          if (string != null) {
-            final _$stringForm = string!.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-            );
-            _$entryLists.add(_$stringForm);
-            _$values.add(_$stringForm.map((e) => e.value).join(','));
-          }
-          if (_$values.isEmpty && _$mapValues.isEmpty) {
-            return const <ParameterEntry>[];
-          }
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf form encoding for Mixed: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf form encoding for Mixed: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$entryLists.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            return _$map.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-              useQueryComponent: useQueryComponent,
-            );
-          }
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (data != null) { final _$dataForm = data!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$dataForm); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for Mixed: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for Mixed: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -992,83 +888,8 @@ void main() {
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            bool useQueryComponent = false,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            final _$entryLists = <List<ParameterEntry>>[];
-            final _$values = <String>{};
-            final _$mapValues = <Map<String, String>>[];
-            if (innerChoice != null) {
-              switch (innerChoice!.currentEncodingShape) {
-                case EncodingShape.simple:
-                  final _$innerChoiceForm = innerChoice!.toForm(
-                    paramName,
-                    explode: explode,
-                    allowEmpty: allowEmpty,
-                    useQueryComponent: useQueryComponent,
-                    allowReserved: allowReserved,
-                  );
-                  _$entryLists.add(_$innerChoiceForm);
-                  _$values.add(_$innerChoiceForm.map((e) => e.value).join(','));
-                  break;
-                case EncodingShape.complex:
-                  final _$innerChoiceForm = innerChoice!.parameterProperties(
-                    allowEmpty: allowEmpty,
-                    allowReserved: allowReserved,
-                  );
-                  _$mapValues.add(_$innerChoiceForm);
-                  break;
-                case EncodingShape.mixed:
-                  throw EncodingException(
-                    'Cannot encode field with mixed encoding shape',
-                  );
-              }
-            }
-            if (string != null) {
-              final _$stringForm = string!.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-              );
-              _$entryLists.add(_$stringForm);
-              _$values.add(_$stringForm.map((e) => e.value).join(','));
-            }
-            if (_$values.isEmpty && _$mapValues.isEmpty) {
-              return const <ParameterEntry>[];
-            }
-            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-              throw EncodingException(
-                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
-              );
-            }
-            if (_$values.isNotEmpty) {
-              if (_$values.length > 1) {
-                throw EncodingException(
-                  r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value',
-                );
-              }
-              return _$entryLists.first;
-            } else {
-              final _$map = <String, String>{};
-              for (final _$m in _$mapValues) {
-                _$map.addAll(_$m);
-              }
-              return _$map.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-                useQueryComponent: useQueryComponent,
-              );
-            }
-          }
-        ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (innerChoice != null) { switch (innerChoice!.currentEncodingShape) { case EncodingShape.simple: final _$innerChoiceForm = innerChoice!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$innerChoiceForm); _$values.add(_$innerChoiceForm.map((e) => e.value).join(',')); break; case EncodingShape.complex: final _$innerChoiceForm = innerChoice!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$innerChoiceForm); break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -1122,83 +943,8 @@ void main() {
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            bool useQueryComponent = false,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            final _$entryLists = <List<ParameterEntry>>[];
-            final _$values = <String>{};
-            final _$mapValues = <Map<String, String>>[];
-            if (innerAnyOf != null) {
-              switch (innerAnyOf!.currentEncodingShape) {
-                case EncodingShape.simple:
-                  final _$innerAnyOfForm = innerAnyOf!.toForm(
-                    paramName,
-                    explode: explode,
-                    allowEmpty: allowEmpty,
-                    useQueryComponent: useQueryComponent,
-                    allowReserved: allowReserved,
-                  );
-                  _$entryLists.add(_$innerAnyOfForm);
-                  _$values.add(_$innerAnyOfForm.map((e) => e.value).join(','));
-                  break;
-                case EncodingShape.complex:
-                  final _$innerAnyOfForm = innerAnyOf!.parameterProperties(
-                    allowEmpty: allowEmpty,
-                    allowReserved: allowReserved,
-                  );
-                  _$mapValues.add(_$innerAnyOfForm);
-                  break;
-                case EncodingShape.mixed:
-                  throw EncodingException(
-                    'Cannot encode field with mixed encoding shape',
-                  );
-              }
-            }
-            if (string != null) {
-              final _$stringForm = string!.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-              );
-              _$entryLists.add(_$stringForm);
-              _$values.add(_$stringForm.map((e) => e.value).join(','));
-            }
-            if (_$values.isEmpty && _$mapValues.isEmpty) {
-              return const <ParameterEntry>[];
-            }
-            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-              throw EncodingException(
-                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
-              );
-            }
-            if (_$values.isNotEmpty) {
-              if (_$values.length > 1) {
-                throw EncodingException(
-                  r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value',
-                );
-              }
-              return _$entryLists.first;
-            } else {
-              final _$map = <String, String>{};
-              for (final _$m in _$mapValues) {
-                _$map.addAll(_$m);
-              }
-              return _$map.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-                useQueryComponent: useQueryComponent,
-              );
-            }
-          }
-        ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (innerAnyOf != null) { switch (innerAnyOf!.currentEncodingShape) { case EncodingShape.simple: final _$innerAnyOfForm = innerAnyOf!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$innerAnyOfForm); _$values.add(_$innerAnyOfForm.map((e) => e.value).join(',')); break; case EncodingShape.complex: final _$innerAnyOfForm = innerAnyOf!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$innerAnyOfForm); break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -1242,75 +988,8 @@ void main() {
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            bool useQueryComponent = false,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            final _$entryLists = <List<ParameterEntry>>[];
-            final _$values = <String>{};
-            final _$mapValues = <Map<String, String>>[];
-            if (myClass != null) {
-              final _$myClassForm = myClass!.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowReserved: allowReserved,
-              );
-              _$mapValues.add(_$myClassForm);
-            }
-            if (int != null) {
-              final _$intForm = int!.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-              );
-              _$entryLists.add(_$intForm);
-              _$values.add(_$intForm.map((e) => e.value).join(','));
-            }
-            if (string != null) {
-              final _$stringForm = string!.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-              );
-              _$entryLists.add(_$stringForm);
-              _$values.add(_$stringForm.map((e) => e.value).join(','));
-            }
-            if (_$values.isEmpty && _$mapValues.isEmpty) {
-              return const <ParameterEntry>[];
-            }
-            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-              throw EncodingException(
-                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
-              );
-            }
-            if (_$values.isNotEmpty) {
-              if (_$values.length > 1) {
-                throw EncodingException(
-                  r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value',
-                );
-              }
-              return _$entryLists.first;
-            } else {
-              final _$map = <String, String>{};
-              for (final _$m in _$mapValues) {
-                _$map.addAll(_$m);
-              }
-              return _$map.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-                useQueryComponent: useQueryComponent,
-              );
-            }
-          }
-        ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (myClass != null) { final _$myClassForm = myClass!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$myClassForm); } if (int != null) { final _$intForm = int!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$intForm); _$values.add(_$intForm.map((e) => e.value).join(',')); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -1527,28 +1206,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expected = r'''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            final _$mapValues = <Map<String, String>>[];
-            if (myClass != null) {
-              _$mapValues.add(
-                myClass!.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowLists: allowLists,
-                  allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-                ),
-              );
-            }
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            return _$map;
-          }
-        ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (myClass != null) { _$mapValues.add(myClass!.parameterProperties(allowEmpty: allowEmpty)); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
+''';
 
       expect(
         collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -718,7 +718,7 @@ void main() {
         const expectedMethod = r'''
 @override
 String toSimple({required bool explode, required bool allowEmpty}) {
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   String? _$discriminatorValue;
   if (company != null) {
     final _$companySimple = company!.parameterProperties(
@@ -732,21 +732,17 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     _$mapValues.add(_$personSimple);
     _$discriminatorValue ??= r'person';
   }
-  final _$map = <String, String>{};
+  final _$map = <String, PropertyValue>{};
   for (final _$m in _$mapValues) {
     _$map.addAll(_$m);
   }
   final _$discValue = _$discriminatorValue;
   if (_$discValue != null) {
-    _$map.putIfAbsent(r'type', () => _$discValue);
+    _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
   }
-  return _$map.toSimple(
-    explode: explode,
-    allowEmpty: allowEmpty,
-    alreadyEncoded: true,
-  );
+  return _$map.toSimple(explode: explode, allowEmpty: allowEmpty);
 }
-      ''';
+''';
 
         expect(generated.trim(), expectedMethod.trim());
       },
@@ -856,33 +852,27 @@ List<ParameterEntry> toForm(
   bool useQueryComponent = false,
   bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
 }) {
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   String? _$discriminatorValue;
   if (company != null) {
-    final _$companyForm = company!.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowReserved: allowReserved,
-    );
+    final _$companyForm = company!.parameterProperties(allowEmpty: allowEmpty);
     _$mapValues.add(_$companyForm);
     _$discriminatorValue ??= r'company';
   }
   if (person != null) {
-    final _$personForm = person!.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowReserved: allowReserved,
-    );
+    final _$personForm = person!.parameterProperties(allowEmpty: allowEmpty);
     _$mapValues.add(_$personForm);
     _$discriminatorValue ??= r'person';
   }
-  final _$map = <String, String>{};
+  final _$map = <String, PropertyValue>{};
   for (final _$m in _$mapValues) {
     _$map.addAll(_$m);
   }
   final _$discValue = _$discriminatorValue;
   if (_$discValue != null) {
-    _$map.putIfAbsent(r'type', () => _$discValue);
+    _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
   }
-  return _$map.toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent);
+  return _$map.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings);
 }
       ''';
 
@@ -1002,7 +992,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
 @override
 String toSimple({required bool explode, required bool allowEmpty}) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   String? _$discriminatorValue;
   if (data != null) {
     final _$dataSimple = data!.parameterProperties(allowEmpty: allowEmpty);
@@ -1030,22 +1020,18 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
     final _$discValue = _$discriminatorValue;
     if (_$discValue != null) {
-      _$map.putIfAbsent(r'type', () => _$discValue);
+      _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
     }
-    return _$map.toSimple(
-      explode: explode,
-      allowEmpty: allowEmpty,
-      alreadyEncoded: true,
-    );
+    return _$map.toSimple(explode: explode, allowEmpty: allowEmpty);
   }
 }
-      ''';
+''';
 
         expect(generated.trim(), expectedMethod.trim());
       },
@@ -1092,15 +1078,9 @@ String toSimple({required bool explode, required bool allowEmpty}) {
       expect(method.name, 'parameterProperties');
       expect(
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
-        'Map<String,String>',
+        'Map<String,PropertyValue>',
       );
-      expect(method.optionalParameters.length, 4);
-
-      final allowReservedParam = method.optionalParameters.firstWhere(
-        (p) => p.name == 'allowReserved',
-      );
-      expect(allowReservedParam.named, isTrue);
-      expect(allowReservedParam.required, isFalse);
+      expect(method.optionalParameters.length, 1);
 
       final allowEmptyParam = method.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -1111,12 +1091,6 @@ String toSimple({required bool explode, required bool allowEmpty}) {
         allowEmptyParam.defaultTo?.accept(emitter).toString(),
         'true',
       );
-
-      final allowListsParam = method.optionalParameters.firstWhere(
-        (p) => p.name == 'allowLists',
-      );
-      expect(allowListsParam.named, isTrue);
-      expect(allowListsParam.required, isFalse);
     });
 
     test('generates complete method for single complex variant', () {
@@ -1146,17 +1120,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  if (user != null) {
-    _$mapValues.add( user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (user != null) { _$mapValues.add(user!.parameterProperties(allowEmpty: allowEmpty)); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
       expect(
@@ -1201,20 +1165,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  if (admin != null) {
-    _$mapValues.add( admin!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-  }
-  if (user != null) {
-    _$mapValues.add( user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (admin != null) { _$mapValues.add(admin!.parameterProperties(allowEmpty: allowEmpty)); } if (user != null) { _$mapValues.add(user!.parameterProperties(allowEmpty: allowEmpty)); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
       expect(
@@ -1264,23 +1215,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  String? _$discriminatorValue;
-  if (data != null) {
-    _$mapValues.add( data!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-    _$discriminatorValue ??= r'data';
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  final _$discValue = _$discriminatorValue;
-  if (_$discValue != null) {
-    _$map.putIfAbsent(r'type', () => _$discValue);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (data != null) { _$mapValues.add(data!.parameterProperties(allowEmpty: allowEmpty)); _$discriminatorValue ??= r'data'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map; }
 ''';
 
       expect(
@@ -1328,8 +1263,8 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (innerChoice != null) {
     switch (innerChoice!.currentEncodingShape) {
       case EncodingShape.simple:
@@ -1338,7 +1273,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         );
       case EncodingShape.complex:
         _$mapValues.add(
-          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ),
+          innerChoice!.parameterProperties(allowEmpty: allowEmpty),
         );
         break;
       case EncodingShape.mixed:
@@ -1347,7 +1282,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         );
     }
   }
-  final _$map = <String, String>{};
+  final _$map = <String, PropertyValue>{};
   for (final _$m in _$mapValues) {
     _$map.addAll(_$m);
   }
@@ -1410,37 +1345,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  String? _$discriminatorValue;
-  if (innerChoice != null) {
-    switch (innerChoice!.currentEncodingShape) {
-      case EncodingShape.simple:
-        throw EncodingException(
-          'Cannot encode simple type to map in parameterProperties',
-        );
-      case EncodingShape.complex:
-        _$mapValues.add(
-          innerChoice!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ),
-        );
-        _$discriminatorValue ??= r'inner';
-        break;
-      case EncodingShape.mixed:
-        throw EncodingException(
-          'Cannot encode field with mixed encoding shape',
-        );
-    }
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  final _$discValue = _$discriminatorValue;
-  if (_$discValue != null) {
-    _$map.putIfAbsent(r'type', () => _$discValue);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (innerChoice != null) { switch (innerChoice!.currentEncodingShape) { case EncodingShape.simple: throw EncodingException( 'Cannot encode simple type to map in parameterProperties', ); case EncodingShape.complex: _$mapValues.add( innerChoice!.parameterProperties(allowEmpty: allowEmpty), ); _$discriminatorValue ??= r'inner'; break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map; }
 ''';
 
         expect(
@@ -1501,22 +1406,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  if (complexData != null) {
-    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-  }
-  if (innerChoice != null) {
-    throw EncodingException(
-      'Cannot encode anyOf with simple type to map in parameterProperties',
-    );
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (complexData != null) { _$mapValues.add(complexData!.parameterProperties(allowEmpty: allowEmpty)); } if (innerChoice != null) { throw EncodingException( 'Cannot encode anyOf with simple type to map in parameterProperties', ); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
         expect(
@@ -1563,22 +1453,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
         final generated = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-  final _$mapValues = <Map<String, String>>[];
-  if (complexData != null) {
-    _$mapValues.add( complexData!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), );
-  }
-  if (string != null) {
-    throw EncodingException(
-      'Cannot encode anyOf with simple type to map in parameterProperties',
-    );
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (complexData != null) { _$mapValues.add(complexData!.parameterProperties(allowEmpty: allowEmpty)); } if (string != null) { throw EncodingException( 'Cannot encode anyOf with simple type to map in parameterProperties', ); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
         expect(
@@ -1608,7 +1483,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowLists = true, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   throw EncodingException(
     r'parameterProperties not supported for SimpleChoice: contains only simple types',
   );
@@ -1621,7 +1496,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       );
     });
 
-    test('passes allowLists to nested complex types', () {
+    test('merges parameterProperties from nested complex types', () {
       final user = ClassModel(
         isDeprecated: false,
         name: 'User',
@@ -1656,32 +1531,7 @@ Map<String, String> parameterProperties({ bool allowEmpty = true, bool allowList
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mapValues = <Map<String, String>>[];
-  if (admin != null) {
-    _$mapValues.add(
-      admin!.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
-    );
-  }
-  if (user != null) {
-    _$mapValues.add(
-      user!.parameterProperties( allowEmpty: allowEmpty, allowLists: allowLists, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ),
-    );
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (admin != null) { _$mapValues.add(admin!.parameterProperties(allowEmpty: allowEmpty)); } if (user != null) { _$mapValues.add(user!.parameterProperties(allowEmpty: allowEmpty)); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
       expect(
@@ -1716,24 +1566,7 @@ Map<String, String> parameterProperties({
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mapValues = <Map<String, String>>[];
-  if (list != null) {
-    if (!allowLists) {
-      throw EncodingException('Lists are not supported in this encoding style');
-    }
-    throw EncodingException('Lists are not supported in parameterProperties');
-  }
-  final _$map = <String, String>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  return _$map;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (list != null) { throw EncodingException('Lists are not supported in parameterProperties'); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map; }
 ''';
 
       expect(
@@ -1742,7 +1575,7 @@ Map<String, String> parameterProperties({
       );
     });
 
-    test('passes allowLists to nested anyOf with mixed encoding', () {
+    test('merges parameterProperties from a nested mixed-encoding anyOf', () {
       final innerAnyOf = AnyOfModel(
         isDeprecated: false,
         name: 'InnerChoice',
@@ -1784,12 +1617,8 @@ Map<String, String> parameterProperties({
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mapValues = <Map<String, String>>[];
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (innerChoice != null) {
     switch (innerChoice!.currentEncodingShape) {
       case EncodingShape.simple:
@@ -1798,11 +1627,7 @@ Map<String, String> parameterProperties({
         );
       case EncodingShape.complex:
         _$mapValues.add(
-          innerChoice!.parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: allowLists,
-            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-          ),
+          innerChoice!.parameterProperties(allowEmpty: allowEmpty),
         );
         break;
       case EncodingShape.mixed:
@@ -1811,7 +1636,7 @@ Map<String, String> parameterProperties({
         );
     }
   }
-  final _$map = <String, String>{};
+  final _$map = <String, PropertyValue>{};
   for (final _$m in _$mapValues) {
     _$map.addAll(_$m);
   }
@@ -2511,61 +2336,9 @@ Map<String, String> parameterProperties({
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-        @override
-        List<ParameterEntry> toForm(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool useQueryComponent = false,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          if (map != null) {
-            throw EncodingException('Map types cannot be form-encoded');
-          }
-          if (string != null) {
-            final _$stringForm = string!.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-            );
-            _$entryLists.add(_$stringForm);
-            _$values.add(_$stringForm.map((e) => e.value).join(','));
-          }
-          if (_$values.isEmpty && _$mapValues.isEmpty) {
-            return const <ParameterEntry>[];
-          }
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf form encoding for FlexValue: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf form encoding for FlexValue: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$entryLists.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            return _$map.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-              useQueryComponent: useQueryComponent,
-            );
-          }
-        }
-      ''';
+@override
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (map != null) { throw EncodingException('Map types cannot be form-encoded'); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for FlexValue: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for FlexValue: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -3083,7 +2856,7 @@ bool operator ==(Object other) {
 @override
 String toSimple({required bool explode, required bool allowEmpty}) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (tonikFile != null) {
     final _$tonikFileSimple = tonikFile!.toBase64String().toSimple(
       explode: explode,
@@ -3109,14 +2882,13 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
     return _$map.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
-      alreadyEncoded: true,
     );
   }
 }
@@ -3166,63 +2938,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
 
         const expectedMethod = r'''
 @override
-List<ParameterEntry> toForm(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$entryLists = <List<ParameterEntry>>[];
-  final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
-  if (tonikFile != null) {
-    final _$tonikFileForm = tonikFile!.toBase64String().toForm(
-      paramName,
-      explode: explode,
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: allowReserved,
-    );
-    _$entryLists.add(_$tonikFileForm);
-    _$values.add(_$tonikFileForm.map((e) => e.value).join(','));
-  }
-  if (text != null) {
-    final _$textForm = text!.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowReserved: allowReserved,
-    );
-    _$mapValues.add(_$textForm);
-  }
-  if (_$values.isEmpty && _$mapValues.isEmpty) {
-    return const <ParameterEntry>[];
-  }
-  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-    throw EncodingException(
-      r'Ambiguous anyOf form encoding for AnyOfBase64: mixing simple and complex values',
-    );
-  }
-  if (_$values.isNotEmpty) {
-    if (_$values.length > 1) {
-      throw EncodingException(
-        r'Ambiguous anyOf form encoding for AnyOfBase64: multiple values provided, anyOf requires exactly one value',
-      );
-    }
-    return _$entryLists.first;
-  } else {
-    final _$map = <String, String>{};
-    for (final _$m in _$mapValues) {
-      _$map.addAll(_$m);
-    }
-    return _$map.toForm(
-      paramName,
-      explode: explode,
-      allowEmpty: allowEmpty,
-      alreadyEncoded: true,
-      useQueryComponent: useQueryComponent,
-    );
-  }
-}
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (tonikFile != null) { final _$tonikFileForm = tonikFile!.toBase64String().toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ); _$entryLists.add(_$tonikFileForm); _$values.add(_$tonikFileForm.map((e) => e.value).join(',')); } if (text != null) { final _$textForm = text!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$textForm); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for AnyOfBase64: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for AnyOfBase64: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
 ''';
 
         expect(generated.trim(), format(expectedMethod).trim());
@@ -3271,7 +2987,7 @@ List<ParameterEntry> toForm(
 @override
 String toLabel({required bool explode, required bool allowEmpty}) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (tonikFile != null) {
     final _$tonikFileLabel = tonikFile!.toBase64String().toLabel(
       explode: explode,
@@ -3297,14 +3013,13 @@ String toLabel({required bool explode, required bool allowEmpty}) {
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
     return _$map.toLabel(
       explode: explode,
       allowEmpty: allowEmpty,
-      alreadyEncoded: true,
     );
   }
 }
@@ -3456,12 +3171,8 @@ EncodingShape get currentEncodingShape {
       final generated = format(method.accept(emitter).toString());
 
       const expected = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mapValues = <Map<String, String>>[];
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (object != null) {
     throw EncodingException(
       r'AnyModel variant of MixedFilter cannot be parameter encoded',
@@ -3469,14 +3180,10 @@ Map<String, String> parameterProperties({
   }
   if (detailedFilter != null) {
     _$mapValues.add(
-      detailedFilter!.parameterProperties(
-        allowEmpty: allowEmpty,
-        allowLists: allowLists,
-        allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-      ),
+      detailedFilter!.parameterProperties(allowEmpty: allowEmpty),
     );
   }
-  final _$map = <String, String>{};
+  final _$map = <String, PropertyValue>{};
   for (final _$m in _$mapValues) {
     _$map.addAll(_$m);
   }
@@ -3496,7 +3203,7 @@ Map<String, String> parameterProperties({
 @override
 String toSimple({required bool explode, required bool allowEmpty}) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (object != null) {
     throw EncodingException(
       r'AnyModel variant of MixedFilter cannot be simple-encoded',
@@ -3522,14 +3229,13 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
     return _$map.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
-      alreadyEncoded: true,
     );
   }
 }
@@ -3545,57 +3251,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
 
       const expected = r'''
 @override
-List<ParameterEntry> toForm(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$entryLists = <List<ParameterEntry>>[];
-  final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
-  if (object != null) {
-    throw EncodingException(
-      r'AnyModel variant of MixedFilter cannot be form-encoded',
-    );
-  }
-  if (detailedFilter != null) {
-    final _$detailedFilterForm = detailedFilter!.parameterProperties(
-      allowEmpty: allowEmpty,
-      allowReserved: allowReserved,
-    );
-    _$mapValues.add(_$detailedFilterForm);
-  }
-  if (_$values.isEmpty && _$mapValues.isEmpty) {
-    return const <ParameterEntry>[];
-  }
-  if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-    throw EncodingException(
-      r'Ambiguous anyOf form encoding for MixedFilter: mixing simple and complex values',
-    );
-  }
-  if (_$values.isNotEmpty) {
-    if (_$values.length > 1) {
-      throw EncodingException(
-        r'Ambiguous anyOf form encoding for MixedFilter: multiple values provided, anyOf requires exactly one value',
-      );
-    }
-    return _$entryLists.first;
-  } else {
-    final _$map = <String, String>{};
-    for (final _$m in _$mapValues) {
-      _$map.addAll(_$m);
-    }
-    return _$map.toForm(
-      paramName,
-      explode: explode,
-      allowEmpty: allowEmpty,
-      alreadyEncoded: true,
-      useQueryComponent: useQueryComponent,
-    );
-  }
-}
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (object != null) { throw EncodingException( r'AnyModel variant of MixedFilter cannot be form-encoded', ); } if (detailedFilter != null) { final _$detailedFilterForm = detailedFilter!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$detailedFilterForm); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for MixedFilter: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf form encoding for MixedFilter: multiple values provided, anyOf requires exactly one value', ); } return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); } }
 ''';
 
       expect(generated.trim(), format(expected).trim());
@@ -3610,7 +3266,7 @@ List<ParameterEntry> toForm(
 @override
 String toLabel({required bool explode, required bool allowEmpty}) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (object != null) {
     throw EncodingException(
       r'AnyModel variant of MixedFilter cannot be label-encoded',
@@ -3636,14 +3292,13 @@ String toLabel({required bool explode, required bool allowEmpty}) {
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
     return _$map.toLabel(
       explode: explode,
       allowEmpty: allowEmpty,
-      alreadyEncoded: true,
     );
   }
 }
@@ -3665,7 +3320,7 @@ String toMatrix(
   required bool allowEmpty,
 }) {
   final _$values = <String>{};
-  final _$mapValues = <Map<String, String>>[];
+  final _$mapValues = <Map<String, PropertyValue>>[];
   if (object != null) {
     throw EncodingException(
       r'AnyModel variant of MixedFilter cannot be matrix-encoded',
@@ -3691,7 +3346,7 @@ String toMatrix(
     }
     return _$values.first;
   } else {
-    final _$map = <String, String>{};
+    final _$map = <String, PropertyValue>{};
     for (final _$m in _$mapValues) {
       _$map.addAll(_$m);
     }
@@ -3699,7 +3354,6 @@ String toMatrix(
       paramName,
       explode: explode,
       allowEmpty: allowEmpty,
-      alreadyEncoded: true,
     );
   }
 }

--- a/packages/tonik_generate/test/src/model/any_of_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_label_generator_test.dart
@@ -138,34 +138,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-          if (class1 != null) {
-            final _$class1Label = class1!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$class1Label);
-            _$discriminatorValue ??= r'class1';
-          }
-          if (class2 != null) {
-            final _$class2Label = class2!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$class2Label);
-            _$discriminatorValue ??= r'class2';
-          }
-          final _$map = <String, String>{};
-          for (final _$m in _$mapValues) {
-            _$map.addAll(_$m);
-          }
-          final _$discValue = _$discriminatorValue;
-          if (_$discValue != null) {
-            _$map.putIfAbsent(r'type', () => _$discValue);
-          }
-          return _$map.toLabel(
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (class1 != null) { final _$class1Label = class1!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$class1Label); _$discriminatorValue ??= r'class1'; } if (class2 != null) { final _$class2Label = class2!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$class2Label); _$discriminatorValue ??= r'class2'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toLabel(explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -209,52 +183,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-          if (data != null) {
-            final _$dataLabel = data!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$dataLabel);
-            _$discriminatorValue ??= r'data';
-          }
-          if (string != null) {
-            final _$stringLabel = string!.toLabel(
-              explode: explode,
-              allowEmpty: allowEmpty,
-            );
-            _$values.add(_$stringLabel);
-          }
-          if (_$values.isEmpty && _$mapValues.isEmpty) return '';
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf label encoding for AnyOfMixed: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf label encoding for AnyOfMixed: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            final _$discValue = _$discriminatorValue;
-            if (_$discValue != null) {
-              _$map.putIfAbsent(r'type', () => _$discValue);
-            }
-            return _$map.toLabel(
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          }
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (data != null) { final _$dataLabel = data!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$dataLabel); _$discriminatorValue ??= r'data'; } if (string != null) { final _$stringLabel = string!.toLabel( explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringLabel); } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf label encoding for AnyOfMixed: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf label encoding for AnyOfMixed: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toLabel(explode: explode, allowEmpty: allowEmpty); } }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -333,61 +263,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expected = r'''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          if (innerChoice != null) {
-            switch (innerChoice!.currentEncodingShape) {
-              case EncodingShape.simple:
-                _$values.add(
-                  innerChoice!.toLabel(explode: explode, allowEmpty: allowEmpty),
-                );
-                break;
-              case EncodingShape.complex:
-                final _$innerChoiceLabel = innerChoice!.parameterProperties(
-                  allowEmpty: allowEmpty,
-                );
-                _$mapValues.add(_$innerChoiceLabel);
-                break;
-              case EncodingShape.mixed:
-                throw EncodingException(
-                  'Cannot encode field with mixed encoding shape',
-                );
-            }
-          }
-          if (string != null) {
-            final _$stringLabel = string!.toLabel(
-              explode: explode,
-              allowEmpty: allowEmpty,
-            );
-            _$values.add(_$stringLabel);
-          }
-          if (_$values.isEmpty && _$mapValues.isEmpty) return '';
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf label encoding for TestAnyOf: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf label encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            return _$map.toLabel(
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          }
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (innerChoice != null) { switch (innerChoice!.currentEncodingShape) { case EncodingShape.simple: _$values.add( innerChoice!.toLabel(explode: explode, allowEmpty: allowEmpty), ); break; case EncodingShape.complex: final _$innerChoiceLabel = innerChoice!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$innerChoiceLabel); break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } if (string != null) { final _$stringLabel = string!.toLabel( explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringLabel); } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf label encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf label encoding for TestAnyOf: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toLabel(explode: explode, allowEmpty: allowEmpty); } }
+''';
 
       expect(
         collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/any_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_matrix_generator_test.dart
@@ -181,43 +181,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-          if (class1 != null) {
-            final _$class1Matrix = class1!.parameterProperties(
-              allowEmpty: allowEmpty,
-            );
-            _$mapValues.add(_$class1Matrix);
-            _$discriminatorValue ??= r'class1';
-          }
-          if (class2 != null) {
-            final _$class2Matrix = class2!.parameterProperties(
-              allowEmpty: allowEmpty,
-            );
-            _$mapValues.add(_$class2Matrix);
-            _$discriminatorValue ??= r'class2';
-          }
-          final _$map = <String, String>{};
-          for (final _$m in _$mapValues) {
-            _$map.addAll(_$m);
-          }
-          final _$discValue = _$discriminatorValue;
-          if (_$discValue != null) {
-            _$map.putIfAbsent(r'type', () => _$discValue);
-          }
-          return _$map.toMatrix(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (class1 != null) { final _$class1Matrix = class1!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$class1Matrix); _$discriminatorValue ??= r'class1'; } if (class2 != null) { final _$class2Matrix = class2!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$class2Matrix); _$discriminatorValue ??= r'class2'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -266,58 +231,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-          if (data != null) {
-            final _$dataMatrix = data!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$dataMatrix);
-            _$discriminatorValue ??= r'data';
-          }
-          if (string != null) {
-            final _$stringMatrix = string!.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            );
-            _$values.add(_$stringMatrix);
-          }
-          if (_$values.isEmpty && _$mapValues.isEmpty) return '';
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf matrix encoding for AnyOfMixed: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf matrix encoding for AnyOfMixed: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            final _$discValue = _$discriminatorValue;
-            if (_$discValue != null) {
-              _$map.putIfAbsent(r'type', () => _$discValue);
-            }
-            return _$map.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          }
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (data != null) { final _$dataMatrix = data!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$dataMatrix); _$discriminatorValue ??= r'data'; } if (string != null) { final _$stringMatrix = string!.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringMatrix); } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf matrix encoding for AnyOfMixed: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf matrix encoding for AnyOfMixed: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); } }
+''';
 
         expect(
           collapseWhitespace(classCode),
@@ -538,7 +453,7 @@ void main() {
           required bool allowEmpty,
         }) {
           final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
+          final _$mapValues = <Map<String, PropertyValue>>[];
           if (innerChoice != null) {
             switch (innerChoice!.currentEncodingShape) {
               case EncodingShape.simple:
@@ -584,7 +499,7 @@ void main() {
             }
             return _$values.first;
           } else {
-            final _$map = <String, String>{};
+            final _$map = <String, PropertyValue>{};
             for (final _$m in _$mapValues) {
               _$map.addAll(_$m);
             }
@@ -592,7 +507,6 @@ void main() {
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
-              alreadyEncoded: true,
             );
           }
         }
@@ -686,41 +600,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-          String toMatrix(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-          }) {
-            final _$values = <String>{};
-            if (list != null) {
-              final _$listMatrix = list!
-                  .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                  .toList()
-                  .toMatrix(
-                    paramName,
-                    explode: explode,
-                    allowEmpty: allowEmpty,
-                    alreadyEncoded: true,
-                  );
-              _$values.add(_$listMatrix);
-            }
-            if (string != null) {
-              final _$stringMatrix = string!.toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-              );
-              _$values.add(_$stringMatrix);
-            }
-            if (_$values.isEmpty) return '';
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf matrix encoding for StringOrIntList: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          }
-        ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (string != null) { final _$stringMatrix = string!.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringMatrix); } if (_$values.isEmpty) return ''; if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf matrix encoding for StringOrIntList: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; }
+''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),
@@ -754,41 +635,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-          String toMatrix(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-          }) {
-            final _$values = <String>{};
-            if (list != null) {
-              final _$listMatrix = list!
-                  .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                  .toList()
-                  .toMatrix(
-                    paramName,
-                    explode: explode,
-                    allowEmpty: allowEmpty,
-                    alreadyEncoded: true,
-                  );
-              _$values.add(_$listMatrix);
-            }
-            if (list2 != null) {
-              final _$list2Matrix = list2!.toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-              );
-              _$values.add(_$list2Matrix);
-            }
-            if (_$values.isEmpty) return '';
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf matrix encoding for StringListOrIntList: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          }
-        ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (list2 != null) { final _$list2Matrix = list2!.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$list2Matrix); } if (_$values.isEmpty) return ''; if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf matrix encoding for StringListOrIntList: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; }
+''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/model/any_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_schema_level_read_write_only_test.dart
@@ -174,11 +174,7 @@ void main() {
       final classCode = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) => throw EncodingException(
+        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
       ''';
@@ -201,24 +197,8 @@ void main() {
       final classCode = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(classCode),

--- a/packages/tonik_generate/test/src/model/any_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_simple_generator_test.dart
@@ -277,34 +277,8 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-
-          if (a != null) {
-            final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$aSimple);
-              _$discriminatorValue ??= r'a';
-          }
-          if (b != null) {
-            final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$bSimple);
-              _$discriminatorValue ??= r'b';
-          }
-
-          final _$map = <String, String>{};
-          for (final _$m in _$mapValues) { _$map.addAll(_$m); }
-          final _$discValue = _$discriminatorValue;
-          if (_$discValue != null) {
-            _$map.putIfAbsent(r'disc', () => _$discValue);
-          }
-          return _$map.toSimple(
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toSimple({required bool explode, required bool allowEmpty}) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); _$discriminatorValue ??= r'a'; } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); _$discriminatorValue ??= r'b'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -369,27 +343,8 @@ void main() {
         final generated = format(klass.accept(emitter).toString());
 
         const expectedMethod = r'''
-          String toSimple({required bool explode, required bool allowEmpty}) {
-            final _$mapValues = <Map<String, String>>[];
-
-            if (a != null) {
-              final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty);
-              _$mapValues.add(_$aSimple);
-            }
-            if (b != null) {
-              final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty);
-              _$mapValues.add(_$bSimple);
-            }
-
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) { _$map.addAll(_$m); }
-            return _$map.toSimple(
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          }
-        ''';
+String toSimple({required bool explode, required bool allowEmpty}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); }
+''';
 
         expect(
           collapseWhitespace(generated),
@@ -494,54 +449,8 @@ void main() {
         final generated = format(klass.accept(emitter).toString());
 
         const expectedMethod = r'''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          final _$values = <String>{};
-          final _$mapValues = <Map<String, String>>[];
-          String? _$discriminatorValue;
-
-          if (string != null) {
-            final _$stringSimple = string!.toSimple(
-              explode: explode,
-              allowEmpty: allowEmpty,
-            );
-            _$values.add(_$stringSimple);
-          }
-          if (user != null) {
-            final _$userSimple = user!.parameterProperties(allowEmpty: allowEmpty);
-            _$mapValues.add(_$userSimple);
-            _$discriminatorValue ??= r'user';
-          }
-
-          if (_$values.isEmpty && _$mapValues.isEmpty) return '';
-          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
-            throw EncodingException(
-              r'Ambiguous anyOf simple encoding for MixedSimple: mixing simple and complex values',
-            );
-          }
-          if (_$values.isNotEmpty) {
-            if (_$values.length > 1) {
-              throw EncodingException(
-                r'Ambiguous anyOf simple encoding for MixedSimple: multiple values provided, anyOf requires exactly one value',
-              );
-            }
-            return _$values.first;
-          } else {
-            final _$map = <String, String>{};
-            for (final _$m in _$mapValues) {
-              _$map.addAll(_$m);
-            }
-            final _$discValue = _$discriminatorValue;
-            if (_$discValue != null) {
-              _$map.putIfAbsent(r'disc', () => _$discValue);
-            }
-            return _$map.toSimple(
-              explode: explode,
-              allowEmpty: allowEmpty,
-              alreadyEncoded: true,
-            );
-          }
-        }
-      ''';
+String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (string != null) { final _$stringSimple = string!.toSimple( explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringSimple); } if (user != null) { final _$userSimple = user!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$userSimple); _$discriminatorValue ??= r'user'; } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); } }
+''';
 
         expect(
           collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
@@ -121,7 +121,7 @@ void main() {
 
       const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -171,7 +171,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -227,7 +227,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -240,7 +240,7 @@ void main() {
     );
 
     test(
-      'toDeepObject method passes allowLists=false to parameterProperties',
+      'toDeepObject method delegates to the parameterProperties encoder',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -268,7 +268,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -305,7 +305,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -342,7 +342,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -404,7 +404,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 
@@ -417,7 +417,7 @@ void main() {
     );
 
     test(
-      'toDeepObject method passes alreadyEncoded=true',
+      'toDeepObject method forwards allowReserved to the encoder',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -441,7 +441,7 @@ void main() {
 
         const expectedToDeepObjectMethod = '''
         List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty, allowLists: false, allowReserved: allowReserved, ).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -508,7 +508,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for ComplexContainer: contains complex types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for ComplexContainer: contains complex types', );
 ''';
 
       expect(
@@ -1012,7 +1012,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for ComplexListContainer: contains complex types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for ComplexListContainer: contains complex types', );
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -59,18 +59,9 @@ void main() {
       expect(parameterPropertiesMethod.type, isNot(MethodType.getter));
       expect(
         parameterPropertiesMethod.returns?.accept(emitter).toString(),
-        'Map<String,String>',
+        'Map<String,PropertyValue>',
       );
-      expect(parameterPropertiesMethod.optionalParameters.length, 5);
-
-      final allowReservedParam = parameterPropertiesMethod.optionalParameters
-          .firstWhere((p) => p.name == 'allowReserved');
-      expect(allowReservedParam.named, isTrue);
-      expect(allowReservedParam.required, isFalse);
-      expect(
-        allowReservedParam.defaultTo?.accept(emitter).toString(),
-        'false',
-      );
+      expect(parameterPropertiesMethod.optionalParameters.length, 1);
 
       final allowEmptyParam = parameterPropertiesMethod.optionalParameters
           .firstWhere((p) => p.name == 'allowEmpty');
@@ -82,33 +73,6 @@ void main() {
       );
       expect(
         allowEmptyParam.type?.accept(emitter).toString(),
-        'bool',
-      );
-
-      final allowListsParam = parameterPropertiesMethod.optionalParameters
-          .firstWhere((p) => p.name == 'allowLists');
-      expect(allowListsParam.named, isTrue);
-      expect(allowListsParam.required, isFalse);
-      expect(
-        allowListsParam.defaultTo?.accept(emitter).toString(),
-        'true',
-      );
-      expect(
-        allowListsParam.type?.accept(emitter).toString(),
-        'bool',
-      );
-
-      final useQueryComponentParam = parameterPropertiesMethod
-          .optionalParameters
-          .firstWhere((p) => p.name == 'useQueryComponent');
-      expect(useQueryComponentParam.named, isTrue);
-      expect(useQueryComponentParam.required, isFalse);
-      expect(
-        useQueryComponentParam.defaultTo?.accept(emitter).toString(),
-        'false',
-      );
-      expect(
-        useQueryComponentParam.type?.accept(emitter).toString(),
         'bool',
       );
     });
@@ -147,29 +111,7 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'id'] = id.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'id']?.allowReserved ?? allowReserved,
-  );
-  if (name != null) {
-    _$result[r'name'] = name!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'name'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'id'] = PropertyValue.scalar(id.toString()); if (name != null) { _$result[r'name'] = PropertyValue.scalar(name!); } else if (allowEmpty) { _$result[r'name'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -192,14 +134,7 @@ Map<String, String> parameterProperties({
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  return <String, String>{};
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return <String, PropertyValue>{}; }
 ''';
 
       expect(
@@ -240,33 +175,7 @@ Map<String, String> parameterProperties({
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (nullableName != null) {
-    _$result[r'nullable_name'] = nullableName!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'nullable_name']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'nullable_name'] = '';
-  }
-  if (nullableCount != null) {
-    _$result[r'nullable_count'] = nullableCount!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'nullable_count']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'nullable_count'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (nullableName != null) { _$result[r'nullable_name'] = PropertyValue.scalar(nullableName!); } else if (allowEmpty) { _$result[r'nullable_name'] = PropertyValue.scalar(''); } if (nullableCount != null) { _$result[r'nullable_count'] = PropertyValue.scalar( nullableCount!.toString(), ); } else if (allowEmpty) { _$result[r'nullable_count'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
       expect(
@@ -309,12 +218,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) =>
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
   throw EncodingException(
     r'parameterProperties not supported for User: contains complex types',
   );
@@ -384,25 +288,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (value.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'value'] = value.toSimple(
-      explode: false,
-      allowEmpty: allowEmpty,
-    );
-  } else {
-    throw EncodingException(
-      r'parameterProperties not supported for Container: contains complex types',
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (value.currentEncodingShape == EncodingShape.simple) { _$result[r'value'] = PropertyValue.scalar( encodeAnyValueToString(value.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for Container: contains complex types', ); } return _$result; }
 ''';
 
         expect(
@@ -467,22 +353,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (data.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'data'] = data.toSimple(explode: false, allowEmpty: allowEmpty);
-  } else {
-    throw EncodingException(
-      r'parameterProperties not supported for FlexibleContainer: contains complex types',
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (data.currentEncodingShape == EncodingShape.simple) { _$result[r'data'] = PropertyValue.scalar( encodeAnyValueToString(data.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for FlexibleContainer: contains complex types', ); } return _$result; }
 ''';
 
         expect(
@@ -544,25 +415,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (combined.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'combined'] = combined.toSimple(
-      explode: false,
-      allowEmpty: allowEmpty,
-    );
-  } else {
-    throw EncodingException(
-      r'parameterProperties not supported for CombinedContainer: contains complex types',
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (combined.currentEncodingShape == EncodingShape.simple) { _$result[r'combined'] = PropertyValue.scalar( encodeAnyValueToString(combined.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for CombinedContainer: contains complex types', ); } return _$result; }
 ''';
 
         expect(
@@ -606,29 +459,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  if (count != null) {
-    _$result[r'count'] = count!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'count']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'count'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); if (count != null) { _$result[r'count'] = PropertyValue.scalar(count!.toString()); } else if (allowEmpty) { _$result[r'count'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -677,15 +508,7 @@ Map<String, String> parameterProperties({
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) =>
-  throw EncodingException(
-    r'parameterProperties not supported for ComplexContainer: contains complex types',
-  );
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for ComplexContainer: contains complex types', );
 ''';
 
       expect(
@@ -749,27 +572,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (value != null) {
-    if (value!.currentEncodingShape == EncodingShape.simple) {
-      _$result[r'value'] = value!.toSimple(
-        explode: false,
-        allowEmpty: allowEmpty,
-      );
-    } else {
-      throw EncodingException(
-        r'parameterProperties not supported for Container: contains complex types',
-      );
-    }
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (value != null) { if (value!.currentEncodingShape == EncodingShape.simple) { _$result[r'value'] = PropertyValue.scalar( encodeAnyValueToString(value!.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for Container: contains complex types', ); } } return _$result; }
 ''';
 
         expect(
@@ -941,66 +744,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  if (count != null) {
-    _$result[r'count'] = count!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'count']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'count'] = '';
-  }
-  _$result[r'active'] = active.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'active']?.allowReserved ?? allowReserved,
-  );
-  if (data1.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'data1'] = data1.toSimple(
-      explode: false,
-      allowEmpty: allowEmpty,
-    );
-  } else {
-    throw EncodingException(
-      r'parameterProperties not supported for MixedContainer: contains complex types',
-    );
-  }
-  if (data2 != null) {
-    if (data2!.currentEncodingShape == EncodingShape.simple) {
-      _$result[r'data2'] = data2!.toSimple(
-        explode: false,
-        allowEmpty: allowEmpty,
-      );
-    } else {
-      throw EncodingException(
-        r'parameterProperties not supported for MixedContainer: contains complex types',
-      );
-    }
-  }
-  if (flexible.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'flexible'] = flexible.toSimple(
-      explode: false,
-      allowEmpty: allowEmpty,
-    );
-  } else {
-    throw EncodingException(
-      r'parameterProperties not supported for MixedContainer: contains complex types',
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); if (count != null) { _$result[r'count'] = PropertyValue.scalar(count!.toString()); } else if (allowEmpty) { _$result[r'count'] = PropertyValue.scalar(''); } _$result[r'active'] = PropertyValue.scalar(active.toString()); if (data1.currentEncodingShape == EncodingShape.simple) { _$result[r'data1'] = PropertyValue.scalar( encodeAnyValueToString(data1.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for MixedContainer: contains complex types', ); } if (data2 != null) { if (data2!.currentEncodingShape == EncodingShape.simple) { _$result[r'data2'] = PropertyValue.scalar( encodeAnyValueToString(data2!.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for MixedContainer: contains complex types', ); } } if (flexible.currentEncodingShape == EncodingShape.simple) { _$result[r'flexible'] = PropertyValue.scalar( encodeAnyValueToString(flexible.toJson(), allowEmpty: allowEmpty), ); } else { throw EncodingException( r'parameterProperties not supported for MixedContainer: contains complex types', ); } return _$result; }
 ''';
 
         expect(
@@ -1045,27 +789,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1124,48 +848,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && ids != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  if (ids != null) {
-    _$result[r'ids'] = ids!
-        .map(
-          (e) => e.uriEncode(
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: fieldEncodings[r'ids']?.allowReserved ?? allowReserved,
-          ),
-        )
-        .toList()
-        .uriEncode(
-          allowEmpty: allowEmpty,
-          useQueryComponent: useQueryComponent,
-          allowReserved: fieldEncodings[r'ids']?.allowReserved ?? allowReserved,
-        );
-  } else if (allowEmpty) {
-    _$result[r'ids'] = '';
-  }
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (ids != null) { _$result[r'ids'] = PropertyValue.array( ids!.map((e) => e.toString()).toList(), ); } else if (allowEmpty) { _$result[r'ids'] = PropertyValue.scalar(''); } if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1211,23 +894,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'tags'] = tags.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-  );
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'tags'] = PropertyValue.array(tags); return _$result; }
 ''';
 
         expect(
@@ -1282,32 +949,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'id'] = id.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'id']?.allowReserved ?? allowReserved,
-  );
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'id'] = PropertyValue.scalar(id.toString()); if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1370,15 +1012,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = '''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) =>
-    throw EncodingException(
-      r'parameterProperties not supported for ComplexListContainer: contains complex types',
-    );
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for ComplexListContainer: contains complex types', );
 ''';
 
         expect(
@@ -1435,36 +1069,7 @@ Map<String, String> parameterProperties({
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && statuses != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  if (statuses != null) {
-    _$result[r'statuses'] = statuses!
-        .map(
-          (e) => e.uriEncode(
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: fieldEncodings[r'statuses']?.allowReserved ?? allowReserved,
-          ),
-        )
-        .toList()
-        .uriEncode(
-          allowEmpty: allowEmpty,
-          useQueryComponent: useQueryComponent,
-          allowReserved: fieldEncodings[r'statuses']?.allowReserved ?? allowReserved,
-        );
-  } else if (allowEmpty) {
-    _$result[r'statuses'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (statuses != null) { _$result[r'statuses'] = PropertyValue.array( statuses!.map((e) => e.toJson()).toList(), ); } else if (allowEmpty) { _$result[r'statuses'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1475,8 +1080,59 @@ Map<String, String> parameterProperties({
     );
 
     test(
-      'generates parameterProperties that throws when allowLists=true '
-      'and list present',
+      'generates parameterProperties for list of composite content that is '
+      'double-encoded (legacy behavior preserved)',
+      () {
+        final oneOfModel = OneOfModel(
+          isDeprecated: false,
+          name: 'StringOrInt',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+          },
+          context: context,
+          examples: const [],
+        );
+
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'CompositeListContainer',
+          properties: [
+            Property(
+              name: 'items',
+              model: ListModel(
+                content: oneOfModel,
+                context: context,
+                examples: const [],
+              ),
+              isRequired: false,
+              isNullable: true,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+        final classCode = format(result.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (items != null) { _$result[r'items'] = PropertyValue.array( items!.map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty)).toList(), ); } else if (allowEmpty) { _$result[r'items'] = PropertyValue.scalar(''); } return _$result; }
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'generates parameterProperties with an array value for a required list '
+      'property',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -1504,23 +1160,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'tags'] = tags.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-  );
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'tags'] = PropertyValue.array(tags); return _$result; }
 ''';
 
         expect(
@@ -1531,8 +1171,8 @@ Map<String, String> parameterProperties({
     );
 
     test(
-      'generates parameterProperties that throws when allowLists=true '
-      'and nullable list present',
+      'generates parameterProperties with an array value for a nullable list '
+      'property',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -1560,27 +1200,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1591,7 +1211,8 @@ Map<String, String> parameterProperties({
     );
 
     test(
-      'generates parameterProperties with allowLists for mixed properties',
+      'generates parameterProperties with scalar and array values for mixed '
+      'properties',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -1628,32 +1249,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1664,7 +1260,8 @@ Map<String, String> parameterProperties({
     );
 
     test(
-      'generates parameterProperties without list check when no lists present',
+      'generates parameterProperties with scalar values for scalar-only '
+      'properties',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -1697,25 +1294,251 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  _$result[r'age'] = age.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'age']?.allowReserved ?? allowReserved,
-  );
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); _$result[r'age'] = PropertyValue.scalar(age.toString()); return _$result; }
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'emits the raw scalar form for every simple property type',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'AllScalarTypes',
+          properties: [
+            Property(
+              name: 'ratio',
+              model: DoubleModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'quantity',
+              model: NumberModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'createdAt',
+              model: DateTimeModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'birthday',
+              model: DateModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'price',
+              model: DecimalModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'link',
+              model: UriModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'status',
+              model: EnumModel<String>(
+                isDeprecated: false,
+                name: 'Status',
+                values: {const EnumEntry(value: 'active')},
+                isNullable: false,
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'level',
+              model: EnumModel<int>(
+                isDeprecated: false,
+                name: 'Level',
+                values: {const EnumEntry(value: 1)},
+                isNullable: false,
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'blob',
+              model: BinaryModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'ratio'] = PropertyValue.scalar(ratio.toString()); _$result[r'quantity'] = PropertyValue.scalar(quantity.toString()); _$result[r'createdAt'] = PropertyValue.scalar( createdAt.toTimeZonedIso8601String(), ); _$result[r'birthday'] = PropertyValue.scalar(birthday.toString()); _$result[r'price'] = PropertyValue.scalar(price.toString()); _$result[r'link'] = PropertyValue.scalar(link.toString()); _$result[r'status'] = PropertyValue.scalar(status.toJson()); _$result[r'level'] = PropertyValue.scalar(level.toJson().toString()); _$result[r'blob'] = PropertyValue.scalar(blob.toBytes().decodeToString()); return _$result; }
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'mixed model AnyModel property emits a raw scalar carrying toString',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'DynamicContainer',
+          properties: [
+            Property(
+              name: 'data',
+              model: AnyModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'data'] = PropertyValue.scalar(data?.toString() ?? ''); return _$result; }
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'mixed model NeverModel property throws that no value is permitted',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'ForbiddenContainer',
+          properties: [
+            Property(
+              name: 'data',
+              model: AnyModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'forbidden',
+              model: NeverModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'data'] = PropertyValue.scalar(data?.toString() ?? ''); throw EncodingException( r'Cannot encode NeverModel property forbidden: this type does not permit any value', ); return _$result; }
+''';
+
+        expect(
+          collapseWhitespace(classCode),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'simple model NeverModel property throws that no value is permitted',
+      () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'ForbiddenSimpleContainer',
+          properties: [
+            Property(
+              name: 'label',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'forbidden',
+              model: NeverModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final generatedClass = generator.generateClass(model);
+        final classCode = format(generatedClass.accept(emitter).toString());
+
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'label'] = PropertyValue.scalar(label); throw EncodingException( r'Cannot encode NeverModel property forbidden: this type does not permit any value', ); return _$result; }
 ''';
 
         expect(
@@ -1764,24 +1587,7 @@ Map<String, String> parameterProperties({
 
         // Should generate null-aware encoding because the model is nullable
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (description != null) {
-    _$result[r'description'] = description!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'description']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'description'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (description != null) { _$result[r'description'] = PropertyValue.scalar(description!); } else if (allowEmpty) { _$result[r'description'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -1845,13 +1651,9 @@ Map<String, String> parameterProperties({
           contains(
             collapseWhitespace(r'''
 if (description != null) {
-  _$result[r'description'] = description!.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'description']?.allowReserved ?? allowReserved,
-  );
+  _$result[r'description'] = PropertyValue.scalar(description!);
 } else if (allowEmpty) {
-  _$result[r'description'] = '';
+  _$result[r'description'] = PropertyValue.scalar('');
 }'''),
           ),
         );
@@ -1859,10 +1661,8 @@ if (description != null) {
     );
 
     test(
-      'generates parameterProperties with null check for required property '
-      'referencing nullable ListModel',
+      'generates null-aware array value for a nullable ListModel property',
       () {
-        // ListModel with isNullable=true
         final model = ClassModel(
           isDeprecated: false,
           name: 'Container',
@@ -1889,24 +1689,13 @@ if (description != null) {
         final generatedClass = generator.generateClass(model);
         final classCode = format(generatedClass.accept(emitter).toString());
 
-        // Should NOT have the unconditional "if (!allowLists)" guard
-        // because the list is nullable (even though required)
-        expect(
-          collapseWhitespace(classCode),
-          isNot(
-            contains(
-              collapseWhitespace(
-                'if (!allowLists) {'
-                "  throw EncodingException('Lists are not supported",
-              ),
-            ),
-          ),
-        );
+        const expectedMethod = r'''
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (items != null) { _$result[r'items'] = PropertyValue.array(items!); } else if (allowEmpty) { _$result[r'items'] = PropertyValue.scalar(''); } return _$result; }
+''';
 
-        // Should have null-aware access
         expect(
           collapseWhitespace(classCode),
-          contains(collapseWhitespace('if (items != null)')),
+          contains(collapseWhitespace(expectedMethod)),
         );
       },
     );
@@ -1945,25 +1734,7 @@ if (description != null) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = '''
-List<ParameterEntry> toForm(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  return parameterProperties(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-  ).toForm(
-    paramName,
-    explode: explode,
-    allowEmpty: allowEmpty,
-    alreadyEncoded: true,
-    useQueryComponent: useQueryComponent,
-  );
-}
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
 ''';
 
         expect(
@@ -2095,24 +1866,7 @@ List<ParameterEntry> toForm(
         // Should generate null-aware encoding because the nested alias
         // is nullable
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (label != null) {
-    _$result[r'label'] = label!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'label']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'label'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (label != null) { _$result[r'label'] = PropertyValue.scalar(label!); } else if (allowEmpty) { _$result[r'label'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -2147,20 +1901,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'signature'] = signature.toBase64String().uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'signature']?.allowReserved ?? allowReserved,
-  );
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String()); return _$result; }
 ''';
 
         expect(
@@ -2195,24 +1936,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (signature != null) {
-    _$result[r'signature'] = signature!.toBase64String().uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'signature']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'signature'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (signature != null) { _$result[r'signature'] = PropertyValue.scalar( signature!.toBase64String(), ); } else if (allowEmpty) { _$result[r'signature'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -2247,24 +1971,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  if (signature != null) {
-    _$result[r'signature'] = signature!.toBase64String().uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'signature']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'signature'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (signature != null) { _$result[r'signature'] = PropertyValue.scalar( signature!.toBase64String(), ); } else if (allowEmpty) { _$result[r'signature'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -2303,28 +2010,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false,
-  Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'declared'] = declared.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'declared']?.allowReserved ?? allowReserved,
-  );
-  for (final _$e in additionalProperties.entries) {
-    _$result[_$e.key] = _$e.value.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: allowReserved,
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'declared'] = PropertyValue.scalar(declared); for (final _$e in additionalProperties.entries) { _$result[_$e.key] = PropertyValue.scalar(_$e.value); } return _$result; }
 ''';
 
         expect(
@@ -2363,27 +2049,7 @@ Map<String, String> parameterProperties({
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  for (final _$e in additionalProperties.entries) {
-    _$result[_$e.key] = _$e.value.toBase64String().uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: allowReserved,
-    );
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); for (final _$e in additionalProperties.entries) { _$result[_$e.key] = PropertyValue.scalar(_$e.value.toBase64String()); } return _$result; }
 ''';
 
         expect(
@@ -2434,32 +2100,7 @@ Map<String, String> parameterProperties({
         final methodCode = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists && tags != null) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'signature'] = signature.toBase64String().uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'signature']?.allowReserved ?? allowReserved,
-  );
-  if (tags != null) {
-    _$result[r'tags'] = tags!.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-    );
-  } else if (allowEmpty) {
-    _$result[r'tags'] = '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String()); if (tags != null) { _$result[r'tags'] = PropertyValue.array(tags!); } else if (allowEmpty) { _$result[r'tags'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(
@@ -2536,20 +2177,11 @@ Map<String, String> parameterProperties({
         final methodCode = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'signature'] = signature.toBase64String().uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'signature']?.allowReserved ?? allowReserved,
-  );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String());
   if (value.currentEncodingShape == EncodingShape.simple) {
-    _$result[r'value'] = value.toSimple(explode: false, allowEmpty: allowEmpty);
+    _$result[r'value'] = PropertyValue.scalar(encodeAnyValueToString(value.toJson(), allowEmpty: allowEmpty));
   } else {
     throw EncodingException(
       r'parameterProperties not supported for ByteMixedContainer: contains complex types',
@@ -2607,29 +2239,7 @@ Map<String, String> parameterProperties({
         final methodCode = format(method.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$result = <String, String>{};
-  _$result[r'name'] = name.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-  );
-  for (final _$e in additionalProperties.entries) {
-    _$result[_$e.key] =
-        _$e.value?.toBase64String().uriEncode(
-          allowEmpty: allowEmpty,
-          useQueryComponent: useQueryComponent,
-          allowReserved: allowReserved,
-        ) ??
-        '';
-  }
-  return _$result;
-}
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); for (final _$e in additionalProperties.entries) { _$result[_$e.key] = PropertyValue.scalar( _$e.value == null ? '' : _$e.value!.toBase64String(), ); } return _$result; }
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -1352,43 +1352,13 @@ factory ModelWithSimpleListRoundtrip.fromForm(
           ''';
 
           const expectedToFormMethod = '''
-List<ParameterEntry> toForm(
-String paramName, {
-required bool explode,
-required bool allowEmpty,
-bool useQueryComponent = false,
-bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-return parameterProperties(
-allowEmpty: allowEmpty,
-useQueryComponent: useQueryComponent,
-allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-).toForm(
-paramName,
-explode: explode,
-allowEmpty: allowEmpty,
-alreadyEncoded: true,
-useQueryComponent: useQueryComponent,
-);
-}
-          ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
           const expectedParameterPropertiesMethod = r'''
-Map<String, String> parameterProperties({
-  bool allowEmpty = true,
-  bool allowLists = true,
-  bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  if (!allowLists) {
-    throw EncodingException('Lists are not supported in this encoding style');
-  }
-  final _$result = <String, String>{};
-  _$result[r'tags'] = tags.uriEncode(
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: fieldEncodings[r'tags']?.allowReserved ?? allowReserved,
-  );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  _$result[r'tags'] = PropertyValue.array(tags);
   return _$result;
 }
           ''';
@@ -1515,7 +1485,45 @@ Map<String, String> parameterProperties({
 
         const expectedToFormBody = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, );
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(result.accept(emitter).toString()),
+          contains(collapseWhitespace(expectedToFormBody)),
+        );
+      });
+
+      test('array property still comma-joins because toForm emits no explode '
+          'descriptor', () {
+        final model = ClassModel(
+          isDeprecated: false,
+          name: 'TagContainer',
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: context),
+                context: context,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final result = generator.generateClass(model);
+
+        const expectedToFormBody = '''
+          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
+            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, );
           }
         ''';
 
@@ -1538,7 +1546,7 @@ Map<String, String> parameterProperties({
 
         const expectedToFormMethod = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, );
           }
         ''';
 
@@ -1786,7 +1794,7 @@ Map<String, String> parameterProperties({
 
           const expectedToFormMethod = '''
           List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {}, }) {
-            return parameterProperties(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ).toForm(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, useQueryComponent: useQueryComponent, );
+            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, );
           }
         ''';
 
@@ -2014,7 +2022,7 @@ Map<String, String> parameterProperties({
 
         const expectedToMatrixMethod = '''
           String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
           }
         ''';
 
@@ -2084,7 +2092,7 @@ Map<String, String> parameterProperties({
 
         const expectedToMatrixMethod = '''
           String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
           }
         ''';
 
@@ -2117,7 +2125,7 @@ Map<String, String> parameterProperties({
 
         const expectedToMatrixMethod = '''
           String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
           }
         ''';
 
@@ -2164,7 +2172,7 @@ Map<String, String> parameterProperties({
 
           const expectedToMatrixMethod = '''
           String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, );
+            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
           }
         ''';
 
@@ -2879,27 +2887,8 @@ Map<String, String> parameterProperties({
           );
 
           const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool useQueryComponent = false,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$result = <String, String>{};
-    _$result[r'name'] = name.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$result[_$e.key] = _$e.value.uriEncode(
-        allowEmpty: allowEmpty,
-        useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
-      );
-    }
-    return _$result;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); for (final _$e in additionalProperties.entries) { _$result[_$e.key] = PropertyValue.scalar(_$e.value.toString()); } return _$result; }
+''';
 
           final generatedClass = generator.generateClass(model);
           expect(
@@ -2941,18 +2930,9 @@ Map<String, String> parameterProperties({
             );
 
             const expectedMethod = r"""
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool useQueryComponent = false,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$result = <String, String>{};
-    _$result[r'version'] = version.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'version']?.allowReserved ?? allowReserved,
-    );
+  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+    final _$result = <String, PropertyValue>{};
+    _$result[r'version'] = PropertyValue.scalar(version.toString());
     if (additionalProperties.isNotEmpty) {
       throw EncodingException(
         r'Additional properties with complex types cannot be parameter encoded.',

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -1285,23 +1285,8 @@ void main() {
 
       test('generates parameterProperties with AP loop', () {
         const expectedMethod = r'''
-  Map<String, String> parameterProperties({
-    bool allowEmpty = true,
-    bool allowLists = true,
-    bool useQueryComponent = false,
-    bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-  }) {
-    final _$result = <String, String>{};
-    _$result[r'name'] = name.uriEncode(
-      allowEmpty: allowEmpty,
-      useQueryComponent: useQueryComponent,
-      allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-    );
-    for (final _$e in additionalProperties.entries) {
-      _$result[_$e.key] = _$e.value?.toString() ?? '';
-    }
-    return _$result;
-  }''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); for (final _$e in additionalProperties.entries) { _$result[_$e.key] = PropertyValue.scalar(_$e.value?.toString() ?? ''); } return _$result; }
+''';
 
         final generatedClass = generator.generateClass(model);
         expect(

--- a/packages/tonik_generate/test/src/model/class_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_label_generator_test.dart
@@ -74,9 +74,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(
@@ -126,9 +125,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
         const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -172,9 +170,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(
@@ -234,9 +231,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
         const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -297,9 +293,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
         const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -322,9 +317,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(

--- a/packages/tonik_generate/test/src/model/class_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_label_generator_test.dart
@@ -76,7 +76,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(
@@ -128,7 +128,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -174,7 +174,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(
@@ -236,7 +236,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -299,7 +299,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
         expect(
@@ -324,7 +324,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
       expect(

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -406,9 +406,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
 
       const expectedMethod = '''
         String toSimple({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -444,9 +443,8 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
 
       const expectedMethod = '''
         String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -464,7 +462,7 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties(allowEmpty: allowEmpty) .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
 ''';
 
       expect(

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -388,29 +388,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool useQueryComponent = false,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          final _$result = <String, String>{};
-          _$result[r'name'] = name.uriEncode(
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: fieldEncodings[r'name']?.allowReserved ?? allowReserved,
-          );
-          if (password == null) {
-            throw EncodingException(r'Required property password is null.');
-          }
-          _$result[r'password'] = password!.uriEncode(
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: fieldEncodings[r'password']?.allowReserved ?? allowReserved,
-          );
-          return _$result;
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); if (password == null) { throw EncodingException(r'Required property password is null.'); } _$result[r'password'] = PropertyValue.scalar(password!); return _$result; }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -429,7 +408,7 @@ void main() {
         String toSimple({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -447,26 +426,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool useQueryComponent = false,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-          ).toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-            useQueryComponent: useQueryComponent,
-          );
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -485,7 +446,7 @@ void main() {
         String toLabel({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toLabel(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -503,19 +464,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty).toMatrix(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties( allowEmpty: allowEmpty, ).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
+''';
 
       expect(
         collapseWhitespace(classCode),
@@ -531,24 +481,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(classCode),

--- a/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
@@ -216,12 +216,7 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool useQueryComponent = false,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) => throw EncodingException(
+        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
           r'ServerStatus is read-only and cannot be encoded.',
         );
       ''';

--- a/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
@@ -1194,7 +1194,7 @@ void main() {
         String toSimple({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -1252,7 +1252,7 @@ void main() {
         String toSimple({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -1284,7 +1284,7 @@ void main() {
         String toSimple({required bool explode, required bool allowEmpty}) {
           return parameterProperties(
             allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+          ).toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
@@ -1192,9 +1192,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
         String toSimple({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -1250,9 +1249,8 @@ void main() {
         final classCode = format(generatedClass.accept(emitter).toString());
         const expectedMethod = '''
         String toSimple({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 
@@ -1282,9 +1280,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
         String toSimple({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-          ).toSimple(explode: explode, allowEmpty: allowEmpty);
+          return parameterProperties(allowEmpty: allowEmpty)
+            .toSimple(explode: explode, allowEmpty: allowEmpty);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/one_of_deep_object_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_deep_object_generator_test.dart
@@ -50,24 +50,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -92,24 +76,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -172,24 +140,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -197,7 +149,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes allowLists=false to parameterProperties', () {
+    test('toDeepObject delegates to the parameterProperties encoder', () {
       final model = OneOfModel(
         isDeprecated: false,
         name: 'OneOfWithAllowLists',
@@ -214,24 +166,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -239,7 +175,7 @@ void main() {
       );
     });
 
-    test('toDeepObject passes alreadyEncoded=true', () {
+    test('toDeepObject forwards allowReserved to the encoder', () {
       final model = OneOfModel(
         isDeprecated: false,
         name: 'OneOfEncoded',
@@ -255,24 +191,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),
@@ -336,24 +256,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          bool allowReserved = false,
-        }) {
-          return parameterProperties(
-            allowEmpty: allowEmpty,
-            allowLists: false,
-            allowReserved: allowReserved,
-          ).toDeepObject(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            alreadyEncoded: true,
-          );
-        }
-      ''';
+List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
 
       expect(
         collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
@@ -122,32 +122,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          return switch (this) {
-            ResponseMessage(:final value) => value.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-            ),
-            ResponseUser(:final value) =>
-              {
-                ...value.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowReserved: allowReserved,
-                ),
-                r'type': r'user',
-              }.toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-                useQueryComponent: useQueryComponent,
-              ),
-          };
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return switch (this) { ResponseMessage(:final value) => value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ), }; }
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -530,33 +506,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          return switch (this) {
-            OuterInner(:final value) =>
-              value.currentEncodingShape == EncodingShape.complex
-                  ? {
-                      ...value.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowReserved: allowReserved,
-                ),
-                      r'type': r'inner',
-                    }.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      alreadyEncoded: true,
-                      useQueryComponent: useQueryComponent,
-                    )
-                  : value.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      useQueryComponent: useQueryComponent,
-                      allowReserved: allowReserved,
-                    ),
-          };
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return switch (this) { OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'inner'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ), }; }
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -643,55 +594,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
-          return switch (this) {
-            OuterInnerA(:final value) =>
-              value.currentEncodingShape == EncodingShape.complex
-                  ? {
-                      ...value.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowReserved: allowReserved,
-                ),
-                      r'type': r'a',
-                    }.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      alreadyEncoded: true,
-                      useQueryComponent: useQueryComponent,
-                    )
-                  : value.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      useQueryComponent: useQueryComponent,
-                      allowReserved: allowReserved,
-                    ),
-            OuterInnerB(:final value) =>
-              value.currentEncodingShape == EncodingShape.complex
-                  ? {
-                      ...value.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowReserved: allowReserved,
-                ),
-                      r'type': r'b',
-                    }.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      alreadyEncoded: true,
-                      useQueryComponent: useQueryComponent,
-                    )
-                  : value.toForm(
-                      paramName,
-                      explode: explode,
-                      allowEmpty: allowEmpty,
-                      useQueryComponent: useQueryComponent,
-                      allowReserved: allowReserved,
-                    ),
-          };
-        }
-      ''';
+List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) { return switch (this) { OuterInnerA(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'a'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ), OuterInnerB(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'b'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, ), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -700,30 +604,31 @@ void main() {
       },
     );
 
-    test('toForm throws for the binary variant and encodes the text variant',
-        () {
-      final model = OneOfModel(
-        isDeprecated: false,
-        name: 'WithBinary',
-        models: {
-          (
-            discriminatorValue: 'binary',
-            model: BinaryModel(context: context),
-          ),
-          (
-            discriminatorValue: 'text',
-            model: StringModel(context: context),
-          ),
-        },
-        context: context,
-        examples: const [],
-      );
+    test(
+      'toForm throws for the binary variant and encodes the text variant',
+      () {
+        final model = OneOfModel(
+          isDeprecated: false,
+          name: 'WithBinary',
+          models: {
+            (
+              discriminatorValue: 'binary',
+              model: BinaryModel(context: context),
+            ),
+            (
+              discriminatorValue: 'text',
+              model: StringModel(context: context),
+            ),
+          },
+          context: context,
+          examples: const [],
+        );
 
-      final classes = generator.generateClasses(model);
-      final baseClass = classes.firstWhere((c) => c.name == 'WithBinary');
-      final generated = format(baseClass.accept(emitter).toString());
+        final classes = generator.generateClasses(model);
+        final baseClass = classes.firstWhere((c) => c.name == 'WithBinary');
+        final generated = format(baseClass.accept(emitter).toString());
 
-      const expectedMethod = '''
+        const expectedMethod = '''
         List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {}, }) {
           return switch (this) {
             WithBinaryBinary() => throw EncodingException(
@@ -740,11 +645,12 @@ void main() {
         }
       ''';
 
-      expect(
-        collapseWhitespace(generated),
-        contains(collapseWhitespace(expectedMethod)),
-      );
-    });
+        expect(
+          collapseWhitespace(generated),
+          contains(collapseWhitespace(expectedMethod)),
+        );
+      },
+    );
   });
 
   group('with alias-to-primitive types', () {

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -746,15 +746,9 @@ void main() {
       expect(method.name, 'parameterProperties');
       expect(
         method.returns?.accept(emitter).toString().replaceAll(' ', ''),
-        'Map<String,String>',
+        'Map<String,PropertyValue>',
       );
-      expect(method.optionalParameters.length, 4);
-
-      final allowReservedParam = method.optionalParameters.firstWhere(
-        (p) => p.name == 'allowReserved',
-      );
-      expect(allowReservedParam.named, isTrue);
-      expect(allowReservedParam.required, isFalse);
+      expect(method.optionalParameters.length, 1);
 
       final allowEmptyParam = method.optionalParameters.firstWhere(
         (p) => p.name == 'allowEmpty',
@@ -767,20 +761,6 @@ void main() {
       );
       expect(
         allowEmptyParam.type?.accept(emitter).toString(),
-        'bool',
-      );
-
-      final allowListsParam = method.optionalParameters.firstWhere(
-        (p) => p.name == 'allowLists',
-      );
-      expect(allowListsParam.named, isTrue);
-      expect(allowListsParam.required, isFalse);
-      expect(
-        allowListsParam.defaultTo?.accept(emitter).toString(),
-        'true',
-      );
-      expect(
-        allowListsParam.type?.accept(emitter).toString(),
         'bool',
       );
     });
@@ -801,15 +781,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) =>
-          throw EncodingException(
-            r'parameterProperties not supported for Value: only contains primitive types',
-          );
-      ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -841,15 +814,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) =>
-          throw EncodingException(
-            r'parameterProperties not supported for Value: only contains primitive types',
-          );
-      ''';
+Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -890,20 +856,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return switch (this) {
-            ResponseUser(:final value) => value.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowLists: allowLists,
-              allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-            ),
-          };
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { ResponseUser(:final value) => value.parameterProperties( allowEmpty: allowEmpty, ), }; }
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -964,31 +918,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Entity');
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return switch (this) {
-            EntityCompany(:final value) => {
-              ...value.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowLists: allowLists,
-                allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-              ),
-              r'type': r'company',
-            },
-            EntityUser(:final value) => {
-              ...value.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowLists: allowLists,
-                allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-              ),
-              r'type': r'person',
-            },
-          };
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { EntityCompany(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'company'), }, EntityUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'person'), }, }; }
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -1032,23 +963,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Value');
 
         const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return switch (this) {
-            ValueUser(:final value) => value.parameterProperties(
-              allowEmpty: allowEmpty,
-              allowLists: allowLists,
-              allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-            ),
-            ValueString() => throw EncodingException(
-              r'parameterProperties not supported for Value: cannot determine properties at runtime',
-            ),
-          };
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { ValueUser(:final value) => value.parameterProperties( allowEmpty: allowEmpty, ), ValueString() => throw EncodingException( r'parameterProperties not supported for Value: cannot determine properties at runtime', ), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -1097,26 +1013,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
         const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return switch (this) {
-            ResponseMessage() => throw EncodingException(
-              r'parameterProperties not supported for Response: cannot determine properties at runtime',
-            ),
-            ResponseUser(:final value) => {
-              ...value.parameterProperties(
-                allowEmpty: allowEmpty,
-                allowLists: allowLists,
-                allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-              ),
-              r'type': r'user',
-            },
-          };
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { ResponseMessage() => throw EncodingException( r'parameterProperties not supported for Response: cannot determine properties at runtime', ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }, }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -1173,18 +1071,10 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
+        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
           return switch (this) {
             OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex
-              ? value.parameterProperties(
-                  allowEmpty: allowEmpty,
-                  allowLists: allowLists,
-                  allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-                )
+              ? value.parameterProperties(allowEmpty: allowEmpty)
               : throw EncodingException(
                   r'parameterProperties not supported for Outer: cannot determine properties at runtime',
                 ),
@@ -1248,27 +1138,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return switch (this) {
-            OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex
-              ? {
-                  ...value.parameterProperties(
-                    allowEmpty: allowEmpty,
-                    allowLists: allowLists,
-                    allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-                  ),
-                  r'type': r'inner',
-                }
-              : throw EncodingException(
-                  r'parameterProperties not supported for Outer: cannot determine properties at runtime',
-                ),
-          };
-        }
-      ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'inner'), } : throw EncodingException( r'parameterProperties not supported for Outer: cannot determine properties at runtime', ), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -1881,11 +1752,7 @@ void main() {
         collapseWhitespace(generated),
         contains(
           collapseWhitespace('''
-            Map<String, String> parameterProperties({
-              bool allowEmpty = true,
-              bool allowLists = true,
-              bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-            }) {
+            Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
               return switch (this) {
                 ValueList() => throw EncodingException(
                   'Lists are not supported in parameterProperties',
@@ -2388,11 +2255,7 @@ void main() {
           collapseWhitespace(generated),
           contains(
             collapseWhitespace('''
-              Map<String, String> parameterProperties({
-                bool allowEmpty = true,
-                bool allowLists = true,
-                bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-              }) {
+              Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
                 return switch (this) {
                   ValueList() => throw EncodingException(
                     'Lists are not supported in parameterProperties',
@@ -2560,22 +2423,8 @@ void main() {
         final generated = format(baseClass.accept(emitter).toString());
 
         const expectedMethod = '''
-          Map<String, String> parameterProperties({
-            bool allowEmpty = true,
-            bool allowLists = true,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            return switch (this) {
-              ValueDetails(:final value) => value == null
-                ? <String, String>{}
-                : value.parameterProperties(
-                    allowEmpty: allowEmpty,
-                    allowLists: allowLists,
-                    allowReserved: allowReserved, fieldEncodings: fieldEncodings,
-                  ),
-            };
-          }
-        ''';
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return switch (this) { ValueDetails(:final value) => value == null ? <String, PropertyValue>{} : value.parameterProperties(allowEmpty: allowEmpty), }; }
+''';
 
         expect(
           collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -781,7 +781,7 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
 
       const expectedMethod = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
 ''';
 
       expect(
@@ -814,7 +814,7 @@ Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => t
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
 
       const expectedMethod = '''
-Map<String, PropertyValue> parameterProperties({ bool allowEmpty = true, }) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException( r'parameterProperties not supported for Value: only contains primitive types', );
 ''';
 
       expect(

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1373,10 +1373,8 @@ void main() {
 
       test('parameterProperties', () {
         expectContainsBody(
-          'Map<String, String> parameterProperties({ bool allowEmpty = true, '
-          'bool allowLists = true, bool allowReserved = false, Map<String, '
-          'FormFieldEncoding> fieldEncodings = const {}, }) => '
-          '$throwExpr',
+          'Map<String, PropertyValue> parameterProperties({bool allowEmpty = '
+          'true}) => $throwExpr',
         );
       });
 

--- a/packages/tonik_generate/test/src/model/one_of_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_label_generator_test.dart
@@ -111,15 +111,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return switch (this) {
-            ChoiceA(:final value) => {
-              ...value.parameterProperties(allowEmpty: allowEmpty),
-              r'type': r'a',
-            }.toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true),
-          };
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { return switch (this) { ChoiceA(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'a'), }.toLabel(explode: explode, allowEmpty: allowEmpty), }; }
+''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(format(expectedMethod))),
@@ -166,8 +159,8 @@ void main() {
           return switch (this) {
             MixedChoiceM(:final value) => {
               ...value.parameterProperties(allowEmpty: allowEmpty),
-              r'kind': r'm',
-            }.toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true),
+              r'kind': PropertyValue.scalar(r'm'),
+            }.toLabel(explode: explode, allowEmpty: allowEmpty),
             MixedChoiceS(:final value) => value.toLabel(explode: explode, allowEmpty: allowEmpty),
           };
         }
@@ -282,21 +275,8 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return switch (this) {
-            OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex
-              ? {
-                  ...value.parameterProperties(allowEmpty: allowEmpty),
-                  r'type': r'inner',
-                }.toLabel(
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                )
-              : value.toLabel(explode: explode, allowEmpty: allowEmpty),
-          };
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { return switch (this) { OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'inner'), }.toLabel(explode: explode, allowEmpty: allowEmpty) : value.toLabel(explode: explode, allowEmpty: allowEmpty), }; }
+''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -383,31 +363,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return switch (this) {
-            OuterInnerA(:final value) => value.currentEncodingShape == EncodingShape.complex
-              ? {
-                  ...value.parameterProperties(allowEmpty: allowEmpty),
-                  r'type': r'a',
-                }.toLabel(
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                )
-              : value.toLabel(explode: explode, allowEmpty: allowEmpty),
-            OuterInnerB(:final value) => value.currentEncodingShape == EncodingShape.complex
-              ? {
-                  ...value.parameterProperties(allowEmpty: allowEmpty),
-                  r'type': r'b',
-                }.toLabel(
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                )
-              : value.toLabel(explode: explode, allowEmpty: allowEmpty),
-          };
-        }
-      ''';
+String toLabel({required bool explode, required bool allowEmpty}) { return switch (this) { OuterInnerA(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'a'), }.toLabel(explode: explode, allowEmpty: allowEmpty) : value.toLabel(explode: explode, allowEmpty: allowEmpty), OuterInnerB(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'b'), }.toLabel(explode: explode, allowEmpty: allowEmpty) : value.toLabel(explode: explode, allowEmpty: allowEmpty), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),

--- a/packages/tonik_generate/test/src/model/one_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_matrix_generator_test.dart
@@ -663,29 +663,8 @@ void main() {
 
       // For List<int>, should map each element to string then call toMatrix
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return switch (this) {
-            StringOrIntListList(:final value) => value
-              .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-              .toList()
-              .toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-              ),
-            StringOrIntListString(:final value) => value.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            ),
-          };
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrIntListList(:final value) => value .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrIntListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
+''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -719,29 +698,8 @@ void main() {
       // For List<DateTime>, should map each element to string then
       // call toMatrix
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return switch (this) {
-            StringOrDateTimeListList(:final value) => value
-                .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toMatrix(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                ),
-            StringOrDateTimeListString(:final value) => value.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            ),
-          };
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrDateTimeListList(:final value) => value .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrDateTimeListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
+''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -783,29 +741,8 @@ void main() {
 
       // For List<Enum>, should map each element to string then call toMatrix
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return switch (this) {
-            StringOrEnumListList(:final value) => value
-                .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-                .toList()
-                .toMatrix(
-                  paramName,
-                  explode: explode,
-                  allowEmpty: allowEmpty,
-                  alreadyEncoded: true,
-                ),
-            StringOrEnumListString(:final value) => value.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            ),
-          };
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrEnumListList(:final value) => value .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrEnumListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
+''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -898,29 +835,8 @@ void main() {
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toMatrix(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-        }) {
-          return switch (this) {
-            StringListOrIntListList(:final value) => value
-              .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty))
-              .toList()
-              .toMatrix(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                alreadyEncoded: true,
-            ),
-            StringListOrIntListListModel(:final value) => value.toMatrix(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-            ),
-          };
-        }
-      ''';
+String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringListOrIntListList(:final value) => value .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty)) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringListOrIntListListModel(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
+''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/model/one_of_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_schema_level_read_write_only_test.dart
@@ -170,11 +170,7 @@ void main() {
       final classCode = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Map<String, String> parameterProperties({
-          bool allowEmpty = true,
-          bool allowLists = true,
-          bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) => throw EncodingException(
+        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
           r'ServerEvent is read-only and cannot be encoded.',
         );
       ''';

--- a/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
@@ -113,20 +113,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
         const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          return switch (this) {
-            ResponseMessage(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ),
-            ResponseUser(:final value) => {
-              ...value.parameterProperties(allowEmpty: allowEmpty),
-              r'type': r'user',
-            }.toSimple( 
-              explode: explode, 
-              allowEmpty: allowEmpty, 
-              alreadyEncoded: true, 
-            ),
-          };
-        }
-      ''';
+String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { ResponseMessage(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -191,23 +179,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Entity');
 
         const expectedMethod = '''
-      String toSimple({required bool explode, required bool allowEmpty}) {
-        return switch (this) {
-          EntityCompany(:final value) => {
-            ...value.parameterProperties(allowEmpty: allowEmpty),
-            r'entity_type': r'company',
-          }.toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ),
-          EntityPerson(:final value) => {
-            ...value.parameterProperties(allowEmpty: allowEmpty),
-            r'entity_type': r'person',
-          }.toSimple( 
-            explode: explode, 
-            allowEmpty: allowEmpty, 
-            alreadyEncoded: true, 
-          ),
-        };
-      }
-    ''';
+String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { EntityCompany(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'company'), }.toSimple(explode: explode, allowEmpty: allowEmpty), EntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -254,16 +227,8 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'MixedEntity');
 
         const expectedMethod = '''
-      String toSimple({required bool explode, required bool allowEmpty}) {
-        return switch (this) {
-          MixedEntityId(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ),
-          MixedEntityPerson(:final value) => {
-            ...value.parameterProperties(allowEmpty: allowEmpty),
-            r'type': r'person',
-          }.toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ),
-        };
-      }
-    ''';
+String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { MixedEntityId(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ), MixedEntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),

--- a/packages/tonik_generate/test/src/util/property_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/property_value_expression_generator_test.dart
@@ -1,0 +1,157 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/util/property_value_expression_generator.dart';
+
+void main() {
+  late Context context;
+  late DartEmitter emitter;
+
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  setUp(() {
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+  });
+
+  String formatExpression(Expression expr) {
+    final method = Method(
+      (b) => b
+        ..name = 'test'
+        ..body = declareFinal('result').assign(expr).statement,
+    );
+    return format(method.accept(emitter).toString());
+  }
+
+  void expectListEmission(
+    Model contentModel,
+    String expectedBody, {
+    required bool isContentNullable,
+    bool useImmutableCollections = false,
+  }) {
+    final result = buildRawStringListExpression(
+      refer('myValue'),
+      contentModel,
+      isContentNullable: isContentNullable,
+      useImmutableCollections: useImmutableCollections,
+    );
+    final expected = format('test() { final result = $expectedBody; }');
+    expect(
+      collapseWhitespace(formatExpression(result)),
+      collapseWhitespace(expected),
+    );
+  }
+
+  group('buildRawStringListExpression', () {
+    test('non-nullable String content returns the list unchanged', () {
+      expectListEmission(
+        StringModel(context: context),
+        'myValue',
+        isContentNullable: false,
+      );
+    });
+
+    test('nullable String content maps null elements to empty string', () {
+      expectListEmission(
+        StringModel(context: context),
+        "myValue.map((e) => e ?? '').toList()",
+        isContentNullable: true,
+      );
+    });
+
+    test('scalar content maps each element to its raw string', () {
+      expectListEmission(
+        IntegerModel(context: context),
+        'myValue.map((e) => e.toString()).toList()',
+        isContentNullable: false,
+      );
+    });
+
+    test('immutable collections unlock the list before mapping', () {
+      expectListEmission(
+        IntegerModel(context: context),
+        'myValue.unlock.map((e) => e.toString()).toList()',
+        isContentNullable: false,
+        useImmutableCollections: true,
+      );
+    });
+
+    test('content-nullable scalar guards null elements to empty string', () {
+      expectListEmission(
+        IntegerModel(context: context),
+        "myValue.map((e) => e == null ? '' : e.toString()).toList()",
+        isContentNullable: true,
+      );
+    });
+
+    test('alias-wrapped content resolves to the aliased scalar mapping', () {
+      expectListEmission(
+        AliasModel(
+          name: 'Count',
+          model: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+        'myValue.map((e) => e.toString()).toList()',
+        isContentNullable: false,
+      );
+    });
+
+    test('composite content is double-encoded (legacy behavior '
+        'preserved)', () {
+      expectListEmission(
+        OneOfModel(
+          isDeprecated: false,
+          name: 'StringOrInt',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+          },
+          context: context,
+          examples: const [],
+        ),
+        'myValue.map((e) => '
+        'encodeAnyToUri(e, allowEmpty: allowEmpty)).toList()',
+        isContentNullable: false,
+      );
+    });
+
+    test('content-nullable composite guards null elements and double-encodes '
+        'the rest', () {
+      expectListEmission(
+        OneOfModel(
+          isDeprecated: false,
+          name: 'StringOrInt',
+          models: {
+            (discriminatorValue: null, model: StringModel(context: context)),
+            (discriminatorValue: null, model: IntegerModel(context: context)),
+          },
+          context: context,
+          examples: const [],
+        ),
+        "myValue.map((e) => e == null ? '' : "
+        'encodeAnyToUri(e, allowEmpty: allowEmpty)).toList()',
+        isContentNullable: true,
+      );
+    });
+
+    test('unsupported content throws an encoding exception', () {
+      expectListEmission(
+        ClassModel(
+          isDeprecated: false,
+          name: 'Nested',
+          properties: const [],
+          context: context,
+          examples: const [],
+        ),
+        "throw EncodingException('Unsupported list content type for URI "
+        "encoding.')",
+        isContentNullable: false,
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
@@ -81,21 +81,6 @@ void main() {
       });
     });
 
-    group('buildMapStringStringType', () {
-      test('returns correct TypeReference for Map<String, String>', () {
-        final result = buildMapStringStringType();
-
-        expect(result.symbol, 'Map');
-        expect(result.url, 'dart:core');
-        expect(result.isNullable, isNull);
-        expect(result.types, hasLength(2));
-        expect(result.types[0].symbol, 'String');
-        expect(result.types[0].url, 'dart:core');
-        expect(result.types[1].symbol, 'String');
-        expect(result.types[1].url, 'dart:core');
-      });
-    });
-
     group('buildEncodingParameters', () {
       test('returns correct list of encoding parameters', () {
         final result = buildEncodingParameters();
@@ -116,21 +101,6 @@ void main() {
         expect(allowEmptyParam.named, isTrue);
         expect(allowEmptyParam.required, isTrue);
       });
-    });
-
-    group('buildEmptyMapStringString', () {
-      test(
-        'returns correct LiteralMapExpression for empty Map<String, String>',
-        () {
-          final result = buildEmptyMapStringString();
-
-          expect(result, isA<LiteralMapExpression>());
-          expect(result.keyType?.symbol, 'String');
-          expect(result.keyType?.url, 'dart:core');
-          expect(result.valueType?.symbol, 'String');
-          expect(result.valueType?.url, 'dart:core');
-        },
-      );
     });
 
     group('typeReference', () {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,7 +12,7 @@ environment:
 
 dependencies:
   collection: ^1.19.1
-  dart_style: ^3.1.9
+  dart_style: ^3.1.11
   logging: ^1.3.0
   meta: ^1.18.2
   path: ^1.9.1


### PR DESCRIPTION
## Summary

Reshapes generated `parameterProperties` in place to a tagged raw-value map. Its signature collapses to:

```dart
Map<String, PropertyValue> parameterProperties({bool allowEmpty = true})
```

Values are now **raw and unescaped** (`PropertyValue.scalar(...)` / `PropertyValue.array([...])`); all object percent-encoding moves into the runtime style/form encoders. All five style delegations (`toSimple`/`toLabel`/`toMatrix`/`toForm`/`toDeepObject`) and the composite (`allOf`/`oneOf`/`anyOf`) merges switch together — they must, because the allOf merge calls member `parameterProperties`, so a partial switch would not compile.

This is wire-preserving for mainstream values: descriptor-less arrays still comma-join, and the style encoders reproduce today's bytes. The `allowLists` guard, the per-property `allowReserved` threading, and the `alreadyEncoded` back-channel disappear from the object path.

## Deliberate wire changes

Four intended micro-divergences, each covered by a test:

1. **Mixed-shape value in a form body** — a space now renders `+` instead of `%20` (honors `useQueryComponent`; decodes identically).
2. **`Any` property values** are now percent-encoded instead of leaking raw through the old already-encoded passthrough (the `.toString()` on that known-buggy path is unchanged).
3. **Empty scalar values** (e.g. an empty `Uri`) now throw uniformly under `allowEmpty: false` via the encoders.
4. **deepObject list rejection** now fires when the array value is encountered rather than via an up-front guard (same exception, same message).

## Known-deferred behavior (composite list content)

For an object property typed as a **list whose content is a simple-shaped composite** (e.g. `array` of `oneOf:[string, integer]`), this change **preserves the pre-existing double-encoding** rather than correcting it, to keep this step to the four divergences above. This corner is not exercised by any integration suite. Two notes:

- The old inner encode used `useQueryComponent`/`allowReserved` flags that the collapsed signature no longer threads, so the preserved double-encode applies those flags on the outer pass only (inner pass uses defaults). The double-encode *nature* is preserved; exact bytes for non-default flags may differ slightly.
- The correct single-encode fix (and the flag fidelity) is tracked as a dedicated follow-up.

## Tests

Full-compilation-unit generated-code expectations across all four generators plus the guard stub: per-raw-scalar-type `parameterProperties` bodies (String/int/double/num/bool/DateTime/Date/BigDecimal/Uri/String enum/int enum/Base64/binary), array/immutable/alias/null-element handling, the null-collection policy (required / optional±allowEmpty / required-nullable throw), read-only exclusion and read-only-class throw, `NeverModel` throw, mixed dispatch, additionalProperties variants, and allOf duplicate-name last-wins merges (including scalar-overwrites-array). A new `property_value_expression_generator` util carries the scalar/array/list emission with its own unit tests. Full integration regeneration passes with all suites green.
