### PR TITLE
fix: serialize empty-string primitive query params instead of throwing

### DIFF
--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -78,6 +78,16 @@ void main() {
       expect(success.response.requestOptions.uri.query, 'string=test');
     });
 
+    test('empty string sends the name with an empty value', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormPrimitive(string: '');
+
+      expect(response, isA<TonikSuccess<void>>());
+
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, 'string=');
+    });
+
     test('boolean', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormPrimitive(boolean: true);
@@ -646,6 +656,16 @@ void main() {
       expect(response, isA<TonikSuccess<void>>());
       final success = response as TonikSuccess<void>;
       expect(success.response.requestOptions.uri.query, 'nullableString=test');
+    });
+
+    test('nullableString with empty string sends an empty value, not omitted',
+        () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormPrimitive(nullableString: '');
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, 'nullableString=');
     });
 
     test('nullableString with null', () async {

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
@@ -106,19 +106,20 @@ void main() {
         expect(success.value.xUserName, userName);
       });
 
-      test('fails to encode empty string', () async {
-        // Empty strings fail encoding with EmptyValueException
+      test('sends empty string as an empty header, decoded back as null',
+          () async {
         const userName = '';
 
         final result = await api.testHeaderRoundtripAliases(userName: userName);
 
         expect(
           result,
-          isA<TonikError<HeadersRoundtripAliasesGet200Response>>(),
+          isA<TonikSuccess<HeadersRoundtripAliasesGet200Response>>(),
         );
-        final error =
-            result as TonikError<HeadersRoundtripAliasesGet200Response>;
-        expect(error.type, TonikErrorType.encoding);
+        final success =
+            result as TonikSuccess<HeadersRoundtripAliasesGet200Response>;
+        expect(success.response.requestOptions.headers['X-User-Name'], '');
+        expect(success.value.xUserName, isNull);
       });
 
       test('roundtrips UserName with special characters', () async {

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_primitive_test.dart
@@ -76,20 +76,25 @@ void main() {
         expect(success.value.xFlexibleValue!.string, 'hello world');
       });
 
-      test('empty string fails at encoding', () async {
+      test('round-trips empty string', () async {
         final result = await api.testHeaderRoundtripAnyOfPrimitive.call(
           flexibleValue: const AnyOfPrimitive(string: ''),
         );
 
         expect(
           result,
-          isA<TonikError<HeadersRoundtripAnyofPrimitiveGet200Response>>(),
+          isA<TonikSuccess<HeadersRoundtripAnyofPrimitiveGet200Response>>(),
         );
-        final error =
-            result as TonikError<HeadersRoundtripAnyofPrimitiveGet200Response>;
+        final success =
+            result
+                as TonikSuccess<HeadersRoundtripAnyofPrimitiveGet200Response>;
 
-        expect(error.type, TonikErrorType.encoding);
-        expect(error.response, isNull);
+        expect(
+          success.response.requestOptions.headers['X-Flexible-Value'],
+          '',
+        );
+        expect(success.value.xFlexibleValue, isNotNull);
+        expect(success.value.xFlexibleValue!.string, '');
       });
     });
 

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_primitive_test.dart
@@ -186,24 +186,29 @@ void main() {
         );
       });
 
-      test('empty string fails at encoding', () async {
+      test('round-trips empty string', () async {
         final result = await api.testHeaderRoundtripOneOfPrimitive.call(
           primitiveUnion: const OneOfPrimitiveString(''),
         );
 
-        // Empty strings throw EmptyValueException during encoding
-        // because allowEmpty is false for headers
         expect(
           result,
-          isA<TonikError<HeadersRoundtripOneofPrimitiveGet200Response>>(),
+          isA<TonikSuccess<HeadersRoundtripOneofPrimitiveGet200Response>>(),
         );
-        final error =
-            result as TonikError<HeadersRoundtripOneofPrimitiveGet200Response>;
+        final success =
+            result
+                as TonikSuccess<HeadersRoundtripOneofPrimitiveGet200Response>;
 
-        expect(error.type, TonikErrorType.encoding);
+        expect(
+          success.response.requestOptions.headers['X-Primitive-Union'],
+          '',
+        );
 
-        // No response because request was never sent
-        expect(error.response, isNull);
+        expect(success.value.xPrimitiveUnion, isA<OneOfPrimitiveString>());
+        expect(
+          (success.value.xPrimitiveUnion! as OneOfPrimitiveString).value,
+          '',
+        );
       });
 
       test('round-trips numeric string', () async {

--- a/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
@@ -14,9 +14,6 @@ extension LabelUriEncoder on Uri {
 extension LabelStringEncoder on String {
   /// Encodes this string value using label style encoding.
   String toLabel({required bool explode, required bool allowEmpty}) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     if (isEmpty) {
       return '.';
     }

--- a/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
@@ -24,11 +24,18 @@ extension MatrixUriEncoder on Uri {
 /// Extension for encoding String values.
 extension MatrixStringEncoder on String {
   /// Encodes this string value using matrix style encoding.
+  ///
+  /// A defined empty string expands to `;name` without `=`.
   String toMatrix(
     String paramName, {
     required bool explode,
     required bool allowEmpty,
-  }) => ';$paramName=${uriEncode(allowEmpty: allowEmpty)}';
+  }) {
+    if (isEmpty) {
+      return ';$paramName';
+    }
+    return ';$paramName=${uriEncode(allowEmpty: allowEmpty)}';
+  }
 }
 
 /// Extension for encoding int values.

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -26,9 +26,6 @@ extension StringUriEncoder on String {
     bool useQueryComponent = false,
     bool allowReserved = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     return encodeUriValue(
       this,
       allowReserved: allowReserved,

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2223,11 +2223,8 @@ void main() {
         );
       });
 
-      test('throws for empty string with allowEmpty=false', () {
-        expect(
-          () => encodeAnyToUri('', allowEmpty: false),
-          throwsA(isA<EmptyValueException>()),
-        );
+      test('encodes empty string as empty with allowEmpty=false', () {
+        expect(encodeAnyToUri('', allowEmpty: false), '');
       });
 
       test('uses query component encoding when requested', () {

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -54,14 +54,14 @@ void main() {
       );
     });
 
-    test('handles empty strings based on allowEmpty', () {
+    test('encodes empty string as an empty value regardless of allowEmpty', () {
       expect(
         ''.toForm('p', explode: false, allowEmpty: true),
         const <ParameterEntry>[(name: 'p', value: '')],
       );
       expect(
-        () => ''.toForm('p', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        ''.toForm('p', explode: false, allowEmpty: false),
+        const <ParameterEntry>[(name: 'p', value: '')],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
@@ -20,11 +20,8 @@ void main() {
       expect(''.toLabel(explode: false, allowEmpty: true), '.');
     });
 
-    test('throws exception for empty String when allowEmpty is false', () {
-      expect(
-        () => ''.toLabel(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+    test('encodes empty String as a bare dot when allowEmpty is false', () {
+      expect(''.toLabel(explode: false, allowEmpty: false), '.');
     });
 
     test('explode parameter has no effect on primitives', () {

--- a/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
@@ -37,12 +37,10 @@ void main() {
       );
     });
 
-    test('encodes empty string with allowEmpty=true', () {
-      expect(''.toMatrix('name', allowEmpty: true, explode: true), ';name=');
-    });
-
-    test('encodes empty string with allowEmpty=false', () {
-      expect(''.toMatrix('name', allowEmpty: false, explode: true), ';name=');
+    test('encodes empty string as name without value regardless of allowEmpty',
+        () {
+      expect(''.toMatrix('name', allowEmpty: true, explode: true), ';name');
+      expect(''.toMatrix('name', allowEmpty: false, explode: true), ';name');
     });
 
     test('encodes special characters', () {

--- a/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
@@ -42,10 +42,7 @@ void main() {
     });
 
     test('encodes empty string with allowEmpty=false', () {
-      expect(
-        () => ''.toMatrix('name', allowEmpty: false, explode: true),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(''.toMatrix('name', allowEmpty: false, explode: true), ';name=');
     });
 
     test('encodes special characters', () {

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -353,12 +353,9 @@ void main() {
     });
 
     group('allowEmpty parameter behavior', () {
-      test('empty string should throw with allowEmpty=false', () {
+      test('empty string encodes to empty with allowEmpty=false', () {
         const value = '';
-        expect(
-          () => value.toSimple(explode: false, allowEmpty: false),
-          throwsException,
-        );
+        expect(value.toSimple(explode: false, allowEmpty: false), '');
       });
 
       test('non-empty string ignores allowEmpty parameter', () {

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -28,15 +28,9 @@ void main() {
       );
     });
 
-    test('handles empty strings with allowEmpty true', () {
+    test('encodes empty string as empty regardless of allowEmpty', () {
       expect(''.uriEncode(allowEmpty: true), '');
-    });
-
-    test('throws exception for empty strings with allowEmpty false', () {
-      expect(
-        () => ''.uriEncode(allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(''.uriEncode(allowEmpty: false), '');
     });
 
     test('encodes special characters', () {


### PR DESCRIPTION
## Problem

A form-style query parameter (the OpenAPI default) whose value is the empty string `""` must serialize to `name=` per RFC 6570 form expansion and the OpenAPI style-examples table. The generated client instead ran the primitive encoder with the empty-value guard active, which threw `EmptyValueException`, so `call()` returned a `TonikError(encoding)` and no request was ever sent. A caller could never send `GET /search?q=`.

## Root cause

The primitive string encoders rejected an empty string based on `allowEmpty` (which maps to the spec's `allowEmptyValue`), even though style serialization of a schema-defined empty string is independent of `allowEmptyValue`. `allowEmptyValue` permits a zero-length string in place of a parameter that would otherwise be omitted; it does not govern how a defined empty-string *value* is serialized, and it defaults to `false`, so the guard rejected legal empty values by default. RFC 6570 has no provision to reject a defined empty string.

## Fix

Remove the empty-string guard from the primitive `String` `uriEncode` and label encoders; an empty string now encodes to its standards-required form. form/simple delegate to `uriEncode`, so they are covered too. Matrix is special-cased to expand a defined empty string as the bare name (no `=`). The guard is retained for empty collections (`List`/`Map`/binary), where "empty" plausibly means "no value".

Standards-required primitive empty-string wire forms:

| Style       | Wire expansion |
|-------------|----------------|
| form query  | `name=`        |
| matrix      | `;name`        |
| label       | `.`            |
| simple      | (empty string) |

## Tests

- Integration: an empty string sends `string=`, and an explicitly-empty nullable string sends `nullableString=` (distinct from `null`, which is omitted).
- Unit: the primitive-string encoder tests across uri/form/simple/matrix/label/any now assert the standards-required empty form instead of throwing.

Full `tonik_util` suite and the query-parameters integration suite pass; `dart analyze` is clean.
