### PR TITLE
fix!: explode form-urlencoded body array properties by default

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -203,6 +203,66 @@ switch (path) {
         }
         break
 
+    case '/form/array-body':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'q=hello&tags=urgent&tags=open'
+        }
+        break
+
+    case '/form/array-explode-false':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=a,b'
+        }
+        break
+
+    case '/form/array-space-delimited':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=a,b'
+        }
+        break
+
+    case '/form/array-explode-true':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=a&tags=b'
+        }
+        break
+
+    case '/form/array-comma-element':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=a,b'
+        }
+        break
+
+    case '/form/array-composite':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'label=hello&tags=x&tags=y'
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -263,6 +263,16 @@ switch (path) {
         }
         break
 
+    case '/form/optional-array':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'q=hello'
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -373,6 +373,21 @@ void main() {
       expect(requestData, 'label=hello&tags=x&tags=y');
     });
 
+    test('omits an absent optional array property while a present scalar '
+        'still serializes', () async {
+      const form = OptionalArrayForm(q: 'hello');
+
+      final response = await api.postOptionalArrayForm(body: form);
+
+      expect(response, isA<TonikSuccess<OptionalArrayForm>>());
+
+      final requestData = (response as TonikSuccess<OptionalArrayForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'q=hello');
+    });
+
     test('sends an empty entry for a single empty-string exploded element',
         () async {
       const form = ArrayExplodeForm(tags: ['']);

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -231,7 +231,7 @@ void main() {
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
       expect(
         requestData,
-        'colors=red,green,blue&numbers=1,2,3',
+        'colors=red&colors=green&colors=blue&numbers=1&numbers=2&numbers=3',
       );
 
       final data = response.value;
@@ -248,7 +248,7 @@ void main() {
 
       final requestData =
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
-      expect(requestData, 'colors=&numbers=');
+      expect(requestData, '');
 
       final data = response.value;
       expect(data.colors, ['red', 'green', 'blue']);
@@ -263,10 +263,129 @@ void main() {
 
       final requestData =
           (response as TonikSuccess<ArrayForm>).response.requestOptions.data;
-      expect(requestData, 'colors=purple&numbers=');
+      expect(requestData, 'colors=purple');
 
       final data = response.value;
       expect(data.colors, ['red', 'green', 'blue']);
+    });
+  });
+
+  group('Array body property explode', () {
+    test('explodes an array property with no encoding into repeated keys '
+        'beside a scalar', () async {
+      const form = ArrayBodyForm(q: 'hello', tags: ['urgent', 'open']);
+
+      final response = await api.postArrayBodyForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayBodyForm>>());
+
+      final success = response as TonikSuccess<ArrayBodyForm>;
+      final requestData = success.response.requestOptions.data;
+      expect(requestData, 'q=hello&tags=urgent&tags=open');
+    });
+
+    test('omits an entire body of only empty exploded arrays', () async {
+      const form = ArrayExplodeForm(tags: []);
+
+      final response = await api.postArrayCommaElementForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, '');
+    });
+
+    test('comma-joins an array property with explicit explode false', () async {
+      const form = ArrayExplodeForm(tags: ['a', 'b']);
+
+      final response = await api.postArrayExplodeFalseForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=a,b');
+    });
+
+    test('comma-joins a spaceDelimited array property with explode omitted',
+        () async {
+      const form = ArrayExplodeForm(tags: ['a', 'b']);
+
+      final response = await api.postArraySpaceDelimitedForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=a,b');
+    });
+
+    test('explodes an array property with explicit explode true into '
+        'repeated keys', () async {
+      const form = ArrayExplodeForm(tags: ['a', 'b']);
+
+      final response = await api.postArrayExplodeTrueForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=a&tags=b');
+    });
+
+    test('percent-encodes a comma inside an exploded array element', () async {
+      const form = ArrayExplodeForm(tags: ['a,b', 'c']);
+
+      final response = await api.postArrayCommaElementForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=a%2Cb&tags=c');
+    });
+
+    test('explodes a member array property of an allOf body', () async {
+      const form = ArrayCompositeForm(
+        arrayCompositeBase: ArrayCompositeBase(label: 'hello'),
+        arrayCompositeTags: ArrayCompositeTags(tags: ['x', 'y']),
+      );
+
+      final response = await api.postArrayCompositeForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayCompositeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayCompositeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'label=hello&tags=x&tags=y');
+    });
+
+    test('sends an empty entry for a single empty-string exploded element',
+        () async {
+      const form = ArrayExplodeForm(tags: ['']);
+
+      final response = await api.postArrayCommaElementForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=');
     });
   });
 
@@ -459,8 +578,7 @@ void main() {
     );
 
     test(
-      'comma-joins an array sibling into a single entry beside the flagged '
-      'scalar',
+      'explodes an array sibling into repeated keys beside the flagged scalar',
       () async {
         const form = AllowReservedArrayForm(
           reserved: 'a/b:c',
@@ -475,13 +593,13 @@ void main() {
             .response
             .requestOptions
             .data;
-        expect(requestData, 'reserved=a/b:c&tags=x,y,z');
+        expect(requestData, 'reserved=a/b:c&tags=x&tags=y&tags=z');
       },
     );
 
     test(
-      'keeps reserved characters literal in the comma-joined elements of a '
-      'flagged array property',
+      'keeps reserved characters literal per exploded element of a flagged '
+      'array property',
       () async {
         const form = AllowReservedArrayFlaggedForm(tags: ['a/b', 'c:d']);
 
@@ -496,7 +614,7 @@ void main() {
                 .response
                 .requestOptions
                 .data;
-        expect(requestData, 'tags=a/b,c:d');
+        expect(requestData, 'tags=a/b&tags=c:d');
       },
     );
 

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -514,6 +514,154 @@ paths:
               schema:
                 $ref: '#/components/schemas/AllowReservedCompositeForm'
 
+  /form/array-body:
+    post:
+      operationId: postArrayBodyForm
+      tags:
+        - form
+      summary: Post a form body with a scalar and an array property, no encoding
+      description: >-
+        Tests that an array property with no Encoding Object explodes into
+        repeated keys under the OAS form default, beside a scalar property.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayBodyForm'
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayBodyForm'
+
+  /form/array-explode-false:
+    post:
+      operationId: postArrayExplodeFalseForm
+      tags:
+        - form
+      summary: Post a form body whose array property sets explode false
+      description: >-
+        Tests that an array property with an explicit explode false Encoding
+        Object comma-joins its elements into a single entry.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayExplodeForm'
+            encoding:
+              tags:
+                explode: false
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayExplodeForm'
+
+  /form/array-space-delimited:
+    post:
+      operationId: postArraySpaceDelimitedForm
+      tags:
+        - form
+      summary: Post a form body whose array property is spaceDelimited without explode
+      description: >-
+        Tests that an array property with a spaceDelimited Encoding Object and
+        explode omitted comma-joins its elements into a single entry, because
+        the style-aware default suppresses explosion.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayExplodeForm'
+            encoding:
+              tags:
+                style: spaceDelimited
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayExplodeForm'
+
+  /form/array-explode-true:
+    post:
+      operationId: postArrayExplodeTrueForm
+      tags:
+        - form
+      summary: Post a form body whose array property sets explode true
+      description: >-
+        Tests that an array property with an explicit explode true Encoding
+        Object explodes its elements into repeated keys.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayExplodeForm'
+            encoding:
+              tags:
+                explode: true
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayExplodeForm'
+
+  /form/array-comma-element:
+    post:
+      operationId: postArrayCommaElementForm
+      tags:
+        - form
+      summary: Post a form body whose array element contains a comma
+      description: >-
+        Tests that an exploded array element containing a comma percent-encodes
+        the comma per exploded key.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayExplodeForm'
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayExplodeForm'
+
+  /form/array-composite:
+    post:
+      operationId: postArrayCompositeForm
+      tags:
+        - form
+      summary: Post an allOf form body whose member has an array property
+      description: >-
+        Tests that an allOf form body explodes an array property contributed by
+        a member schema, beside a scalar member property.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/ArrayCompositeForm'
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/ArrayCompositeForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -759,3 +907,54 @@ components:
     AllowReservedCompositeForm:
       allOf:
         - $ref: '#/components/schemas/ReservedBase'
+
+    ArrayBodyForm:
+      type: object
+      required:
+        - q
+        - tags
+      properties:
+        q:
+          type: string
+          description: Scalar property sent as a single entry
+        tags:
+          type: array
+          items:
+            type: string
+          description: Array property exploded into repeated keys
+
+    ArrayExplodeForm:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          description: Array property whose explode behavior is under test
+
+    ArrayCompositeBase:
+      type: object
+      required:
+        - label
+      properties:
+        label:
+          type: string
+          description: Scalar member property
+
+    ArrayCompositeTags:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          description: Array member property exploded into repeated keys
+
+    ArrayCompositeForm:
+      allOf:
+        - $ref: '#/components/schemas/ArrayCompositeBase'
+        - $ref: '#/components/schemas/ArrayCompositeTags'

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -662,6 +662,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/ArrayCompositeForm'
 
+  /form/optional-array:
+    post:
+      operationId: postOptionalArrayForm
+      tags:
+        - form
+      summary: Post a form body whose array property is optional and absent
+      description: >-
+        Tests that an optional simple-content array property left null is
+        omitted entirely from the body while a present scalar property still
+        serializes.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/OptionalArrayForm'
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/OptionalArrayForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -958,3 +982,17 @@ components:
       allOf:
         - $ref: '#/components/schemas/ArrayCompositeBase'
         - $ref: '#/components/schemas/ArrayCompositeTags'
+
+    OptionalArrayForm:
+      type: object
+      required:
+        - q
+      properties:
+        q:
+          type: string
+          description: Scalar property that is always present
+        tags:
+          type: array
+          items:
+            type: string
+          description: Optional array property omitted entirely when absent

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -68,10 +68,8 @@ BuiltExpression buildToFormValueExpression(
 /// Builds a `<String, FormFieldEncoding>` map literal for the object `toForm`
 /// call, keyed by raw spec name to match the class's own per-property lookup.
 ///
-/// Emits per-property `explode: true` for every writable simple-content array
-/// property whose effective explode is true, so the runtime serializes it as
-/// repeated keys, merged with `allowReserved` for any property that opts in.
-/// Returns null when no property needs either descriptor.
+/// Returns null when no property needs a descriptor, so the call omits the
+/// argument entirely.
 Expression? _fieldEncodingsLiteral(
   Model model,
   Map<Property, FieldEncoding>? encoding,
@@ -115,8 +113,8 @@ Expression? _fieldEncodingsLiteral(
   return literalMap(entries, refer('String', 'dart:core'), descriptor);
 }
 
-/// The OAS default explodes only `form`/absent style; `spaceDelimited` and
-/// `pipeDelimited` with explode omitted comma-join.
+/// With `explode` omitted, only `form`/absent style defaults to exploding;
+/// every other style comma-joins.
 bool _explodeDefault(FieldEncoding? encoding) =>
     encoding?.explode ??
     (encoding?.style == null || encoding?.style == EncodingStyle.form);

--- a/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_value_expression_generator.dart
@@ -51,7 +51,7 @@ BuiltExpression buildToFormValueExpression(
     explode: literalBool(explodeLiteral),
     allowEmpty: literalBool(allowEmptyLiteral),
     useQueryComponent: useQueryComponent ? literalBool(true) : null,
-    fieldEncodings: _fieldEncodingsLiteral(encoding),
+    fieldEncodings: _fieldEncodingsLiteral(model, encoding),
   );
 
   if (entries == null) {
@@ -66,29 +66,77 @@ BuiltExpression buildToFormValueExpression(
 }
 
 /// Builds a `<String, FormFieldEncoding>` map literal for the object `toForm`
-/// call, containing only the writable properties that opt into `allowReserved`.
-/// Keyed by raw spec name to match the class's own per-property lookup. Returns
-/// null when no property opts in so the call omits the argument.
+/// call, keyed by raw spec name to match the class's own per-property lookup.
+///
+/// Emits per-property `explode: true` for every writable simple-content array
+/// property whose effective explode is true, so the runtime serializes it as
+/// repeated keys, merged with `allowReserved` for any property that opts in.
+/// Returns null when no property needs either descriptor.
 Expression? _fieldEncodingsLiteral(
+  Model model,
   Map<Property, FieldEncoding>? encoding,
 ) {
-  if (encoding == null) return null;
+  final encodingByProperty = encoding ?? const {};
+  final encodingByName = <String, FieldEncoding>{
+    for (final entry in encodingByProperty.entries) entry.key.name: entry.value,
+  };
+
+  final properties = <Property>[
+    ..._collectFormProperties(model),
+    ...encodingByProperty.keys,
+  ];
 
   final descriptor = refer(
     'FormFieldEncoding',
     'package:tonik_util/tonik_util.dart',
   );
-  final reserved = <Expression, Expression>{
-    for (final entry in encoding.entries)
-      if (!entry.key.isReadOnly && entry.value.allowReserved)
-        specLiteralString(entry.key.name): descriptor.constInstance([], {
-          'allowReserved': literalBool(true),
-        }),
-  };
 
-  if (reserved.isEmpty) return null;
+  final entries = <Expression, Expression>{};
+  final seen = <String>{};
+  for (final property in properties) {
+    if (property.isReadOnly) continue;
+    if (!seen.add(property.name)) continue;
 
-  return literalMap(reserved, refer('String', 'dart:core'), descriptor);
+    final fieldEncoding = encodingByName[property.name];
+    final allowReserved = fieldEncoding?.allowReserved ?? false;
+    final explode =
+        _isSimpleContentList(property.model) && _explodeDefault(fieldEncoding);
+
+    if (!allowReserved && !explode) continue;
+
+    entries[specLiteralString(property.name)] = descriptor.constInstance([], {
+      if (allowReserved) 'allowReserved': literalBool(true),
+      if (explode) 'explode': literalBool(true),
+    });
+  }
+
+  if (entries.isEmpty) return null;
+
+  return literalMap(entries, refer('String', 'dart:core'), descriptor);
+}
+
+/// The OAS default explodes only `form`/absent style; `spaceDelimited` and
+/// `pipeDelimited` with explode omitted comma-join.
+bool _explodeDefault(FieldEncoding? encoding) =>
+    encoding?.explode ??
+    (encoding?.style == null || encoding?.style == EncodingStyle.form);
+
+List<Property> _collectFormProperties(Model model) {
+  switch (model.resolved) {
+    case final ClassModel m:
+      return m.properties;
+    case final AllOfModel m:
+      return [
+        for (final member in m.models) ..._collectFormProperties(member),
+      ];
+    default:
+      return const [];
+  }
+}
+
+bool _isSimpleContentList(Model model) {
+  final resolved = model.resolved;
+  return resolved is ListModel && resolved.hasSimpleContent;
 }
 
 Expression _entriesToBody(Expression entries) {

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1956,6 +1956,7 @@ void main() {
                     useQueryComponent: true,
                     fieldEncodings: <String, FormFieldEncoding>{
                       r'reserved': const FormFieldEncoding(allowReserved: true),
+                      r'tags': const FormFieldEncoding(explode: true),
                     },
                   )
                   .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -417,6 +417,102 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
+    test('ClassModel body omits explode for a pipeDelimited array property '
+        'with explode unset', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          tags: const FieldEncoding(
+            allowReserved: false,
+            style: EncodingStyle.pipeDelimited,
+            explode: null,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body omits explode for an array property with '
+        'composite content', () {
+      final item = ClassModel(
+        name: 'Item',
+        isDeprecated: false,
+        properties: const [],
+        context: context,
+        examples: const [],
+      );
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: item,
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
     test('ClassModel body omits explode for a scalar property', () {
       final name = Property(
         name: 'name',

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -213,8 +213,8 @@ void main() {
       expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
     });
 
-    test('ClassModel body threads a fieldEncodings map for a flagged array '
-        'property', () {
+    test('ClassModel body threads a merged allowReserved and explode '
+        'descriptor for a flagged array property', () {
       final tags = Property(
         name: 'tags',
         model: ListModel(
@@ -258,7 +258,304 @@ void main() {
                 allowEmpty: true,
                 useQueryComponent: true,
                 fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
-                  r'tags': const _i2.FormFieldEncoding(allowReserved: true),
+                  r'tags': const _i2.FormFieldEncoding(
+                    allowReserved: true,
+                    explode: true,
+                  ),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body emits explode true for an array property with no '
+        'spec encoding', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: true),
+                },
+              )
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body omits explode for an array property with explicit '
+        'explode false', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          tags: const FieldEncoding(
+            allowReserved: false,
+            style: EncodingStyle.form,
+            explode: false,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body omits explode for a spaceDelimited array property '
+        'with explode unset', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+        encoding: {
+          tags: const FieldEncoding(
+            allowReserved: false,
+            style: EncodingStyle.spaceDelimited,
+            explode: null,
+          ),
+        },
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body omits explode for a scalar property', () {
+      final name = Property(
+        name: 'name',
+        model: StringModel(context: context),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [name],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('ClassModel body excludes a read-only array property from explode '
+        'descriptors', () {
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isReadOnly: true,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        name: 'Form',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm('', explode: true, allowEmpty: true, useQueryComponent: true)
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''');
+
+      expect(collapseWhitespace(bodyOf(result)), collapseWhitespace(expected));
+    });
+
+    test('allOf body emits explode true for a member array property', () {
+      final label = Property(
+        name: 'label',
+        model: StringModel(context: context),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final tags = Property(
+        name: 'tags',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      final base = ClassModel(
+        name: 'Base',
+        isDeprecated: false,
+        properties: [label],
+        context: context,
+        examples: const [],
+      );
+      final tagged = ClassModel(
+        name: 'Tagged',
+        isDeprecated: false,
+        properties: [tags],
+        context: context,
+        examples: const [],
+      );
+      final model = AllOfModel(
+        name: 'Form',
+        models: {base, tagged},
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final result = buildToFormValueExpression(
+        'body',
+        model,
+        useQueryComponent: true,
+      );
+
+      final expected = format(r'''
+        test() {
+          body
+              .toForm(
+                '',
+                explode: true,
+                allowEmpty: true,
+                useQueryComponent: true,
+                fieldEncodings: <_i1.String, _i2.FormFieldEncoding>{
+                  r'tags': const _i2.FormFieldEncoding(explode: true),
                 },
               )
               .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -81,6 +81,14 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
         allowReserved: false,
       );
       final encoding = fieldEncodings[name];
+      final explodeArray = encoding?.explode ?? false;
+
+      // A null/absent array property is flattened to an empty scalar upstream;
+      // exploding it yields an empty list, so it drops out of the body.
+      if (entry.value case ScalarPropertyValue(value: '') when explodeArray) {
+        continue;
+      }
+
       // A present descriptor always carries a concrete allowReserved, so the
       // object-level value is only a fallback for properties without one.
       final valueAllowReserved = encoding?.allowReserved ?? allowReserved;
@@ -96,7 +104,7 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
             ),
           ));
         case ArrayPropertyValue(:final values):
-          if (encoding?.explode ?? false) {
+          if (explodeArray) {
             for (final element in values) {
               result.add((
                 name: encodedKey,

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -94,6 +94,31 @@ void main() {
         const <ParameterEntry>[(name: 'tags', value: '')],
       );
     });
+
+    test('omits an empty scalar flagged as an exploded array beside a '
+        'scalar', () {
+      expect(
+        <String, PropertyValue>{
+          'name': const PropertyValue.scalar('John'),
+          'numbers': const PropertyValue.scalar(''),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          fieldEncodings: const {'numbers': FormFieldEncoding(explode: true)},
+        ),
+        const <ParameterEntry>[(name: 'name', value: 'John')],
+      );
+    });
+
+    test('keeps an empty scalar with no explode descriptor', () {
+      expect(
+        <String, PropertyValue>{
+          'name': const PropertyValue.scalar(''),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'name', value: '')],
+      );
+    });
   });
 
   group('object-level explode=true comma inside element', () {


### PR DESCRIPTION
## What

Array properties of an object in an `application/x-www-form-urlencoded` request body were always comma-joined, so a body like `{q: "hello", tags: ["urgent", "open"]}` serialized to:

```
q=hello&tags=urgent,open
```

Per the OpenAPI **Encoding Object**, a form-body property defaults to `style: form, explode: true`, and RFC 6570 form expansion serializes an exploded array as **repeated keys**. The same body now serializes to:

```
q=hello&tags=urgent&tags=open
```

## How

The request-body call site emits a per-property `FormFieldEncoding(explode: ...)` descriptor for every writable simple-content array property, resolved with the style-aware OAS default:

- `explode` defaults **true** only for `form` (or absent) style.
- `spaceDelimited` / `pipeDelimited` with `explode` omitted resolve to **false** and comma-join (the runtime's only supported joining for those styles).
- An explicit `explode: false` in the spec keeps the comma-joined form.
- `explode: true` is emitted only for effective-true array properties, so generated output stays minimal for scalars and effective-false cases.
- `allowReserved` composes with explode: a flagged array keeps reserved characters literal per exploded element; an unflagged element percent-encodes them.
- allOf bodies explode member array properties.

An empty exploded array is omitted from the body entirely; a body of only empty exploded arrays serializes to an empty body.

## Wire behavior (before → after)

| Case | Before | After |
|---|---|---|
| Array property, default encoding | `q=hello&tags=urgent,open` | `q=hello&tags=urgent&tags=open` |
| Explicit `explode: false` | `tags=a,b` | `tags=a,b` (unchanged) |
| `spaceDelimited`, explode omitted | `tags=a,b` | `tags=a,b` (unchanged) |
| allOf member array | `label=hello&tags=x,y` | `label=hello&tags=x&tags=y` |
| Comma inside element (unflagged) | `tags=a%2Cb,c` | `tags=a%2Cb&tags=c` |
| Empty array | `colors=` | omitted |

Query-object parameters, cookies, and oneOf/anyOf form bodies are unchanged.

## Notes

This is a breaking wire change (`fix!`) for consumers that relied on the previous comma-joined output for form-body array properties. Delimited-style array joining is documented as a known limitation.
