### PR TITLE
fix: omit empty array query parameters instead of throwing

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
@@ -78,6 +78,31 @@ void main() {
         'anyValue=first%20name,Jane,a%2Cb,v1,c%26d,v2',
       );
     });
+
+    test('getQueryAny with empty list value omits the parameter', () async {
+      final api = buildApi();
+      final result = await api.getQueryAny(anyValue: const <dynamic>[]);
+      final success = result as TonikSuccess;
+      expect(success.response.requestOptions.uri.query, '');
+    });
+
+    test('getQueryAnyNoExplode with empty list value omits the parameter',
+        () async {
+      final api = buildApi();
+      final result = await api.getQueryAnyNoExplode(
+        anyValue: const <dynamic>[],
+      );
+      final success = result as TonikSuccess;
+      expect(success.response.requestOptions.uri.query, '');
+    });
+
+    test('getQueryAny with non-empty list serializes comma-separated',
+        () async {
+      final api = buildApi();
+      final result = await api.getQueryAny(anyValue: <dynamic>['a', 'b', 'c']);
+      final success = result as TonikSuccess;
+      expect(success.response.requestOptions.uri.query, 'anyValue=a,b,c');
+    });
   });
 
   group('Query parameters - spaceDelimited style', () {

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -633,6 +633,14 @@ void main() {
         'listNullableInteger=1&listNullableInteger=&listNullableInteger=2',
       );
     });
+
+    test('empty array drops the whole query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormListExplode(listString: const []);
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
+    });
   });
 
   group('primitive - new types', () {

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -538,6 +538,28 @@ void main() {
         'listNullableInteger=1,,2',
       );
     });
+
+    test('empty array is the only param and drops the whole query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormList(listString: const []);
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
+    });
+
+    test('empty array is dropped while a populated param remains', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormList(
+        listString: const [],
+        listNullableInteger: [1, 2],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listNullableInteger=1,2',
+      );
+    });
   });
 
   group('list - explode true', () {

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -563,6 +563,16 @@ void main() {
         'listEnum=high%20priority%7Curgent%7Clow%20priority',
       );
     });
+
+    test('empty array is dropped from the query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedList(
+        listString: const [],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
+    });
   });
 
   group('list - explode true', () {

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -573,6 +573,20 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(success.response.requestOptions.uri.query, '');
     });
+
+    test('empty array is dropped while a populated param remains', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedList(
+        listString: const [],
+        listOneOfPrimitive: [const OneOfPrimitiveString('test')],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listOneOfPrimitive=test',
+      );
+    });
   });
 
   group('list - explode true', () {
@@ -631,6 +645,16 @@ void main() {
         success.response.requestOptions.uri.query,
         'listEnum=high%20priority&listEnum=urgent&listEnum=low%20priority',
       );
+    });
+
+    test('empty array drops the whole query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedListExplode(
+        listString: const [],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
     });
   });
 

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -563,6 +563,16 @@ void main() {
         'listEnum=high%20priority%20urgent%20low%20priority',
       );
     });
+
+    test('empty array is dropped from the query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedList(
+        listString: const [],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
+    });
   });
 
   group('list - explode true', () {

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -573,6 +573,20 @@ void main() {
       final success = response as TonikSuccess<void>;
       expect(success.response.requestOptions.uri.query, '');
     });
+
+    test('empty array is dropped while a populated param remains', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedList(
+        listString: const [],
+        listOneOfPrimitive: [const OneOfPrimitiveString('test')],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'listOneOfPrimitive=test',
+      );
+    });
   });
 
   group('list - explode true', () {
@@ -631,6 +645,16 @@ void main() {
         success.response.requestOptions.uri.query,
         'listEnum=high%20priority&listEnum=urgent&listEnum=low%20priority',
       );
+    });
+
+    test('empty array drops the whole query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedListExplode(
+        listString: const [],
+      );
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
     });
   });
 

--- a/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_form_query_parameter_expression_generator.dart
@@ -49,21 +49,19 @@ List<Code> _buildToFormQueryParameterCode(
   }
 
   if (isAnyModelFormValue(model)) {
+    final entries =
+        refer('encodeAnyToFormEntries', 'package:tonik_util/tonik_util.dart')
+            .call(
+      [refer(parameterName)],
+      {
+        'name': specLiteralString(rawName),
+        'explode': literalBool(explode),
+        'allowEmpty': literalBool(allowEmpty),
+        if (allowReserved) 'allowReserved': literalBool(true),
+      },
+    );
     return [
-      const Code(r'_$entries.add(('),
-      Code('name: ${specLiteralStringCode(rawName)}, '),
-      const Code('value: '),
-      refer('encodeAnyToForm', 'package:tonik_util/tonik_util.dart')
-          .call(
-            [refer(parameterName)],
-            {
-              'explode': literalBool(explode),
-              'allowEmpty': literalBool(allowEmpty),
-              if (allowReserved) 'allowReserved': literalBool(true),
-            },
-          )
-          .code,
-      const Code('),);'),
+      refer(r'_$entries').property('addAll').call([entries]).statement,
     ];
   }
 

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -2286,15 +2286,15 @@ void main() {
       const expectedMethod = r'''
         String? _queryParameters({required Object? meta}) {
           final _$entries = <ParameterEntry>[];
-          _$entries.add((
-            name: r'meta',
-            value: encodeAnyToForm(
+          _$entries.addAll(
+            encodeAnyToFormEntries(
               meta,
+              name: r'meta',
               explode: false,
               allowEmpty: false,
               allowReserved: true,
             ),
-          ));
+          );
           if (_$entries.isEmpty) {
             return null;
           }

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -255,7 +255,7 @@ void main() {
         );
       });
 
-      test('AnyModel appends a single encodeAnyToForm entry', () {
+      test('AnyModel appends entries via encodeAnyToFormEntries', () {
         final parameter = createParameter(
           name: 'anyParam',
           rawName: 'anyParam',
@@ -272,14 +272,14 @@ void main() {
         final generated = emitCodes(codes);
         final expected = format(r'''
           test() {
-            _$entries.add((
-              name: r'anyParam',
-              value: _i1.encodeAnyToForm(
+            _$entries.addAll(
+              _i1.encodeAnyToFormEntries(
                 anyParam,
+                name: r'anyParam',
                 explode: false,
                 allowEmpty: true,
               ),
-            ));
+            );
           }
         ''');
 

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -392,6 +392,37 @@ String encodeAnyToForm(
   );
 }
 
+/// Encodes a top-level form query parameter whose runtime value has an unknown
+/// type, omitting an empty list so the parameter is absent from the query.
+///
+/// An empty [List] value yields no entries; every other value (including an
+/// empty [Map], which still raises [EmptyValueException]) is delegated to
+/// [encodeAnyToForm] and returned as a single entry.
+List<ParameterEntry> encodeAnyToFormEntries(
+  Object? value, {
+  required String name,
+  required bool explode,
+  required bool allowEmpty,
+  bool useQueryComponent = false,
+  bool allowReserved = false,
+}) {
+  if (value is List && value.isEmpty) {
+    return const [];
+  }
+  return [
+    (
+      name: name,
+      value: encodeAnyToForm(
+        value,
+        explode: explode,
+        allowEmpty: allowEmpty,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
+    ),
+  ];
+}
+
 String _formEntriesToString(
   List<ParameterEntry> entries, {
   required bool explode,

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -394,10 +394,6 @@ String encodeAnyToForm(
 
 /// Encodes a top-level form query parameter whose runtime value has an unknown
 /// type, omitting an empty list so the parameter is absent from the query.
-///
-/// An empty [List] value yields no entries; every other value (including an
-/// empty [Map], which still raises [EmptyValueException]) is delegated to
-/// [encodeAnyToForm] and returned as a single entry.
 List<ParameterEntry> encodeAnyToFormEntries(
   Object? value, {
   required String name,

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -192,9 +192,8 @@ extension FormBigDecimalEncoder on BigDecimal {
 extension FormStringListEncoder on List<String> {
   /// Encodes this List value using form style encoding.
   ///
-  /// An empty list is omitted entirely (no entries), per RFC 6570 form
-  /// expansion — an empty array is a valid value and is not gated by
-  /// [allowEmpty], which concerns empty-string values.
+  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
+  /// empty arrays.
   ///
   /// The [alreadyEncoded] parameter indicates whether the items are already
   /// URI-encoded and should not be encoded again.

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -192,8 +192,7 @@ extension FormBigDecimalEncoder on BigDecimal {
 extension FormStringListEncoder on List<String> {
   /// Encodes this List value using form style encoding.
   ///
-  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
-  /// empty arrays.
+  /// An empty list is omitted, regardless of [allowEmpty].
   ///
   /// The [alreadyEncoded] parameter indicates whether the items are already
   /// URI-encoded and should not be encoded again.

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -192,6 +192,10 @@ extension FormBigDecimalEncoder on BigDecimal {
 extension FormStringListEncoder on List<String> {
   /// Encodes this List value using form style encoding.
   ///
+  /// An empty list is omitted entirely (no entries), per RFC 6570 form
+  /// expansion — an empty array is a valid value and is not gated by
+  /// [allowEmpty], which concerns empty-string values.
+  ///
   /// The [alreadyEncoded] parameter indicates whether the items are already
   /// URI-encoded and should not be encoded again.
   List<ParameterEntry> toForm(
@@ -202,8 +206,8 @@ extension FormStringListEncoder on List<String> {
     bool useQueryComponent = false,
     bool allowReserved = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
+    if (isEmpty) {
+      return const [];
     }
 
     if (!explode) {

--- a/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
@@ -18,9 +18,9 @@ extension PipeDelimitedStringListEncoder on List<String> {
   /// - explode=false: pipe-separated values (value1|value2|value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// The [allowEmpty] parameter controls whether empty lists are allowed:
-  /// - When `true`, empty lists are encoded as a list with an empty string
-  /// - When `false`, empty lists throw an [EmptyValueException]
+  /// An empty list is omitted entirely (returns `const []`), per RFC 6570
+  /// form expansion — an empty array is a valid value and is not gated by
+  /// [allowEmpty], which concerns empty-string values.
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
@@ -34,10 +34,7 @@ extension PipeDelimitedStringListEncoder on List<String> {
     bool allowReserved = false,
   }) {
     if (isEmpty) {
-      if (!allowEmpty) {
-        throw const EmptyValueException();
-      }
-      return [''];
+      return const [];
     }
 
     if (explode) {

--- a/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
@@ -18,9 +18,8 @@ extension PipeDelimitedStringListEncoder on List<String> {
   /// - explode=false: pipe-separated values (value1|value2|value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// An empty list is omitted entirely (returns `const []`), per RFC 6570
-  /// form expansion — an empty array is a valid value and is not gated by
-  /// [allowEmpty], which concerns empty-string values.
+  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
+  /// empty arrays.
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.

--- a/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/pipe_delimited_encoder_extensions.dart
@@ -18,8 +18,7 @@ extension PipeDelimitedStringListEncoder on List<String> {
   /// - explode=false: pipe-separated values (value1|value2|value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
-  /// empty arrays.
+  /// An empty list is omitted, regardless of [allowEmpty].
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.

--- a/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
@@ -18,9 +18,8 @@ extension SpaceDelimitedStringListEncoder on List<String> {
   /// - explode=false: space-separated values (value1%20value2%20value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// An empty list is omitted entirely (returns `const []`), per RFC 6570
-  /// form expansion — an empty array is a valid value and is not gated by
-  /// [allowEmpty], which concerns empty-string values.
+  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
+  /// empty arrays.
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.

--- a/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
@@ -18,9 +18,9 @@ extension SpaceDelimitedStringListEncoder on List<String> {
   /// - explode=false: space-separated values (value1%20value2%20value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// The [allowEmpty] parameter controls whether empty lists are allowed:
-  /// - When `true`, empty lists are encoded as a list with an empty string
-  /// - When `false`, empty lists throw an [EmptyValueException]
+  /// An empty list is omitted entirely (returns `const []`), per RFC 6570
+  /// form expansion — an empty array is a valid value and is not gated by
+  /// [allowEmpty], which concerns empty-string values.
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
@@ -35,10 +35,7 @@ extension SpaceDelimitedStringListEncoder on List<String> {
     bool allowReserved = false,
   }) {
     if (isEmpty) {
-      if (!allowEmpty) {
-        throw const EmptyValueException();
-      }
-      return [''];
+      return const [];
     }
 
     if (explode) {

--- a/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/space_delimited_encoder_extensions.dart
@@ -18,8 +18,7 @@ extension SpaceDelimitedStringListEncoder on List<String> {
   /// - explode=false: space-separated values (value1%20value2%20value3)
   /// - explode=true: multiple parameter instances (handled at parameter level)
   ///
-  /// An empty list is omitted; [allowEmpty] gates empty-string values, not
-  /// empty arrays.
+  /// An empty list is omitted, regardless of [allowEmpty].
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.

--- a/packages/tonik_util/test/form_encoder_decoder_round_trip_test.dart
+++ b/packages/tonik_util/test/form_encoder_decoder_round_trip_test.dart
@@ -2,6 +2,7 @@ import 'package:big_decimal/big_decimal.dart';
 import 'package:test/test.dart';
 import 'package:tonik_util/src/decoding/form_decoder.dart';
 import 'package:tonik_util/src/encoding/form_encoder_extensions.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
 
 /// Tests to verify that form encoding and decoding are perfect inverses.
 /// These tests ensure data integrity through encode/decode cycles.
@@ -336,14 +337,10 @@ void main() {
         expect(decoded, original);
       });
 
-      test('empty list', () {
+      test('empty list produces no wire entries', () {
         const original = <String>[];
-        final encoded = original
-            .toForm('p', explode: false, allowEmpty: true)
-            .single
-            .value;
-        final decoded = encoded.decodeFormStringList();
-        expect(decoded, original);
+        final encoded = original.toForm('p', explode: false, allowEmpty: true);
+        expect(encoded, const <ParameterEntry>[]);
       });
 
       test('list with empty strings', () {

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1843,6 +1843,68 @@ void main() {
     });
   });
 
+  group('encodeAnyToFormEntries', () {
+    test('empty list value yields no entries', () {
+      expect(
+        encodeAnyToFormEntries(
+          <dynamic>[],
+          name: 'anyValue',
+          explode: false,
+          allowEmpty: false,
+        ),
+        const <ParameterEntry>[],
+      );
+    });
+
+    test('empty list value yields no entries when explode is true', () {
+      expect(
+        encodeAnyToFormEntries(
+          <dynamic>[],
+          name: 'anyValue',
+          explode: true,
+          allowEmpty: false,
+        ),
+        const <ParameterEntry>[],
+      );
+    });
+
+    test('populated list value yields a single joined entry', () {
+      expect(
+        encodeAnyToFormEntries(
+          <dynamic>['a', 'b', 'c'],
+          name: 'anyValue',
+          explode: false,
+          allowEmpty: false,
+        ),
+        const [(name: 'anyValue', value: 'a,b,c')],
+      );
+    });
+
+    test('scalar value yields a single entry', () {
+      expect(
+        encodeAnyToFormEntries(
+          'hello',
+          name: 'anyValue',
+          explode: false,
+          allowEmpty: false,
+        ),
+        const [(name: 'anyValue', value: 'hello')],
+      );
+    });
+
+    test('empty map value throws EmptyValueException', () {
+      expect(
+        () => encodeAnyToFormEntries(
+          <String, dynamic>{},
+          name: 'anyValue',
+          explode: false,
+          allowEmpty: false,
+        ),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
+
   group('encodeAnyToDeepObject', () {
     group('ParameterEncodable', () {
       test('encodes ParameterEncodable instance', () {

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -224,28 +224,22 @@ void main() {
       );
     });
 
-    test('empty list with explode=false yields a single empty-value entry', () {
+    test('empty list is omitted regardless of explode and allowEmpty', () {
       expect(
         <String>[].toForm('p', explode: false, allowEmpty: true),
-        const <ParameterEntry>[(name: 'p', value: '')],
+        const <ParameterEntry>[],
       );
-    });
-
-    test('empty list with explode=true yields no entries', () {
       expect(
         <String>[].toForm('p', explode: true, allowEmpty: true),
         const <ParameterEntry>[],
       );
-    });
-
-    test('empty list throws when allowEmpty=false', () {
       expect(
-        () => <String>[].toForm('p', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String>[].toForm('p', explode: false, allowEmpty: false),
+        const <ParameterEntry>[],
       );
       expect(
-        () => <String>[].toForm('p', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String>[].toForm('p', explode: true, allowEmpty: false),
+        const <ParameterEntry>[],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/pipe_delimited_encoder_extensions_test.dart
@@ -29,26 +29,21 @@ void main() {
         expect(result, ['a%26b|c%3Dd']);
       });
 
-      test('encodes empty list when allowEmpty is true', () {
+      test('omits empty list when allowEmpty is true', () {
         final result = <String>[].toPipeDelimited(
           explode: false,
           allowEmpty: true,
         );
-        expect(result, ['']);
+        expect(result, const <String>[]);
       });
 
-      test(
-        'throws EmptyValueException when empty list and allowEmpty is false',
-        () {
-          expect(
-            () => <String>[].toPipeDelimited(
-              explode: false,
-              allowEmpty: false,
-            ),
-            throwsA(isA<EmptyValueException>()),
-          );
-        },
-      );
+      test('omits empty list when allowEmpty is false', () {
+        final result = <String>[].toPipeDelimited(
+          explode: false,
+          allowEmpty: false,
+        );
+        expect(result, const <String>[]);
+      });
 
       test('encodes single item list', () {
         final result = ['single'].toPipeDelimited(
@@ -96,26 +91,21 @@ void main() {
         expect(result, ['item%201', 'item%202']);
       });
 
-      test('encodes empty list when allowEmpty is true', () {
+      test('omits empty list when allowEmpty is true', () {
         final result = <String>[].toPipeDelimited(
           explode: true,
           allowEmpty: true,
         );
-        expect(result, ['']);
+        expect(result, const <String>[]);
       });
 
-      test(
-        'throws EmptyValueException when empty list and allowEmpty is false',
-        () {
-          expect(
-            () => <String>[].toPipeDelimited(
-              explode: true,
-              allowEmpty: false,
-            ),
-            throwsA(isA<EmptyValueException>()),
-          );
-        },
-      );
+      test('omits empty list when allowEmpty is false', () {
+        final result = <String>[].toPipeDelimited(
+          explode: true,
+          allowEmpty: false,
+        );
+        expect(result, const <String>[]);
+      });
 
       test('encodes single item list', () {
         final result = ['single'].toPipeDelimited(

--- a/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/space_delimited_encoder_extensions_test.dart
@@ -29,26 +29,21 @@ void main() {
         expect(result, ['a%26b%20c%3Dd']);
       });
 
-      test('encodes empty list when allowEmpty is true', () {
+      test('omits empty list when allowEmpty is true', () {
         final result = <String>[].toSpaceDelimited(
           explode: false,
           allowEmpty: true,
         );
-        expect(result, ['']);
+        expect(result, const <String>[]);
       });
 
-      test(
-        'throws EmptyValueException when empty list and allowEmpty is false',
-        () {
-          expect(
-            () => <String>[].toSpaceDelimited(
-              explode: false,
-              allowEmpty: false,
-            ),
-            throwsA(isA<EmptyValueException>()),
-          );
-        },
-      );
+      test('omits empty list when allowEmpty is false', () {
+        final result = <String>[].toSpaceDelimited(
+          explode: false,
+          allowEmpty: false,
+        );
+        expect(result, const <String>[]);
+      });
 
       test('encodes single item list', () {
         final result = ['single'].toSpaceDelimited(
@@ -129,26 +124,21 @@ void main() {
         expect(result, ['item%201', 'item%202']);
       });
 
-      test('encodes empty list when allowEmpty is true', () {
+      test('omits empty list when allowEmpty is true', () {
         final result = <String>[].toSpaceDelimited(
           explode: true,
           allowEmpty: true,
         );
-        expect(result, ['']);
+        expect(result, const <String>[]);
       });
 
-      test(
-        'throws EmptyValueException when empty list and allowEmpty is false',
-        () {
-          expect(
-            () => <String>[].toSpaceDelimited(
-              explode: true,
-              allowEmpty: false,
-            ),
-            throwsA(isA<EmptyValueException>()),
-          );
-        },
-      );
+      test('omits empty list when allowEmpty is false', () {
+        final result = <String>[].toSpaceDelimited(
+          explode: true,
+          allowEmpty: false,
+        );
+        expect(result, const <String>[]);
+      });
 
       test('encodes single item list', () {
         final result = ['single'].toSpaceDelimited(


### PR DESCRIPTION
## Problem

An empty array serialized as a query parameter with `style: form` (`explode: false`), `spaceDelimited`, or `pipeDelimited` threw `EmptyValueException` at runtime, so a legal empty array could never be sent. The exploded form path already omits empty arrays, so the non-exploded paths were asymmetrically broken.

RFC 6570 form expansion treats a zero-member list as undefined and omits the variable entirely — an empty array is a valid value and must not fail to serialize.

## Fix

The list encoders now return no entries for an empty list, regardless of `allowEmpty`/`explode`, so the parameter is omitted from the query string:

- `FormStringListEncoder.toForm`
- `SpaceDelimitedStringListEncoder.toSpaceDelimited`
- `PipeDelimitedStringListEncoder.toPipeDelimited`

The same fix is extended to free-form (`{}` / Any-typed) form query parameters: a new `encodeAnyToFormEntries` yields no entries for an empty list value, and the query form generator emits it, so an empty-list Any value is omitted rather than throwing.

Empty maps and empty binary values are unaffected (an empty collection of unknown-keyed properties is distinct from an empty array). Non-empty encoding is unchanged.

### Scope note on request bodies

The change is limited to query serialization. `application/x-www-form-urlencoded` bodies use a separate property encoder and are unaffected (an empty non-exploded array property still serializes to `field=`). The `spaceDelimited`/`pipeDelimited` list encoders are also shared by the multipart part generator, so an empty array in a delimited-style multipart part would likewise be omitted — a consequence that is consistent with the query behavior and covered by the encoders' `allowEmpty: true` empty-list unit tests (no current operation exercises that combination).

## Tests

- Unit tests updated across the three encoders to assert omission for an empty list over the `{explode} × {allowEmpty}` matrix.
- `encodeAnyToFormEntries` unit tests: empty list → no entries, populated list → single entry, scalar → single entry, empty map → still throws.
- Generator tests updated (full method-body comparisons) for the new AnyModel emission.
- Integration tests: empty array as the only param drops the whole query; empty array dropped while a populated sibling remains; explode true/false; spaceDelimited/pipeDelimited; and empty-list Any query params (boolean_schemas suite).

Generated client code is regenerated via the setup script; there is no unexpected generated-code churn.
