### PR TITLE
feat!: transmit HTTP header field-values literally

### DIFF
--- a/integration_test/composition/composition_test/test/all_of_test.dart
+++ b/integration_test/composition/composition_test/test/all_of_test.dart
@@ -62,7 +62,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfPrimitive.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -72,7 +76,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfPrimitive.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -163,10 +171,16 @@ void main() {
       );
     });
 
-    test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
-      final reconstructed = AllOfPrimitive.fromSimple(simple, explode: true);
-      expect(reconstructed, allOf);
+    test('literal simple explode true is not round-trippable', () {
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
+      expect(
+        () => AllOfPrimitive.fromSimple(simple, explode: true),
+        throwsA(isA<InvalidFormatException>()),
+      );
     });
 
     test('toSimple - explode false', () {
@@ -177,7 +191,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfPrimitive.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -275,7 +293,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfComplex.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -288,7 +310,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfComplex.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -386,7 +412,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfComplex.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -399,7 +429,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfComplex.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -497,7 +531,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfEnum.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -510,7 +548,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfEnum.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -666,7 +708,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = NestedAllOfInAllOf.fromSimple(
         simple,
         explode: true,
@@ -682,7 +728,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = NestedAllOfInAllOf.fromSimple(
         simple,
         explode: false,
@@ -888,7 +938,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = TwoLevelAllOf.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -901,7 +955,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = TwoLevelAllOf.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -1016,7 +1074,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = ThreeLevelAllOf.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -1029,7 +1091,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = ThreeLevelAllOf.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -1570,7 +1636,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = allOf.toSimple(explode: true, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix.fromSimple(
           simple,
           explode: true,
@@ -1586,7 +1656,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = allOf.toSimple(explode: false, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix.fromSimple(
           simple,
           explode: false,
@@ -1747,7 +1821,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = allOf.toSimple(explode: true, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = MultiLevelNesting.fromSimple(
           simple,
           explode: true,
@@ -1763,7 +1841,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = allOf.toSimple(explode: false, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = MultiLevelNesting.fromSimple(
           simple,
           explode: false,
@@ -1981,7 +2063,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfWithSimpleList.fromSimple(
         simple,
         explode: true,
@@ -1997,7 +2083,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       expect(
         () => AllOfWithSimpleList.fromSimple(simple, explode: false),
         throwsA(isA<InvalidTypeException>()),
@@ -2186,7 +2276,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfWithEnumList.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -2199,7 +2293,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       expect(
         () => AllOfWithEnumList.fromSimple(simple, explode: false),
         throwsA(isA<InvalidTypeException>()),
@@ -2397,7 +2495,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = allOf.toSimple(explode: true, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         expect(
           () => ComplexListComposition.fromSimple(simple, explode: false),
           throwsA(isA<DecodingException>()),
@@ -2416,7 +2518,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = allOf.toSimple(explode: false, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         expect(
           () => ComplexListComposition.fromSimple(simple, explode: false),
           throwsA(isA<DecodingException>()),
@@ -2745,7 +2851,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfDoubleList.fromSimple(simple, explode: true);
       expect(reconstructed, allOf);
     });
@@ -2758,7 +2868,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfDoubleList.fromSimple(simple, explode: false);
       expect(reconstructed, allOf);
     });
@@ -2861,7 +2975,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = allOf.toSimple(explode: true, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AllOfOneOfDoubleList.fromSimple(
           simple,
           explode: true,
@@ -2877,7 +2995,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = allOf.toSimple(explode: false, allowEmpty: true);
+        final simple = allOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AllOfOneOfDoubleList.fromSimple(
           simple,
           explode: false,
@@ -3026,7 +3148,11 @@ void main() {
     });
 
     test('simple roundtrip - explode true', () {
-      final simple = allOf.toSimple(explode: true, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: true,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfDirectPrimitive.fromSimple(
         simple,
         explode: true,
@@ -3039,7 +3165,11 @@ void main() {
     });
 
     test('simple roundtrip - explode false', () {
-      final simple = allOf.toSimple(explode: false, allowEmpty: true);
+      final simple = allOf.toSimple(
+        explode: false,
+        allowEmpty: true,
+        literal: true,
+      );
       final reconstructed = AllOfDirectPrimitive.fromSimple(
         simple,
         explode: false,

--- a/integration_test/composition/composition_test/test/any_of_test.dart
+++ b/integration_test/composition/composition_test/test/any_of_test.dart
@@ -60,7 +60,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -70,7 +74,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -159,7 +167,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -172,7 +184,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -284,7 +300,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: true);
         // After simple roundtrip, both int and string fields are set because
         // "42" can be decoded as both an integer and a string.
@@ -298,7 +318,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: false);
         // After simple roundtrip, both int and string fields are set because
         // "42" can be decoded as both an integer and a string.
@@ -411,7 +435,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: true);
         // After simple roundtrip, both bool and string fields are set because
         // "true" can be decoded as both a boolean and a string.
@@ -425,7 +453,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfPrimitive.fromSimple(simple, explode: false);
         // After simple roundtrip, both bool and string fields are set because
         // "true" can be decoded as both a boolean and a string.
@@ -571,7 +603,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -581,7 +617,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -667,7 +707,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -677,7 +721,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -769,7 +817,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -782,7 +834,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfComplex.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -876,7 +932,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfEnum.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -886,7 +946,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfEnum.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -972,7 +1036,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfEnum.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -982,7 +1050,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfEnum.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1121,7 +1193,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -1131,7 +1207,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1217,7 +1297,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -1227,7 +1311,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1315,7 +1403,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -1325,7 +1417,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfMixed.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -1473,7 +1569,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAnyOfInAllOf.fromSimple(
           simple,
           explode: true,
@@ -1489,7 +1589,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAnyOfInAllOf.fromSimple(
           simple,
           explode: false,
@@ -1590,7 +1694,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAnyOfInAllOf.fromSimple(
           simple,
           explode: true,
@@ -1606,7 +1714,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAnyOfInAllOf.fromSimple(
           simple,
           explode: false,
@@ -1789,7 +1901,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAllOfInAnyOf.fromSimple(
           simple,
           explode: true,
@@ -1818,7 +1934,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedAllOfInAnyOf.fromSimple(
           simple,
           explode: false,
@@ -1927,7 +2047,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedOneOfInAnyOf.fromSimple(
           simple,
           explode: true,
@@ -1940,7 +2064,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedOneOfInAnyOf.fromSimple(
           simple,
           explode: false,
@@ -2029,7 +2157,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedOneOfInAnyOf.fromSimple(
           simple,
           explode: true,
@@ -2042,7 +2174,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedOneOfInAnyOf.fromSimple(
           simple,
           explode: false,
@@ -2187,7 +2323,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -2197,7 +2337,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: false);
         expect(reconstructed, anyOf);
       });
@@ -2305,7 +2449,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: true);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2325,7 +2473,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: false);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2439,7 +2591,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: true);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2457,7 +2613,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelAnyOf.fromSimple(simple, explode: false);
         // Both twoLevelAnyOfModel and string are set because any string
         // can be decoded to String.
@@ -2553,7 +2713,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -2563,7 +2727,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(
           simple,
           explode: false,
@@ -2678,7 +2846,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(simple, explode: true);
         // Both threeLevelAnyOfModel and string are set because any
         // string can be decoded to String.
@@ -2696,7 +2868,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(
           simple,
           explode: false,
@@ -2823,7 +2999,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(simple, explode: true);
         // Both threeLevelAnyOfModel and string are set because any
         // string can be decoded to String.
@@ -2845,7 +3025,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ThreeLevelAnyOf.fromSimple(
           simple,
           explode: false,
@@ -2984,7 +3168,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = DeepNestedAnyOf.fromSimple(simple, explode: true);
         // Both nestedAnyOfInAnyOf and enum1 are set because
         // NestedAnyOfInAnyOf.anyOfPrimitive contains a String variant.
@@ -3006,7 +3194,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = DeepNestedAnyOf.fromSimple(
           simple,
           explode: false,
@@ -3111,7 +3303,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = DeepNestedAnyOf.fromSimple(simple, explode: true);
         expect(reconstructed, anyOf);
       });
@@ -3121,7 +3317,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = DeepNestedAnyOf.fromSimple(
           simple,
           explode: false,
@@ -3222,7 +3422,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromSimple(
           simple,
           explode: true,
@@ -3235,7 +3439,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromSimple(
           simple,
           explode: false,
@@ -3334,7 +3542,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromSimple(
           simple,
           explode: true,
@@ -3347,7 +3559,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedAnyOfOneOf.fromSimple(
           simple,
           explode: false,
@@ -3440,7 +3656,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithSimpleList.fromSimple(
           simple,
           explode: true,
@@ -3461,7 +3681,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithSimpleList.fromSimple(
           simple,
           explode: false,
@@ -3562,7 +3786,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithSimpleList.fromSimple(
           simple,
           explode: true,
@@ -3585,7 +3813,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithSimpleList.fromSimple(
           simple,
           explode: false,
@@ -3896,7 +4128,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithComplexList.fromSimple(
           simple,
           explode: true,
@@ -3909,7 +4145,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithComplexList.fromSimple(
           simple,
           explode: false,
@@ -4052,7 +4292,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithMixedLists.fromSimple(
           simple,
           explode: true,
@@ -4065,7 +4309,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithMixedLists.fromSimple(
           simple,
           explode: false,
@@ -4232,7 +4480,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithMixedLists.fromSimple(
           simple,
           explode: true,
@@ -4245,7 +4497,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithMixedLists.fromSimple(
           simple,
           explode: false,
@@ -4396,7 +4652,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithEnumList.fromSimple(
           simple,
           explode: true,
@@ -4420,7 +4680,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithEnumList.fromSimple(
           simple,
           explode: false,
@@ -4522,7 +4786,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithEnumList.fromSimple(
           simple,
           explode: true,
@@ -4540,7 +4808,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithEnumList.fromSimple(
           simple,
           explode: false,
@@ -4833,7 +5105,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedListInAnyOf.fromSimple(
           simple,
           explode: true,
@@ -4849,7 +5125,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = NestedListInAnyOf.fromSimple(
           simple,
           explode: false,
@@ -5091,7 +5371,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = anyOf.toSimple(explode: true, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithListOfComposites.fromSimple(
           simple,
           explode: true,
@@ -5107,7 +5391,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = anyOf.toSimple(explode: false, allowEmpty: true);
+        final simple = anyOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = AnyOfWithListOfComposites.fromSimple(
           simple,
           explode: false,

--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -60,7 +60,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -70,7 +74,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -159,7 +167,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -172,7 +184,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -264,7 +280,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -274,7 +294,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfPrimitive.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -362,7 +386,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfComplex.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -372,7 +400,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfComplex.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -458,7 +490,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfComplex.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -468,7 +504,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfComplex.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -556,7 +596,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfEnum.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -566,7 +610,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfEnum.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -652,7 +700,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfEnum.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -662,7 +714,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfEnum.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -750,7 +806,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -760,7 +820,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -846,7 +910,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: true);
         expect(reconstructed, oneOf);
       });
@@ -856,7 +924,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: false);
         expect(reconstructed, oneOf);
       });
@@ -982,7 +1054,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: true);
         // Ambiguous: Enum1.value2 encodes to 'value2', which is
         // indistinguishable from a plain string. Without discriminators,
@@ -1005,7 +1081,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = OneOfMixed.fromSimple(simple, explode: false);
         // Ambiguous: Enum1.value2 encodes to 'value2', which is
         // indistinguishable from a plain string. Without discriminators,
@@ -1115,7 +1195,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1128,7 +1212,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1223,7 +1311,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1236,7 +1328,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1335,7 +1431,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1348,7 +1448,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1445,7 +1549,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1458,7 +1566,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedOneOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1565,7 +1677,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAllOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1581,7 +1697,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAllOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1684,7 +1804,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAllOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1697,7 +1821,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAllOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1817,7 +1945,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1837,7 +1969,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -1941,7 +2077,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -1954,7 +2094,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -2072,7 +2216,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: true,
@@ -2092,7 +2240,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = NestedAnyOfInOneOf.fromSimple(
             simple,
             explode: false,
@@ -2322,7 +2474,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: true,
@@ -2335,7 +2491,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: false,
@@ -2435,7 +2595,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: true,
@@ -2448,7 +2612,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: false,
@@ -2574,7 +2742,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: true,
@@ -2596,7 +2768,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: false,
@@ -2711,7 +2887,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: true,
@@ -2727,7 +2907,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = DeepNestedOneOf.fromSimple(
               simple,
               explode: false,
@@ -2822,7 +3006,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = DeepNestedOneOf.fromSimple(
             simple,
             explode: true,
@@ -2835,7 +3023,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = DeepNestedOneOf.fromSimple(
             simple,
             explode: false,
@@ -2928,7 +3120,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(simple, explode: true);
           expect(reconstructed, oneOf);
         });
@@ -2938,7 +3134,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(
             simple,
             explode: false,
@@ -3027,7 +3227,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(simple, explode: true);
           expect(reconstructed, oneOf);
         });
@@ -3037,7 +3241,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(
             simple,
             explode: false,
@@ -3128,7 +3336,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(simple, explode: true);
           expect(reconstructed, oneOf);
         });
@@ -3138,7 +3350,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelOneOf.fromSimple(
             simple,
             explode: false,
@@ -3266,7 +3482,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelMixedOneOfAllOf.fromSimple(
             simple,
             explode: true,
@@ -3292,7 +3512,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = TwoLevelMixedOneOfAllOf.fromSimple(
             simple,
             explode: false,
@@ -3404,7 +3628,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedOneOfAllOf.fromSimple(
           simple,
           explode: true,
@@ -3417,7 +3645,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = TwoLevelMixedOneOfAllOf.fromSimple(
           simple,
           explode: false,
@@ -3523,7 +3755,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: true,
@@ -3536,7 +3772,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: false,
@@ -3646,7 +3886,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: true,
@@ -3662,7 +3906,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: false,
@@ -3766,7 +4014,11 @@ void main() {
           });
 
           test('simple roundtrip - explode true', () {
-            final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: true,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: true,
@@ -3779,7 +4031,11 @@ void main() {
           });
 
           test('simple roundtrip - explode false', () {
-            final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+            final simple = oneOf.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             final reconstructed = ThreeLevelOneOf.fromSimple(
               simple,
               explode: false,
@@ -3871,7 +4127,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelOneOf.fromSimple(
             simple,
             explode: true,
@@ -3884,7 +4144,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelOneOf.fromSimple(
             simple,
             explode: false,
@@ -4112,7 +4376,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelMixedOneOfAllOfAnyOf.fromSimple(
             simple,
             explode: true,
@@ -4125,7 +4393,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelMixedOneOfAllOfAnyOf.fromSimple(
             simple,
             explode: false,
@@ -4233,7 +4505,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: true,
@@ -4246,7 +4522,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: false,
@@ -4343,7 +4623,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: true,
@@ -4356,7 +4640,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: false,
@@ -4477,7 +4765,11 @@ void main() {
         });
 
         test('simple roundtrip - explode true', () {
-          final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: true,
@@ -4501,7 +4793,11 @@ void main() {
         });
 
         test('simple roundtrip - explode false', () {
-          final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+          final simple = oneOf.toSimple(
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          );
           final reconstructed = ThreeLevelWithRefs.fromSimple(
             simple,
             explode: false,
@@ -4614,7 +4910,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix2.fromSimple(
           simple,
           explode: true,
@@ -4630,7 +4930,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix2.fromSimple(
           simple,
           explode: false,
@@ -4725,7 +5029,11 @@ void main() {
       });
 
       test('simple roundtrip - explode true', () {
-        final simple = oneOf.toSimple(explode: true, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix2.fromSimple(
           simple,
           explode: true,
@@ -4738,7 +5046,11 @@ void main() {
       });
 
       test('simple roundtrip - explode false', () {
-        final simple = oneOf.toSimple(explode: false, allowEmpty: true);
+        final simple = oneOf.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        );
         final reconstructed = ComplexNestedMix2.fromSimple(
           simple,
           explode: false,

--- a/integration_test/medama/medama_test/test/event_api_test.dart
+++ b/integration_test/medama/medama_test/test/event_api_test.dart
@@ -496,7 +496,7 @@ void main() {
         final success = response as TonikSuccess<PostEventHitResponse>;
         expect(
           success.response.requestOptions.headers['User-Agent'],
-          '''Mozilla%2F5.0%20(Windows%20NT%2010.0%3B%20Win64%3B%20x64)%20AppleWebKit%2F537.36''',
+          'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36',
         );
       });
 
@@ -518,7 +518,7 @@ void main() {
         final success = response as TonikSuccess<PostEventHitResponse>;
         expect(
           success.response.requestOptions.headers['Accept-Language'],
-          'en-US%2Cen%3Bq%3D0.9%2Cde%3Bq%3D0.8',
+          'en-US,en;q=0.9,de;q=0.8',
         );
       });
 
@@ -541,7 +541,7 @@ void main() {
         final success = response as TonikSuccess<PostEventHitResponse>;
         expect(
           success.response.requestOptions.headers['User-Agent'],
-          'TestBrowser%2F1.0',
+          'TestBrowser/1.0',
         );
         expect(
           success.response.requestOptions.headers['Accept-Language'],
@@ -561,13 +561,13 @@ void main() {
               q: false,
             ),
           ),
-          acceptLanguage: 'en-US,en;q=0.9,zh-CN;q=0.8,日本語;q=0.7',
+          acceptLanguage: 'en-US,en;q=0.9,zh-CN;q=0.8,*;q=0.5',
         );
 
         final success = response as TonikSuccess<PostEventHitResponse>;
         expect(
           success.response.requestOptions.headers['Accept-Language'],
-          '''en-US%2Cen%3Bq%3D0.9%2Czh-CN%3Bq%3D0.8%2C%E6%97%A5%E6%9C%AC%E8%AA%9E%3Bq%3D0.7''',
+          'en-US,en;q=0.9,zh-CN;q=0.8,*;q=0.5',
         );
       });
     });
@@ -843,7 +843,7 @@ void main() {
         final success = response as TonikSuccess<GetEventPingResponse>;
         expect(
           success.response.requestOptions.headers['If-Modified-Since'],
-          'Wed%2C%2021%20Oct%202015%2007%3A28%3A00%20GMT',
+          'Wed, 21 Oct 2015 07:28:00 GMT',
         );
       });
 

--- a/integration_test/query_parameters/query_parameters_test/test/byte_composite_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/byte_composite_test.dart
@@ -49,7 +49,11 @@ void main() {
         tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
       );
 
-      final wire = value.uriEncode(allowEmpty: false);
+      final wire = value.toSimple(
+        explode: true,
+        allowEmpty: false,
+        literal: true,
+      );
       final decoded = AnyOfByte.fromSimple(wire, explode: true);
 
       expect(decoded.tonikFile?.toBytes(), [0xDE, 0xAD, 0xBE, 0xEF]);
@@ -77,7 +81,11 @@ void main() {
     test('decoder round-trips the encoder output', () {
       const value = OneOfByteBase64(TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]));
 
-      final wire = value.uriEncode(allowEmpty: false);
+      final wire = value.toSimple(
+        explode: true,
+        allowEmpty: false,
+        literal: true,
+      );
       final decoded = OneOfByte.fromSimple(wire, explode: true);
 
       expect(decoded, isA<OneOfByteBase64>());
@@ -111,7 +119,11 @@ void main() {
         tonikFile: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
       );
 
-      final wire = value.uriEncode(allowEmpty: false);
+      final wire = value.toSimple(
+        explode: true,
+        allowEmpty: false,
+        literal: true,
+      );
       final decoded = AllOfByte.fromSimple(wire, explode: true);
 
       expect(decoded.tonikFile.toBytes(), [0xDE, 0xAD, 0xBE, 0xEF]);

--- a/integration_test/simple_encoding/openapi.yaml
+++ b/integration_test/simple_encoding/openapi.yaml
@@ -1256,6 +1256,7 @@ components:
         - inactive
         - pending
         - archived
+        - 50% off
 
     PriorityEnum:
       type: integer

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
@@ -1,0 +1,149 @@
+import 'package:big_decimal/big_decimal.dart';
+import 'package:dio/dio.dart';
+import 'package:simple_encoding_api/simple_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  SimpleEncodingApi buildApi({Map<String, dynamic> rawHeaders = const {}}) {
+    return SimpleEncodingApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': '200', ...rawHeaders},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('primitive string header transmits literal values', () {
+    for (final value in ['acme corp', '50%', '75%2Fdone', 'a%20b']) {
+      test('transmits $value verbatim on the wire', () async {
+        final api = buildApi();
+        final response = await api.testHeaderRoundtripPrimitives(string: value);
+
+        final success =
+            response
+                as TonikSuccess<HeadersRoundtripPrimitivesGet200Response>;
+        expect(success.response.requestOptions.headers['x-string'], value);
+      });
+    }
+  });
+
+  group('server-originated response header decodes literally', () {
+    test('50% response header parses as 50%', () async {
+      final api = buildApi(rawHeaders: {'X-String': '50%'});
+      final response = await api.testHeaderRoundtripPrimitives();
+
+      final success =
+          response as TonikSuccess<HeadersRoundtripPrimitivesGet200Response>;
+      expect(success.value.xString, '50%');
+    });
+
+    test('75%2Fdone response header remains unchanged', () async {
+      final api = buildApi(rawHeaders: {'X-String': '75%2Fdone'});
+      final response = await api.testHeaderRoundtripPrimitives();
+
+      final success =
+          response as TonikSuccess<HeadersRoundtripPrimitivesGet200Response>;
+      expect(success.value.xString, '75%2Fdone');
+    });
+
+    test('a%20b response header remains unchanged', () async {
+      final api = buildApi(rawHeaders: {'X-String': 'a%20b'});
+      final response = await api.testHeaderRoundtripPrimitives();
+
+      final success =
+          response as TonikSuccess<HeadersRoundtripPrimitivesGet200Response>;
+      expect(success.value.xString, 'a%20b');
+    });
+  });
+
+  group('base64 header retains standard-alphabet characters', () {
+    test('bytes producing + / = survive on the wire and roundtrip', () async {
+      // These bytes base64-encode to a value containing '+', '/', and '='.
+      final bytes = [0xFB, 0xFF, 0xBF, 0x00];
+      final api = buildApi();
+      final response = await api.testHeaderRoundtripBase64(
+        fileData: TonikFileBytes(bytes),
+      );
+
+      final success =
+          response as TonikSuccess<HeadersRoundtripBase64Get200Response>;
+      final wire = success.response.requestOptions.headers['x-file-data'];
+      expect(wire, '+/+/AA==');
+      expect(success.value.xFileData?.toBytes(), bytes);
+    });
+  });
+
+  group('path parameters keep URI percent-encoding', () {
+    test('reserved characters in a string path segment are encoded', () async {
+      final api = buildApi();
+      final response = await api.testPrimitiveInPath(
+        integer: 1,
+        double: 1,
+        number: 1,
+        string: 'a b/c%d',
+        boolean: true,
+        datetime: DateTime.utc(1970),
+        date: Date(2000, 1, 1),
+        decimal: BigDecimal.parse('1'),
+        uri: Uri.parse('https://example.com'),
+        $enum: StatusEnum.active,
+      );
+
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/primitive/1/1.0/1/a%20b%2Fc%25d/true/'
+            '1970-01-01T00%3A00%3A00.000Z/2000-01-01/1/'
+            'https%3A%2F%2Fexample.com/active',
+      );
+    });
+  });
+
+  group('control characters are rejected before dispatch', () {
+    final cases = <String, String>{
+      'carriage return': 'a${String.fromCharCode(13)}b',
+      'line feed': 'a${String.fromCharCode(10)}b',
+      'null byte': 'a${String.fromCharCode(0)}b',
+      'unit separator': 'a${String.fromCharCode(31)}b',
+    };
+    for (final entry in cases.entries) {
+      test('${entry.key} in a header value is rejected pre-dispatch, '
+          'while the same header without it succeeds', () async {
+        final api = buildApi();
+
+        final control = await api.testHeaderRoundtripPrimitives(string: 'ab');
+        expect(
+          control,
+          isA<TonikSuccess<HeadersRoundtripPrimitivesGet200Response>>(),
+        );
+
+        final response = await api.testHeaderRoundtripPrimitives(
+          string: entry.value,
+        );
+
+        expect(
+          response,
+          isA<TonikError<HeadersRoundtripPrimitivesGet200Response>>(),
+        );
+        final error =
+            response
+                as TonikError<HeadersRoundtripPrimitivesGet200Response>;
+        expect(error.response, isNull);
+      });
+    }
+  });
+}

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
@@ -142,8 +142,8 @@ void main() {
         final error =
             response
                 as TonikError<HeadersRoundtripPrimitivesGet200Response>;
-        // Rejection is transport-provided: Dio refuses to send a header with a
-        // control character, so the request never dispatches.
+        // Rejection is transport-provided (Dio refuses control chars), not
+        // a Tonik guard.
         expect(error.type, TonikErrorType.network);
         expect(error.response, isNull);
       });

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_literal_primitives_test.dart
@@ -142,6 +142,9 @@ void main() {
         final error =
             response
                 as TonikError<HeadersRoundtripPrimitivesGet200Response>;
+        // Rejection is transport-provided: Dio refuses to send a header with a
+        // control character, so the request never dispatches.
+        expect(error.type, TonikErrorType.network);
         expect(error.response, isNull);
       });
     }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
@@ -135,18 +135,18 @@ void main() {
         expect(success.value.xUserName, isNotNull);
       });
 
-      test('roundtrips UserName with unicode characters', () async {
+      test('UserName with non-ASCII characters cannot be sent literally',
+          () async {
+        // Header field-values are transmitted literally, but HTTP forbids
+        // non-ASCII octets in a header value, so the transport rejects it.
         const userName = 'José García';
 
         final result = await api.testHeaderRoundtripAliases(userName: userName);
 
         expect(
           result,
-          isA<TonikSuccess<HeadersRoundtripAliasesGet200Response>>(),
+          isA<TonikError<HeadersRoundtripAliasesGet200Response>>(),
         );
-        final success =
-            result as TonikSuccess<HeadersRoundtripAliasesGet200Response>;
-        expect(success.value.xUserName, isNotNull);
       });
     });
 

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
@@ -137,8 +137,7 @@ void main() {
 
       test('UserName with non-ASCII characters cannot be sent literally',
           () async {
-        // Header field-values are transmitted literally, but HTTP forbids
-        // non-ASCII octets in a header value, so the transport rejects it.
+        // HTTP forbids non-ASCII header octets, so the transport rejects it.
         const userName = 'José García';
 
         final result = await api.testHeaderRoundtripAliases(userName: userName);

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
@@ -159,8 +159,8 @@ void main() {
         // Server-originated: X-Composite-Entity is injected via Dio, not
         // sent by Tonik's encoder.
         // created_at is required for the merged allOf object to decode.
-        // ignore: lines_longer_than_80_chars
-        const literal = 'name,x%2Fy 50%,created_at,2024-01-15T10:30:00.000Z,specific_field,keep%2Fraw';
+        const literal =
+            '''name,x%2Fy 50%,created_at,2024-01-15T10:30:00.000Z,specific_field,keep%2Fraw''';
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
@@ -152,5 +152,42 @@ void main() {
         },
       );
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected allOf object header '
+          'decode verbatim', () async {
+        // X-Composite-Entity is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        // The value is one simple-style object literal; created_at is required
+        // and must parse as a date-time for the object to decode.
+        // ignore: lines_longer_than_80_chars
+        const literal = 'name,x%2Fy 50%,created_at,2024-01-15T10:30:00.000Z,specific_field,keep%2Fraw';
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Composite-Entity': literal,
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripAllOfSimple.call();
+
+        final success =
+            result as TonikSuccess<HeadersRoundtripAllofSimpleGet200Response>;
+        expect(success.value.xCompositeEntity, isNotNull);
+        expect(success.value.xCompositeEntity!.baseEntity.name, 'x%2Fy 50%');
+        expect(
+          success.value.xCompositeEntity!.compositeEntityModel.specificField,
+          'keep%2Fraw',
+        );
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_allof_simple_test.dart
@@ -156,11 +156,9 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected allOf object header '
           'decode verbatim', () async {
-        // X-Composite-Entity is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
-        // The value is one simple-style object literal; created_at is required
-        // and must parse as a date-time for the object to decode.
+        // Server-originated: X-Composite-Entity is injected via Dio, not
+        // sent by Tonik's encoder.
+        // created_at is required for the merged allOf object to decode.
         // ignore: lines_longer_than_80_chars
         const literal = 'name,x%2Fy 50%,created_at,2024-01-15T10:30:00.000Z,specific_field,keep%2Fraw';
         final injected = SimpleEncodingApi(

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
@@ -69,10 +69,10 @@ void main() {
         final success =
             result as TonikSuccess<HeadersRoundtripAnyofComplexGet200Response>;
 
-        // Spaces are URL encoded in simple-style headers.
+        // Header field-values are transmitted literally: the space survives.
         expect(
           success.response.requestOptions.headers['X-Flexible-Object'],
-          'name,hello%20world',
+          'name,hello world',
         );
         expect(success.value.xFlexibleObject, isNotNull);
         expect(success.value.xFlexibleObject!.class1, isNotNull);

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
@@ -184,9 +184,8 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected anyOf object header '
           'decode verbatim', () async {
-        // X-Flexible-Object is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
+        // Server-originated: X-Flexible-Object is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
@@ -180,5 +180,35 @@ void main() {
         },
       );
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected anyOf object header '
+          'decode verbatim', () async {
+        // X-Flexible-Object is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Flexible-Object': 'name,x%2Fy 50%',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripAnyOfComplex.call();
+
+        final success =
+            result as TonikSuccess<HeadersRoundtripAnyofComplexGet200Response>;
+        expect(success.value.xFlexibleObject, isNotNull);
+        expect(success.value.xFlexibleObject!.class1, isNotNull);
+        expect(success.value.xFlexibleObject!.class1!.name, 'x%2Fy 50%');
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
@@ -224,9 +224,8 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected anyOf header '
           'decode verbatim', () async {
-        // X-Flexible-Value is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
+        // Server-originated: X-Flexible-Value is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
@@ -67,10 +67,10 @@ void main() {
             result
                 as TonikSuccess<HeadersRoundtripAnyofPrimitiveGet200Response>;
 
-        // Spaces are URL encoded in simple-style headers.
+        // Header field-values are transmitted literally: the space survives.
         expect(
           success.response.requestOptions.headers['X-Flexible-Value'],
-          'hello%20world',
+          'hello world',
         );
         expect(success.value.xFlexibleValue, isNotNull);
         expect(success.value.xFlexibleValue!.string, 'hello world');

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
@@ -220,5 +220,35 @@ void main() {
         },
       );
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected anyOf header '
+          'decode verbatim', () async {
+        // X-Flexible-Value is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Flexible-Value': 'a%2Fb 50%',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripAnyOfPrimitive.call();
+
+        final success =
+            result
+                as TonikSuccess<HeadersRoundtripAnyofPrimitiveGet200Response>;
+        expect(success.value.xFlexibleValue, isNotNull);
+        expect(success.value.xFlexibleValue!.string, 'a%2Fb 50%');
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
@@ -54,9 +54,10 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.flexibleValue, isNotNull);
-        expect(success.value.xDynamicValue!.flexibleValue!.string, isNotNull);
+        expect(
+          success.value.xDynamicValue!.flexibleValue!.string,
+          'hello',
+        );
       });
 
       test('roundtrips FlexibleValue with integer', () async {
@@ -79,8 +80,7 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.flexibleValue, isNotNull);
+        expect(success.value.xDynamicValue!.flexibleValue!.int, 42);
       });
 
       test('roundtrips FlexibleValue with boolean', () async {
@@ -103,8 +103,7 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.flexibleValue, isNotNull);
+        expect(success.value.xDynamicValue!.flexibleValue!.bool, isTrue);
       });
     });
 
@@ -131,7 +130,10 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
+        final object =
+            success.value.xDynamicValue!.flexibleValue!.simpleObject;
+        expect(object?.name, 'test-object');
+        expect(object?.value, 100);
       });
     });
 
@@ -160,8 +162,12 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.entityType, isNotNull);
+        final entity = success.value.xDynamicValue!.entityType;
+        expect(entity, isA<EntityTypeCompanyEntity>());
+        expect(
+          (entity! as EntityTypeCompanyEntity).value.companyName,
+          'Acme Inc',
+        );
       });
 
       test('roundtrips PersonEntity', () async {
@@ -189,8 +195,11 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.entityType, isNotNull);
+        final entity = success.value.xDynamicValue!.entityType;
+        expect(entity, isA<EntityTypePersonEntity>());
+        final decoded = (entity! as EntityTypePersonEntity).value;
+        expect(decoded.firstName, 'John');
+        expect(decoded.lastName, 'Doe');
       });
     });
 
@@ -224,12 +233,15 @@ void main() {
                 as TonikSuccess<
                   HeadersRoundtripComplexDynamicCompositeGet200Response
                 >;
-        expect(success.value.xDynamicValue, isNotNull);
-        expect(success.value.xDynamicValue!.compositeEntity, isNotNull);
+        final composite = success.value.xDynamicValue!.compositeEntity;
+        expect(composite?.baseEntity.name, 'entity-123');
+        expect(composite?.compositeEntityModel.specificField, 'Test Entity');
+        expect(composite?.timestampMixin.createdAt, DateTime.utc(2024, 1, 15));
+        expect(composite?.timestampMixin.updatedAt, DateTime.utc(2024, 1, 16));
       });
     });
 
-    group('with mixed variants (encoding error expected)', () {
+    group('with multiple variants set', () {
       test('fails when FlexibleValue has mixed shapes', () async {
         // FlexibleValue with both primitive (string) and complex (SimpleObject)
         // should cause encoding error due to mixed shapes
@@ -258,9 +270,11 @@ void main() {
         expect(error.type, TonikErrorType.encoding);
       });
 
-      test('fails when multiple complex variants are set', () async {
-        // Setting both entityType and compositeEntity should cause encoding
-        // issues as anyOf requires exactly one value
+      test('two complex variants merge into one property map and decode back',
+          () async {
+        // entityType and compositeEntity are both complex (map) shapes, so
+        // there is no simple/complex mix: their property maps merge into a
+        // single header and both variants decode back from it.
         const company = CompanyEntity(
           $type: CompanyEntityTypeModel.company,
           companyName: 'Acme',
@@ -283,20 +297,19 @@ void main() {
           dynamicValue: input,
         );
 
-        // This may encode successfully if both map to the same encoding shape
-        // or fail if there's ambiguity
+        final success =
+            result
+                as TonikSuccess<
+                  HeadersRoundtripComplexDynamicCompositeGet200Response
+                >;
+        final value = success.value.xDynamicValue!;
+        final entity = value.entityType;
+        expect(entity, isA<EntityTypeCompanyEntity>());
+        expect((entity! as EntityTypeCompanyEntity).value.companyName, 'Acme');
+        expect(value.compositeEntity?.baseEntity.name, 'id');
         expect(
-          result,
-          anyOf(
-            isA<
-              TonikSuccess<
-                HeadersRoundtripComplexDynamicCompositeGet200Response
-              >
-            >(),
-            isA<
-              TonikError<HeadersRoundtripComplexDynamicCompositeGet200Response>
-            >(),
-          ),
+          value.compositeEntity?.compositeEntityModel.specificField,
+          'name',
         );
       });
     });

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
@@ -300,5 +300,45 @@ void main() {
         );
       });
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected dynamic-composite header '
+          'decode verbatim', () async {
+        // X-Dynamic-Value is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Dynamic-Value': 'name,x%2Fy 50%,value,9',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripDynamicComposite();
+
+        final success =
+            result
+                as TonikSuccess<
+                  HeadersRoundtripComplexDynamicCompositeGet200Response
+                >;
+        expect(success.value.xDynamicValue, isNotNull);
+        expect(success.value.xDynamicValue!.flexibleValue, isNotNull);
+        expect(
+          success.value.xDynamicValue!.flexibleValue!.simpleObject,
+          isNotNull,
+        );
+        expect(
+          success.value.xDynamicValue!.flexibleValue!.simpleObject!.name,
+          'x%2Fy 50%',
+        );
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_dynamic_composite_test.dart
@@ -272,9 +272,8 @@ void main() {
 
       test('two complex variants merge into one property map and decode back',
           () async {
-        // entityType and compositeEntity are both complex (map) shapes, so
-        // there is no simple/complex mix: their property maps merge into a
-        // single header and both variants decode back from it.
+        // Both variants share one merged property map, so either decodes
+        // from it.
         const company = CompanyEntity(
           $type: CompanyEntityTypeModel.company,
           companyName: 'Acme',
@@ -317,9 +316,8 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected dynamic-composite header '
           'decode verbatim', () async {
-        // X-Dynamic-Value is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
+        // Server-originated: X-Dynamic-Value is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enum_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enum_lists_test.dart
@@ -280,8 +280,8 @@ void main() {
     group('server-originated response', () {
       test('injected literal enum list splits on commas and maps each '
           'element to its enum value', () async {
-        // X-Status-List is injected via Dio, not through Tonik's request
-        // encoder, so the decoded list reflects the server-originated literal.
+        // Server-originated: X-Status-List is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enum_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enum_lists_test.dart
@@ -276,5 +276,36 @@ void main() {
         expect(success.value.xPriorityList, isNull);
       });
     });
+
+    group('server-originated response', () {
+      test('injected literal enum list splits on commas and maps each '
+          'element to its enum value', () async {
+        // X-Status-List is injected via Dio, not through Tonik's request
+        // encoder, so the decoded list reflects the server-originated literal.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Status-List': 'active,pending,archived',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final response = await injected.testHeaderRoundtripEnumLists();
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripListsEnumsGet200Response>;
+        expect(success.value.xStatusList, [
+          StatusEnum.active,
+          StatusEnum.pending,
+          StatusEnum.archived,
+        ]);
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enums_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enums_test.dart
@@ -299,5 +299,30 @@ void main() {
         expect(success.value.xPriority, PriorityEnum.two);
       });
     });
+
+    group('server-originated response', () {
+      test('an injected enum header whose member value carries a percent '
+          'sequence decodes literally', () async {
+        // X-Status is not set as a request param here, so the value Imposter
+        // echoes back is the injected literal, independent of Tonik's request
+        // encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {'X-Response-Status': '200', 'X-Status': '50% off'},
+              ),
+            ),
+          ),
+        );
+
+        final response = await injected.testHeaderRoundtripEnums();
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripEnumsGet200Response>;
+        expect(success.value.xStatus, StatusEnum.$50PercentOff);
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enums_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_enums_test.dart
@@ -303,9 +303,8 @@ void main() {
     group('server-originated response', () {
       test('an injected enum header whose member value carries a percent '
           'sequence decodes literally', () async {
-        // X-Status is not set as a request param here, so the value Imposter
-        // echoes back is the injected literal, independent of Tonik's request
-        // encoder.
+        // Server-originated: X-Status is injected via Dio, not sent by
+        // Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
@@ -41,7 +41,7 @@ void main() {
       expect(success.response.statusCode, 200);
       expect(
         success.response.requestOptions.headers['x-nullable-string-list'],
-        'hello%20world,foo%2Fbar,',
+        'hello world,foo/bar,',
       );
     });
 

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
@@ -70,5 +70,34 @@ void main() {
         isA<TonikError<HeadersRoundtripListsNullableGet200Response>>(),
       );
     });
+
+    group('server-originated response', () {
+      test('injected literal decodes reserved chars verbatim and empty '
+          'elements as null', () async {
+        // X-Nullable-String-List is not set as a request parameter here, so the
+        // echoed value is a server-originated literal independent of Tonik's
+        // request encoder. This exercises the nullable-item decoder branch that
+        // splits on commas and converts empty elements to null.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Nullable-String-List': 'a%2Fb,,50%',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final response = await injected.testHeaderRoundtripNullableLists();
+
+        final success = response
+            as TonikSuccess<HeadersRoundtripListsNullableGet200Response>;
+        expect(success.value.xNullableStringList, ['a%2Fb', null, '50%']);
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_lists_test.dart
@@ -74,10 +74,8 @@ void main() {
     group('server-originated response', () {
       test('injected literal decodes reserved chars verbatim and empty '
           'elements as null', () async {
-        // X-Nullable-String-List is not set as a request parameter here, so the
-        // echoed value is a server-originated literal independent of Tonik's
-        // request encoder. This exercises the nullable-item decoder branch that
-        // splits on commas and converts empty elements to null.
+        // Server-originated: X-Nullable-String-List injected via Dio;
+        // exercises the empty-element→null branch.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_objects_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_objects_test.dart
@@ -296,5 +296,100 @@ void main() {
         expect(success.value.xUserProfile, isNull);
       });
     });
+
+    group('literal special characters', () {
+      test('object property value keeps spaces, slash, percent literal '
+          'on the wire and through decode', () async {
+        final api = buildApi(responseStatus: '200');
+        const name = 'a/b c%2Fd 100%';
+        final response = await api.testHeaderRoundtripObjects(
+          simpleObject: const SimpleObject(name: name, value: 7),
+        );
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripObjectsGet200Response>;
+        expect(
+          success.response.requestOptions.headers['X-Simple-Object'],
+          'name,a/b c%2Fd 100%,value,7',
+        );
+        expect(success.value.xSimpleObject?.name, name);
+        expect(success.value.xSimpleObject?.value, 7);
+      });
+
+      test('object Uri property keeps its literal slashes and colon', () async {
+        final api = buildApi(responseStatus: '200');
+        final response = await api.testHeaderRoundtripObjects(
+          userProfile: UserProfile(
+            id: 1,
+            username: 'john_doe',
+            isVerified: true,
+            createdAt: DateTime.utc(2024),
+            email: 'john@example.com',
+            website: Uri.parse('https://example.com/a/b'),
+          ),
+        );
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripObjectsGet200Response>;
+        final wire =
+            success.response.requestOptions.headers['X-User-Profile'] as String;
+        expect(wire, contains('website,https://example.com/a/b'));
+        expect(
+          success.value.xUserProfile?.website,
+          Uri.parse('https://example.com/a/b'),
+        );
+      });
+    });
+
+    group('delimiter collision', () {
+      test('a comma inside an object value cannot round-trip: it is '
+          'transmitted literally and decode reads it as a new key/value',
+          () async {
+        // Literal encoding does not escape the simple-style `,` delimiter, so
+        // an in-value comma is indistinguishable from the property separator.
+        // The value transmits verbatim; decode cannot recover the original.
+        final api = buildApi(responseStatus: '200');
+        final response = await api.testHeaderRoundtripObjects(
+          simpleObject: const SimpleObject(name: 'a,b', value: 5),
+        );
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripObjectsGet200Response>;
+        expect(
+          success.response.requestOptions.headers['X-Simple-Object'],
+          'name,a,b,value,5',
+        );
+        expect(success.value.xSimpleObject?.name, 'a');
+      });
+    });
+
+    group('server-originated composite response', () {
+      test('literal percent sequences in an injected object header '
+          'survive decode without re-decoding', () async {
+        // Inject the header value directly via Dio, NOT through Tonik's
+        // request encoder, so the server-originated value is echoed verbatim
+        // and the client must decode it literally.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Simple-Object': 'name,x%2Fy 50%,value,9',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final response = await injected.testHeaderRoundtripObjects();
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripObjectsGet200Response>;
+        expect(success.value.xSimpleObject?.name, 'x%2Fy 50%');
+        expect(success.value.xSimpleObject?.value, 9);
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_objects_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_objects_test.dart
@@ -345,9 +345,8 @@ void main() {
       test('a comma inside an object value cannot round-trip: it is '
           'transmitted literally and decode reads it as a new key/value',
           () async {
-        // Literal encoding does not escape the simple-style `,` delimiter, so
-        // an in-value comma is indistinguishable from the property separator.
-        // The value transmits verbatim; decode cannot recover the original.
+        // Literal encoding doesn't escape the `,` delimiter, so an in-value
+        // comma can't round-trip.
         final api = buildApi(responseStatus: '200');
         final response = await api.testHeaderRoundtripObjects(
           simpleObject: const SimpleObject(name: 'a,b', value: 5),
@@ -366,9 +365,8 @@ void main() {
     group('server-originated composite response', () {
       test('literal percent sequences in an injected object header '
           'survive decode without re-decoding', () async {
-        // Inject the header value directly via Dio, NOT through Tonik's
-        // request encoder, so the server-originated value is echoed verbatim
-        // and the client must decode it literally.
+        // Server-originated: X-Simple-Object is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
@@ -69,10 +69,10 @@ void main() {
         final success =
             result as TonikSuccess<HeadersRoundtripOneofComplexGet200Response>;
 
-        // Spaces are URL encoded in simple-style headers.
+        // Header field-values are transmitted literally: the space survives.
         expect(
           success.response.requestOptions.headers['X-Complex-Union'],
-          'name,hello%20world',
+          'name,hello world',
         );
         expect(success.value.xComplexUnion, isA<OneOfComplexClass1>());
         final class1 = success.value.xComplexUnion! as OneOfComplexClass1;

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
@@ -226,9 +226,8 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected oneOf object header '
           'decode verbatim', () async {
-        // X-Complex-Union is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
+        // Server-originated: X-Complex-Union is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
@@ -222,5 +222,35 @@ void main() {
         expect(success.value.xComplexUnion, isNull);
       });
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected oneOf object header '
+          'decode verbatim', () async {
+        // X-Complex-Union is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Complex-Union': 'name,x%2Fy 50%',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripOneOfComplex.call();
+
+        final success =
+            result as TonikSuccess<HeadersRoundtripOneofComplexGet200Response>;
+        expect(success.value.xComplexUnion, isA<OneOfComplexClass1>());
+        final class1 = success.value.xComplexUnion! as OneOfComplexClass1;
+        expect(class1.value.name, 'x%2Fy 50%');
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
@@ -176,7 +176,7 @@ void main() {
 
         expect(
           success.response.requestOptions.headers['X-Primitive-Union'],
-          'hello%20world',
+          'hello world',
         );
 
         expect(success.value.xPrimitiveUnion, isA<OneOfPrimitiveString>());

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
@@ -254,5 +254,38 @@ void main() {
         expect(success.value.xPrimitiveUnion, isNull);
       });
     });
+
+    group('server-originated response', () {
+      test('literal percent sequences in an injected oneOf header '
+          'decode verbatim', () async {
+        // X-Primitive-Union is not set as a request param here, so the value
+        // Imposter echoes back is the injected literal, independent of Tonik's
+        // request encoder.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-Primitive-Union': 'x%2Fy 50%',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final result = await injected.testHeaderRoundtripOneOfPrimitive.call();
+
+        final success =
+            result
+                as TonikSuccess<HeadersRoundtripOneofPrimitiveGet200Response>;
+        expect(success.value.xPrimitiveUnion, isA<OneOfPrimitiveString>());
+        expect(
+          (success.value.xPrimitiveUnion! as OneOfPrimitiveString).value,
+          'x%2Fy 50%',
+        );
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
@@ -258,9 +258,8 @@ void main() {
     group('server-originated response', () {
       test('literal percent sequences in an injected oneOf header '
           'decode verbatim', () async {
-        // X-Primitive-Union is not set as a request param here, so the value
-        // Imposter echoes back is the injected literal, independent of Tonik's
-        // request encoder.
+        // Server-originated: X-Primitive-Union is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_simple_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_simple_lists_test.dart
@@ -341,8 +341,8 @@ void main() {
     group('server-originated response', () {
       test('injected literal string list splits on commas only and keeps '
           'reserved chars verbatim', () async {
-        // X-String-List is injected via Dio, not through Tonik's request
-        // encoder, so the decoded list reflects the server-originated literal.
+        // Server-originated: X-String-List is injected via Dio, not
+        // sent by Tonik's encoder.
         final injected = SimpleEncodingApi(
           CustomServer(
             baseUrl: baseUrl,

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_simple_lists_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_simple_lists_test.dart
@@ -337,5 +337,32 @@ void main() {
         expect(success.value.xBooleanList, isNull);
       });
     });
+
+    group('server-originated response', () {
+      test('injected literal string list splits on commas only and keeps '
+          'reserved chars verbatim', () async {
+        // X-String-List is injected via Dio, not through Tonik's request
+        // encoder, so the decoded list reflects the server-originated literal.
+        final injected = SimpleEncodingApi(
+          CustomServer(
+            baseUrl: baseUrl,
+            serverConfig: ServerConfig(
+              baseOptions: BaseOptions(
+                headers: {
+                  'X-Response-Status': '200',
+                  'X-String-List': 'a%2Fb,50%,c d',
+                },
+              ),
+            ),
+          ),
+        );
+
+        final response = await injected.testHeaderRoundtripSimpleLists();
+
+        final success =
+            response as TonikSuccess<HeadersRoundtripListsSimpleGet200Response>;
+        expect(success.value.xStringList, ['a%2Fb', '50%', 'c d']);
+      });
+    });
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/simple_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/simple_test.dart
@@ -277,7 +277,7 @@ void main() {
     );
     expect(
       success.response.requestOptions.headers['x-timestamp'],
-      '1970-01-01T14%3A30%3A00.000Z',
+      '1970-01-01T14:30:00.000Z',
     );
   });
 }

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1489,7 +1489,7 @@ class AllOfGenerator {
         const Code('allowEmpty: allowEmpty,'),
         const Code(
           ').toSimple('
-          'explode: explode, allowEmpty: allowEmpty);',
+          'explode: explode, allowEmpty: allowEmpty, literal: literal);',
         ),
       ];
 
@@ -1498,65 +1498,9 @@ class AllOfGenerator {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'toSimple'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll(buildEncodingParameters())
+          ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..lambda = false
           ..body = Block.of(bodyCode),
-      );
-    }
-
-    final dynamicModels = normalizedProperties.where((prop) {
-      final shape = prop.property.model.encodingShape;
-      return shape == EncodingShape.mixed;
-    }).toList();
-
-    final hasDynamicModelsOld = dynamicModels.isNotEmpty;
-    final needsRuntimeValidation = hasDynamicModelsOld && model.hasSimpleTypes;
-
-    if (needsRuntimeValidation) {
-      final encodingShapeType = refer(
-        'EncodingShape',
-        'package:tonik_util/tonik_util.dart',
-      );
-      final validationCode = <Code>[];
-
-      for (final prop in dynamicModels) {
-        validationCode.addAll([
-          Code('if (${prop.normalizedName}.currentEncodingShape != '),
-          encodingShapeType.property('simple').code,
-          const Code(') {'),
-          refer('EncodingException', 'package:tonik_util/tonik_util.dart')
-              .call([
-                literalString(
-                  'Cannot encode mixed allOf ${model.name}: '
-                  '${prop.normalizedName} is complex',
-                ),
-              ])
-              .thrown
-              .statement,
-          const Code('}'),
-        ]);
-      }
-
-      validationCode.addAll([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toSimple')
-            .call([], {
-              'explode': refer('explode'),
-              'allowEmpty': refer('allowEmpty'),
-            })
-            .returned
-            .statement,
-      ]);
-
-      return Method(
-        (b) => b
-          ..annotations.add(refer('override', 'dart:core'))
-          ..name = 'toSimple'
-          ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll(buildEncodingParameters())
-          ..lambda = false
-          ..body = Block.of(validationCode),
       );
     }
 
@@ -1566,7 +1510,7 @@ class AllOfGenerator {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'toSimple'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll(buildEncodingParameters())
+          ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..lambda = false
           ..body = generateEncodingExceptionExpression(
             'Simple encoding not supported: contains complex types',
@@ -1613,6 +1557,7 @@ class AllOfGenerator {
                     prop.property.model,
                     explode: refer('explode'),
                     allowEmpty: refer('allowEmpty'),
+                    literal: refer('literal'),
                   ).expression,
                 )
                 .statement,
@@ -1645,7 +1590,7 @@ class AllOfGenerator {
             ..annotations.add(refer('override', 'dart:core'))
             ..name = 'toSimple'
             ..returns = refer('String', 'dart:core')
-            ..optionalParameters.addAll(buildEncodingParameters())
+            ..optionalParameters.addAll(buildSimpleEncodingParameters())
             ..lambda = false
             ..body = Block.of(valueCollectionCode),
         );
@@ -1657,7 +1602,7 @@ class AllOfGenerator {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'toSimple'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll(buildEncodingParameters())
+          ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..lambda = false
           ..body = Block.of([
             refer('parameterProperties')
@@ -1666,6 +1611,7 @@ class AllOfGenerator {
                 .call([], {
                   'explode': refer('explode'),
                   'allowEmpty': refer('allowEmpty'),
+                  'literal': refer('literal'),
                 })
                 .returned
                 .statement,
@@ -1679,7 +1625,7 @@ class AllOfGenerator {
           ..annotations.add(refer('override', 'dart:core'))
           ..name = 'toSimple'
           ..returns = refer('String', 'dart:core')
-          ..optionalParameters.addAll(buildEncodingParameters())
+          ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..lambda = false
           ..body = const Code("return '';"),
       );
@@ -1704,6 +1650,7 @@ class AllOfGenerator {
           .call([], {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
+            'literal': refer('literal'),
           })
           .returned
           .statement;
@@ -1717,6 +1664,7 @@ class AllOfGenerator {
           .call([], {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
+            'literal': refer('literal'),
           })
           .returned
           .statement;
@@ -1727,7 +1675,7 @@ class AllOfGenerator {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'toSimple'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll(buildEncodingParameters())
+        ..optionalParameters.addAll(buildSimpleEncodingParameters())
         ..lambda = false
         ..body = Block.of([simpleBody]),
     );

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -344,7 +344,7 @@ class AnyOfGenerator {
       codes.add(
         Code(
           'final $tmpVarName = $fieldName!.toBase64String().$toMethodName( '
-          'explode: explode, allowEmpty: allowEmpty);',
+          'explode: explode, allowEmpty: allowEmpty, literal: literal);',
         ),
       );
       if (needsValues) {
@@ -360,7 +360,7 @@ class AnyOfGenerator {
       codes.add(
         Code(
           'final $tmpVarName = $fieldName!.$toMethodName( '
-          'explode: explode, allowEmpty: allowEmpty);',
+          'explode: explode, allowEmpty: allowEmpty, literal: literal);',
         ),
       );
       if (needsValues) {
@@ -376,6 +376,7 @@ class AnyOfGenerator {
               fieldModel,
               explode: refer('explode'),
               allowEmpty: refer('allowEmpty'),
+              literal: refer('literal'),
             ).expression.statement,
           ]),
         );
@@ -434,7 +435,7 @@ class AnyOfGenerator {
         codes.add(
           Code(
             '_\$values.add($fieldName!.$toMethodName('
-            'explode: explode, allowEmpty: allowEmpty));',
+            'explode: explode, allowEmpty: allowEmpty, literal: literal));',
           ),
         );
       }
@@ -1046,7 +1047,8 @@ class AnyOfGenerator {
       ..add(const Code(r'return _$map.toSimple('))
       ..addAll([
         const Code('explode: explode, '),
-        const Code('allowEmpty: allowEmpty'),
+        const Code('allowEmpty: allowEmpty, '),
+        const Code('literal: literal'),
         const Code(');'),
       ]);
 
@@ -1098,7 +1100,7 @@ class AnyOfGenerator {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'toSimple'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll(buildEncodingParameters())
+        ..optionalParameters.addAll(buildSimpleEncodingParameters())
         ..lambda = false
         ..body = Block.of(body),
     );

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1630,7 +1630,7 @@ class ClassGenerator {
       ..annotations.add(refer('override', 'dart:core'))
       ..name = 'toSimple'
       ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll(buildEncodingParameters())
+      ..optionalParameters.addAll(buildSimpleEncodingParameters())
       ..body = Block.of([
         refer('parameterProperties')
             .call([], {'allowEmpty': refer('allowEmpty')})
@@ -1638,6 +1638,7 @@ class ClassGenerator {
             .call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
+              'literal': refer('literal'),
             })
             .returned
             .statement,

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -438,9 +438,10 @@ class EnumGenerator {
           ..name = 'toSimple'
           ..returns = refer('String', 'dart:core')
           ..lambda = true
-          ..optionalParameters.addAll(buildEncodingParameters())
+          ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..body = const Code(
-            'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty)',
+            'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, '
+            'literal: literal)',
           ),
       );
     }
@@ -451,7 +452,7 @@ class EnumGenerator {
         ..name = 'toSimple'
         ..returns = refer('String', 'dart:core')
         ..lambda = false
-        ..optionalParameters.addAll(buildEncodingParameters())
+        ..optionalParameters.addAll(buildSimpleEncodingParameters())
         ..body = Block.of([
           Code('if (this == $actualEnumName.$fallbackNormalizedName) {'),
           generateEncodingExceptionExpression(
@@ -461,7 +462,7 @@ class EnumGenerator {
           const Code('}'),
           const Code(
             '''
-return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty);
+return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
 ''',
           ),
         ]),

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -937,11 +937,13 @@ class OneOfGenerator {
             const Code(','),
             const Code('}'),
             const Code(
-              '.toSimple(explode: explode, allowEmpty: allowEmpty) : ',
+              '.toSimple(explode: explode, allowEmpty: allowEmpty, '
+              'literal: literal) : ',
             ),
             refer('value').property('toSimple').call([], {
               'explode': refer('explode'),
               'allowEmpty': refer('allowEmpty'),
+              'literal': refer('literal'),
             }).code,
             const Code(','),
           ]);
@@ -970,7 +972,8 @@ class OneOfGenerator {
             const Code(','),
             const Code('}'),
             const Code(
-              '.toSimple(explode: explode, allowEmpty: allowEmpty),',
+              '.toSimple(explode: explode, allowEmpty: allowEmpty, '
+              'literal: literal),',
             ),
           ]);
         }
@@ -987,6 +990,7 @@ class OneOfGenerator {
             m.model.resolved as ListModel,
             explode: refer('explode'),
             allowEmpty: refer('allowEmpty'),
+            literal: refer('literal'),
           ).code,
           const Code(','),
         ]);
@@ -1022,6 +1026,7 @@ class OneOfGenerator {
           ).property('toBase64String').call([]).property('toSimple').call([], {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
+            'literal': refer('literal'),
           }).code,
           const Code(','),
         ]);
@@ -1064,6 +1069,7 @@ class OneOfGenerator {
           refer('value').property('toSimple').call([], {
             'explode': refer('explode'),
             'allowEmpty': refer('allowEmpty'),
+            'literal': refer('literal'),
           }).code,
           const Code(','),
         ]);
@@ -1081,7 +1087,7 @@ class OneOfGenerator {
         ..annotations.add(refer('override', 'dart:core'))
         ..name = 'toSimple'
         ..returns = refer('String', 'dart:core')
-        ..optionalParameters.addAll(buildEncodingParameters())
+        ..optionalParameters.addAll(buildSimpleEncodingParameters())
         ..lambda = false
         ..body = body,
     );

--- a/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
+++ b/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
@@ -64,7 +64,7 @@ Method buildReadOnlyToSimpleMethod(Code exceptionBody) {
       ..annotations.add(refer('override', 'dart:core'))
       ..name = 'toSimple'
       ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll(buildEncodingParameters())
+      ..optionalParameters.addAll(buildSimpleEncodingParameters())
       ..lambda = true
       ..body = exceptionBody,
   );

--- a/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
@@ -242,15 +242,16 @@ Expression _buildFromSimpleExpression(
 Expression _buildListDecode(
   Expression value,
   bool isRequired, {
+  bool nullableElements = false,
   Map<String, Expression> contextParam = const {},
 }) {
-  return value
-      .property(
-        isRequired
-            ? 'decodeSimpleStringList'
-            : 'decodeSimpleNullableStringList',
-      )
-      .call([], contextParam);
+  final decoder = switch ((isRequired, nullableElements)) {
+    (true, false) => 'decodeSimpleStringList',
+    (false, false) => 'decodeSimpleNullableStringList',
+    (true, true) => 'decodeSimpleStringNullableList',
+    (false, true) => 'decodeSimpleNullableStringNullableList',
+  };
+  return value.property(decoder).call([], contextParam);
 }
 
 Expression _buildListFromSimpleExpression(
@@ -281,7 +282,12 @@ Expression _buildListFromSimpleExpression(
   );
 
   return switch (content) {
-    StringModel() => listDecode,
+    StringModel() => _buildListDecode(
+      value,
+      isRequired,
+      nullableElements: model.isContentNullable,
+      contextParam: contextParam,
+    ),
     IntegerModel() => _buildPrimitiveList(
       listDecode,
       'decodeSimpleInt',

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -4,12 +4,16 @@ import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
+/// [literal], when supplied, is forwarded as the `literal:` named argument to
+/// every leaf `toSimple`/`uriEncode` call so composite header field-values are
+/// transmitted without URI encoding. It is omitted for path/query callers.
 BuiltExpression buildSimpleParameterExpression(
   Expression valueExpression,
   Model model, {
   required Expression explode,
   required Expression allowEmpty,
   bool isNullable = false,
+  Expression? literal,
 }) {
   return BuiltExpression.simple(
     _buildSimpleParameterExpression(
@@ -18,9 +22,22 @@ BuiltExpression buildSimpleParameterExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isNullable: isNullable,
+      literal: literal,
     ),
   );
 }
+
+Map<String, Expression> _simpleArgs(
+  Expression explode,
+  Expression allowEmpty,
+  Expression? literal, {
+  bool alreadyEncoded = false,
+}) => {
+  'explode': explode,
+  'allowEmpty': allowEmpty,
+  if (alreadyEncoded) 'alreadyEncoded': literalBool(true),
+  'literal': ?literal,
+};
 
 Expression _buildSimpleParameterExpression(
   Expression valueExpression,
@@ -28,6 +45,7 @@ Expression _buildSimpleParameterExpression(
   required Expression explode,
   required Expression allowEmpty,
   bool isNullable = false,
+  Expression? literal,
 }) {
   final propertyAccess = isNullable
       ? valueExpression.nullSafeProperty('toSimple')
@@ -49,10 +67,7 @@ Expression _buildSimpleParameterExpression(
     OneOfModel() ||
     AnyOfModel() => propertyAccess.call(
       [],
-      {
-        'explode': explode,
-        'allowEmpty': allowEmpty,
-      },
+      _simpleArgs(explode, allowEmpty, literal),
     ),
     final ListModel m => _buildListSimpleExpression(
       valueExpression,
@@ -61,6 +76,7 @@ Expression _buildSimpleParameterExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
       isContentNullable: m.isContentNullable || m.content.isEffectivelyNullable,
+      literal: literal,
     ),
     AliasModel() => _buildSimpleParameterExpression(
       valueExpression,
@@ -68,14 +84,12 @@ Expression _buildSimpleParameterExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isNullable: isNullable,
+      literal: literal,
     ),
     AnyModel() =>
       refer('encodeAnyToSimple', 'package:tonik_util/tonik_util.dart').call(
         [valueExpression],
-        {
-          'explode': explode,
-          'allowEmpty': allowEmpty,
-        },
+        _simpleArgs(explode, allowEmpty, literal),
       ),
     Base64Model() =>
       (isNullable
@@ -85,10 +99,7 @@ Expression _buildSimpleParameterExpression(
           .property('toSimple')
           .call(
             [],
-            {
-              'explode': explode,
-              'allowEmpty': allowEmpty,
-            },
+            _simpleArgs(explode, allowEmpty, literal),
           ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be simple-encoded',
@@ -99,6 +110,7 @@ Expression _buildSimpleParameterExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isNullable: isNullable,
+      literal: literal,
     ),
     _ => generateEncodingExceptionExpression(
       'Unsupported model type for simple encoding.',
@@ -113,6 +125,7 @@ Expression _buildListSimpleExpression(
   required Expression allowEmpty,
   bool isNullable = false,
   bool isContentNullable = false,
+  Expression? literal,
 }) {
   final listPropertyAccess = isNullable
       ? valueExpression.nullSafeProperty('toSimple')
@@ -131,10 +144,7 @@ Expression _buildListSimpleExpression(
   return switch (contentModel) {
     StringModel() when !isContentNullable => listPropertyAccess.call(
       [],
-      {
-        'explode': explode,
-        'allowEmpty': allowEmpty,
-      },
+      _simpleArgs(explode, allowEmpty, literal),
     ),
     StringModel() =>
       listMapAccess
@@ -152,10 +162,7 @@ Expression _buildListSimpleExpression(
           .property('toSimple')
           .call(
             [],
-            {
-              'explode': explode,
-              'allowEmpty': allowEmpty,
-            },
+            _simpleArgs(explode, allowEmpty, literal),
           ),
     IntegerModel() ||
     DoubleModel() ||
@@ -179,6 +186,7 @@ Expression _buildListSimpleExpression(
                     contentModel,
                     explode: explode,
                     allowEmpty: allowEmpty,
+                    literal: literal,
                   ),
                 ).code,
             ).closure,
@@ -188,11 +196,7 @@ Expression _buildListSimpleExpression(
           .property('toSimple')
           .call(
             [],
-            {
-              'explode': explode,
-              'allowEmpty': allowEmpty,
-              'alreadyEncoded': literalBool(true),
-            },
+            _simpleArgs(explode, allowEmpty, literal, alreadyEncoded: true),
           ),
     AliasModel() => _buildListSimpleExpression(
       valueExpression,
@@ -201,6 +205,7 @@ Expression _buildListSimpleExpression(
       allowEmpty: allowEmpty,
       isNullable: isNullable,
       isContentNullable: isContentNullable,
+      literal: literal,
     ),
     AnyModel() || AllOfModel() || OneOfModel() || AnyOfModel() =>
       listMapAccess
@@ -211,9 +216,13 @@ Expression _buildListSimpleExpression(
                   Parameter((b) => b..name = 'e'),
                 )
                 ..body = refer(
-                  'encodeAnyToUri',
+                  'encodeAnyToSimple',
                   'package:tonik_util/tonik_util.dart',
-                ).call([refer('e')], {'allowEmpty': allowEmpty}).code,
+                ).call([refer('e')], _simpleArgs(
+                  explode,
+                  allowEmpty,
+                  literal,
+                )).code,
             ).closure,
           ])
           .property('toList')
@@ -221,11 +230,7 @@ Expression _buildListSimpleExpression(
           .property('toSimple')
           .call(
             [],
-            {
-              'explode': explode,
-              'allowEmpty': allowEmpty,
-              'alreadyEncoded': literalBool(true),
-            },
+            _simpleArgs(explode, allowEmpty, literal, alreadyEncoded: true),
           ),
     Base64Model() =>
       listMapAccess
@@ -243,11 +248,7 @@ Expression _buildListSimpleExpression(
           .property('toSimple')
           .call(
             [],
-            {
-              'explode': explode,
-              'allowEmpty': allowEmpty,
-              'alreadyEncoded': literalBool(true),
-            },
+            _simpleArgs(explode, allowEmpty, literal, alreadyEncoded: true),
           ),
     MapModel() => _buildListMapContentSimpleExpression(
       valueExpression,
@@ -255,13 +256,11 @@ Expression _buildListSimpleExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isNullable: isNullable,
+      literal: literal,
     ),
     ClassModel() || ListModel() => listPropertyAccess.call(
       [],
-      {
-        'explode': explode,
-        'allowEmpty': allowEmpty,
-      },
+      _simpleArgs(explode, allowEmpty, literal),
     ),
     BinaryModel() => generateEncodingExceptionExpression(
       'Binary data cannot be simple-encoded',
@@ -278,6 +277,7 @@ Expression _buildMapSimpleExpression(
   required Expression explode,
   required Expression allowEmpty,
   bool isNullable = false,
+  Expression? literal,
 }) {
   final converted = buildMapToStringMapExpression(
     valueExpression,
@@ -299,10 +299,7 @@ Expression _buildMapSimpleExpression(
 
   return toSimpleAccess.call(
     [],
-    {
-      'explode': explode,
-      'allowEmpty': allowEmpty,
-    },
+    _simpleArgs(explode, allowEmpty, literal),
   );
 }
 
@@ -312,6 +309,7 @@ Expression _buildListMapContentSimpleExpression(
   required Expression explode,
   required Expression allowEmpty,
   bool isNullable = false,
+  Expression? literal,
 }) {
   final converted = buildMapToStringMapExpression(
     refer('e'),
@@ -339,10 +337,7 @@ Expression _buildListMapContentSimpleExpression(
             )
             ..body = converted.property('toSimple').call(
               [],
-              {
-                'explode': explode,
-                'allowEmpty': allowEmpty,
-              },
+              _simpleArgs(explode, allowEmpty, literal),
             ).code,
         ).closure,
       ])
@@ -351,10 +346,6 @@ Expression _buildListMapContentSimpleExpression(
       .property('toSimple')
       .call(
         [],
-        {
-          'explode': explode,
-          'allowEmpty': allowEmpty,
-          'alreadyEncoded': literalBool(true),
-        },
+        _simpleArgs(explode, allowEmpty, literal, alreadyEncoded: true),
       );
 }

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -5,7 +5,8 @@ import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
 /// [literal], when supplied, is forwarded as the `literal:` named argument to
-/// every leaf `toSimple`/`uriEncode` call so composite header field-values are
+/// every leaf `toSimple` (and to `encodeAnyToSimple` for the
+/// AnyModel/composite-list branch) so composite header field-values are
 /// transmitted without URI encoding. It is omitted for path/query callers.
 BuiltExpression buildSimpleParameterExpression(
   Expression valueExpression,

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -4,10 +4,8 @@ import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/map_value_to_string_expression_builder.dart';
 
-/// [literal], when supplied, is forwarded as the `literal:` named argument to
-/// every leaf `toSimple` (and to `encodeAnyToSimple` for the
-/// AnyModel/composite-list branch) so composite header field-values are
-/// transmitted without URI encoding. It is omitted for path/query callers.
+/// [literal] emits `literal: true` for composite header field-values (sent
+/// without URI encoding); omitted for path/query callers.
 BuiltExpression buildSimpleParameterExpression(
   Expression valueExpression,
   Model model, {

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -105,6 +105,10 @@ BuiltExpression buildToSimplePathParameterExpression(
 
 /// [isNullChecked] suppresses null-aware access for callers already
 /// inside an `if (param != null)` block.
+///
+/// Primitive and primitive-list header models are encoded literally, since HTTP
+/// header field-values are transmitted as-is. Composite/map/alias/AnyModel
+/// header models stay non-literal.
 BuiltExpression buildToSimpleHeaderParameterExpression(
   String parameterName,
   RequestHeaderObject parameter, {
@@ -120,6 +124,7 @@ BuiltExpression buildToSimpleHeaderParameterExpression(
       isNullable: !isNullChecked && model.isEffectivelyNullable,
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: true,
     ),
   );
 }
@@ -148,14 +153,16 @@ Expression _buildSimpleSerializationExpression(
   required bool isNullable,
   required bool explode,
   required bool allowEmpty,
+  bool literal = false,
 }) {
   final useNullAware = isNullable;
 
-  Expression callToSimple(Expression target) {
+  Expression callToSimple(Expression target, {required bool asLiteral}) {
     const methodName = 'toSimple';
     final args = <String, Expression>{
       'explode': literalBool(explode),
       'allowEmpty': literalBool(allowEmpty),
+      if (asLiteral) 'literal': literalBool(true),
     };
     if (useNullAware) {
       return target.nullSafeProperty(methodName).call([], args);
@@ -176,15 +183,15 @@ Expression _buildSimpleSerializationExpression(
     BooleanModel() ||
     DateTimeModel() ||
     DecimalModel() ||
-    UriModel() => callToSimple(receiver),
+    UriModel() ||
+    DateModel() => callToSimple(receiver, asLiteral: literal),
 
-    // Complex types that should have toSimple methods
-    DateModel() ||
+    // Composite types stay non-literal until a later step.
     EnumModel() ||
     ClassModel() ||
     AllOfModel() ||
     OneOfModel() ||
-    AnyOfModel() => callToSimple(receiver),
+    AnyOfModel() => callToSimple(receiver, asLiteral: false),
 
     // MapModel: convert values to strings, then call toSimple
     MapModel() => _buildMapSimpleExpression(
@@ -203,6 +210,7 @@ Expression _buildSimpleSerializationExpression(
       final args = <String, Expression>{
         'explode': literalBool(explode),
         'allowEmpty': literalBool(allowEmpty),
+        if (literal) 'literal': literalBool(true),
       };
       return base64Expr.property('toSimple').call([], args);
     }(),
@@ -215,9 +223,10 @@ Expression _buildSimpleSerializationExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isContentNullable: m.isContentNullable || m.content.isEffectivelyNullable,
+      literal: literal,
     ),
 
-    // Alias models delegate to their underlying type
+    // Alias stays non-literal until a later step: [literal] is not threaded.
     AliasModel() => _buildSimpleSerializationExpression(
       receiver,
       model.model,
@@ -248,10 +257,12 @@ Expression _handleListExpression(
   required bool explode,
   required bool allowEmpty,
   required bool isContentNullable,
+  bool literal = false,
 }) {
   final toSimpleArgs = <String, Expression>{
     'explode': literalBool(explode),
     'allowEmpty': literalBool(allowEmpty),
+    if (literal) 'literal': literalBool(true),
   };
 
   Expression callToSimpleOnList(Expression listExpr) {
@@ -282,6 +293,25 @@ Expression _handleListExpression(
       .property('toList')
       .call([]);
 
+  // [asLiteral] threads literal encoding through both the per-element and the
+  // whole-list toSimple; composite element kinds pass false.
+  Expression mappedSerialize({required bool asLiteral}) => mappedList(
+    nullGuard(
+      _buildSimpleSerializationExpression(
+        refer('e'),
+        contentModel,
+        isNullable: false,
+        explode: explode,
+        allowEmpty: allowEmpty,
+        literal: asLiteral,
+      ),
+    ),
+  ).property('toSimple').call([], {
+    'explode': literalBool(explode),
+    'allowEmpty': literalBool(allowEmpty),
+    if (asLiteral) 'literal': literalBool(true),
+  });
+
   return switch (contentModel) {
     NeverModel() => generateEncodingExceptionExpression(
       'Cannot encode List<NeverModel> - this type does not permit any value.',
@@ -302,6 +332,7 @@ Expression _handleListExpression(
         nullGuard(
           refer('e').property('uriEncode').call([], {
             'allowEmpty': literalBool(allowEmpty),
+            if (literal) 'literal': literalBool(true),
           }),
         ),
       ).property('toSimple').call([], {
@@ -309,26 +340,17 @@ Expression _handleListExpression(
         'alreadyEncoded': literalBool(true),
       }),
 
-    DateTimeModel() ||
-    DecimalModel() ||
-    UriModel() ||
-    DateModel() ||
+    DateTimeModel() || DecimalModel() || UriModel() || DateModel() =>
+      mappedSerialize(asLiteral: literal),
+
+    // Composite element kinds stay non-literal until a later step.
     EnumModel() ||
     ClassModel() ||
     AllOfModel() ||
     OneOfModel() ||
-    AnyOfModel() => mappedList(
-      nullGuard(
-        _buildSimpleSerializationExpression(
-          refer('e'),
-          contentModel,
-          isNullable: false,
-          explode: explode,
-          allowEmpty: allowEmpty,
-        ),
-      ),
-    ).property('toSimple').call([], toSimpleArgs),
+    AnyOfModel() => mappedSerialize(asLiteral: false),
 
+    // Alias content stays non-literal: the recursion drops [literal].
     AliasModel() => _handleListExpression(
       receiver,
       contentModel.model,

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -106,9 +106,8 @@ BuiltExpression buildToSimplePathParameterExpression(
 /// [isNullChecked] suppresses null-aware access for callers already
 /// inside an `if (param != null)` block.
 ///
-/// Primitive and primitive-list header models are encoded literally, since HTTP
-/// header field-values are transmitted as-is. Composite/map/alias/AnyModel
-/// header models stay non-literal.
+/// Every supported header model is encoded literally, since HTTP header
+/// field-values are transmitted as-is.
 BuiltExpression buildToSimpleHeaderParameterExpression(
   String parameterName,
   RequestHeaderObject parameter, {
@@ -186,12 +185,11 @@ Expression _buildSimpleSerializationExpression(
     UriModel() ||
     DateModel() => callToSimple(receiver, asLiteral: literal),
 
-    // Composite types stay non-literal until a later step.
     EnumModel() ||
     ClassModel() ||
     AllOfModel() ||
     OneOfModel() ||
-    AnyOfModel() => callToSimple(receiver, asLiteral: false),
+    AnyOfModel() => callToSimple(receiver, asLiteral: literal),
 
     // MapModel: convert values to strings, then call toSimple
     MapModel() => _buildMapSimpleExpression(
@@ -200,6 +198,7 @@ Expression _buildSimpleSerializationExpression(
       isNullable: isNullable,
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     ),
 
     // Base64Model: convert to base64 string, then call toSimple
@@ -226,13 +225,13 @@ Expression _buildSimpleSerializationExpression(
       literal: literal,
     ),
 
-    // Alias stays non-literal until a later step: [literal] is not threaded.
     AliasModel() => _buildSimpleSerializationExpression(
       receiver,
       model.model,
       isNullable: isNullable,
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     ),
 
     AnyModel() =>
@@ -241,6 +240,7 @@ Expression _buildSimpleSerializationExpression(
         {
           'explode': literalBool(explode),
           'allowEmpty': literalBool(allowEmpty),
+          if (literal) 'literal': literalBool(true),
         },
       ),
 
@@ -343,14 +343,12 @@ Expression _handleListExpression(
     DateTimeModel() || DecimalModel() || UriModel() || DateModel() =>
       mappedSerialize(asLiteral: literal),
 
-    // Composite element kinds stay non-literal until a later step.
     EnumModel() ||
     ClassModel() ||
     AllOfModel() ||
     OneOfModel() ||
-    AnyOfModel() => mappedSerialize(asLiteral: false),
+    AnyOfModel() => mappedSerialize(asLiteral: literal),
 
-    // Alias content stays non-literal: the recursion drops [literal].
     AliasModel() => _handleListExpression(
       receiver,
       contentModel.model,
@@ -358,6 +356,7 @@ Expression _handleListExpression(
       explode: explode,
       allowEmpty: allowEmpty,
       isContentNullable: isContentNullable,
+      literal: literal,
     ),
 
     AnyModel() => callToSimpleOnList(receiver),
@@ -374,6 +373,7 @@ Expression _handleListExpression(
       isNullable: isNullable,
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     ),
 
     _ => generateEncodingExceptionExpression(
@@ -388,6 +388,7 @@ Expression _buildMapSimpleExpression(
   required bool isNullable,
   required bool explode,
   required bool allowEmpty,
+  bool literal = false,
 }) {
   final converted = buildMapToStringMapExpression(
     receiver,
@@ -412,6 +413,7 @@ Expression _buildMapSimpleExpression(
     {
       'explode': literalBool(explode),
       'allowEmpty': literalBool(allowEmpty),
+      if (literal) 'literal': literalBool(true),
     },
   );
 }
@@ -422,6 +424,7 @@ Expression _buildListMapContentSimpleExpression(
   required bool isNullable,
   required bool explode,
   required bool allowEmpty,
+  bool literal = false,
 }) {
   final converted = buildMapToStringMapExpression(
     refer('e'),
@@ -452,6 +455,7 @@ Expression _buildListMapContentSimpleExpression(
               {
                 'explode': literalBool(explode),
                 'allowEmpty': literalBool(allowEmpty),
+                if (literal) 'literal': literalBool(true),
               },
             ).code,
         ).closure,
@@ -465,6 +469,7 @@ Expression _buildListMapContentSimpleExpression(
           'explode': literalBool(explode),
           'allowEmpty': literalBool(allowEmpty),
           'alreadyEncoded': literalBool(true),
+          if (literal) 'literal': literalBool(true),
         },
       );
 }

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -293,8 +293,6 @@ Expression _handleListExpression(
       .property('toList')
       .call([]);
 
-  // [asLiteral] threads literal encoding through both the per-element and the
-  // whole-list toSimple; composite element kinds pass false.
   Expression mappedSerialize({required bool asLiteral}) => mappedList(
     nullGuard(
       _buildSimpleSerializationExpression(

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -106,8 +106,7 @@ BuiltExpression buildToSimplePathParameterExpression(
 /// [isNullChecked] suppresses null-aware access for callers already
 /// inside an `if (param != null)` block.
 ///
-/// Every supported header model is encoded literally, since HTTP header
-/// field-values are transmitted as-is.
+/// Header field-values are encoded literally (sent as-is).
 BuiltExpression buildToSimpleHeaderParameterExpression(
   String parameterName,
   RequestHeaderObject parameter, {

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -223,6 +223,13 @@ List<Parameter> buildEncodingParameters() => [
   buildBoolParameter('allowEmpty', required: true),
 ];
 
+/// Encoding parameters for simple-style `toSimple`, which additionally accepts
+/// [literal] so header field-values are transmitted without URI encoding.
+List<Parameter> buildSimpleEncodingParameters() => [
+  ...buildEncodingParameters(),
+  buildBoolParameter('literal'),
+];
+
 /// A `Map<String, FormFieldEncoding> fieldEncodings = const {}` parameter that
 /// carries per-property reserved-character overrides into form encoding.
 Parameter buildFieldEncodingsParameter() => Parameter(

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1387,7 +1387,7 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
 
       const expectedToSimple = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; if (list != null) { final _$listSimple = list! .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); } if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( 'Cannot encode to simple: all properties are null', ); } return _$values.first; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$values = <String>{}; if (list != null) { final _$listSimple = list! .map( (e) => e.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ), ) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, literal: literal, ); _$values.add(_$listSimple); } if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( 'Cannot encode to simple: all properties are null', ); } return _$values.first; }
 ''';
 
       expect(
@@ -2533,10 +2533,15 @@ String uriEncode({ required bool allowEmpty, bool useQueryComponent = false, boo
     test('toSimple base64-encodes byte member', () {
       const expected = '''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   return signature!.toBase64String().toSimple(
     explode: explode,
     allowEmpty: allowEmpty,
+    literal: literal,
   );
 }
 ''';
@@ -2630,7 +2635,11 @@ String toMatrix(
     test('toSimple throws for binary member', () {
       const expected = '''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   throw EncodingException('Binary data cannot be simple-encoded');
 }
 ''';

--- a/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
@@ -51,7 +51,7 @@ void main() {
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToSimple = r'''
-String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$listSimple = list .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$values = <String>{}; final _$listSimple = list .map( (e) => e.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ), ) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, literal: literal, ); _$values.add(_$listSimple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
 ''';
 
     expect(
@@ -95,7 +95,7 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToSimple = r'''
-String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$listSimple = list .map((e) => e.toSimple(explode: explode, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listSimple); final _$list2Simple = list2 .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty)) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$list2Simple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$values = <String>{}; final _$listSimple = list .map( (e) => e.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ), ) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, literal: literal, ); _$values.add(_$listSimple); final _$list2Simple = list2 .map( (e) => encodeAnyToSimple( e, explode: explode, allowEmpty: allowEmpty, literal: literal, ), ) .toList() .toSimple( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, literal: literal, ); _$values.add(_$list2Simple); if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf simple encoding: all values must encode to the same result', ); } return _$values.first; }
 ''';
 
     expect(
@@ -151,9 +151,13 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
     final combinedClass = generator.generateClass(model);
 
     const expectedToSimpleMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 
@@ -178,8 +182,16 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
     final combinedClass = generator.generateClass(model);
 
     const expectedToSimpleMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          return bigDecimal.toSimple(explode: explode, allowEmpty: allowEmpty);
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
+          return bigDecimal.toSimple(
+            explode: explode,
+            allowEmpty: allowEmpty,
+            literal: literal,
+          );
         }
       ''';
 
@@ -216,8 +228,16 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
       final combinedClass = generator.generateClass(model);
 
       const expectedToSimpleMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
-          return status.toSimple(explode: explode, allowEmpty: allowEmpty);
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
+          return status.toSimple(
+            explode: explode,
+            allowEmpty: allowEmpty,
+            literal: literal,
+          );
         }
       ''';
 
@@ -261,7 +281,11 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
       final combinedClass = generator.generateClass(model);
 
       const expectedToSimpleMethod = '''
-          String toSimple({required bool explode, required bool allowEmpty}) {
+          String toSimple({
+            required bool explode,
+            required bool allowEmpty,
+            bool literal = false,
+          }) {
             throw EncodingException(
               'Simple encoding not supported: contains complex types',
             );
@@ -303,8 +327,16 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
       final combinedClass = generator.generateClass(model);
 
       const expectedToSimpleMethod = '''
-          String toSimple({required bool explode, required bool allowEmpty}) {
-            return status.toSimple(explode: explode, allowEmpty: allowEmpty);
+          String toSimple({
+            required bool explode,
+            required bool allowEmpty,
+            bool literal = false,
+          }) {
+            return status.toSimple(
+              explode: explode,
+              allowEmpty: allowEmpty,
+              literal: literal,
+            );
           }
         ''';
 
@@ -361,14 +393,18 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$val
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToSimpleMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           if (currentEncodingShape == EncodingShape.mixed) {
             throw EncodingException(
               'Simple encoding not supported: contains complex types',
             );
           }
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -1108,7 +1108,11 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
             switch (innerChoice!.currentEncodingShape) {
               case EncodingShape.simple:
                 _$values.add(
-                  innerChoice!.toSimple(explode: explode, allowEmpty: allowEmpty),
+                  innerChoice!.toSimple(
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    literal: literal,
+                  ),
                 );
                 break;
               case EncodingShape.complex:
@@ -1147,12 +1151,17 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-          String toSimple({required bool explode, required bool allowEmpty}) {
+          String toSimple({
+            required bool explode,
+            required bool allowEmpty,
+            bool literal = false,
+          }) {
             final _$values = <String>{};
             if (int != null) {
               final _$intSimple = int!.toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
+                literal: literal,
               );
               _$values.add(_$intSimple);
             }
@@ -1160,6 +1169,7 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
               final _$stringSimple = string!.toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
+                literal: literal,
               );
               _$values.add(_$stringSimple);
             }

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -700,13 +700,17 @@ void main() {
         );
         expect(toSimpleMethod.name, 'toSimple');
         expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toSimpleMethod.optionalParameters.length, 2);
+        expect(toSimpleMethod.optionalParameters.length, 3);
         expect(
           toSimpleMethod.optionalParameters.any((p) => p.name == 'explode'),
           isTrue,
         );
         expect(
           toSimpleMethod.optionalParameters.any((p) => p.name == 'allowEmpty'),
+          isTrue,
+        );
+        expect(
+          toSimpleMethod.optionalParameters.any((p) => p.name == 'literal'),
           isTrue,
         );
 
@@ -717,7 +721,11 @@ void main() {
 
         const expectedMethod = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   final _$mapValues = <Map<String, PropertyValue>>[];
   String? _$discriminatorValue;
   if (company != null) {
@@ -740,7 +748,11 @@ String toSimple({required bool explode, required bool allowEmpty}) {
   if (_$discValue != null) {
     _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
   }
-  return _$map.toSimple(explode: explode, allowEmpty: allowEmpty);
+  return _$map.toSimple(
+    explode: explode,
+    allowEmpty: allowEmpty,
+    literal: literal,
+  );
 }
 ''';
 
@@ -904,7 +916,7 @@ List<ParameterEntry> toForm(
         );
         expect(toSimpleMethod.name, 'toSimple');
         expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toSimpleMethod.optionalParameters.length, 2);
+        expect(toSimpleMethod.optionalParameters.length, 3);
 
         final format = DartFormatter(
           languageVersion: DartFormatter.latestLanguageVersion,
@@ -913,16 +925,25 @@ List<ParameterEntry> toForm(
 
         const expectedMethod = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   final _$values = <String>{};
   if (int != null) {
-    final _$intSimple = int!.toSimple(explode: explode, allowEmpty: allowEmpty);
+    final _$intSimple = int!.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
     _$values.add(_$intSimple);
   }
   if (string != null) {
     final _$stringSimple = string!.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     );
     _$values.add(_$stringSimple);
   }
@@ -990,7 +1011,11 @@ String toSimple({required bool explode, required bool allowEmpty}) {
 
         const expectedMethod = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   final _$values = <String>{};
   final _$mapValues = <Map<String, PropertyValue>>[];
   String? _$discriminatorValue;
@@ -1003,6 +1028,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     final _$stringSimple = string!.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     );
     _$values.add(_$stringSimple);
   }
@@ -1028,7 +1054,11 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     if (_$discValue != null) {
       _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
     }
-    return _$map.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return _$map.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
 }
 ''';
@@ -2854,13 +2884,18 @@ bool operator ==(Object other) {
 
         const expectedMethod = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   final _$values = <String>{};
   final _$mapValues = <Map<String, PropertyValue>>[];
   if (tonikFile != null) {
     final _$tonikFileSimple = tonikFile!.toBase64String().toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     );
     _$values.add(_$tonikFileSimple);
   }
@@ -2889,6 +2924,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     return _$map.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     );
   }
 }
@@ -3201,7 +3237,11 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
       const expected = r'''
 @override
-String toSimple({required bool explode, required bool allowEmpty}) {
+String toSimple({
+  required bool explode,
+  required bool allowEmpty,
+  bool literal = false,
+}) {
   final _$values = <String>{};
   final _$mapValues = <Map<String, PropertyValue>>[];
   if (object != null) {
@@ -3236,6 +3276,7 @@ String toSimple({required bool explode, required bool allowEmpty}) {
     return _$map.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
+      literal: literal,
     );
   }
 }

--- a/packages/tonik_generate/test/src/model/any_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_simple_generator_test.dart
@@ -277,7 +277,7 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-String toSimple({required bool explode, required bool allowEmpty}) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); _$discriminatorValue ??= r'a'; } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); _$discriminatorValue ??= r'b'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); _$discriminatorValue ??= r'a'; } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); _$discriminatorValue ??= r'b'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ); }
 ''';
 
       expect(
@@ -343,7 +343,7 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$map
         final generated = format(klass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toSimple({required bool explode, required bool allowEmpty}) { final _$mapValues = <Map<String, PropertyValue>>[]; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$mapValues = <Map<String, PropertyValue>>[]; if (a != null) { final _$aSimple = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aSimple); } if (b != null) { final _$bSimple = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bSimple); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ); }
 ''';
 
         expect(
@@ -374,21 +374,26 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$map
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           final _$values = <String>{};
           if (bool != null) {
-            final _$boolSimple = bool!.toSimple( explode: explode, allowEmpty: allowEmpty, );
+            final _$boolSimple = bool!.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, );
             _$values.add(_$boolSimple);
           }
           if (int != null) {
             final _$intSimple = int!.toSimple(
               explode: explode,
               allowEmpty: allowEmpty,
+              literal: literal,
             );
             _$values.add(_$intSimple);
           }
           if (string != null) {
-            final _$stringSimple = string!.toSimple( explode: explode, allowEmpty: allowEmpty, );
+            final _$stringSimple = string!.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, );
             _$values.add(_$stringSimple);
           }
 
@@ -449,7 +454,7 @@ String toSimple({required bool explode, required bool allowEmpty}) { final _$map
         final generated = format(klass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toSimple({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (string != null) { final _$stringSimple = string!.toSimple( explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringSimple); } if (user != null) { final _$userSimple = user!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$userSimple); _$discriminatorValue ??= r'user'; } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple(explode: explode, allowEmpty: allowEmpty); } }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (string != null) { final _$stringSimple = string!.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ); _$values.add(_$stringSimple); } if (user != null) { final _$userSimple = user!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$userSimple); _$discriminatorValue ??= r'user'; } if (_$values.isEmpty && _$mapValues.isEmpty) return ''; if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: mixing simple and complex values', ); } if (_$values.isNotEmpty) { if (_$values.length > 1) { throw EncodingException( r'Ambiguous anyOf simple encoding for MixedSimple: multiple values provided, anyOf requires exactly one value', ); } return _$values.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'disc', () => PropertyValue.scalar(_$discValue)); } return _$map.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ); } }
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -405,9 +405,13 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
@@ -1179,21 +1179,27 @@ void main() {
       );
 
       expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-      expect(toSimpleMethod.optionalParameters, hasLength(2));
+      expect(toSimpleMethod.optionalParameters, hasLength(3));
       expect(
         toSimpleMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty']),
+        containsAll(['explode', 'allowEmpty', 'literal']),
       );
       expect(
-        toSimpleMethod.optionalParameters.every((p) => p.required),
+        toSimpleMethod.optionalParameters
+            .where((p) => p.name != 'literal')
+            .every((p) => p.required),
         isTrue,
       );
 
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 
@@ -1248,9 +1254,13 @@ void main() {
 
         final classCode = format(generatedClass.accept(emitter).toString());
         const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 
@@ -1279,9 +1289,13 @@ void main() {
 
       final classCode = format(generatedClass.accept(emitter).toString());
       const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty);
+            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         }
       ''';
 

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -27,6 +27,18 @@ void main() {
     );
   }
 
+  String formatMethod(Method method, String className) {
+    final clazz = Class(
+      (b) => b
+        ..name = className
+        ..methods.add(method),
+    );
+    final library = Library((b) => b..body.add(clazz));
+    return format(
+      library.accept(DartEmitter(useNullSafetySyntax: true)).toString(),
+    );
+  }
+
   setUp(() {
     nameGenerator = NameGenerator();
     nameManager = NameManager(
@@ -1038,7 +1050,7 @@ void main() {
         );
 
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(toSimple.optionalParameters, hasLength(2));
+        expect(toSimple.optionalParameters, hasLength(3));
 
         final explodeParam = toSimple.optionalParameters.firstWhere(
           (p) => p.name == 'explode',
@@ -1054,10 +1066,23 @@ void main() {
         expect(allowEmptyParam.named, isTrue);
         expect(allowEmptyParam.required, isTrue);
 
-        final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
+        const expected = '''
+          class Status {
+            @override
+            String toSimple({
+              required bool explode,
+              required bool allowEmpty,
+              bool literal = false,
+            }) => rawValue.toSimple(
+              explode: explode,
+              allowEmpty: allowEmpty,
+              literal: literal,
+            );
+          }
+        ''';
         expect(
-          body,
-          'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty)',
+          collapseWhitespace(formatMethod(toSimple, 'Status')),
+          collapseWhitespace(format(expected)),
         );
         expect(toSimple.lambda, isTrue);
       });
@@ -1082,12 +1107,25 @@ void main() {
         );
 
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(toSimple.optionalParameters, hasLength(2));
+        expect(toSimple.optionalParameters, hasLength(3));
 
-        final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
+        const expected = '''
+          class Status {
+            @override
+            String toSimple({
+              required bool explode,
+              required bool allowEmpty,
+              bool literal = false,
+            }) => rawValue.toSimple(
+              explode: explode,
+              allowEmpty: allowEmpty,
+              literal: literal,
+            );
+          }
+        ''';
         expect(
-          body,
-          'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty)',
+          collapseWhitespace(formatMethod(toSimple, 'Status')),
+          collapseWhitespace(format(expected)),
         );
         expect(toSimple.lambda, isTrue);
       });
@@ -1111,12 +1149,25 @@ void main() {
         );
 
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(toSimple.optionalParameters, hasLength(2));
+        expect(toSimple.optionalParameters, hasLength(3));
 
-        final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
+        const expected = '''
+          class Status {
+            @override
+            String toSimple({
+              required bool explode,
+              required bool allowEmpty,
+              bool literal = false,
+            }) => rawValue.toSimple(
+              explode: explode,
+              allowEmpty: allowEmpty,
+              literal: literal,
+            );
+          }
+        ''';
         expect(
-          body,
-          'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty)',
+          collapseWhitespace(formatMethod(toSimple, 'Status')),
+          collapseWhitespace(format(expected)),
         );
         expect(toSimple.lambda, isTrue);
       });
@@ -1141,12 +1192,25 @@ void main() {
         );
 
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
-        expect(toSimple.optionalParameters, hasLength(2));
+        expect(toSimple.optionalParameters, hasLength(3));
 
-        final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
+        const expected = '''
+          class Status {
+            @override
+            String toSimple({
+              required bool explode,
+              required bool allowEmpty,
+              bool literal = false,
+            }) => rawValue.toSimple(
+              explode: explode,
+              allowEmpty: allowEmpty,
+              literal: literal,
+            );
+          }
+        ''';
         expect(
-          body,
-          'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty)',
+          collapseWhitespace(formatMethod(toSimple, 'Status')),
+          collapseWhitespace(format(expected)),
         );
         expect(toSimple.lambda, isTrue);
       });
@@ -2087,14 +2151,14 @@ void main() {
 
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
         expect(toSimple.lambda, isFalse);
-        expect(toSimple.optionalParameters, hasLength(2));
+        expect(toSimple.optionalParameters, hasLength(3));
 
         final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
         const expectedBody = '''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty);
+          return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -2153,14 +2153,29 @@ void main() {
         expect(toSimple.lambda, isFalse);
         expect(toSimple.optionalParameters, hasLength(3));
 
-        final body = toSimple.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
-          if (this == Status.unknown) {
-            throw EncodingException(r'Cannot encode unknown enum value');
+        const expected = '''
+          class Status {
+            @override
+            String toSimple({
+              required bool explode,
+              required bool allowEmpty,
+              bool literal = false,
+            }) {
+              if (this == Status.unknown) {
+                throw EncodingException(r'Cannot encode unknown enum value');
+              }
+              return rawValue.toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                literal: literal,
+              );
+            }
           }
-          return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
         ''';
-        expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
+        expect(
+          collapseWhitespace(formatMethod(toSimple, 'Status')),
+          collapseWhitespace(format(expected)),
+        );
       });
 
       test('toForm throws when encoding fallback case', () {

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -1906,15 +1906,21 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
           contains(
             collapseWhitespace('''
               @override
-              String toSimple({required bool explode, required bool allowEmpty}) {
+              String toSimple({
+                required bool explode,
+                required bool allowEmpty,
+                bool literal = false,
+              }) {
                 return switch (this) {
                   ValueList(:final value) => value.toSimple(
                     explode: explode,
                     allowEmpty: allowEmpty,
+                    literal: literal,
                   ),
                   ValueStr(:final value) => value.toSimple(
                     explode: explode,
                     allowEmpty: allowEmpty,
+                    literal: literal,
                   ),
                 };
               }
@@ -1964,7 +1970,11 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
           contains(
             collapseWhitespace('''
               @override
-              String toSimple({required bool explode, required bool allowEmpty}) {
+              String toSimple({
+                required bool explode,
+                required bool allowEmpty,
+                bool literal = false,
+              }) {
                 return switch (this) {
                   ValueList() => throw EncodingException(
                     'Lists with complex content are not supported for encoding',
@@ -1972,6 +1982,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
                   ValueStr(:final value) => value.toSimple(
                     explode: explode,
                     allowEmpty: allowEmpty,
+                    literal: literal,
                   ),
                 };
               }
@@ -2377,8 +2388,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
           contains(
             collapseWhitespace(
               'ValueDetails(:final value) => value == null '
-              "? '' : value.toSimple(explode: explode, "
-              'allowEmpty: allowEmpty),',
+              "? '' : value.toSimple( explode: explode, "
+              'allowEmpty: allowEmpty, literal: literal, ),',
             ),
           ),
         );
@@ -3567,15 +3578,21 @@ bool operator ==(Object other) {
 
         const expectedMethod = '''
           @override
-          String toSimple({required bool explode, required bool allowEmpty}) {
+          String toSimple({
+            required bool explode,
+            required bool allowEmpty,
+            bool literal = false,
+          }) {
             return switch (this) {
               ValueBase64(:final value) => value.toBase64String().toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
+                literal: literal,
               ),
               ValueText(:final value) => value.toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
+                literal: literal,
               ),
             };
           }
@@ -3639,17 +3656,23 @@ bool operator ==(Object other) {
 
         const expectedMethod = '''
           @override
-          String toSimple({required bool explode, required bool allowEmpty}) {
+          String toSimple({
+            required bool explode,
+            required bool allowEmpty,
+            bool literal = false,
+          }) {
             return switch (this) {
               ValueNullableData(:final value) => value == null
                   ? ''
                   : value.toBase64String().toSimple(
                       explode: explode,
                       allowEmpty: allowEmpty,
+                      literal: literal,
                     ),
               ValueText(:final value) => value.toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
+                literal: literal,
               ),
             };
           }

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -1329,8 +1329,8 @@ void main() {
 
       test('toSimple', () {
         expectContainsBody(
-          'String toSimple({required bool explode, required bool '
-          'allowEmpty}) => $throwExpr',
+          'String toSimple({ required bool explode, required bool allowEmpty, '
+          'bool literal = false, }) => $throwExpr',
         );
       });
 

--- a/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_simple_generator_test.dart
@@ -55,10 +55,14 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Result');
 
       const expectedMethod = '''
-        String toSimple({required bool explode, required bool allowEmpty}) {
+        String toSimple({
+          required bool explode,
+          required bool allowEmpty,
+          bool literal = false,
+        }) {
           return switch (this) {
-            ResultError(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ),
-            ResultSuccess(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ),
+            ResultError(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ),
+            ResultSuccess(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ),
           };
         }
       ''';
@@ -113,7 +117,7 @@ void main() {
         final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
         const expectedMethod = '''
-String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { ResponseMessage(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { return switch (this) { ResponseMessage(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal), }; }
 ''';
 
         expect(
@@ -179,7 +183,7 @@ String toSimple({required bool explode, required bool allowEmpty}) { return swit
         final baseClass = classes.firstWhere((c) => c.name == 'Entity');
 
         const expectedMethod = '''
-String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { EntityCompany(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'company'), }.toSimple(explode: explode, allowEmpty: allowEmpty), EntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { return switch (this) { EntityCompany(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'company'), }.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal), EntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'entity_type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal), }; }
 ''';
 
         expect(
@@ -227,7 +231,7 @@ String toSimple({required bool explode, required bool allowEmpty}) { return swit
         final baseClass = classes.firstWhere((c) => c.name == 'MixedEntity');
 
         const expectedMethod = '''
-String toSimple({required bool explode, required bool allowEmpty}) { return switch (this) { MixedEntityId(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, ), MixedEntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty), }; }
+String toSimple({ required bool explode, required bool allowEmpty, bool literal = false, }) { return switch (this) { MixedEntityId(:final value) => value.toSimple( explode: explode, allowEmpty: allowEmpty, literal: literal, ), MixedEntityPerson(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'person'), }.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal), }; }
 ''';
 
         expect(

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -245,8 +245,11 @@ void main() {
           Options _options({required String xMyHeader}) {
             final _$headers = <String, dynamic>{};
             _$headers['Accept'] = r'*/*';
-            _$headers[r'X-My-Header'] =
-                xMyHeader.toSimple(explode: false, allowEmpty: false);
+            _$headers[r'X-My-Header'] = xMyHeader.toSimple(
+              explode: false,
+              allowEmpty: false,
+              literal: true,
+            );
             return Options(
               method: 'GET',
               headers: _$headers,
@@ -392,17 +395,29 @@ void main() {
           }) {
             final _$headers = <String, dynamic>{};
             _$headers['Accept'] = r'*/*';
-            _$headers[r'X-Required-String'] =
-                xRequiredString.toSimple(explode: false, allowEmpty: false);
-            _$headers[r'X-Required-Date'] =
-                xRequiredDate.toSimple(explode: false, allowEmpty: true);
+            _$headers[r'X-Required-String'] = xRequiredString.toSimple(
+              explode: false,
+              allowEmpty: false,
+              literal: true,
+            );
+            _$headers[r'X-Required-Date'] = xRequiredDate.toSimple(
+              explode: false,
+              allowEmpty: true,
+              literal: true,
+            );
             if (xOptionalBool != null) {
-              _$headers[r'X-Optional-Bool'] = xOptionalBool
-                  .toSimple(explode: false, allowEmpty: false);
+              _$headers[r'X-Optional-Bool'] = xOptionalBool.toSimple(
+                explode: false,
+                allowEmpty: false,
+                literal: true,
+              );
             }
             if (xOptionalList != null) {
-              _$headers[r'X-Optional-List'] = xOptionalList
-                  .toSimple(explode: true, allowEmpty: false);
+              _$headers[r'X-Optional-List'] = xOptionalList.toSimple(
+                explode: true,
+                allowEmpty: false,
+                literal: true,
+              );
             }
             return Options(
               method: 'GET',
@@ -547,7 +562,11 @@ void main() {
         Options _options({required String xMyHeader}) {
           final _$headers = <String, dynamic>{};
           _$headers['Accept'] = r'*/*';
-          _$headers[r'X-My-Header'] = xMyHeader.toSimple(explode: true, allowEmpty: true);
+          _$headers[r'X-My-Header'] = xMyHeader.toSimple(
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          );
           return Options(
             method: 'GET',
             headers: _$headers,
@@ -1058,7 +1077,11 @@ void main() {
       const expectedMethod = r'''
         Options _options({required String accept}) {
           final _$headers = <String, dynamic>{};
-          _$headers[r'Accept'] = accept.toSimple(explode: false, allowEmpty: false);
+          _$headers[r'Accept'] = accept.toSimple(
+            explode: false,
+            allowEmpty: false,
+            literal: true,
+          );
           return Options(
             method: 'GET',
             headers: _$headers,
@@ -1137,7 +1160,11 @@ void main() {
         Options _options({String? accept}) {
           final _$headers = <String, dynamic>{};
           if (accept != null) {
-            _$headers[r'Accept'] = accept.toSimple(explode: false, allowEmpty: false);
+            _$headers[r'Accept'] = accept.toSimple(
+              explode: false,
+              allowEmpty: false,
+              literal: true,
+            );
           } else {
             _$headers['Accept'] = r'application/json,application/xml';
           }

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -503,8 +503,11 @@ void main() {
               final _$headers = <String, dynamic>{};
               _$headers['Accept'] = r'*/*';
               if (xNullableObject != null) {
-                _$headers[r'X-Nullable-Object'] =
-                    xNullableObject.toSimple(explode: false, allowEmpty: false);
+                _$headers[r'X-Nullable-Object'] = xNullableObject.toSimple(
+                  explode: false,
+                  allowEmpty: false,
+                  literal: true,
+                );
               }
               return Options(
                 method: 'GET',
@@ -645,9 +648,15 @@ void main() {
             final _$headers = <String, dynamic>{};
             _$headers['Accept'] = r'*/*';
             _$headers[r'X-Colors'] = xColors
-                .map((e) => e.toSimple(explode: true, allowEmpty: false))
+                .map(
+                  (e) => e.toSimple(
+                    explode: true,
+                    allowEmpty: false,
+                    literal: true,
+                  ),
+                )
                 .toList()
-                .toSimple(explode: true, allowEmpty: false);
+                .toSimple(explode: true, allowEmpty: false, literal: true);
             return Options(
               method: 'GET',
               headers: _$headers,

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -366,6 +366,40 @@ void main() {
       );
     });
 
+    test('generates empty-to-null decoder for nullable-item string lists', () {
+      final value = refer('value');
+      final nullableItemStringListModel = ListModel(
+        content: StringModel(context: context),
+        context: context,
+        examples: const [],
+        isContentNullable: true,
+      );
+
+      expect(
+        buildSimpleValueExpression(
+          value,
+          model: nullableItemStringListModel,
+          isRequired: true,
+          nameManager: nameManager,
+          package: 'tonik_core',
+          explode: literalBool(false),
+        ).accept(emitter).toString(),
+        'value.decodeSimpleStringNullableList()',
+      );
+
+      expect(
+        buildSimpleValueExpression(
+          value,
+          model: nullableItemStringListModel,
+          isRequired: false,
+          nameManager: nameManager,
+          package: 'tonik_core',
+          explode: literalBool(false),
+        ).accept(emitter).toString(),
+        'value.decodeSimpleNullableStringNullableList()',
+      );
+    });
+
     test('generates for alias types', () {
       final value = refer('value');
       final stringAlias = AliasModel(

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -403,7 +403,7 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty)).toList().toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value.map((e) => encodeAnyToSimple(e, explode: explode, allowEmpty: allowEmpty)).toList().toSimple(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -27,6 +27,15 @@ void main() {
   String emit(BuiltExpression built) =>
       built.expression.accept(emitter).toString();
 
+  String methodBody(BuiltExpression built) {
+    final method = Method(
+      (b) => b
+        ..name = 'test'
+        ..body = declareFinal('result').assign(built.expression).statement,
+    );
+    return format(method.accept(emitter).toString());
+  }
+
   group('buildToSimplePathParameterExpression', () {
     test('for String parameter', () {
       final parameter = PathParameterObject(
@@ -98,6 +107,42 @@ void main() {
       );
     });
 
+    test('for integer list parameter omits literal arg', () {
+      final parameter = PathParameterObject(
+        name: 'ids',
+        rawName: 'ids',
+        description: 'IDs parameter',
+        model: ListModel(
+          content: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        encoding: PathParameterEncoding.simple,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      expect(
+        collapseWhitespace(
+          methodBody(buildToSimplePathParameterExpression('ids', parameter)),
+        ),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = ids
+                  .map((e) => e.uriEncode(allowEmpty: true))
+                  .toList()
+                  .toSimple(explode: false, allowEmpty: true, alreadyEncoded: true);
+            }
+          '''),
+        ),
+      );
+    });
+
     test('for NeverModel parameter throws EncodingException', () {
       final parameter = PathParameterObject(
         name: 'neverParam',
@@ -121,75 +166,246 @@ void main() {
   });
 
   group('buildToSimpleHeaderParameterExpression', () {
-    test('for String header', () {
-      final parameter = RequestHeaderObject(
-        name: 'authorization',
-        rawName: 'Authorization',
-        description: 'Authorization header',
-        model: StringModel(context: context),
-        encoding: HeaderParameterEncoding.simple,
-        explode: false,
-        allowEmptyValue: false,
-        isRequired: true,
-        isDeprecated: false,
-        context: context,
-        examples: const [],
-        defaultValue: null,
+    RequestHeaderObject header(Model model) => RequestHeaderObject(
+      name: 'value',
+      rawName: 'X-Value',
+      description: 'header',
+      model: model,
+      encoding: HeaderParameterEncoding.simple,
+      explode: false,
+      allowEmptyValue: false,
+      isRequired: true,
+      isDeprecated: false,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    for (final model in <Model>[
+      StringModel(context: Context.initial()),
+      IntegerModel(context: Context.initial()),
+      DoubleModel(context: Context.initial()),
+      NumberModel(context: Context.initial()),
+      BooleanModel(context: Context.initial()),
+      DateTimeModel(context: Context.initial()),
+      DecimalModel(context: Context.initial()),
+      UriModel(context: Context.initial()),
+      DateModel(context: Context.initial()),
+    ]) {
+      test('primitive ${model.runtimeType} header emits literal: true', () {
+        final built = buildToSimpleHeaderParameterExpression(
+          'value',
+          header(model),
+        );
+        expect(
+          collapseWhitespace(methodBody(built)),
+          collapseWhitespace(
+            format('''
+              test() {
+                final result = value.toSimple(
+                  explode: false,
+                  allowEmpty: true,
+                  literal: true,
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    }
+
+    test('base64 header emits literal toSimple on base64 string', () {
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(Base64Model(context: context)),
       );
       expect(
-        emit(
-          buildToSimpleHeaderParameterExpression('authorization', parameter),
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toBase64String().toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
+            }
+          '''),
         ),
-        'authorization.toSimple(explode: false, allowEmpty: true, )',
       );
     });
 
-    test('for DateTime header with custom params', () {
-      final parameter = RequestHeaderObject(
-        name: 'ifModifiedSince',
-        rawName: 'If-Modified-Since',
-        description: 'If-Modified-Since header',
-        model: DateTimeModel(context: context),
-        encoding: HeaderParameterEncoding.simple,
-        explode: false,
-        allowEmptyValue: false,
-        isRequired: true,
+    test('string list header emits literal toSimple on the list', () {
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(
+          ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+        ),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
+            }
+          '''),
+        ),
+      );
+    });
+
+    test(
+      'integer list header emits literal on element encode and final toSimple',
+      () {
+        final built = buildToSimpleHeaderParameterExpression(
+          'value',
+          header(
+            ListModel(
+              content: IntegerModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+          ),
+        );
+        expect(
+          collapseWhitespace(methodBody(built)),
+          collapseWhitespace(
+            format('''
+              test() {
+                final result = value
+                    .map((e) => e.uriEncode(allowEmpty: true, literal: true))
+                    .toList()
+                    .toSimple(
+                      explode: false,
+                      allowEmpty: true,
+                      literal: true,
+                      alreadyEncoded: true,
+                    );
+              }
+            '''),
+          ),
+        );
+      },
+    );
+
+    test('dateTime list header emits literal on element and list', () {
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(
+          ListModel(
+            content: DateTimeModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+        ),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value
+                  .map(
+                    (e) => e.toSimple(
+                      explode: false,
+                      allowEmpty: true,
+                      literal: true,
+                    ),
+                  )
+                  .toList()
+                  .toSimple(explode: false, allowEmpty: true, literal: true);
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('enum header stays non-literal (deferred)', () {
+      final model = EnumModel<String>(
+        name: 'Status',
+        values: {const EnumEntry(value: 'active')},
+        isNullable: false,
         isDeprecated: false,
+        context: context,
+        examples: const [],
+      );
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(model),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toSimple(explode: false, allowEmpty: true);
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('alias header stays non-literal (deferred)', () {
+      final model = AliasModel(
+        name: 'MyString',
+        model: StringModel(context: context),
         context: context,
         examples: const [],
         defaultValue: null,
       );
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(model),
+      );
       expect(
-        emit(
-          buildToSimpleHeaderParameterExpression(
-            'ifModifiedSince',
-            parameter,
-            explode: true,
-            allowEmpty: false,
-          ),
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toSimple(explode: false, allowEmpty: true);
+            }
+          '''),
         ),
-        'ifModifiedSince.toSimple(explode: true, allowEmpty: false, )',
+      );
+    });
+
+    test('map header stays non-literal (deferred)', () {
+      final model = MapModel(
+        valueModel: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(model),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toSimple(explode: false, allowEmpty: true);
+            }
+          '''),
+        ),
       );
     });
 
     test('for NeverModel header throws EncodingException', () {
-      final parameter = RequestHeaderObject(
-        name: 'neverHeader',
-        rawName: 'NeverHeader',
-        description: 'Never header',
-        model: NeverModel(context: context),
-        encoding: HeaderParameterEncoding.simple,
-        explode: false,
-        allowEmptyValue: false,
-        isRequired: true,
-        isDeprecated: false,
-        context: context,
-        examples: const [],
-        defaultValue: null,
-      );
       expect(
         emit(
-          buildToSimpleHeaderParameterExpression('neverHeader', parameter),
+          buildToSimpleHeaderParameterExpression(
+            'neverHeader',
+            header(NeverModel(context: context)),
+          ),
         ),
         '''throw  EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -328,7 +328,7 @@ void main() {
       );
     });
 
-    test('enum header stays non-literal (deferred)', () {
+    test('enum header emits literal toSimple', () {
       final model = EnumModel<String>(
         name: 'Status',
         values: {const EnumEntry(value: 'active')},
@@ -346,14 +346,46 @@ void main() {
         collapseWhitespace(
           format('''
             test() {
-              final result = value.toSimple(explode: false, allowEmpty: true);
+              final result = value.toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
             }
           '''),
         ),
       );
     });
 
-    test('alias header stays non-literal (deferred)', () {
+    test('class header emits literal toSimple', () {
+      final model = ClassModel(
+        name: 'Point',
+        properties: const [],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(model),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value.toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('alias header threads literal into the resolved model', () {
       final model = AliasModel(
         name: 'MyString',
         model: StringModel(context: context),
@@ -370,14 +402,18 @@ void main() {
         collapseWhitespace(
           format('''
             test() {
-              final result = value.toSimple(explode: false, allowEmpty: true);
+              final result = value.toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
             }
           '''),
         ),
       );
     });
 
-    test('map header stays non-literal (deferred)', () {
+    test('map header emits literal toSimple', () {
       final model = MapModel(
         valueModel: StringModel(context: context),
         context: context,
@@ -392,7 +428,69 @@ void main() {
         collapseWhitespace(
           format('''
             test() {
-              final result = value.toSimple(explode: false, allowEmpty: true);
+              final result = value.toSimple(
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('AnyModel header emits encodeAnyToSimple with literal: true', () {
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(AnyModel(context: context)),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = encodeAnyToSimple(
+                value,
+                explode: false,
+                allowEmpty: true,
+                literal: true,
+              );
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('enum list header emits literal on element and list', () {
+      final model = EnumModel<String>(
+        name: 'Status',
+        values: {const EnumEntry(value: 'active')},
+        isNullable: false,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+      );
+      final built = buildToSimpleHeaderParameterExpression(
+        'value',
+        header(
+          ListModel(content: model, context: context, examples: const []),
+        ),
+      );
+      expect(
+        collapseWhitespace(methodBody(built)),
+        collapseWhitespace(
+          format('''
+            test() {
+              final result = value
+                  .map(
+                    (e) => e.toSimple(
+                      explode: false,
+                      allowEmpty: true,
+                      literal: true,
+                    ),
+                  )
+                  .toList()
+                  .toSimple(explode: false, allowEmpty: true, literal: true);
             }
           '''),
         ),
@@ -1197,6 +1295,65 @@ void main() {
           );
         },
       );
+
+      test(
+        'header List<Map<String, int>> threads literal into element and list '
+        'toSimple',
+        () {
+          final built = buildToSimpleHeaderParameterExpression(
+            'value',
+            RequestHeaderObject(
+              name: 'value',
+              rawName: 'X-Value',
+              description: 'header',
+              model: ListModel(
+                content: MapModel(
+                  valueModel: IntegerModel(context: context),
+                  context: context,
+                  examples: const [],
+                ),
+                context: context,
+                examples: const [],
+              ),
+              encoding: HeaderParameterEncoding.simple,
+              explode: false,
+              allowEmptyValue: false,
+              isRequired: true,
+              isDeprecated: false,
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+          );
+
+          expect(
+            collapseWhitespace(methodBody(built)),
+            collapseWhitespace(
+              format('''
+                test() {
+                  final result = value
+                      .map(
+                        (e) => e
+                            .map((k, v) => MapEntry(k, v.toString()))
+                            .toSimple(
+                              explode: false,
+                              allowEmpty: true,
+                              literal: true,
+                            ),
+                      )
+                      .toList()
+                      .toSimple(
+                        explode: false,
+                        allowEmpty: true,
+                        alreadyEncoded: true,
+                        literal: true,
+                      );
+                }
+              '''),
+            ),
+          );
+        },
+      );
     });
 
     group('nullable list content', () {
@@ -1366,7 +1523,8 @@ void main() {
         emit(
           buildToSimpleHeaderParameterExpression('xCustomHeader', parameter),
         ),
-        'xCustomHeader?.toSimple(explode: false, allowEmpty: true, )',
+        'xCustomHeader?.toSimple(explode: false, allowEmpty: true, '
+        'literal: true, )',
       );
     });
 
@@ -1403,7 +1561,8 @@ void main() {
               isNullChecked: true,
             ),
           ),
-          'xCustomHeader.toSimple(explode: false, allowEmpty: true, )',
+          'xCustomHeader.toSimple(explode: false, allowEmpty: true, '
+          'literal: true, )',
         );
       },
     );
@@ -1441,7 +1600,8 @@ void main() {
               isNullChecked: true,
             ),
           ),
-          'xNullableObject.toSimple(explode: false, allowEmpty: true, )',
+          'xNullableObject.toSimple(explode: false, allowEmpty: true, '
+          'literal: true, )',
         );
       },
     );
@@ -1477,10 +1637,75 @@ void main() {
               parameter,
             ),
           ),
-          'xNullableHeader?.toSimple(explode: false, allowEmpty: true, )',
+          'xNullableHeader?.toSimple(explode: false, allowEmpty: true, '
+          'literal: true, )',
         );
       },
     );
+  });
+
+  group('dual-context: same model literal in header, URI-encoded in path', () {
+    test('ClassModel header emits literal while path stays byte-identical', () {
+      final model = ClassModel(
+        name: 'Point',
+        properties: const [],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final headerBuilt = buildToSimpleHeaderParameterExpression(
+        'value',
+        RequestHeaderObject(
+          name: 'value',
+          rawName: 'X-Value',
+          description: 'header',
+          model: model,
+          encoding: HeaderParameterEncoding.simple,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+      );
+      final pathBuilt = buildToSimplePathParameterExpression(
+        'value',
+        PathParameterObject(
+          name: 'value',
+          rawName: 'value',
+          description: 'path',
+          model: model,
+          encoding: PathParameterEncoding.simple,
+          explode: false,
+          allowEmptyValue: false,
+          isRequired: true,
+          isDeprecated: false,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+      );
+      expect(
+        collapseWhitespace(methodBody(headerBuilt)),
+        collapseWhitespace(
+          format(
+            'test() { final result = value.toSimple(explode: false, '
+            'allowEmpty: true, literal: true); }',
+          ),
+        ),
+      );
+      expect(
+        collapseWhitespace(methodBody(pathBuilt)),
+        collapseWhitespace(
+          format(
+            'test() { final result = '
+            'value.toSimple(explode: false, allowEmpty: true); }',
+          ),
+        ),
+      );
+    });
   });
 
   group('simpleEncodingThrowReason', () {

--- a/packages/tonik_util/lib/src/date.dart
+++ b/packages/tonik_util/lib/src/date.dart
@@ -85,8 +85,11 @@ class Date {
   /// Converts this [Date] to a simple string format.
   ///
   /// Returns the date in ISO 8601 format (YYYY-MM-DD).
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 
   /// Converts this [Date] to a form-encoded parameter entry.
   List<ParameterEntry> toForm(
@@ -125,14 +128,19 @@ class Date {
   }
 
   /// URI encodes this Date value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) => toString().uriEncode(
     allowEmpty: allowEmpty,
     useQueryComponent: useQueryComponent,
     allowReserved: allowReserved,
+    literal: literal,
   );
 
   /// Creates a copy of this [Date] with the given fields replaced

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -7,9 +7,8 @@ import 'package:tonik_util/src/offset_date_time.dart';
 
 /// Extensions for decoding simple form values from strings.
 ///
-/// Simple-style input is treated as a literal (unencoded) field value:
-/// percent-decoding is intentionally not performed, so reserved characters
-/// like `%2F` reach the caller verbatim.
+/// Input is a literal field value: percent-decoding is intentionally not
+/// performed.
 extension SimpleDecoder on String? {
   /// Decodes a string to a string.
   ///
@@ -225,8 +224,7 @@ extension SimpleDecoder on String? {
 
   /// Decodes a base64-encoded string to binary data (`List<int>`).
   ///
-  /// The raw base64 text is passed directly to `base64.decode`; standard
-  /// `+`, `/` and `=` characters are preserved.
+  /// Base64 text is decoded as-is; `+`, `/` and `=` are preserved.
   /// Throws [InvalidTypeException] if the value is null or cannot be decoded.
   List<int> decodeSimpleBase64({String? context}) {
     if (this == null) {

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -6,6 +6,10 @@ import 'package:tonik_util/src/decoding/decoding_exception.dart';
 import 'package:tonik_util/src/offset_date_time.dart';
 
 /// Extensions for decoding simple form values from strings.
+///
+/// Simple-style input is treated as a literal (unencoded) field value:
+/// percent-decoding is intentionally not performed, so reserved characters
+/// like `%2F` reach the caller verbatim.
 extension SimpleDecoder on String? {
   /// Decodes a string to a string.
   ///

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -20,15 +20,7 @@ extension SimpleDecoder on String? {
       );
     }
 
-    try {
-      return Uri.decodeComponent(this!);
-    } on Object {
-      throw InvalidTypeException(
-        value: this!,
-        targetType: String,
-        context: context,
-      );
-    }
+    return this!;
   }
 
   /// Decodes a string to a nullable string.
@@ -36,16 +28,7 @@ extension SimpleDecoder on String? {
   /// Returns null if the string is empty or null.
   String? decodeSimpleNullableString({String? context}) {
     if (this?.isEmpty ?? true) return null;
-
-    try {
-      return Uri.decodeComponent(this!);
-    } on Object {
-      throw InvalidTypeException(
-        value: this!,
-        targetType: String,
-        context: context,
-      );
-    }
+    return this!;
   }
 
   /// Decodes a string to an integer.
@@ -93,8 +76,7 @@ extension SimpleDecoder on String? {
       );
     }
     try {
-      final decoded = Uri.decodeComponent(this!);
-      return double.parse(decoded);
+      return double.parse(this!);
     } on Object {
       throw InvalidTypeException(
         value: this!,
@@ -158,8 +140,7 @@ extension SimpleDecoder on String? {
       );
     }
     try {
-      final decoded = Uri.decodeComponent(this!);
-      return OffsetDateTime.parse(decoded);
+      return OffsetDateTime.parse(this!);
     } on Object {
       throw InvalidTypeException(
         value: this!,
@@ -240,9 +221,8 @@ extension SimpleDecoder on String? {
 
   /// Decodes a base64-encoded string to binary data (`List<int>`).
   ///
-  /// Base64 output can contain `+`, `/` and `=`, which are percent-encoded on
-  /// the wire, so the value is percent-decoded before base64 decoding, like
-  /// [decodeSimpleString].
+  /// The raw base64 text is passed directly to `base64.decode`; standard
+  /// `+`, `/` and `=` characters are preserved.
   /// Throws [InvalidTypeException] if the value is null or cannot be decoded.
   List<int> decodeSimpleBase64({String? context}) {
     if (this == null) {
@@ -256,7 +236,7 @@ extension SimpleDecoder on String? {
       return <int>[];
     }
     try {
-      return base64.decode(Uri.decodeComponent(this!));
+      return base64.decode(this!);
     } on Object {
       throw InvalidTypeException(
         value: this!,
@@ -399,8 +379,7 @@ extension SimpleDecoder on String? {
       );
     }
     try {
-      final decoded = Uri.decodeComponent(this!);
-      return Uri.parse(decoded);
+      return Uri.parse(this!);
     } on FormatException catch (e) {
       throw InvalidTypeException(
         value: this!,

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -117,10 +117,16 @@ String encodeAnyToLabel(
 /// Note: when an unsupported nested element raises [EncodingException], the
 /// message identifies only the inner type — no path / key context is attached
 /// to indicate where in the structure the failure originated.
+///
+/// When [literal] is true, values are transmitted without URI encoding, as
+/// required for HTTP header field-values; the flag is threaded through the
+/// [ParameterEncodable] branch, every primitive branch, and recursive
+/// map / list element encoding.
 String encodeAnyToSimple(
   Object? value, {
   required bool explode,
   required bool allowEmpty,
+  bool literal = false,
 }) {
   if (value == null) {
     if (!allowEmpty) {
@@ -129,28 +135,60 @@ String encodeAnyToSimple(
     return '';
   }
   if (value is ParameterEncodable) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is String) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is int) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is double) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is bool) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is DateTime) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is Uri) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is BigDecimal) {
-    return value.toSimple(explode: explode, allowEmpty: allowEmpty);
+    return value.toSimple(
+      explode: explode,
+      allowEmpty: allowEmpty,
+      literal: literal,
+    );
   }
   if (value is Map<String, dynamic>) {
     if (value.isEmpty && !allowEmpty) {
@@ -162,12 +200,14 @@ String encodeAnyToSimple(
           entry.value,
           explode: explode,
           allowEmpty: allowEmpty,
+          literal: literal,
         ),
     };
     return encoded.toSimple(
       explode: explode,
       allowEmpty: allowEmpty,
       alreadyEncoded: true,
+      literal: literal,
     );
   }
   if (value is List<dynamic>) {
@@ -180,6 +220,7 @@ String encodeAnyToSimple(
             item,
             explode: explode,
             allowEmpty: allowEmpty,
+            literal: literal,
           ),
         )
         .toList();
@@ -187,6 +228,7 @@ String encodeAnyToSimple(
       explode: explode,
       allowEmpty: allowEmpty,
       alreadyEncoded: true,
+      literal: literal,
     );
   }
   throw EncodingException(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -118,10 +118,8 @@ String encodeAnyToLabel(
 /// message identifies only the inner type — no path / key context is attached
 /// to indicate where in the structure the failure originated.
 ///
-/// When [literal] is true, values are transmitted without URI encoding, as
-/// required for HTTP header field-values; the flag is threaded through the
-/// [ParameterEncodable] branch, every primitive branch, and recursive
-/// map / list element encoding.
+/// When [literal] is true, values are sent without URI encoding (HTTP header
+/// field-values), including nested map/list elements.
 String encodeAnyToSimple(
   Object? value, {
   required bool explode,

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -36,10 +36,8 @@ abstract interface class SimpleEncodable {
   ///
   /// When [explode] is true, object properties become key=value pairs.
   /// When [allowEmpty] is false, empty values throw an exception.
-  /// When [literal] is true, values are transmitted without URI encoding, as
-  /// required for HTTP header field-values. Literal output is encode-only: the
-  /// matching `fromSimple` does not reverse it, since header field-values are
-  /// write-only on the client.
+  /// When [literal] is true, the value is sent without URI encoding (HTTP
+  /// header field-values); encode-only — `fromSimple` does not reverse it.
   String toSimple({
     required bool explode,
     required bool allowEmpty,
@@ -106,9 +104,8 @@ abstract interface class JsonEncodable {
 
 /// Marker interface for types that support URI encoding.
 ///
-/// The concrete extensions add a `literal` parameter, but it is deliberately
-/// left off this interface: it is only ever passed on statically-typed
-/// receivers, never through the marker type.
+/// `literal` is intentionally omitted here: it is only passed on
+/// statically-typed receivers, never through this marker type.
 abstract interface class UriEncodable {
   /// URI encodes this value.
   ///

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -36,9 +36,12 @@ abstract interface class SimpleEncodable {
   ///
   /// When [explode] is true, object properties become key=value pairs.
   /// When [allowEmpty] is false, empty values throw an exception.
+  /// When [literal] is true, values are transmitted without URI encoding, as
+  /// required for HTTP header field-values.
   String toSimple({
     required bool explode,
     required bool allowEmpty,
+    bool literal = false,
   });
 }
 

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -37,7 +37,9 @@ abstract interface class SimpleEncodable {
   /// When [explode] is true, object properties become key=value pairs.
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [literal] is true, values are transmitted without URI encoding, as
-  /// required for HTTP header field-values.
+  /// required for HTTP header field-values. Literal output is encode-only: the
+  /// matching `fromSimple` does not reverse it, since header field-values are
+  /// write-only on the client.
   String toSimple({
     required bool explode,
     required bool allowEmpty,
@@ -103,6 +105,10 @@ abstract interface class JsonEncodable {
 }
 
 /// Marker interface for types that support URI encoding.
+///
+/// The concrete extensions add a `literal` parameter, but it is deliberately
+/// left off this interface: it is only ever passed on statically-typed
+/// receivers, never through the marker type.
 abstract interface class UriEncodable {
   /// URI encodes this value.
   ///

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -3,28 +3,39 @@ import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/property_value.dart';
 import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 
-String _encodeValue(PropertyValue value) => switch (value) {
-  ScalarPropertyValue(:final value) => encodeUriValue(
-    value,
-    allowReserved: false,
-    useQueryComponent: false,
-  ),
-  ArrayPropertyValue(:final values) => values
-      .map(
-        (element) => encodeUriValue(
-          element,
-          allowReserved: false,
-          useQueryComponent: false,
-        ),
-      )
-      .join(','),
-};
+String _encodeValue(PropertyValue value, {required bool literal}) =>
+    switch (value) {
+      ScalarPropertyValue(:final value) => literal
+          ? value
+          : encodeUriValue(
+              value,
+              allowReserved: false,
+              useQueryComponent: false,
+            ),
+      ArrayPropertyValue(:final values) => values
+          .map(
+            (element) => literal
+                ? element
+                : encodeUriValue(
+                    element,
+                    allowReserved: false,
+                    useQueryComponent: false,
+                  ),
+          )
+          .join(','),
+    };
 
-String _collapsedPairs(Map<String, PropertyValue> map) => map.entries
+String _encodeKey(String key, {required bool literal}) =>
+    literal ? key : Uri.encodeComponent(key);
+
+String _collapsedPairs(
+  Map<String, PropertyValue> map, {
+  required bool literal,
+}) => map.entries
     .expand(
       (e) => [
-        Uri.encodeComponent(e.key),
-        _encodeValue(e.value),
+        _encodeKey(e.key, literal: literal),
+        _encodeValue(e.value, literal: literal),
       ],
     )
     .join(',');
@@ -55,7 +66,14 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
 /// not a parity gap to "fix".
 extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Encodes this property map using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) {
+  ///
+  /// When [literal] is true, keys and values are emitted without URI encoding,
+  /// as required for HTTP header field-values.
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) {
     _guardEmpty(this, allowEmpty: allowEmpty);
     if (isEmpty) {
       return '';
@@ -64,12 +82,12 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return entries
           .map(
             (e) =>
-                '${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value)}',
+                '${_encodeKey(e.key, literal: literal)}='
+                '${_encodeValue(e.value, literal: literal)}',
           )
           .join(',');
     }
-    return _collapsedPairs(this);
+    return _collapsedPairs(this, literal: literal);
   }
 
   /// Encodes this property map using label style encoding.
@@ -83,11 +101,11 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
           .map(
             (e) =>
                 '.${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value)}',
+                '${_encodeValue(e.value, literal: false)}',
           )
           .join();
     }
-    return '.${_collapsedPairs(this)}';
+    return '.${_collapsedPairs(this, literal: false)}';
   }
 
   /// Encodes this property map using matrix style encoding.
@@ -105,11 +123,11 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
           .map(
             (e) =>
                 ';${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value)}',
+                '${_encodeValue(e.value, literal: false)}',
           )
           .join();
     }
-    return ';$paramName=${_collapsedPairs(this)}';
+    return ';$paramName=${_collapsedPairs(this, literal: false)}';
   }
 
   /// Encodes this property map using deepObject style encoding.

--- a/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
@@ -11,57 +11,81 @@ extension SimpleUriEncoder on Uri {
   ///
   /// The [explode] and [allowEmpty] parameters are accepted for consistency
   /// but have no effect on Uri encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding String values.
 extension SimpleStringEncoder on String {
   /// Encodes this string value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding int values.
 extension SimpleIntEncoder on int {
   /// Encodes this int value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding double values.
 extension SimpleDoubleEncoder on double {
   /// Encodes this double value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding num values.
 extension SimpleNumEncoder on num {
   /// Encodes this num value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding bool values.
 extension SimpleBoolEncoder on bool {
   /// Encodes this bool value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding DateTime values.
 extension SimpleDateTimeEncoder on DateTime {
   /// Encodes this DateTime value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding BigDecimal values.
 extension SimpleBigDecimalEncoder on BigDecimal {
   /// Encodes this BigDecimal value using simple style encoding.
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      uriEncode(allowEmpty: allowEmpty);
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => uriEncode(allowEmpty: allowEmpty, literal: literal);
 }
 
 /// Extension for encoding List values.

--- a/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
@@ -101,11 +101,18 @@ extension SimpleStringListEncoder on List<String> {
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
+  ///
+  /// [literal] joins members with `,` without encoding any member.
   String toSimple({
     required bool explode,
     required bool allowEmpty,
     bool alreadyEncoded = false,
-  }) => uriEncode(allowEmpty: allowEmpty, alreadyEncoded: alreadyEncoded);
+    bool literal = false,
+  }) => uriEncode(
+    allowEmpty: allowEmpty,
+    alreadyEncoded: alreadyEncoded,
+    literal: literal,
+  );
 }
 
 /// Extension for encoding Map values.
@@ -122,10 +129,14 @@ extension SimpleStringMapEncoder on Map<String, String> {
   /// The [alreadyEncoded] parameter indicates whether the values are already
   /// URL-encoded. When `true`, values are not re-encoded to prevent double
   /// encoding.
+  ///
+  /// [literal] emits keys and values unencoded: `k1=v1,k2=v2` when [explode],
+  /// `k1,v1,k2,v2` otherwise.
   String toSimple({
     required bool explode,
     required bool allowEmpty,
     bool alreadyEncoded = false,
+    bool literal = false,
   }) {
     if (explode) {
       // explode=true: key1=value1,key2=value2
@@ -134,6 +145,9 @@ extension SimpleStringMapEncoder on Map<String, String> {
       }
       if (isEmpty) {
         return '';
+      }
+      if (literal) {
+        return entries.map((e) => '${e.key}=${e.value}').join(',');
       }
       return entries
           .map(
@@ -144,7 +158,11 @@ extension SimpleStringMapEncoder on Map<String, String> {
           .join(',');
     } else {
       // explode=false: use uriEncode for key,value pairs
-      return uriEncode(allowEmpty: allowEmpty, alreadyEncoded: alreadyEncoded);
+      return uriEncode(
+        allowEmpty: allowEmpty,
+        alreadyEncoded: alreadyEncoded,
+        literal: literal,
+      );
     }
   }
 }
@@ -162,7 +180,13 @@ extension SimpleBinaryEncoder on List<int> {
   /// The [allowEmpty] parameter controls whether empty lists are allowed:
   /// - When `true`, empty lists are encoded as empty strings
   /// - When `false`, empty lists throw an exception
-  String toSimple({required bool explode, required bool allowEmpty}) {
+  ///
+  /// [literal] returns the UTF-8 conversion without a URI-encoding pass.
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
@@ -170,6 +194,6 @@ extension SimpleBinaryEncoder on List<int> {
       return '';
     }
     final str = decodeToString();
-    return Uri.encodeComponent(str);
+    return literal ? str : Uri.encodeComponent(str);
   }
 }

--- a/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
@@ -172,7 +172,8 @@ extension SimpleBinaryEncoder on List<int> {
   /// Encodes binary data to a UTF-8 string using simple style encoding.
   ///
   /// Uses Utf8Decoder with allowMalformed: true to handle any byte sequence.
-  /// The resulting string is then URL-encoded for safe transport.
+  /// The resulting string is then URL-encoded for safe transport, unless
+  /// [literal] is set.
   ///
   /// The [explode] parameter is accepted for consistency but has no effect
   /// on binary encoding (binary data is treated as a primitive value).

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -235,7 +235,11 @@ extension StringListUriEncoder on List<String> {
       return '';
     }
 
-    if (literal || alreadyEncoded) {
+    if (literal) {
+      return join(',');
+    }
+
+    if (alreadyEncoded) {
       return join(',');
     }
 

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -57,8 +57,7 @@ extension StringUriEncoder on String {
 extension IntUriEncoder on int {
   /// URI encodes this int value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
-  /// [allowReserved].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -101,8 +100,7 @@ extension DoubleUriEncoder on double {
 extension NumUriEncoder on num {
   /// URI encodes this num value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
-  /// [allowReserved].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -122,8 +120,7 @@ extension NumUriEncoder on num {
 extension BoolUriEncoder on bool {
   /// URI encodes this bool value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
-  /// [allowReserved].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -166,8 +163,7 @@ extension DateTimeUriEncoder on DateTime {
 extension BigDecimalUriEncoder on BigDecimal {
   /// URI encodes this BigDecimal value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
-  /// [allowReserved].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -184,16 +184,23 @@ extension BinaryUriEncoder on List<int> {
   /// URI encodes this binary data value.
   ///
   /// Converts the binary data to a UTF-8 string first, then URI encodes it.
+  ///
+  /// [literal] returns the UTF-8 conversion unencoded, overriding
+  /// [useQueryComponent] and [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
     if (isEmpty) {
       return '';
+    }
+    if (literal) {
+      return decodeToString();
     }
     return encodeUriValue(
       decodeToString(),
@@ -210,11 +217,15 @@ extension StringListUriEncoder on List<String> {
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URL-encoded. When `true`, items are not re-encoded to prevent
   /// double encoding.
+  ///
+  /// [literal] joins members with `,` without encoding any member, overriding
+  /// [useQueryComponent] and [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -224,7 +235,7 @@ extension StringListUriEncoder on List<String> {
       return '';
     }
 
-    if (alreadyEncoded) {
+    if (literal || alreadyEncoded) {
       return join(',');
     }
 
@@ -241,11 +252,15 @@ extension StringListUriEncoder on List<String> {
 /// Extension for URI encoding Map values.
 extension StringMapUriEncoder on Map<String, String> {
   /// URI encodes this Map value.
+  ///
+  /// [literal] emits keys and values unencoded as `k1,v1,k2,v2`, overriding
+  /// [useQueryComponent] and [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool alreadyEncoded = false,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
@@ -253,6 +268,10 @@ extension StringMapUriEncoder on Map<String, String> {
 
     if (isEmpty) {
       return '';
+    }
+
+    if (literal) {
+      return entries.expand((e) => [e.key, e.value]).join(',');
     }
 
     String encode(String value) => encodeUriValue(

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -7,27 +7,43 @@ import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 /// Extension for URI encoding Uri values.
 extension UriEncoder on Uri {
   /// URI encodes this Uri value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => encodeUriValue(
-    toString(),
-    allowReserved: allowReserved,
-    useQueryComponent: useQueryComponent,
-  );
+    bool literal = false,
+  }) {
+    if (literal) {
+      return toString();
+    }
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
+  }
 }
 
 /// Extension for URI encoding String values.
 extension StringUriEncoder on String {
   /// URI encodes this string value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
     if (isEmpty && !allowEmpty) {
       throw const EmptyValueException();
+    }
+    if (literal) {
+      return this;
     }
     return encodeUriValue(
       this,
@@ -40,11 +56,18 @@ extension StringUriEncoder on String {
 /// Extension for URI encoding int values.
 extension IntUriEncoder on int {
   /// URI encodes this int value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
+    if (literal) {
+      return toString();
+    }
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -54,25 +77,41 @@ extension IntUriEncoder on int {
 /// Extension for URI encoding double values.
 extension DoubleUriEncoder on double {
   /// URI encodes this double value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => encodeUriValue(
-    toString(),
-    allowReserved: allowReserved,
-    useQueryComponent: useQueryComponent,
-  );
+    bool literal = false,
+  }) {
+    if (literal) {
+      return toString();
+    }
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
+  }
 }
 
 /// Extension for URI encoding num values.
 extension NumUriEncoder on num {
   /// URI encodes this num value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
+    if (literal) {
+      return toString();
+    }
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -82,11 +121,18 @@ extension NumUriEncoder on num {
 /// Extension for URI encoding bool values.
 extension BoolUriEncoder on bool {
   /// URI encodes this bool value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
+    if (literal) {
+      return toString();
+    }
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();
@@ -96,25 +142,41 @@ extension BoolUriEncoder on bool {
 /// Extension for URI encoding DateTime values.
 extension DateTimeUriEncoder on DateTime {
   /// URI encodes this DateTime value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
-  }) => encodeUriValue(
-    toTimeZonedIso8601String(),
-    allowReserved: allowReserved,
-    useQueryComponent: useQueryComponent,
-  );
+    bool literal = false,
+  }) {
+    if (literal) {
+      return toTimeZonedIso8601String();
+    }
+    return encodeUriValue(
+      toTimeZonedIso8601String(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
+  }
 }
 
 /// Extension for URI encoding BigDecimal values.
 extension BigDecimalUriEncoder on BigDecimal {
   /// URI encodes this BigDecimal value.
+  ///
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
     bool allowReserved = false,
+    bool literal = false,
   }) {
+    if (literal) {
+      return toString();
+    }
     return useQueryComponent
         ? Uri.encodeQueryComponent(toString())
         : toString();

--- a/packages/tonik_util/test/src/date_test.dart
+++ b/packages/tonik_util/test/src/date_test.dart
@@ -467,6 +467,11 @@ void main() {
           .value;
       expect(encoded, '2023-12-25');
     });
+
+    test('literal returns plain string form', () {
+      final date = Date(2023, 12, 25);
+      expect(date.uriEncode(allowEmpty: true, literal: true), '2023-12-25');
+    });
   });
 
   group('matrix encoding', () {

--- a/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
@@ -326,35 +326,41 @@ void main() {
       });
     });
 
-    group('Escaping and percent-encoding', () {
-      test('decodeSimpleString decodes percent-encoded comma', () {
-        expect('foo%2Cbar'.decodeSimpleString(), 'foo,bar');
+    group('Literal percent handling', () {
+      test('decodeSimpleString returns percent signs literally', () {
+        expect('50%'.decodeSimpleString(), '50%');
+        expect('75%2Fdone'.decodeSimpleString(), '75%2Fdone');
+        expect('a%20b'.decodeSimpleString(), 'a%20b');
+        expect('foo%2Cbar'.decodeSimpleString(), 'foo%2Cbar');
+        expect('%ZZ'.decodeSimpleString(), '%ZZ');
+        expect('trailing%'.decodeSimpleString(), 'trailing%');
       });
 
-      test('decodeSimpleNullableString decodes percent-encoded comma', () {
-        expect('foo%2Cbar'.decodeSimpleNullableString(), 'foo,bar');
+      test('decodeSimpleNullableString returns percent signs literally', () {
+        expect('50%'.decodeSimpleNullableString(), '50%');
+        expect('foo%2Cbar'.decodeSimpleNullableString(), 'foo%2Cbar');
+        expect('%ZZ'.decodeSimpleNullableString(), '%ZZ');
         expect(''.decodeSimpleNullableString(), isNull);
         expect((null as String?).decodeSimpleNullableString(), isNull);
       });
 
-      test(
-        'decodeSimpleStringList splits only on unescaped commas and decodes',
-        () {
-          expect('foo,bar%2Cbaz,,qux'.decodeSimpleStringList(), [
-            'foo',
-            'bar,baz',
-            '',
-            'qux',
-          ]);
-          expect('foo%2Cbar'.decodeSimpleStringList(), ['foo,bar']);
-          expect(''.decodeSimpleStringList(), isEmpty);
-        },
-      );
+      test('decodeSimpleStringList splits on commas and keeps members raw', () {
+        expect('a%2Cb,c'.decodeSimpleStringList(), ['a%2Cb', 'c']);
+        expect('foo,bar%2Cbaz,,qux'.decodeSimpleStringList(), [
+          'foo',
+          'bar%2Cbaz',
+          '',
+          'qux',
+        ]);
+        expect('foo%2Cbar'.decodeSimpleStringList(), ['foo%2Cbar']);
+        expect(''.decodeSimpleStringList(), isEmpty);
+      });
 
-      test('decodeSimpleNullableStringList splits and decodes', () {
+      test('decodeSimpleNullableStringList keeps members raw', () {
+        expect('a%2Cb,c'.decodeSimpleNullableStringList(), ['a%2Cb', 'c']);
         expect('foo,bar%2Cbaz,,qux'.decodeSimpleNullableStringList(), [
           'foo',
-          'bar,baz',
+          'bar%2Cbaz',
           '',
           'qux',
         ]);
@@ -362,51 +368,49 @@ void main() {
         expect((null as String?).decodeSimpleNullableStringList(), isNull);
       });
 
-      test('decodeSimpleStringNullableList splits, decodes, and converts empty '
-          'to null', () {
+      test('decodeSimpleStringNullableList keeps members raw and empty to null',
+          () {
         expect('foo,bar%2Cbaz,,qux'.decodeSimpleStringNullableList(), [
           'foo',
-          'bar,baz',
+          'bar%2Cbaz',
           null,
           'qux',
         ]);
-        expect('foo%2Cbar'.decodeSimpleStringNullableList(), ['foo,bar']);
+        expect('foo%2Cbar'.decodeSimpleStringNullableList(), ['foo%2Cbar']);
         expect(''.decodeSimpleStringNullableList(), isEmpty);
       });
 
-      test(
-        'decodeSimpleNullableStringNullableList splits, decodes, and converts '
-        'empty to null',
-        () {
-          expect(
-            'foo,bar%2Cbaz,,qux'.decodeSimpleNullableStringNullableList(),
-            ['foo', 'bar,baz', null, 'qux'],
-          );
-          expect(''.decodeSimpleNullableStringNullableList(), isNull);
-          expect(
-            (null as String?).decodeSimpleNullableStringNullableList(),
-            isNull,
-          );
-        },
-      );
-
-      test('decodeSimpleDateTime accepts percent-encoded ISO strings', () {
+      test('decodeSimpleNullableStringNullableList keeps members raw', () {
         expect(
-          '2023-12-25T10%3A30%3A00.000Z'.decodeSimpleDateTime().toUtc(),
-          DateTime.utc(2023, 12, 25, 10, 30),
+          'foo,bar%2Cbaz,,qux'.decodeSimpleNullableStringNullableList(),
+          ['foo', 'bar%2Cbaz', null, 'qux'],
+        );
+        expect(''.decodeSimpleNullableStringNullableList(), isNull);
+        expect(
+          (null as String?).decodeSimpleNullableStringNullableList(),
+          isNull,
         );
       });
 
-      test('decodeSimpleUri accepts percent-encoded values', () {
+      test('decodeSimpleDateTime does not percent-decode before parsing', () {
         expect(
-          'https%3A%2F%2Fexample.com%2Fpath%3Fq%3D1'.decodeSimpleUri(),
-          Uri.parse('https://example.com/path?q=1'),
+          () => '2023-12-25T10%3A30%3A00.000Z'.decodeSimpleDateTime(),
+          throwsA(isA<InvalidTypeException>()),
         );
       });
 
-      test('decodeSimpleDouble accepts percent-encoded exponent plus sign', () {
-        const s = '1.7976931348623157e%2B308';
-        expect(s.decodeSimpleDouble(), closeTo(1.7976931348623157e308, 0));
+      test('decodeSimpleUri does not percent-decode before parsing', () {
+        expect(
+          'https://example.com/a%20b'.decodeSimpleUri(),
+          Uri.parse('https://example.com/a%20b'),
+        );
+      });
+
+      test('decodeSimpleDouble does not percent-decode before parsing', () {
+        expect(
+          () => '1.5%2B0'.decodeSimpleDouble(),
+          throwsA(isA<InvalidTypeException>()),
+        );
       });
     });
 
@@ -472,14 +476,14 @@ void main() {
         expect(decoded, original);
       });
 
-      test('percent-decodes base64 padding before decoding', () {
-        const encoded = '3q2%2B7w%3D%3D';
+      test('decodes standard base64 with padding directly', () {
+        const encoded = '3q2+7w==';
         final result = encoded.decodeSimpleBase64();
         expect(result, [0xDE, 0xAD, 0xBE, 0xEF]);
       });
 
-      test('percent-decodes base64 forward slashes before decoding', () {
-        const encoded = '%2F%2F8%3D';
+      test('decodes standard base64 with forward slashes directly', () {
+        const encoded = '//8=';
         final result = encoded.decodeSimpleBase64();
         expect(result, [0xFF, 0xFF]);
       });
@@ -498,9 +502,9 @@ void main() {
         );
       });
 
-      test('throws InvalidTypeException for malformed percent-escape', () {
+      test('throws InvalidTypeException for percent-encoded base64', () {
         expect(
-          () => '%ZZ'.decodeSimpleBase64(),
+          () => '3q2%2B7w%3D%3D'.decodeSimpleBase64(),
           throwsA(isA<InvalidTypeException>()),
         );
       });

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -35,11 +35,16 @@ class TestEncodableModel implements ParameterEncodable {
   }
 
   @override
-  String toSimple({required bool explode, required bool allowEmpty}) {
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) {
+    final suffix = literal ? '!literal' : '';
     if (explode) {
-      return 'name=$name,value=$value';
+      return 'name=$name$suffix,value=$value';
     }
-    return 'name,$name,value,$value';
+    return 'name,$name$suffix,value,$value';
   }
 
   @override
@@ -144,8 +149,11 @@ class QueryComponentAwareEncodable implements ParameterEncodable {
       throw UnimplementedError();
 
   @override
-  String toSimple({required bool explode, required bool allowEmpty}) =>
-      throw UnimplementedError();
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) => throw UnimplementedError();
 
   @override
   List<ParameterEntry> toDeepObject(
@@ -985,6 +993,100 @@ void main() {
             allowEmpty: true,
           ),
           '',
+        );
+      });
+    });
+
+    group('literal', () {
+      test('forwards literal to the ParameterEncodable branch', () {
+        const model = TestEncodableModel(name: 'has space', value: 42);
+        expect(
+          encodeAnyToSimple(
+            model,
+            explode: false,
+            allowEmpty: false,
+            literal: true,
+          ),
+          'name,has space!literal,value,42',
+        );
+      });
+
+      test('forwards literal to a primitive string branch', () {
+        expect(
+          encodeAnyToSimple(
+            'a/b c%2Fd',
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          ),
+          'a/b c%2Fd',
+        );
+      });
+
+      test('emits map keys and values literally with explode=false', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'q p': 'a/b', 'e%2Fc': 'x y'},
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          ),
+          'q p,a/b,e%2Fc,x y',
+        );
+      });
+
+      test('emits map keys and values literally with explode=true', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{'q p': 'a/b', 'e%2Fc': 'x y'},
+            explode: true,
+            allowEmpty: true,
+            literal: true,
+          ),
+          'q p=a/b,e%2Fc=x y',
+        );
+      });
+
+      test('emits list elements literally', () {
+        expect(
+          encodeAnyToSimple(
+            <dynamic>['hello world', 'a/b', 'c%2Fd'],
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          ),
+          'hello world,a/b,c%2Fd',
+        );
+      });
+
+      test('emits nested map and list values literally including percent, '
+          'slash, space, and comma', () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'tags': <dynamic>['a%2Fb', 'c d'],
+              'path': 'x/y%2Fz',
+            },
+            explode: false,
+            allowEmpty: true,
+            literal: true,
+          ),
+          'tags,a%2Fb,c d,path,x/y%2Fz',
+        );
+      });
+
+      test('default literal=false remains byte-identical for nested map/list',
+          () {
+        expect(
+          encodeAnyToSimple(
+            <String, dynamic>{
+              'tags': <dynamic>['a%2Fb', 'c d'],
+              'path': 'x/y%2Fz',
+            },
+            explode: false,
+            allowEmpty: true,
+          ),
+          'tags,a%252Fb,c%20d,path,x%2Fy%252Fz',
         );
       });
     });

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -130,6 +130,30 @@ void main() {
       expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
       expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
     });
+
+    test('literal leaves reserved keys and values unencoded with '
+        'explode=false', () {
+      const value = {
+        'a/b': PropertyValue.scalar('x=y+z'),
+        'tags': PropertyValue.array(['a,b', 'c d']),
+      };
+      expect(
+        value.toSimple(explode: false, allowEmpty: true, literal: true),
+        'a/b,x=y+z,tags,a,b,c d',
+      );
+    });
+
+    test('literal leaves reserved keys and values unencoded with '
+        'explode=true', () {
+      const value = {
+        'a/b': PropertyValue.scalar('x=y+z'),
+        'tags': PropertyValue.array(['a,b', 'c d']),
+      };
+      expect(
+        value.toSimple(explode: true, allowEmpty: true, literal: true),
+        'a/b=x=y+z,tags=a,b,c d',
+      );
+    });
   });
 
   group('PropertyValueStyleEncoders.toLabel', () {

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -1,10 +1,14 @@
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 import 'package:tonik_util/src/date.dart';
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/simple_encoder_extensions.dart';
 
 void main() {
+  setUpAll(tz.initializeTimeZones);
+
   group('SimpleUriEncoder', () {
     test('encodes HTTPS Uri', () {
       final value = Uri.parse('https://example.com/path?query=value');
@@ -1303,11 +1307,59 @@ void main() {
       );
     });
 
+    test('non-UTC DateTime keeps the offset colon literal', () {
+      final dateTime = tz.TZDateTime(
+        tz.getLocation('Asia/Kolkata'),
+        2023,
+        12,
+        25,
+        20,
+        0,
+        45,
+      );
+      expect(
+        dateTime.toSimple(explode: false, allowEmpty: true, literal: true),
+        '2023-12-25T20:00:45+05:30',
+      );
+    });
+
+    test('non-UTC DateTime offset colon is percent-encoded by default', () {
+      final dateTime = tz.TZDateTime(
+        tz.getLocation('Asia/Kolkata'),
+        2023,
+        12,
+        25,
+        20,
+        0,
+        45,
+      );
+      expect(
+        dateTime.toSimple(explode: false, allowEmpty: true),
+        '2023-12-25T20%3A00%3A45%2B05%3A30',
+      );
+    });
+
     test('Uri keeps punctuation literal', () {
       final uri = Uri.parse('https://example.com/path?query=value');
       expect(
         uri.toSimple(explode: false, allowEmpty: true, literal: true),
         'https://example.com/path?query=value',
+      );
+    });
+
+    test('Uri keeps the fragment delimiter literal', () {
+      final uri = Uri.parse('https://example.com/p#frag');
+      expect(
+        uri.toSimple(explode: false, allowEmpty: true, literal: true),
+        'https://example.com/p#frag',
+      );
+    });
+
+    test('Uri fragment delimiter is percent-encoded without literal', () {
+      final uri = Uri.parse('https://example.com/p#frag');
+      expect(
+        uri.toSimple(explode: false, allowEmpty: true),
+        'https%3A%2F%2Fexample.com%2Fp%23frag',
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
 import 'package:timezone/data/latest.dart' as tz;
@@ -1411,12 +1413,138 @@ void main() {
       );
     });
 
+    test('list joins members without encoding them', () {
+      expect(
+        ['a b', 'c/d', '50%'].toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        ),
+        'a b,c/d,50%',
+      );
+    });
+
+    test('list keeps percent sequences verbatim under explode', () {
+      expect(
+        ['%2F', 'plain%'].toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        ),
+        '%2F,plain%',
+      );
+    });
+
+    test('empty list still throws when allowEmpty is false', () {
+      expect(
+        () => <String>[].toSimple(
+          explode: false,
+          allowEmpty: false,
+          literal: true,
+        ),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('non-explode map emits k1,v1,k2,v2 verbatim', () {
+      expect(
+        {'k': 'a b'}.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        ),
+        'k,a b',
+      );
+    });
+
+    test('explode map emits k=v verbatim', () {
+      expect(
+        {'k': 'a b'}.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        ),
+        'k=a b',
+      );
+    });
+
+    test('explode map keeps percent sequences in keys and values verbatim', () {
+      expect(
+        {'50%': '%2F', 'k2': 'c/d'}.toSimple(
+          explode: true,
+          allowEmpty: true,
+          literal: true,
+        ),
+        '50%=%2F,k2=c/d',
+      );
+    });
+
+    test('empty explode map still throws when allowEmpty is false', () {
+      expect(
+        () => <String, String>{}.toSimple(
+          explode: true,
+          allowEmpty: false,
+          literal: true,
+        ),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('binary returns UTF-8 conversion without a URI-encoding pass', () {
+      expect(
+        utf8.encode('a b/:').toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        ),
+        'a b/:',
+      );
+    });
+
+    test('empty binary still throws when allowEmpty is false', () {
+      expect(
+        () => <int>[].toSimple(
+          explode: false,
+          allowEmpty: false,
+          literal: true,
+        ),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('base64-shaped string keeps + / = literal', () {
+      expect(
+        'YWI+Y2Q/ZWY='.toSimple(
+          explode: false,
+          allowEmpty: true,
+          literal: true,
+        ),
+        'YWI+Y2Q/ZWY=',
+      );
+    });
+
     test('literal false stays byte-identical to default simple behavior', () {
       expect(
         'a b/:'.toSimple(explode: false, allowEmpty: true),
         'a%20b%2F%3A',
       );
       expect(42.toSimple(explode: false, allowEmpty: true), '42');
+      expect(
+        ['a b', 'c/d'].toSimple(explode: false, allowEmpty: true),
+        'a%20b,c%2Fd',
+      );
+      expect(
+        {'k': 'a b'}.toSimple(explode: false, allowEmpty: true),
+        'k,a%20b',
+      );
+      expect(
+        {'k': 'a b'}.toSimple(explode: true, allowEmpty: true),
+        'k=a%20b',
+      );
+      expect(
+        utf8.encode('a b/:').toSimple(explode: false, allowEmpty: true),
+        'a%20b%2F%3A',
+      );
     });
   });
 }

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -1,5 +1,7 @@
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
+import 'package:tonik_util/src/date.dart';
+import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/simple_encoder_extensions.dart';
 
 void main() {
@@ -1275,6 +1277,94 @@ void main() {
         value.toSimple(explode: true, allowEmpty: true),
         value.toSimple(explode: false, allowEmpty: true),
       );
+    });
+  });
+
+  group('literal', () {
+    test('string is returned byte-for-byte unchanged', () {
+      expect(
+        'a b%,/:&=+%2F'.toSimple(explode: false, allowEmpty: true, literal: true),
+        'a b%,/:&=+%2F',
+      );
+    });
+
+    test('empty string still throws when allowEmpty is false', () {
+      expect(
+        () => ''.toSimple(explode: false, allowEmpty: false, literal: true),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('DateTime keeps literal colons', () {
+      final dateTime = DateTime.utc(2023, 12, 25, 10, 30, 45);
+      expect(
+        dateTime.toSimple(explode: false, allowEmpty: true, literal: true),
+        '2023-12-25T10:30:45.000Z',
+      );
+    });
+
+    test('Uri keeps punctuation literal', () {
+      final uri = Uri.parse('https://example.com/path?query=value');
+      expect(
+        uri.toSimple(explode: false, allowEmpty: true, literal: true),
+        'https://example.com/path?query=value',
+      );
+    });
+
+    test('int uses plain string form', () {
+      expect(
+        (-123).toSimple(explode: false, allowEmpty: true, literal: true),
+        '-123',
+      );
+    });
+
+    test('double uses plain string form', () {
+      expect(
+        3.14.toSimple(explode: false, allowEmpty: true, literal: true),
+        '3.14',
+      );
+    });
+
+    test('num uses plain string form', () {
+      expect(
+        (3.14 as num).toSimple(explode: false, allowEmpty: true, literal: true),
+        '3.14',
+      );
+    });
+
+    test('bool uses plain string form', () {
+      expect(
+        true.toSimple(explode: false, allowEmpty: true, literal: true),
+        'true',
+      );
+    });
+
+    test('BigDecimal uses plain string form', () {
+      expect(
+        BigDecimal.parse(
+          '123.456',
+        ).toSimple(explode: false, allowEmpty: true, literal: true),
+        '123.456',
+      );
+    });
+
+    test('Date uses plain string form', () {
+      expect(
+        Date(
+          2023,
+          12,
+          25,
+        ).toSimple(explode: false, allowEmpty: true, literal: true),
+        '2023-12-25',
+      );
+    });
+
+    test('literal false stays byte-identical to default simple behavior', () {
+      expect(
+        'a b/:'.toSimple(explode: false, allowEmpty: true),
+        'a%20b%2F%3A',
+      );
+      expect(42.toSimple(explode: false, allowEmpty: true), '42');
     });
   });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -628,6 +628,17 @@ void main() {
       );
     });
 
+    test('list joins members verbatim when literal and alreadyEncoded', () {
+      expect(
+        ['a b', 'c/d', '%2F'].uriEncode(
+          allowEmpty: true,
+          literal: true,
+          alreadyEncoded: true,
+        ),
+        'a b,c/d,%2F',
+      );
+    });
+
     test('empty list still throws when allowEmpty is false', () {
       expect(
         () => <String>[].uriEncode(allowEmpty: false, literal: true),

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
 import 'package:timezone/data/latest.dart' as tz;
@@ -612,11 +614,95 @@ void main() {
       );
     });
 
+    test('list joins members without encoding them', () {
+      expect(
+        ['a b', 'c/d', '50%'].uriEncode(allowEmpty: true, literal: true),
+        'a b,c/d,50%',
+      );
+    });
+
+    test('list keeps already-percent-encoded members verbatim', () {
+      expect(
+        ['%2F', 'plain%'].uriEncode(allowEmpty: true, literal: true),
+        '%2F,plain%',
+      );
+    });
+
+    test('empty list still throws when allowEmpty is false', () {
+      expect(
+        () => <String>[].uriEncode(allowEmpty: false, literal: true),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty list allowed when allowEmpty is true', () {
+      expect(<String>[].uriEncode(allowEmpty: true, literal: true), '');
+    });
+
+    test('map emits keys and values verbatim as k1,v1,k2,v2', () {
+      expect(
+        {'k1': 'a b', 'k2': 'c/d'}.uriEncode(allowEmpty: true, literal: true),
+        'k1,a b,k2,c/d',
+      );
+    });
+
+    test('map keeps percent sequences in keys and values verbatim', () {
+      expect(
+        {'50%': '%2F'}.uriEncode(allowEmpty: true, literal: true),
+        '50%,%2F',
+      );
+    });
+
+    test('empty map still throws when allowEmpty is false', () {
+      expect(
+        () => <String, String>{}.uriEncode(allowEmpty: false, literal: true),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty map allowed when allowEmpty is true', () {
+      expect(<String, String>{}.uriEncode(allowEmpty: true, literal: true), '');
+    });
+
+    test('binary returns UTF-8 conversion without a URI-encoding pass', () {
+      expect(
+        utf8.encode('a b/:').uriEncode(allowEmpty: true, literal: true),
+        'a b/:',
+      );
+    });
+
+    test('empty binary still throws when allowEmpty is false', () {
+      expect(
+        () => <int>[].uriEncode(allowEmpty: false, literal: true),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty binary allowed when allowEmpty is true', () {
+      expect(<int>[].uriEncode(allowEmpty: true, literal: true), '');
+    });
+
+    test('base64-shaped string keeps + / = literal', () {
+      expect(
+        'YWI+Y2Q/ZWY='.uriEncode(allowEmpty: true, literal: true),
+        'YWI+Y2Q/ZWY=',
+      );
+    });
+
     test('literal false stays byte-identical to default URI behavior', () {
       expect('a b/:'.uriEncode(allowEmpty: true), 'a%20b%2F%3A');
       expect(42.uriEncode(allowEmpty: true), '42');
       final uri = Uri.parse('https://example.com');
       expect(uri.uriEncode(allowEmpty: true), 'https%3A%2F%2Fexample.com');
+      expect(
+        ['a b', 'c/d'].uriEncode(allowEmpty: true),
+        'a%20b,c%2Fd',
+      );
+      expect(
+        {'k': 'a b'}.uriEncode(allowEmpty: true),
+        'k,a%20b',
+      );
+      expect(utf8.encode('a b/:').uriEncode(allowEmpty: true), 'a%20b%2F%3A');
     });
   });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -479,4 +479,92 @@ void main() {
       );
     });
   });
+
+  group('literal', () {
+    test('string is returned byte-for-byte unchanged', () {
+      expect(
+        'a b%,/:&=+%2F'.uriEncode(allowEmpty: true, literal: true),
+        'a b%,/:&=+%2F',
+      );
+    });
+
+    test('string literal keeps unicode unchanged', () {
+      expect('你好'.uriEncode(allowEmpty: true, literal: true), '你好');
+    });
+
+    test('empty string still throws when allowEmpty is false', () {
+      expect(
+        () => ''.uriEncode(allowEmpty: false, literal: true),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('empty string allowed when allowEmpty is true', () {
+      expect(''.uriEncode(allowEmpty: true, literal: true), '');
+    });
+
+    test('DateTime keeps literal colons', () {
+      final dateTime = DateTime.utc(2023, 12, 25, 10, 30, 45);
+      expect(
+        dateTime.uriEncode(allowEmpty: true, literal: true),
+        '2023-12-25T10:30:45.000Z',
+      );
+    });
+
+    test('Uri keeps punctuation literal', () {
+      final uri = Uri.parse('https://example.com/path?query=value');
+      expect(
+        uri.uriEncode(allowEmpty: true, literal: true),
+        'https://example.com/path?query=value',
+      );
+    });
+
+    test('int uses plain string form', () {
+      expect((-123).uriEncode(allowEmpty: true, literal: true), '-123');
+    });
+
+    test('double uses plain string form', () {
+      expect(3.14.uriEncode(allowEmpty: true, literal: true), '3.14');
+    });
+
+    test('num uses plain string form', () {
+      expect((3.14 as num).uriEncode(allowEmpty: true, literal: true), '3.14');
+    });
+
+    test('bool uses plain string form', () {
+      expect(true.uriEncode(allowEmpty: true, literal: true), 'true');
+    });
+
+    test('BigDecimal uses plain string form', () {
+      expect(
+        BigDecimal.parse('123.456').uriEncode(allowEmpty: true, literal: true),
+        '123.456',
+      );
+    });
+
+    test('takes precedence over useQueryComponent', () {
+      expect(
+        'a b'.uriEncode(
+          allowEmpty: true,
+          literal: true,
+          useQueryComponent: true,
+        ),
+        'a b',
+      );
+    });
+
+    test('takes precedence over allowReserved', () {
+      expect(
+        'a&b=c'.uriEncode(allowEmpty: true, literal: true, allowReserved: true),
+        'a&b=c',
+      );
+    });
+
+    test('literal false stays byte-identical to default URI behavior', () {
+      expect('a b/:'.uriEncode(allowEmpty: true), 'a%20b%2F%3A');
+      expect(42.uriEncode(allowEmpty: true), '42');
+      final uri = Uri.parse('https://example.com');
+      expect(uri.uriEncode(allowEmpty: true), 'https%3A%2F%2Fexample.com');
+    });
+  });
 }

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -1,9 +1,13 @@
 import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
 void main() {
+  setUpAll(tz.initializeTimeZones);
+
   group('UriEncoder', () {
     test('encodes URI values', () {
       final uri = Uri.parse('https://example.com/path?query=value');
@@ -511,11 +515,59 @@ void main() {
       );
     });
 
+    test('non-UTC DateTime keeps the offset colon literal', () {
+      final dateTime = tz.TZDateTime(
+        tz.getLocation('Asia/Kolkata'),
+        2023,
+        12,
+        25,
+        20,
+        0,
+        45,
+      );
+      expect(
+        dateTime.uriEncode(allowEmpty: true, literal: true),
+        '2023-12-25T20:00:45+05:30',
+      );
+    });
+
+    test('non-UTC DateTime offset colon is percent-encoded by default', () {
+      final dateTime = tz.TZDateTime(
+        tz.getLocation('Asia/Kolkata'),
+        2023,
+        12,
+        25,
+        20,
+        0,
+        45,
+      );
+      expect(
+        dateTime.uriEncode(allowEmpty: true),
+        '2023-12-25T20%3A00%3A45%2B05%3A30',
+      );
+    });
+
     test('Uri keeps punctuation literal', () {
       final uri = Uri.parse('https://example.com/path?query=value');
       expect(
         uri.uriEncode(allowEmpty: true, literal: true),
         'https://example.com/path?query=value',
+      );
+    });
+
+    test('Uri keeps the fragment delimiter literal', () {
+      final uri = Uri.parse('https://example.com/p#frag');
+      expect(
+        uri.uriEncode(allowEmpty: true, literal: true),
+        'https://example.com/p#frag',
+      );
+    });
+
+    test('Uri fragment delimiter is percent-encoded without literal', () {
+      final uri = Uri.parse('https://example.com/p#frag');
+      expect(
+        uri.uriEncode(allowEmpty: true),
+        'https%3A%2F%2Fexample.com%2Fp%23frag',
       );
     });
 


### PR DESCRIPTION
## Summary

HTTP header field-values are not URI components, so tonik must not percent-encode them on send or percent-decode them on receive (RFC 9110 §5.5; OpenAPI). This change makes header field-values literal in both directions, for every supported header shape, with no configuration option and no legacy encoding mode.

- **Request headers** are serialized literally: the value and its OpenAPI `style: simple` delimiters are emitted without a URI percent-encoding pass.
- **Response headers** are returned exactly as received: no `Uri.decodeComponent`, so a literal `%` or apparent `%xx` survives.

Path, query, form, multipart, and body serialization are unchanged.

## How it works

An internal `literal` argument (default `false`) is threaded through the `tonik_util` simple/URI encoders and the generated composite `toSimple` methods. Generated header call sites pass `literal: true`; path/query call sites omit the argument entirely, so their output stays byte-identical. Response-header decoding drops percent-decoding unconditionally (the simple decoder is only ever used for response headers). The same model therefore serializes literally in a header and percent-encoded in a path or query.

### Covered shapes
- Scalars: `String`, `int`, `double`, `num`, `bool`, `DateTime`, `BigDecimal`, `Date`, `Uri`.
- Collections: `List`, `Map`, binary, and base64.
- Composites: enums, objects, `allOf`/`oneOf`/`anyOf`, aliases, `AnyModel`, and lists of supported values.

### Interface change
`SimpleEncodable.toSimple` gains an optional `literal` parameter; all implementors (generated models and the runtime encoders) are updated together.

## Behavior notes
- Control characters (CR, LF, NUL) in a literal header value are rejected before dispatch by the transport, verified by integration tests (rejection, never sanitization).
- Simple-style arrays/objects delimit with `,` (and `=` when exploded); an in-value delimiter cannot round-trip. This inherent limitation is documented explicitly in tests — no escape convention is invented.
- Non-ASCII header field-values are not transmittable over the transport and are asserted as rejected.

## Tests
- Unit coverage across `tonik_util` (encoders/decoder) and `tonik_generate` (every composite generator), with generated-code assertions as full method-body comparisons.
- Integration coverage asserts literal request values on the wire and independent server-originated response values for scalars, collections, objects, enums, and each composition family.

`fvm dart analyze packages/` and `fvm dart analyze integration_test` are clean; all unit suites and the full integration suite pass; patch coverage is ≥ 90%.
