### PR TITLE
fix: override path-item parameters with operation-level ones by (name, location)

### DIFF
--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -1729,6 +1729,35 @@ paths:
         '204':
           description: OK
 
+  /parameter-override:
+    parameters:
+      - name: status
+        in: query
+        required: false
+        style: form
+        explode: false
+        schema:
+          type: string
+    get:
+      operationId: testParameterOverride
+      tags:
+        - query
+      summary: Test operation-level override of a path-item-level parameter
+      description: >-
+        The path-item-level status parameter is overridden by the
+        operation-level status parameter of the same name and location
+      parameters:
+        - name: status
+          in: query
+          required: true
+          style: form
+          explode: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: OK
+
 components:
   schemas:
     Filter:

--- a/integration_test/query_parameters/query_parameters_test/test/parameter_override_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/parameter_override_test.dart
@@ -1,0 +1,39 @@
+import 'package:dio/dio.dart';
+import 'package:query_parameters_api/query_parameters_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  test('operation-level override emits the status query key exactly once',
+      () async {
+    final api = buildQueryApi(responseStatus: '204');
+    final response = await api.testParameterOverride(status: 'active');
+
+    expect(response, isA<TonikSuccess<void>>());
+
+    final success = response as TonikSuccess<void>;
+    expect(success.response.requestOptions.uri.query, 'status=active');
+  });
+}

--- a/packages/tonik_parse/lib/src/operation_importer.dart
+++ b/packages/tonik_parse/lib/src/operation_importer.dart
@@ -3,6 +3,7 @@ import 'package:logging/logging.dart';
 import 'package:tonik_core/tonik_core.dart' as core;
 import 'package:tonik_parse/src/model/open_api_object.dart';
 import 'package:tonik_parse/src/model/operation.dart';
+import 'package:tonik_parse/src/model/parameter.dart';
 import 'package:tonik_parse/src/model/path_item.dart';
 import 'package:tonik_parse/src/model/reference.dart';
 import 'package:tonik_parse/src/model/response.dart';
@@ -162,7 +163,10 @@ class OperationImporter {
 
     final pathParameters = pathItem.parameters ?? [];
     final operationParameters = operation.parameters ?? [];
-    final allParameters = [...pathParameters, ...operationParameters];
+    final allParameters = _dedupeParameters([
+      ...pathParameters,
+      ...operationParameters,
+    ]);
 
     final (headers, queryParams, pathParams, cookieParams) = parameterImporter
         .importOperationParameters(allParameters, context.push('parameters'));
@@ -222,6 +226,59 @@ class OperationImporter {
     }
 
     return schemes;
+  }
+
+  /// Later entries win, so an operation-level parameter (appended after
+  /// path-item-level ones) overrides an identically keyed path-item one.
+  /// Parameters whose key cannot be resolved are never dropped.
+  List<ReferenceWrapper<Parameter>> _dedupeParameters(
+    List<ReferenceWrapper<Parameter>> parameters,
+  ) {
+    final result = <ReferenceWrapper<Parameter>>[];
+    final keyToIndex = <(ParameterLocation, String), int>{};
+
+    for (final wrapper in parameters) {
+      final parameter = _resolveParameter(wrapper);
+
+      if (parameter == null) {
+        result.add(wrapper);
+        continue;
+      }
+
+      final key = (parameter.location, parameter.name);
+      final existingIndex = keyToIndex[key];
+      if (existingIndex == null) {
+        keyToIndex[key] = result.length;
+        result.add(wrapper);
+      } else {
+        result[existingIndex] = wrapper;
+      }
+    }
+
+    return result;
+  }
+
+  Parameter? _resolveParameter(
+    ReferenceWrapper<Parameter> wrapper, [
+    Set<String>? visitedRefs,
+  ]) {
+    switch (wrapper) {
+      case InlinedObject<Parameter>():
+        return wrapper.object;
+      case Reference<Parameter>():
+        if (!wrapper.ref.startsWith('#/components/parameters/')) {
+          return null;
+        }
+
+        final seen = visitedRefs ?? <String>{};
+        if (!seen.add(wrapper.ref)) return null;
+
+        final refName = wrapper.ref.split('/').last;
+        final refParameter = openApiObject.components?.parameters?[refName];
+        if (refParameter == null) return null;
+
+        return _resolveParameter(refParameter, seen);
+    }
   }
 
   PathItem _resolvePathItem(ReferenceWrapper<PathItem> wrapper) {

--- a/packages/tonik_parse/lib/src/operation_importer.dart
+++ b/packages/tonik_parse/lib/src/operation_importer.dart
@@ -271,7 +271,9 @@ class OperationImporter {
         }
 
         final seen = visitedRefs ?? <String>{};
-        if (!seen.add(wrapper.ref)) return null;
+        if (!seen.add(wrapper.ref)) {
+          throw ArgumentError('Cyclic parameter reference: ${wrapper.ref}');
+        }
 
         final refName = wrapper.ref.split('/').last;
         final refParameter = openApiObject.components?.parameters?[refName];

--- a/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
+++ b/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
@@ -1,0 +1,288 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+void main() {
+  Operation operationFor(Map<String, dynamic> fileContent) {
+    final api = Importer().import(fileContent);
+    return api.operations.firstWhere((o) => o.operationId == 'listItems');
+  }
+
+  Map<String, dynamic> specWith({
+    required Map<String, dynamic> pathParameter,
+    required Map<String, dynamic> operationParameter,
+    Map<String, dynamic>? components,
+  }) => {
+    'openapi': '3.0.3',
+    'info': {'title': 'Test API', 'version': '1.0.0'},
+    'paths': {
+      '/items': {
+        'parameters': [pathParameter],
+        'get': {
+          'operationId': 'listItems',
+          'parameters': [operationParameter],
+          'responses': {
+            '200': {'description': 'OK'},
+          },
+        },
+      },
+    },
+    if (components != null) 'components': {'parameters': components},
+  };
+
+  test('operation-level query param overrides path-item query param of '
+      'same name', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final params = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
+  test('operation-level header param overrides path-item header param of '
+      'same name', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'x-token',
+          'in': 'header',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'x-token',
+          'in': 'header',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final params = operation.headers
+        .whereType<RequestHeaderObject>()
+        .where((h) => h.rawName == 'x-token')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
+  test('operation-level path param overrides path-item path param of '
+      'same name', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'id',
+          'in': 'path',
+          'required': true,
+          'description': 'path-item id',
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'id',
+          'in': 'path',
+          'required': true,
+          'description': 'operation id',
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final params = operation.pathParameters
+        .whereType<PathParameterObject>()
+        .where((p) => p.rawName == 'id')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.description, 'operation id');
+  });
+
+  test('operation-level cookie param overrides path-item cookie param of '
+      'same name', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'session',
+          'in': 'cookie',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'session',
+          'in': 'cookie',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final params = operation.cookieParameters
+        .whereType<CookieParameterObject>()
+        .where((p) => p.rawName == 'session')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
+  test(r'operation inline param overrides path-item $ref param of '
+      'same name and location', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {r'$ref': '#/components/parameters/Status'},
+        operationParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+        components: {
+          'Status': {
+            'name': 'status',
+            'in': 'query',
+            'required': false,
+            'schema': {'type': 'string'},
+          },
+        },
+      ),
+    );
+
+    final params = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
+  test(r'operation $ref param overrides path-item inline param of '
+      'same name and location', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {r'$ref': '#/components/parameters/Status'},
+        components: {
+          'Status': {
+            'name': 'status',
+            'in': 'query',
+            'required': true,
+            'schema': {'type': 'string'},
+          },
+        },
+      ),
+    );
+
+    final params = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
+  test('same name in different locations are both preserved', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'status',
+          'in': 'header',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final queryStatus = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    final headerStatus = operation.headers
+        .whereType<RequestHeaderObject>()
+        .where((h) => h.rawName == 'status')
+        .toList();
+    expect(queryStatus, hasLength(1));
+    expect(headerStatus, hasLength(1));
+  });
+
+  test('different names in same location are both preserved', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': false,
+          'schema': {'type': 'string'},
+        },
+        operationParameter: {
+          'name': 'kind',
+          'in': 'query',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+      ),
+    );
+
+    final names = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .map((p) => p.rawName)
+        .toSet();
+    expect(names, containsAll(['status', 'kind']));
+  });
+
+  test(r'chained path-item $ref is overridden by operation inline param of '
+      'same name and location', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {r'$ref': '#/components/parameters/StatusAlias'},
+        operationParameter: {
+          'name': 'status',
+          'in': 'query',
+          'required': true,
+          'schema': {'type': 'string'},
+        },
+        components: {
+          'StatusAlias': {r'$ref': '#/components/parameters/Status'},
+          'Status': {
+            'name': 'status',
+            'in': 'query',
+            'required': false,
+            'schema': {'type': 'string'},
+          },
+        },
+      ),
+    );
+
+    final params = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+}

--- a/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
+++ b/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
@@ -285,4 +285,43 @@ void main() {
     expect(params, hasLength(1));
     expect(params.single.isRequired, isTrue);
   });
+
+  test(r'cyclic parameter $ref chain throws ArgumentError', () {
+    final fileContent = specWith(
+      pathParameter: {r'$ref': '#/components/parameters/A'},
+      operationParameter: {
+        'name': 'kind',
+        'in': 'query',
+        'required': true,
+        'schema': {'type': 'string'},
+      },
+      components: {
+        'A': {r'$ref': '#/components/parameters/B'},
+        'B': {r'$ref': '#/components/parameters/A'},
+      },
+    );
+
+    expect(
+      () => Importer().import(fileContent),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
+
+  test(r'unresolvable parameter $ref is passed through to the importer '
+      'and throws', () {
+    final fileContent = specWith(
+      pathParameter: {r'$ref': '#/components/parameters/DoesNotExist'},
+      operationParameter: {
+        'name': 'kind',
+        'in': 'query',
+        'required': true,
+        'schema': {'type': 'string'},
+      },
+    );
+
+    expect(
+      () => Importer().import(fileContent),
+      throwsA(isA<ArgumentError>()),
+    );
+  });
 }

--- a/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
+++ b/packages/tonik_parse/test/operation/operation_parameter_override_test.dart
@@ -286,6 +286,31 @@ void main() {
     expect(params.single.isRequired, isTrue);
   });
 
+  test(r'same $ref used by both path-item and operation resolves to one '
+      'param without cycle detection', () {
+    final operation = operationFor(
+      specWith(
+        pathParameter: {r'$ref': '#/components/parameters/Status'},
+        operationParameter: {r'$ref': '#/components/parameters/Status'},
+        components: {
+          'Status': {
+            'name': 'status',
+            'in': 'query',
+            'required': true,
+            'schema': {'type': 'string'},
+          },
+        },
+      ),
+    );
+
+    final params = operation.queryParameters
+        .whereType<QueryParameterObject>()
+        .where((p) => p.rawName == 'status')
+        .toList();
+    expect(params, hasLength(1));
+    expect(params.single.isRequired, isTrue);
+  });
+
   test(r'cyclic parameter $ref chain throws ArgumentError', () {
     final fileContent = specWith(
       pathParameter: {r'$ref': '#/components/parameters/A'},


### PR DESCRIPTION
## Summary

Per OpenAPI 3.0.3, a parameter declared at the Path Item level applies to all operations under that path but is **overridden** by an operation-level parameter with the same unique key — the combination of `name` + `in` (location). Tonik previously concatenated the path-item and operation parameter lists with no deduplication, so an operation-level `status` (query) declared alongside a path-item-level `status` (query) produced **two** generated parameters that both serialized to the same wire key. A request therefore emitted `status=<v1>&status=<v2>` instead of the single, overridden value the spec mandates.

## Fix

Deduplicate the parameter list in the parser (`operation_importer.dart`) by `(location, name)` before import, with the operation-level definition winning (it is appended after the path-item list, so last-wins). `$ref` parameters are resolved via `components.parameters` — including chained refs — so ref-based collisions dedupe too. The override applies uniformly to all four locations (query, header, path, cookie).

The core `*ParameterObject` models were intentionally left without `==`/`hashCode`: they also accumulate into global cross-operation sets, where structural equality would wrongly merge identically-named parameters from unrelated operations. Deduplication happens on the raw parameter wrappers instead.

Edge cases:
- Unresolvable / external / missing `$ref`s are kept as-is and surface downstream with context (rather than being silently dropped).
- A cyclic parameter `$ref` chain throws a clear `ArgumentError` at the resolution layer.

## Tests

- Unit tests covering override for each of the four locations, `$ref` collisions in both directions, chained-`$ref` override, non-colliding preservation, cyclic-ref error, and unresolvable-ref passthrough.
- Integration test asserting the overridden query key is emitted exactly once on the wire.