### PR TITLE
Handle root JSON string request bodies

### DIFF
--- a/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
+++ b/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
@@ -41,7 +41,7 @@ packages:
     source: hosted
     version: "2.13.1"
   big_decimal:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: big_decimal
       sha256: "6413818091e80c907bb73bae383418db5c148fd7fd283e56197bfeeeb212d5bd"

--- a/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
+++ b/integration_test/adversarial_strings/adversarial_strings_test/pubspec.lock
@@ -97,7 +97,7 @@ packages:
     source: hosted
     version: "3.0.7"
   dio:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: dio
       sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c

--- a/integration_test/adversarial_strings/adversarial_strings_test/pubspec.yaml
+++ b/integration_test/adversarial_strings/adversarial_strings_test/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   adversarial_strings_api:
     path: ../adversarial_strings_api
+  dio: ^5.8.0+1
   tonik_util: ^0.1.0
 
 dev_dependencies:

--- a/integration_test/adversarial_strings/adversarial_strings_test/pubspec.yaml
+++ b/integration_test/adversarial_strings/adversarial_strings_test/pubspec.yaml
@@ -11,6 +11,7 @@ environment:
 dependencies:
   adversarial_strings_api:
     path: ../adversarial_strings_api
+  big_decimal: ^0.7.0
   dio: ^5.8.0+1
   tonik_util: ^0.1.0
 

--- a/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
@@ -286,7 +286,7 @@ void main() {
 
       await SendRootAlias(dio).call(body: 'alias-body');
 
-      expect(adapter.capturedBodyAsString, jsonEncode('alias-body'));
+      expect(adapter.capturedBodyAsString, '"alias-body"');
       expect(jsonDecode(adapter.capturedBodyAsString), 'alias-body');
     });
 
@@ -298,7 +298,7 @@ void main() {
         body: const RootStringOneOfString('one-of-body'),
       );
 
-      expect(adapter.capturedBodyAsString, jsonEncode('one-of-body'));
+      expect(adapter.capturedBodyAsString, '"one-of-body"');
       expect(jsonDecode(adapter.capturedBodyAsString), 'one-of-body');
     });
 
@@ -310,7 +310,7 @@ void main() {
         body: const RootStringAnyOf(string: 'any-of-body'),
       );
 
-      expect(adapter.capturedBodyAsString, jsonEncode('any-of-body'));
+      expect(adapter.capturedBodyAsString, '"any-of-body"');
       expect(jsonDecode(adapter.capturedBodyAsString), 'any-of-body');
     });
   });

--- a/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
@@ -3,6 +3,7 @@ import 'dart:convert';
 import 'dart:typed_data';
 
 import 'package:adversarial_strings_api/adversarial_strings_api.dart';
+import 'package:big_decimal/big_decimal.dart';
 import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
@@ -302,6 +303,30 @@ void main() {
       expect(jsonDecode(adapter.capturedBodyAsString), 'one-of-body');
     });
 
+    test('oneOf integer variant is sent as a JSON number', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootOneOf(dio).call(
+        body: const RootStringOneOfInt(7),
+      );
+
+      expect(adapter.capturedBodyAsString, '7');
+      expect(jsonDecode(adapter.capturedBodyAsString), 7);
+    });
+
+    test('oneOf bool variant is sent as a JSON boolean', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootOneOf(dio).call(
+        body: const RootStringOneOfBool(true),
+      );
+
+      expect(adapter.capturedBodyAsString, 'true');
+      expect(jsonDecode(adapter.capturedBodyAsString), isTrue);
+    });
+
     test('anyOf string variant is sent as a quoted JSON string', () async {
       final adapter = _CapturingAdapter();
       final dio = _capturingDio(adapter);
@@ -312,6 +337,30 @@ void main() {
 
       expect(adapter.capturedBodyAsString, '"any-of-body"');
       expect(jsonDecode(adapter.capturedBodyAsString), 'any-of-body');
+    });
+
+    test('anyOf bool variant is sent as a JSON boolean', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootAnyOf(dio).call(
+        body: const RootStringAnyOf(bool: true),
+      );
+
+      expect(adapter.capturedBodyAsString, 'true');
+      expect(jsonDecode(adapter.capturedBodyAsString), isTrue);
+    });
+
+    test('oneOf decimal variant is sent as a quoted JSON string', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootDecimalOneOf(dio).call(
+        body: RootDecimalOneOfDecimal(BigDecimal.parse('12.34')),
+      );
+
+      expect(adapter.capturedBodyAsString, '"12.34"');
+      expect(jsonDecode(adapter.capturedBodyAsString), '12.34');
     });
   });
 

--- a/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/adversarial_strings_test.dart
@@ -1,4 +1,9 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:typed_data';
+
 import 'package:adversarial_strings_api/adversarial_strings_api.dart';
+import 'package:dio/dio.dart';
 import 'package:test/test.dart';
 
 void main() {
@@ -274,6 +279,42 @@ void main() {
     });
   });
 
+  group('root JSON string request bodies', () {
+    test('alias body is sent as a quoted JSON string', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootAlias(dio).call(body: 'alias-body');
+
+      expect(adapter.capturedBodyAsString, jsonEncode('alias-body'));
+      expect(jsonDecode(adapter.capturedBodyAsString), 'alias-body');
+    });
+
+    test('oneOf string variant is sent as a quoted JSON string', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootOneOf(dio).call(
+        body: const RootStringOneOfString('one-of-body'),
+      );
+
+      expect(adapter.capturedBodyAsString, jsonEncode('one-of-body'));
+      expect(jsonDecode(adapter.capturedBodyAsString), 'one-of-body');
+    });
+
+    test('anyOf string variant is sent as a quoted JSON string', () async {
+      final adapter = _CapturingAdapter();
+      final dio = _capturingDio(adapter);
+
+      await SendRootAnyOf(dio).call(
+        body: const RootStringAnyOf(string: 'any-of-body'),
+      );
+
+      expect(adapter.capturedBodyAsString, jsonEncode('any-of-body'));
+      expect(jsonDecode(adapter.capturedBodyAsString), 'any-of-body');
+    });
+  });
+
   group('object with quoted property name', () {
     test('toJson uses quoted property key', () {
       const obj = ObjectWithQuotedProp(id: 'x');
@@ -294,4 +335,32 @@ void main() {
       expect(reconstructed.id, 'round-trip');
     });
   });
+}
+
+Dio _capturingDio(_CapturingAdapter adapter) {
+  return Dio(BaseOptions(baseUrl: 'https://example.com'))
+    ..httpClientAdapter = adapter;
+}
+
+class _CapturingAdapter implements HttpClientAdapter {
+  List<int>? capturedBody;
+
+  String get capturedBodyAsString => utf8.decode(capturedBody!);
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    final chunks = requestStream == null
+        ? const <Uint8List>[]
+        : await requestStream.toList();
+    capturedBody = chunks.expand((chunk) => chunk).toList();
+
+    return ResponseBody.fromString('', 204);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -185,8 +185,69 @@ paths:
         '200':
           description: OK
 
+  /json-root-alias:
+    post:
+      operationId: sendRootAlias
+      tags:
+        - adversarial
+      summary: JSON string alias request body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RootStringAlias'
+      responses:
+        '204':
+          description: Stored
+
+  /json-root-one-of:
+    post:
+      operationId: sendRootOneOf
+      tags:
+        - adversarial
+      summary: JSON string oneOf request body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RootStringOneOf'
+      responses:
+        '204':
+          description: Stored
+
+  /json-root-any-of:
+    post:
+      operationId: sendRootAnyOf
+      tags:
+        - adversarial
+      summary: JSON string anyOf request body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RootStringAnyOf'
+      responses:
+        '204':
+          description: Stored
+
 components:
   schemas:
+    RootStringAlias:
+      type: string
+
+    RootStringOneOf:
+      oneOf:
+        - type: string
+        - type: integer
+
+    RootStringAnyOf:
+      anyOf:
+        - type: string
+        - type: boolean
+
     BasicObject:
       type: object
       required:

--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -233,6 +233,22 @@ paths:
         '204':
           description: Stored
 
+  /json-root-decimal-one-of:
+    post:
+      operationId: sendRootDecimalOneOf
+      tags:
+        - adversarial
+      summary: JSON decimal oneOf request body
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RootDecimalOneOf'
+      responses:
+        '204':
+          description: Stored
+
 components:
   schemas:
     RootStringAlias:
@@ -242,11 +258,18 @@ components:
       oneOf:
         - type: string
         - type: integer
+        - type: boolean
 
     RootStringAnyOf:
       anyOf:
         - type: string
         - type: boolean
+
+    RootDecimalOneOf:
+      oneOf:
+        - type: string
+          format: decimal
+        - type: integer
 
     BasicObject:
       type: object

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -120,7 +120,7 @@ class DataGenerator {
             inlineHelpers.addAll(jsonBuilt.inlineFunctions);
             switchCases
               ..add(const Code(' value => '))
-              ..add(jsonBuilt.unsafeRawBody.code)
+              ..add(_jsonRequestBodyExpression(jsonBuilt, c.model).code)
               ..add(const Code(','));
           case .form:
             switchCases
@@ -260,9 +260,20 @@ class DataGenerator {
               ..add(const Code(';'));
         }
       case ContentType.json:
+        final encodesJsonRoot = _encodesJsonRoot(model);
         final jsonBuilt = buildToJsonPropertyExpression(
           'body',
-          property,
+          encodesJsonRoot && !isRequired
+              ? Property(
+                  name: 'body',
+                  model: model,
+                  isRequired: true,
+                  isNullable: false,
+                  isDeprecated: false,
+                  defaultValue: null,
+                  examples: const [],
+                )
+              : property,
           nameManager: nameManager,
           package: package,
           helperContext: helperContext,
@@ -270,8 +281,11 @@ class DataGenerator {
           contextProperty: 'body',
         );
         inlineHelpers.addAll(jsonBuilt.inlineFunctions);
+        if (encodesJsonRoot && !isRequired) {
+          bodyCode.insert(0, const Code('if (body == null) return null;\n'));
+        }
         bodyCode
-          ..add(jsonBuilt.unsafeRawBody.code)
+          ..add(_jsonRequestBodyExpression(jsonBuilt, model).code)
           ..add(const Code(';'));
       case ContentType.form:
         final formExpr = buildToFormValueExpression(
@@ -354,4 +368,27 @@ class DataGenerator {
         ]),
     );
   }
+}
+
+Expression _jsonRequestBodyExpression(BuiltExpression built, Model model) {
+  final expression = built.unsafeRawBody;
+  if (!_encodesJsonRoot(model)) return expression;
+  return refer('jsonEncode', 'dart:convert').call([expression]);
+}
+
+bool _encodesJsonRoot(Model model) {
+  final resolved = model.resolved;
+  return switch (resolved) {
+    StringModel() ||
+    DateTimeModel() ||
+    DateModel() ||
+    DecimalModel() ||
+    UriModel() ||
+    BinaryModel() ||
+    Base64Model() ||
+    EnumModel<String>() ||
+    AnyModel() => true,
+    final CompositeModel m => m.containedModels.any(_encodesJsonRoot),
+    _ => false,
+  };
 }

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -176,6 +176,59 @@ void main() {
       );
     });
 
+    test('JSON encodes string scalar in multi-content request body', () {
+      final operation = Operation(
+        operationId: 'testOp',
+        path: '/test',
+        method: HttpMethod.post,
+        requestBody: RequestBodyObject(
+          name: 'test',
+          context: testContext,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: StringModel(context: testContext),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+            RequestContent(
+              model: StringModel(context: testContext),
+              contentType: ContentType.text,
+              rawContentType: 'text/plain',
+              examples: const [],
+            ),
+          },
+        ),
+        responses: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        queryParameters: const {},
+        headers: const {},
+        context: testContext,
+        tags: const {},
+        isDeprecated: false,
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+        Object? _data({required Test body}) {
+          return switch (body) {
+            final TestJson value => jsonEncode(value.value),
+            final TestPlain value => value.value,
+          };
+        }
+      ''';
+
+      final method = generator.generateDataMethod(operation);
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
     test(
       'handles single-content JSON with a recursive named MapModel body',
       () {
@@ -323,7 +376,7 @@ void main() {
       },
     );
 
-    test('handles primitive model in request body', () {
+    test('JSON encodes primitive string model in request body', () {
       final operation = Operation(
         operationId: 'testOp',
         path: '/test',
@@ -355,7 +408,156 @@ void main() {
 
       const expectedMethod = '''
         Object? _data({required String body}) {
-          return body;
+          return jsonEncode(body);
+        }
+      ''';
+
+      final method = generator.generateDataMethod(operation);
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('JSON encodes optional primitive string request body', () {
+      final operation = Operation(
+        operationId: 'testOp',
+        path: '/test',
+        method: HttpMethod.post,
+        requestBody: RequestBodyObject(
+          name: 'test',
+          context: testContext,
+          description: null,
+          isRequired: false,
+          content: {
+            RequestContent(
+              model: StringModel(context: testContext),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+          },
+        ),
+        responses: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        queryParameters: const {},
+        headers: const {},
+        context: testContext,
+        tags: const {},
+        isDeprecated: false,
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+        Object? _data({String? body}) {
+          if (body == null) return null;
+          return jsonEncode(body);
+        }
+      ''';
+
+      final method = generator.generateDataMethod(operation);
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('JSON encodes string alias model in request body', () {
+      final operation = Operation(
+        operationId: 'testOp',
+        path: '/test',
+        method: HttpMethod.post,
+        requestBody: RequestBodyObject(
+          name: 'test',
+          context: testContext,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: AliasModel(
+                name: 'UserId',
+                model: StringModel(context: testContext),
+                context: testContext,
+                examples: const [],
+                defaultValue: null,
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+          },
+        ),
+        responses: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        queryParameters: const {},
+        headers: const {},
+        context: testContext,
+        tags: const {},
+        isDeprecated: false,
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+        Object? _data({required UserId body}) {
+          return jsonEncode(body);
+        }
+      ''';
+
+      final method = generator.generateDataMethod(operation);
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('JSON encodes string enum model in request body', () {
+      final operation = Operation(
+        operationId: 'testOp',
+        path: '/test',
+        method: HttpMethod.post,
+        requestBody: RequestBodyObject(
+          name: 'test',
+          context: testContext,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: EnumModel<String>(
+                name: 'Status',
+                values: {
+                  const EnumEntry(value: 'active'),
+                  const EnumEntry(value: 'inactive'),
+                },
+                isNullable: false,
+                isDeprecated: false,
+                context: testContext,
+                examples: const [],
+              ),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+          },
+        ),
+        responses: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        queryParameters: const {},
+        headers: const {},
+        context: testContext,
+        tags: const {},
+        isDeprecated: false,
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = '''
+        Object? _data({required Status body}) {
+          return jsonEncode(body.toJson());
         }
       ''';
 
@@ -399,7 +601,8 @@ void main() {
 
       const expectedMethod = '''
         Object? _data({Date? body}) {
-          return body?.toJson();
+          if (body == null) return null;
+          return jsonEncode(body.toJson());
         }
       ''';
 
@@ -443,7 +646,8 @@ void main() {
 
       const expectedMethod = '''
         Object? _data({BigDecimal? body}) {
-          return body?.toString();
+          if (body == null) return null;
+          return jsonEncode(body.toString());
         }
       ''';
 
@@ -505,7 +709,7 @@ void main() {
         Object? _data({required Test body}) {
           return switch (body) {
             final TestJson value => value.value,
-            final TestJsonProblem value => value.value.toJson(),
+            final TestJsonProblem value => jsonEncode(value.value.toJson()),
           };
         }
       ''';

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -2587,6 +2587,8 @@ Future<TonikResult<void>> call({
 
         final result = generator.generateCallableOperation(operation);
         final code = result.code;
+        expect(code, contains("import 'dart:convert' as"));
+        expect(code, contains('.jsonEncode(body);'));
         expect(
           code,
           contains(

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -2587,8 +2587,6 @@ Future<TonikResult<void>> call({
 
         final result = generator.generateCallableOperation(operation);
         final code = result.code;
-        expect(code, contains("import 'dart:convert' as"));
-        expect(code, contains('.jsonEncode(body);'));
         expect(
           code,
           contains(


### PR DESCRIPTION
## Summary
- Encode root JSON string-like request bodies with `jsonEncode` so aliases, enums, `oneOf`, and `anyOf` variants are sent as quoted JSON strings.
- Cover required and optional primitive string request bodies in generator tests.
- Add adversarial integration coverage for alias, `oneOf`, and `anyOf` JSON string payloads.

## Testing
- Unit tests added for data generation and callable operation output.
- Integration tests added to verify captured request bodies are valid quoted JSON strings.