### PR TITLE
fix: decode whole-number JSON double to integer variant in primitive oneOf

### DIFF
--- a/integration_test/composition/composition_test/imposter/imposter-config.json
+++ b/integration_test/composition/composition_test/imposter/imposter-config.json
@@ -1,0 +1,7 @@
+{
+  "plugin": "openapi",
+  "specFile": "../../openapi.yaml",
+  "response": {
+    "scriptFile": "response.groovy"
+  }
+}

--- a/integration_test/composition/composition_test/imposter/response.groovy
+++ b/integration_test/composition/composition_test/imposter/response.groovy
@@ -1,0 +1,14 @@
+// Tests drive the exact response body (e.g. a whole-number double like 42.0)
+// through the X-Response-Body header so they can assert how the client decodes
+// numeric JSON forms that jsonDecode materializes as a Dart double.
+def headers = context.request.headers
+def body = headers['X-Response-Body'] ?: headers['x-response-body']
+
+if (context.request.path.endsWith('/echo') && body != null) {
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'application/json')
+        .withContent(body)
+} else {
+    respond().usingDefaultBehaviour()
+}

--- a/integration_test/composition/composition_test/pubspec.lock
+++ b/integration_test/composition/composition_test/pubspec.lock
@@ -344,6 +344,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.18"
+  test_helpers:
+    dependency: "direct dev"
+    description:
+      path: "../../test_helpers"
+      relative: true
+    source: path
+    version: "1.0.0"
   tonik_util:
     dependency: "direct main"
     description:

--- a/integration_test/composition/composition_test/pubspec.yaml
+++ b/integration_test/composition/composition_test/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
 dev_dependencies:
   test: ^1.25.15
+  test_helpers:
+    path: ../../test_helpers
   very_good_analysis: ^10.2.0
 
 

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -1,0 +1,105 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  CompositionApi buildApi(String responseBody) {
+    return CompositionApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Body': responseBody},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('OneOfPrimitive decodes JSON number to the integer variant', () {
+    test('whole-number double 42.0 decodes to OneOfPrimitiveInt(42)', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(42));
+    });
+
+    test('exponent double 4e1 decodes to OneOfPrimitiveInt(40)', () async {
+      final api = buildApi('4e1');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(40));
+    });
+
+    test('integer 42 decodes to OneOfPrimitiveInt(42)', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(42));
+    });
+
+    test('string "hello" decodes to OneOfPrimitiveString', () async {
+      final api = buildApi('"hello"');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveString('hello'));
+    });
+  });
+
+  group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {
+    test('whole-number double 42.0 decodes to the integer variant', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(success.value, const OneOfIntegerOrClass1Int(42));
+    });
+
+    test('integer 42 decodes to the integer variant', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(success.value, const OneOfIntegerOrClass1Int(42));
+    });
+
+    test('object body decodes to the Class1 variant', () async {
+      final api = buildApi('{"name": "widget"}');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(
+        success.value,
+        const OneOfIntegerOrClass1Class1(Class1(name: 'widget')),
+      );
+    });
+  });
+}

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -89,6 +89,27 @@ void main() {
 
       expect(success.value, const OneOfIntegerOrNumberNumber(42.0));
     });
+
+    test('integer 42 decodes to OneOfIntegerOrNumberInt(42)', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberInt(42));
+    });
+
+    test('fractional double 42.5 decodes to OneOfIntegerOrNumberNumber(42.5)',
+        () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberNumber(42.5));
+    });
   });
 
   group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -66,6 +66,29 @@ void main() {
 
       expect(success.value, const OneOfPrimitiveString('hello'));
     });
+
+    test('fractional double 42.5 surfaces a decoding TonikError', () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final error = result as TonikError<OneOfPrimitive>;
+
+      expect(error.type, TonikErrorType.decoding);
+      expect(error.error, isA<InvalidTypeException>());
+    });
+  });
+
+  group('OneOfIntegerOrNumber decodes JSON number to the number variant', () {
+    test('whole-number double 42.0 decodes to the number variant', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberNumber(42.0));
+    });
   });
 
   group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {
@@ -100,6 +123,17 @@ void main() {
         success.value,
         const OneOfIntegerOrClass1Class1(Class1(name: 'widget')),
       );
+    });
+
+    test('fractional double 42.5 surfaces a decoding TonikError', () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final error = result as TonikError<OneOfIntegerOrClass1>;
+
+      expect(error.type, TonikErrorType.decoding);
+      expect(error.error, isA<JsonDecodingException>());
     });
   });
 }

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -59,6 +59,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/OneOfPrimitive'
 
+  /one-of-integer-or-number/echo:
+    post:
+      operationId: echoOneOfIntegerOrNumber
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfIntegerOrNumber'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfIntegerOrNumber'
+
   /one-of-integer-or-object/echo:
     post:
       operationId: echoOneOfIntegerOrClass1
@@ -116,6 +134,11 @@ components:
       oneOf:
         - type: integer
         - $ref: '#/components/schemas/Class1'
+
+    OneOfIntegerOrNumber:
+      oneOf:
+        - type: integer
+        - type: number
 
     OneOfComplex:
       oneOf:

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -41,6 +41,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/Shape'
 
+  /one-of-primitive/echo:
+    post:
+      operationId: echoOneOfPrimitive
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfPrimitive'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfPrimitive'
+
+  /one-of-integer-or-object/echo:
+    post:
+      operationId: echoOneOfIntegerOrClass1
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfIntegerOrClass1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfIntegerOrClass1'
+
 components:
   schemas:
     Class1:
@@ -71,12 +107,17 @@ components:
         - 1
         - 2
 
-    OneOfPrimitive: 
+    OneOfPrimitive:
       oneOf:
         - type: string
         - type: integer
 
-    OneOfComplex: 
+    OneOfIntegerOrClass1:
+      oneOf:
+        - type: integer
+        - $ref: '#/components/schemas/Class1'
+
+    OneOfComplex:
       oneOf:
         - $ref: '#/components/schemas/Class1'
         - $ref: '#/components/schemas/Class2'

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -482,6 +482,17 @@ class OneOfGenerator {
       (m) => m.model.resolved is AnyModel,
     );
 
+    // A whole-number JSON double denotes an integer, so an integer member
+    // decodes through decodeJsonInt. Skip this when a double/num member is
+    // present so that variant keeps owning whole-number doubles.
+    final hasNumberMember = model.models.any(
+      (m) =>
+          m.model.resolved is DoubleModel || m.model.resolved is NumberModel,
+    );
+    final routeIntegerThroughDecode =
+        !hasNumberMember &&
+        model.models.any((m) => m.model.resolved is IntegerModel);
+
     if (hasPrimitives && hasOnlyPrimitives && !hasAnyModel) {
       final cases = <Code>[];
 
@@ -492,6 +503,26 @@ class OneOfGenerator {
                 (m) => m.model.resolved is PrimitiveModel,
               )) {
         final variantName = variantNames[m]!;
+
+        if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
+          final decodeBuilt = buildFromJsonValueExpression(
+            'json',
+            model: m.model,
+            nameManager: nameManager,
+            package: package,
+            helperContext: helperContext,
+            contextClass: className,
+            useImmutableCollections: useImmutableCollections,
+            receiverOverride: refer('s'),
+          );
+          cases.addAll([
+            refer('num', 'dart:core').code,
+            const Code(' s => '),
+            refer(variantName).call([decodeBuilt.unsafeRawBody]).code,
+            const Code(','),
+          ]);
+          continue;
+        }
 
         cases.addAll([
           typeReference(
@@ -526,12 +557,38 @@ class OneOfGenerator {
             .where(
               (m) => m.model.resolved is PrimitiveModel,
             )) {
+      final variantName = variantNames[m]!;
+
+      if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
+        final decodeBuilt = buildFromJsonValueExpression(
+          'json',
+          model: m.model,
+          nameManager: nameManager,
+          package: package,
+          helperContext: helperContext,
+          contextClass: className,
+          useImmutableCollections: useImmutableCollections,
+        );
+        blocks.addAll([
+          const Code('try {'),
+          refer(
+            variantName,
+          ).call([decodeBuilt.unsafeRawBody]).returned.statement,
+          const Code('} on '),
+          refer(
+            'InvalidTypeException',
+            'package:tonik_util/tonik_util.dart',
+          ).code,
+          const Code(' catch (_) {}'),
+        ]);
+        continue;
+      }
+
       final typeRef = typeReference(
         m.model.resolved,
         nameManager,
         package,
       );
-      final variantName = variantNames[m]!;
 
       blocks.addAll([
         const Code('if ('),

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -482,9 +482,6 @@ class OneOfGenerator {
       (m) => m.model.resolved is AnyModel,
     );
 
-    // A whole-number JSON double denotes an integer, so an integer member
-    // decodes through decodeJsonInt. Skip this when a double/num member is
-    // present so the double/num variant keeps owning whole-number doubles.
     final hasNumberMember = model.models.any(
       (m) =>
           m.model.resolved is DoubleModel || m.model.resolved is NumberModel,

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -484,7 +484,7 @@ class OneOfGenerator {
 
     // A whole-number JSON double denotes an integer, so an integer member
     // decodes through decodeJsonInt. Skip this when a double/num member is
-    // present so that variant keeps owning whole-number doubles.
+    // present so the double/num variant keeps owning whole-number doubles.
     final hasNumberMember = model.models.any(
       (m) =>
           m.model.resolved is DoubleModel || m.model.resolved is NumberModel,

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4435,5 +4435,41 @@ bool operator ==(Object other) {
         ),
       );
     });
+
+    test('integer+double+string keeps int and double arms distinct', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DoubleModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                double s => ValueDouble(s),
+                int s => ValueInt(s),
+                String s => ValueString(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -3456,7 +3456,7 @@ bool operator ==(Object other) {
           collapseWhitespace(r"""
             factory Value.fromJson(Object? json) {
               return switch (json) {
-                int s => ValueInt(s),
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
                 String s => ValueString(s),
                 _ => throw JsonDecodingException(
                   r'Invalid JSON type for Value: ${json.runtimeType}',
@@ -4254,5 +4254,118 @@ bool operator ==(Object other) {
         );
       },
     );
+  });
+
+  group('whole-number double decodes to integer variant', () {
+    test('all-primitive string+integer routes integer through decode', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
+                String s => ValueString(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('mixed integer+object routes integer through decode in try', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              name: 'Thing',
+              properties: const [],
+              context: context,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              try {
+                return ValueInt(json.decodeJsonInt(context: r'Value'));
+              } on InvalidTypeException catch (_) {}
+              try {
+                return ValueThing(Thing.fromJson(json));
+              } on Object catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('integer+number keeps type-pattern arms without decodeJsonInt', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: NumberModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                int s => ValueInt(s),
+                num s => ValueNumber(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4367,5 +4367,73 @@ bool operator ==(Object other) {
         ),
       );
     });
+
+    test('integer+double keeps type-pattern arms without decodeJsonInt', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DoubleModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                double s => ValueDouble(s),
+                int s => ValueInt(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('integer+decimal routes integer through decode', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DecimalModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                BigDecimal s => ValueDecimal(s),
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -96,7 +96,7 @@ void main() {
         const expectedMethod = r'''
           factory Result.fromJson(Object? json) {
             return switch (json) {
-              int s => ResultError(s),
+              num s => ResultError(s.decodeJsonInt(context: r'Result')),
               String s => ResultSuccess(s),
               _ => throw JsonDecodingException(
                 r'Invalid JSON type for Result: ${json.runtimeType}',
@@ -1141,7 +1141,7 @@ void main() {
           factory Result.fromJson(Object? json) {
             return switch (json) {
               String s => ResultErrorCode(s),
-              int s => ResultInt(s),
+              num s => ResultInt(s.decodeJsonInt(context: r'Result')),
               _ => throw JsonDecodingException(
                 r'Invalid JSON type for Result: ${json.runtimeType}',
               ),


### PR DESCRIPTION
## Summary

A `oneOf` whose members are primitives including `type: integer` generated a `fromJson` that dispatched purely on the Dart runtime type. Because `jsonDecode` materializes whole-number numbers written in fractional or exponent form (`42.0`, `4e1`) as a Dart `double`, those inputs matched neither the `int` nor `String` arm and threw instead of decoding to the integer variant.

This decodes such whole-number doubles to the integer variant, matching Tonik's permissive integer-decoding policy already applied by the scalar, enum, and list integer decoders.

## Approach

The integer member is now routed through the existing `decodeJsonInt()` runtime util (which already accepts a whole-number double) instead of matching on Dart type. The whole-number check lives only in that util — nothing is inlined into generated code.

- **All-primitive dispatch**: the integer member is matched as `num` and decoded via `decodeJsonInt()`.
- **Mixed integer + object dispatch**: the integer member is decoded via `decodeJsonInt()` inside a `try { … } on InvalidTypeException catch (_) {}` so it accepts int + whole-number double and falls through to other variants otherwise.
- **Guarded**: this routing is skipped when the `oneOf` also has a `number`/`double` member, so that variant keeps owning doubles.

## Tests

- Unit tests (`one_of_generator_test.dart`): full-method-body comparisons for the all-primitive path, the mixed path, and the number+integer guard case.
- Integration tests (composition suite): `OneOfPrimitive` and a new `oneOf: [integer, object]` schema decode `42.0` / `4e1` to the integer variant.

All unit suites, the composition integration suite, and analysis pass; patch coverage is 100%.
