### PR TITLE
fix!: single-encode composite list elements in object properties

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -273,6 +273,16 @@ switch (path) {
         }
         break
 
+    case '/form/composite-list':
+        def requestBody = context.request.body
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withHeader 'x-raw-request-body', requestBody
+            withContent 'tags=a%2Cb&tags=7'
+        }
+        break
+
     case '/custom/form':
         def formBody = 'field1=custom+value&field2=100'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -402,6 +402,25 @@ void main() {
           .data;
       expect(requestData, 'tags=');
     });
+
+    test('single-encodes a reserved char in a composite array elem', () async {
+      const form = CompositeListForm(
+        tags: [
+          CompositeListFormTagsArrayOneOfModelString('a,b'),
+          CompositeListFormTagsArrayOneOfModelInt(7),
+        ],
+      );
+
+      final response = await api.postCompositeListForm(body: form);
+
+      expect(response, isA<TonikSuccess<CompositeListForm>>());
+
+      final requestData = (response as TonikSuccess<CompositeListForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, 'tags=a%2Cb&tags=7');
+    });
   });
 
   group('Type conversions', () {

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -686,6 +686,30 @@ paths:
               schema:
                 $ref: '#/components/schemas/OptionalArrayForm'
 
+  /form/composite-list:
+    post:
+      operationId: postCompositeListForm
+      tags:
+        - form
+      summary: Post a form body with an array-of-oneOf property
+      description: >-
+        Tests that a property typed as an array of a simple composite
+        (oneOf of scalars) single-encodes each element on the wire, so a
+        reserved character in an element renders once, not double-encoded.
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              $ref: '#/components/schemas/CompositeListForm'
+      responses:
+        '200':
+          description: Echo response with exact request body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/CompositeListForm'
+
   /custom/form:
     post:
       operationId: postCustomForm
@@ -996,3 +1020,18 @@ components:
           items:
             type: string
           description: Optional array property omitted entirely when absent
+
+    CompositeListForm:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer
+          description: >-
+            Array of a simple composite whose elements single-encode on the
+            wire

--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -368,6 +368,27 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  /label/object/composite-list/{value}:
+    get:
+      operationId: testLabelObjectCompositeList
+      tags: [label]
+      summary: Label-style object with a composite-list property (explode=false)
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: label
+          explode: false
+          schema:
+            $ref: '#/components/schemas/CompositeListObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
   /label/special-keys/{value}:
     get:
       operationId: testLabelSpecialKeys
@@ -1610,6 +1631,16 @@ components:
           type: string
         count:
           type: integer
+
+    CompositeListObject:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            $ref: '#/components/schemas/OneOfPrimitive'
 
     ComplexObject:
       type: object

--- a/integration_test/path_encoding/path_encoding_test/test/label_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/label_test.dart
@@ -195,6 +195,28 @@ void main() {
         '/v1/label/object/explode/.name=test.count=5',
       );
     });
+
+    test(
+      'composite-list property comma-joins elements and escapes reserved '
+      'characters once',
+      () async {
+        final api = buildLabelApi();
+        final response = await api.testLabelObjectCompositeList(
+          value: const CompositeListObject(
+            tags: [OneOfPrimitiveString('a,b'), OneOfPrimitiveInt(7)],
+          ),
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/label/object/composite-list/.tags,a%2Cb,7',
+        );
+      },
+    );
   });
 
   group('Label style - Combined', () {

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -200,10 +200,16 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/PriorityEnum'
+        - name: simpleCompositeList
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/SimpleCompositeListClass'
       responses:
         '204':
           description: OK
-  
+
   /form-complex-explode:
     get:
       operationId: testFormComplexExplode
@@ -1866,3 +1872,14 @@ components:
           type: string
         nested:
           $ref: '#/components/schemas/ClassNested'
+    SimpleCompositeListClass:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            oneOf:
+              - type: string
+              - type: integer

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -284,6 +284,26 @@ void main() {
         'allOfComplex=name,test,age,1,value,test,amount,1',
       );
     });
+
+    test('simpleCompositeList single-encodes a reserved char in a composite '
+        'array element', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormComplex(
+        simpleCompositeList: const SimpleCompositeListClass(
+          tags: [
+            SimpleCompositeListClassTagsArrayOneOfModelString('a,b'),
+            SimpleCompositeListClassTagsArrayOneOfModelInt(7),
+          ],
+        ),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'simpleCompositeList=tags,a%2Cb,7',
+      );
+    });
   });
 
   group('complex - explode true', () {

--- a/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/property_value_expression_generator.dart
@@ -30,12 +30,11 @@ Expression additionalPropertyRawScalar(Expression value, Model valueModel) {
 /// Builds a `List<String>` of per-element strings for a simple-content list
 /// whose element type is [contentModel].
 ///
-/// For scalar content these are raw (unescaped): the traversal mirrors the
-/// URI-encode list handling minus the per-element percent-encoding, so element
-/// boundaries reach the form encoder intact (`.unlock` for immutable
-/// collections, a null-element to `''` guard for nullable content). Composite
-/// content is instead pre-encoded here, so it is double-encoded once the form
-/// encoder runs.
+/// Both scalar and composite content are raw (unescaped): the traversal mirrors
+/// the URI-encode list handling minus the per-element percent-encoding, so
+/// element boundaries reach the form encoder intact (`.unlock` for immutable
+/// collections, a null-element to `''` guard for nullable content). The late
+/// style/form encoder does the single percent-encode.
 Expression buildRawStringListExpression(
   Expression valueExpression,
   Model contentModel, {
@@ -80,13 +79,11 @@ Expression buildRawStringListExpression(
     EnumModel() => mapToRaw(
       nullGuard(buildRawStringExpression(refer('e'), contentModel)),
     ),
-    // Elements are percent-encoded here, then again by the form encoder, so
-    // composite content stays double-encoded on the wire as it was before.
     AnyModel() || AnyOfModel() || OneOfModel() || AllOfModel() => mapToRaw(
       nullGuard(
-        refer('encodeAnyToUri', _tonikUtilUrl).call(
+        refer('encodeAnyValueToString', _tonikUtilUrl).call(
           [
-            refer('e'),
+            refer('e').property('toJson').call([]),
           ],
           {'allowEmpty': refer('allowEmpty')},
         ),

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -1080,8 +1080,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
     );
 
     test(
-      'generates parameterProperties for list of composite content that is '
-      'double-encoded (legacy behavior preserved)',
+      'generates parameterProperties for a list of composite content as raw '
+      'elements',
       () {
         final oneOfModel = OneOfModel(
           isDeprecated: false,
@@ -1120,7 +1120,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
         final classCode = format(result.accept(emitter).toString());
 
         const expectedMethod = r'''
-Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (items != null) { _$result[r'items'] = PropertyValue.array( items!.map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty)).toList(), ); } else if (allowEmpty) { _$result[r'items'] = PropertyValue.scalar(''); } return _$result; }
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; if (items != null) { _$result[r'items'] = PropertyValue.array( items! .map( (e) => encodeAnyValueToString(e.toJson(), allowEmpty: allowEmpty), ) .toList(), ); } else if (allowEmpty) { _$result[r'items'] = PropertyValue.scalar(''); } return _$result; }
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/util/property_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/property_value_expression_generator_test.dart
@@ -101,8 +101,7 @@ void main() {
       );
     });
 
-    test('composite content is double-encoded (legacy behavior '
-        'preserved)', () {
+    test('composite content maps each element to its raw string', () {
       expectListEmission(
         OneOfModel(
           isDeprecated: false,
@@ -115,13 +114,12 @@ void main() {
           examples: const [],
         ),
         'myValue.map((e) => '
-        'encodeAnyToUri(e, allowEmpty: allowEmpty)).toList()',
+        'encodeAnyValueToString(e.toJson(), allowEmpty: allowEmpty)).toList()',
         isContentNullable: false,
       );
     });
 
-    test('content-nullable composite guards null elements and double-encodes '
-        'the rest', () {
+    test('content-nullable composite guards null elements to empty string', () {
       expectListEmission(
         OneOfModel(
           isDeprecated: false,
@@ -134,7 +132,7 @@ void main() {
           examples: const [],
         ),
         "myValue.map((e) => e == null ? '' : "
-        'encodeAnyToUri(e, allowEmpty: allowEmpty)).toList()',
+        'encodeAnyValueToString(e.toJson(), allowEmpty: allowEmpty)).toList()',
         isContentNullable: true,
       );
     });


### PR DESCRIPTION
## What

An object property typed as an array whose element type is a simple-shaped composition — an `array` of `oneOf`/`anyOf`/`allOf` of scalars — was percent-encoded **twice** on the wire: once per element when the property map was built, and again by the late form/style encoder. A reserved character such as a comma rendered as `%252C` instead of `%2C`.

Scalar-element arrays were already correct (single-encoded); only the composite-element arm double-encoded. No integration schema exercised a list-of-simple-composite object property, so the bug was latent.

## How

The composite arm of the per-element list builder now emits each element **raw** — the same discipline the scalar arm already uses — so the style/form encoder performs the single, correct percent-encode. A null-element guard is kept around the raw expression (the raw conversion is a fresh null surface). AnyModel list content is emitted raw on the same path.

The query/path parameter encoding path is untouched — its trailing per-element encode is the terminal single encode there and is unaffected.

## Wire behavior (before → after)

For an object property `tags` typed `array` of `oneOf: [string, integer]` with an element containing a comma:

| | Before | After |
|---|---|---|
| Form body | `tags=a%252Cb&tags=7` | `tags=a%2Cb&tags=7` |
| Query object (form style) | `simpleCompositeList=tags,a%252Cb,7` | `simpleCompositeList=tags,a%2Cb,7` |

## Notes

This is a breaking wire change (`fix!`) only for the previously-double-encoded composite-list case, which was a bug — no correct consumer relied on the doubled encoding. Single-encoding matches the scalar-list branch and the four array-serializing styles (form/simple/label/matrix); deepObject still rejects arrays as before.
