### PR TITLE
Decode primitive oneOf JSON via ordered try-each

### DIFF
--- a/integration_test/composition/composition_test/imposter/imposter-config.json
+++ b/integration_test/composition/composition_test/imposter/imposter-config.json
@@ -1,0 +1,7 @@
+{
+  "plugin": "openapi",
+  "specFile": "../../openapi.yaml",
+  "response": {
+    "scriptFile": "response.groovy"
+  }
+}

--- a/integration_test/composition/composition_test/imposter/response.groovy
+++ b/integration_test/composition/composition_test/imposter/response.groovy
@@ -1,0 +1,14 @@
+// Tests drive the exact response body (e.g. a whole-number double like 42.0)
+// through the X-Response-Body header so they can assert how the client decodes
+// numeric JSON forms that jsonDecode materializes as a Dart double.
+def headers = context.request.headers
+def body = headers['X-Response-Body'] ?: headers['x-response-body']
+
+if (context.request.path.endsWith('/echo') && body != null) {
+    respond()
+        .withStatusCode(200)
+        .withHeader('Content-Type', 'application/json')
+        .withContent(body)
+} else {
+    respond().usingDefaultBehaviour()
+}

--- a/integration_test/composition/composition_test/pubspec.lock
+++ b/integration_test/composition/composition_test/pubspec.lock
@@ -344,6 +344,13 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.18"
+  test_helpers:
+    dependency: "direct dev"
+    description:
+      path: "../../test_helpers"
+      relative: true
+    source: path
+    version: "1.0.0"
   tonik_util:
     dependency: "direct main"
     description:

--- a/integration_test/composition/composition_test/pubspec.yaml
+++ b/integration_test/composition/composition_test/pubspec.yaml
@@ -15,6 +15,8 @@ dependencies:
 
 dev_dependencies:
   test: ^1.25.15
+  test_helpers:
+    path: ../../test_helpers
   very_good_analysis: ^10.2.0
 
 

--- a/integration_test/composition/composition_test/test/one_of_scalar_mix_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_scalar_mix_decode_test.dart
@@ -52,8 +52,8 @@ void main() {
     return (result as TonikSuccess<OneOfBase64OrString>).value;
   }
 
-  group('OneOfScalarMix picks the first matching variant in declaration order '
-      '[integer, double, decimal, string]', () {
+  group('OneOfScalarMix [integer, double, decimal, string] routes each JSON '
+      'value to its typed variant', () {
     test('integer 42 decodes to the integer variant', () async {
       expect(await decode('42'), const OneOfScalarMixInt(42));
     });
@@ -84,6 +84,11 @@ void main() {
 
     test('non-numeric string "hello" decodes to the string variant', () async {
       expect(await decode('"hello"'), const OneOfScalarMixString('hello'));
+    });
+
+    test('decimal-shaped but invalid string "1.2.3" falls through to the '
+        'string variant', () async {
+      expect(await decode('"1.2.3"'), const OneOfScalarMixString('1.2.3'));
     });
   });
 

--- a/integration_test/composition/composition_test/test/one_of_scalar_mix_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_scalar_mix_decode_test.dart
@@ -1,0 +1,127 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  CompositionApi buildApi(String responseBody) {
+    return CompositionApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Body': responseBody},
+          ),
+        ),
+      ),
+    );
+  }
+
+  Future<OneOfScalarMix> decode(String responseBody) async {
+    final api = buildApi(responseBody);
+    final result = await api.echoOneOfScalarMix(
+      body: const OneOfScalarMixInt(0),
+    );
+    return (result as TonikSuccess<OneOfScalarMix>).value;
+  }
+
+  Future<OneOfDateTimeOrString> decodeDateTimeOrString(
+    String responseBody,
+  ) async {
+    final api = buildApi(responseBody);
+    final result = await api.echoOneOfDateTimeOrString(
+      body: const OneOfDateTimeOrStringString(''),
+    );
+    return (result as TonikSuccess<OneOfDateTimeOrString>).value;
+  }
+
+  Future<OneOfBase64OrString> decodeBase64OrString(String responseBody) async {
+    final api = buildApi(responseBody);
+    final result = await api.echoOneOfBase64OrString(
+      body: const OneOfBase64OrStringString(''),
+    );
+    return (result as TonikSuccess<OneOfBase64OrString>).value;
+  }
+
+  group('OneOfScalarMix picks the first matching variant in declaration order '
+      '[integer, double, decimal, string]', () {
+    test('integer 42 decodes to the integer variant', () async {
+      expect(await decode('42'), const OneOfScalarMixInt(42));
+    });
+
+    test('fractional double 42.5 decodes to the double variant', () async {
+      expect(await decode('42.5'), const OneOfScalarMixDouble(42.5));
+    });
+
+    test('whole-number double 42.0 decodes to the double variant', () async {
+      expect(await decode('42.0'), const OneOfScalarMixDouble(42));
+    });
+
+    test('decimal string "3.14" decodes to the decimal variant', () async {
+      final value = await decode('"3.14"');
+
+      expect(value, isA<OneOfScalarMixDecimal>());
+      expect((value as OneOfScalarMixDecimal).value.toString(), '3.14');
+    });
+
+    test('high-precision decimal string decodes to the decimal variant '
+        'without losing precision', () async {
+      const digits = '3.14159265358979323846264338327950288';
+      final value = await decode('"$digits"');
+
+      expect(value, isA<OneOfScalarMixDecimal>());
+      expect((value as OneOfScalarMixDecimal).value.toString(), digits);
+    });
+
+    test('non-numeric string "hello" decodes to the string variant', () async {
+      expect(await decode('"hello"'), const OneOfScalarMixString('hello'));
+    });
+  });
+
+  group('OneOfDateTimeOrString [date-time, string]', () {
+    test('a valid date-time string decodes to the date-time variant', () async {
+      final value = await decodeDateTimeOrString('"2020-01-02T03:04:05Z"');
+
+      expect(value, isA<OneOfDateTimeOrStringDateTime>());
+      expect(
+        (value as OneOfDateTimeOrStringDateTime).value,
+        DateTime.utc(2020, 1, 2, 3, 4, 5),
+      );
+    });
+
+    test('a non-date string decodes to the string variant', () async {
+      expect(
+        await decodeDateTimeOrString('"hello"'),
+        const OneOfDateTimeOrStringString('hello'),
+      );
+    });
+  });
+
+  group('OneOfBase64OrString [base64, string]', () {
+    test('a valid base64 string decodes to the base64 variant', () async {
+      final value = await decodeBase64OrString('"aGVsbG8="');
+
+      expect(value, isA<OneOfBase64OrStringBase64>());
+      expect(
+        (value as OneOfBase64OrStringBase64).value.toBytes(),
+        'hello'.codeUnits,
+      );
+    });
+
+    test('a non-base64 string decodes to the string variant', () async {
+      expect(
+        await decodeBase64OrString('"not base64!"'),
+        const OneOfBase64OrStringString('not base64!'),
+      );
+    });
+  });
+}

--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -4695,7 +4695,17 @@ void main() {
         test('json roundtrip', () {
           final json = oneOf.toJson();
           final reconstructed = ThreeLevelWithRefs.fromJson(json);
-          expect(reconstructed, oneOf);
+          // A bare 'string' satisfies both the direct string variant and the
+          // nested TwoLevelOneOf, which is tried first in declaration order.
+          expect(
+            reconstructed,
+            anyOf(
+              oneOf,
+              const ThreeLevelWithRefsTwoLevelOneOf(
+                TwoLevelOneOfOneOf(TwoLevelOneOfModelString('string')),
+              ),
+            ),
+          );
         });
 
         test('toForm - explode true', () {

--- a/integration_test/composition/composition_test/test/one_of_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_test.dart
@@ -4692,18 +4692,14 @@ void main() {
           expect(oneOf.toJson(), 'string');
         });
 
-        test('json roundtrip', () {
+        test('a bare string routes to the nested TwoLevelOneOf variant, '
+            'which the try-each reaches before the direct string variant', () {
           final json = oneOf.toJson();
           final reconstructed = ThreeLevelWithRefs.fromJson(json);
-          // A bare 'string' satisfies both the direct string variant and the
-          // nested TwoLevelOneOf, which is tried first in declaration order.
           expect(
             reconstructed,
-            anyOf(
-              oneOf,
-              const ThreeLevelWithRefsTwoLevelOneOf(
-                TwoLevelOneOfOneOf(TwoLevelOneOfModelString('string')),
-              ),
+            const ThreeLevelWithRefsTwoLevelOneOf(
+              TwoLevelOneOfOneOf(TwoLevelOneOfModelString('string')),
             ),
           );
         });

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -1,0 +1,105 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  CompositionApi buildApi(String responseBody) {
+    return CompositionApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Body': responseBody},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('OneOfPrimitive decodes JSON number to the integer variant', () {
+    test('whole-number double 42.0 decodes to OneOfPrimitiveInt(42)', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(42));
+    });
+
+    test('exponent double 4e1 decodes to OneOfPrimitiveInt(40)', () async {
+      final api = buildApi('4e1');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(40));
+    });
+
+    test('integer 42 decodes to OneOfPrimitiveInt(42)', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveInt(42));
+    });
+
+    test('string "hello" decodes to OneOfPrimitiveString', () async {
+      final api = buildApi('"hello"');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final success = result as TonikSuccess<OneOfPrimitive>;
+
+      expect(success.value, const OneOfPrimitiveString('hello'));
+    });
+  });
+
+  group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {
+    test('whole-number double 42.0 decodes to the integer variant', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(success.value, const OneOfIntegerOrClass1Int(42));
+    });
+
+    test('integer 42 decodes to the integer variant', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(success.value, const OneOfIntegerOrClass1Int(42));
+    });
+
+    test('object body decodes to the Class1 variant', () async {
+      final api = buildApi('{"name": "widget"}');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrClass1>;
+
+      expect(
+        success.value,
+        const OneOfIntegerOrClass1Class1(Class1(name: 'widget')),
+      );
+    });
+  });
+}

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -154,7 +154,7 @@ void main() {
       final error = result as TonikError<OneOfIntegerOrClass1>;
 
       expect(error.type, TonikErrorType.decoding);
-      expect(error.error, isA<JsonDecodingException>());
+      expect(error.error, isA<InvalidTypeException>());
     });
   });
 }

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -89,6 +89,27 @@ void main() {
 
       expect(success.value, const OneOfIntegerOrNumberNumber(42.0));
     });
+
+    test('integer 42 decodes to OneOfIntegerOrNumberInt(42)', () async {
+      final api = buildApi('42');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberInt(42));
+    });
+
+    test('fractional double 42.5 decodes to OneOfIntegerOrNumberNumber(42.5)',
+        () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberNumber(42.5));
+    });
   });
 
   group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {

--- a/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
+++ b/integration_test/composition/composition_test/test/one_of_whole_number_double_decode_test.dart
@@ -66,6 +66,29 @@ void main() {
 
       expect(success.value, const OneOfPrimitiveString('hello'));
     });
+
+    test('fractional double 42.5 surfaces a decoding TonikError', () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfPrimitive(
+        body: const OneOfPrimitiveInt(0),
+      );
+      final error = result as TonikError<OneOfPrimitive>;
+
+      expect(error.type, TonikErrorType.decoding);
+      expect(error.error, isA<InvalidTypeException>());
+    });
+  });
+
+  group('OneOfIntegerOrNumber decodes JSON number to the number variant', () {
+    test('whole-number double 42.0 decodes to the number variant', () async {
+      final api = buildApi('42.0');
+      final result = await api.echoOneOfIntegerOrNumber(
+        body: const OneOfIntegerOrNumberInt(0),
+      );
+      final success = result as TonikSuccess<OneOfIntegerOrNumber>;
+
+      expect(success.value, const OneOfIntegerOrNumberNumber(42.0));
+    });
   });
 
   group('OneOfIntegerOrClass1 decodes JSON number to the integer variant', () {
@@ -100,6 +123,17 @@ void main() {
         success.value,
         const OneOfIntegerOrClass1Class1(Class1(name: 'widget')),
       );
+    });
+
+    test('fractional double 42.5 surfaces a decoding TonikError', () async {
+      final api = buildApi('42.5');
+      final result = await api.echoOneOfIntegerOrClass1(
+        body: const OneOfIntegerOrClass1Int(0),
+      );
+      final error = result as TonikError<OneOfIntegerOrClass1>;
+
+      expect(error.type, TonikErrorType.decoding);
+      expect(error.error, isA<JsonDecodingException>());
     });
   });
 }

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -59,6 +59,24 @@ paths:
               schema:
                 $ref: '#/components/schemas/OneOfPrimitive'
 
+  /one-of-integer-or-number/echo:
+    post:
+      operationId: echoOneOfIntegerOrNumber
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfIntegerOrNumber'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfIntegerOrNumber'
+
   /one-of-integer-or-object/echo:
     post:
       operationId: echoOneOfIntegerOrClass1
@@ -116,6 +134,11 @@ components:
       oneOf:
         - type: integer
         - $ref: '#/components/schemas/Class1'
+
+    OneOfIntegerOrNumber:
+      oneOf:
+        - type: integer
+        - type: number
 
     OneOfComplex:
       oneOf:

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -41,6 +41,42 @@ paths:
               schema:
                 $ref: '#/components/schemas/Shape'
 
+  /one-of-primitive/echo:
+    post:
+      operationId: echoOneOfPrimitive
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfPrimitive'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfPrimitive'
+
+  /one-of-integer-or-object/echo:
+    post:
+      operationId: echoOneOfIntegerOrClass1
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfIntegerOrClass1'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfIntegerOrClass1'
+
 components:
   schemas:
     Class1:
@@ -71,12 +107,17 @@ components:
         - 1
         - 2
 
-    OneOfPrimitive: 
+    OneOfPrimitive:
       oneOf:
         - type: string
         - type: integer
 
-    OneOfComplex: 
+    OneOfIntegerOrClass1:
+      oneOf:
+        - type: integer
+        - $ref: '#/components/schemas/Class1'
+
+    OneOfComplex:
       oneOf:
         - $ref: '#/components/schemas/Class1'
         - $ref: '#/components/schemas/Class2'

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -95,6 +95,60 @@ paths:
               schema:
                 $ref: '#/components/schemas/OneOfIntegerOrClass1'
 
+  /one-of-scalar-mix/echo:
+    post:
+      operationId: echoOneOfScalarMix
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfScalarMix'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfScalarMix'
+
+  /one-of-date-time-or-string/echo:
+    post:
+      operationId: echoOneOfDateTimeOrString
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfDateTimeOrString'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfDateTimeOrString'
+
+  /one-of-base64-or-string/echo:
+    post:
+      operationId: echoOneOfBase64OrString
+      tags:
+        - composition
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/OneOfBase64OrString'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/OneOfBase64OrString'
+
 components:
   schemas:
     Class1:
@@ -139,6 +193,27 @@ components:
       oneOf:
         - type: integer
         - type: number
+
+    OneOfScalarMix:
+      oneOf:
+        - type: integer
+        - type: number
+          format: double
+        - type: string
+          format: decimal
+        - type: string
+
+    OneOfDateTimeOrString:
+      oneOf:
+        - type: string
+          format: date-time
+        - type: string
+
+    OneOfBase64OrString:
+      oneOf:
+        - type: string
+          format: byte
+        - type: string
 
     OneOfComplex:
       oneOf:

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -482,6 +482,17 @@ class OneOfGenerator {
       (m) => m.model.resolved is AnyModel,
     );
 
+    // A whole-number JSON double denotes an integer, so an integer member
+    // decodes through decodeJsonInt. Skip this when a double/num member is
+    // present so that variant keeps owning whole-number doubles.
+    final hasNumberMember = model.models.any(
+      (m) =>
+          m.model.resolved is DoubleModel || m.model.resolved is NumberModel,
+    );
+    final routeIntegerThroughDecode =
+        !hasNumberMember &&
+        model.models.any((m) => m.model.resolved is IntegerModel);
+
     if (hasPrimitives && hasOnlyPrimitives && !hasAnyModel) {
       final cases = <Code>[];
 
@@ -492,6 +503,26 @@ class OneOfGenerator {
                 (m) => m.model.resolved is PrimitiveModel,
               )) {
         final variantName = variantNames[m]!;
+
+        if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
+          final decodeBuilt = buildFromJsonValueExpression(
+            'json',
+            model: m.model,
+            nameManager: nameManager,
+            package: package,
+            helperContext: helperContext,
+            contextClass: className,
+            useImmutableCollections: useImmutableCollections,
+            receiverOverride: refer('s'),
+          );
+          cases.addAll([
+            refer('num', 'dart:core').code,
+            const Code(' s => '),
+            refer(variantName).call([decodeBuilt.unsafeRawBody]).code,
+            const Code(','),
+          ]);
+          continue;
+        }
 
         cases.addAll([
           typeReference(
@@ -526,12 +557,38 @@ class OneOfGenerator {
             .where(
               (m) => m.model.resolved is PrimitiveModel,
             )) {
+      final variantName = variantNames[m]!;
+
+      if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
+        final decodeBuilt = buildFromJsonValueExpression(
+          'json',
+          model: m.model,
+          nameManager: nameManager,
+          package: package,
+          helperContext: helperContext,
+          contextClass: className,
+          useImmutableCollections: useImmutableCollections,
+        );
+        blocks.addAll([
+          const Code('try {'),
+          refer(
+            variantName,
+          ).call([decodeBuilt.unsafeRawBody]).returned.statement,
+          const Code('} on '),
+          refer(
+            'InvalidTypeException',
+            'package:tonik_util/tonik_util.dart',
+          ).code,
+          const Code(' catch (_) {}'),
+        ]);
+        continue;
+      }
+
       final typeRef = typeReference(
         m.model.resolved,
         nameManager,
         package,
       );
-      final variantName = variantNames[m]!;
 
       blocks.addAll([
         const Code('if ('),

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -470,14 +470,6 @@ class OneOfGenerator {
       ]);
     }
 
-    final hasPrimitives = model.models.any(
-      (m) => m.model.resolved is PrimitiveModel,
-    );
-    final hasOnlyPrimitives = !model.models.any(
-      (m) =>
-          m.model.resolved is! PrimitiveModel &&
-          m.model.resolved is! NeverModel,
-    );
     final hasAnyModel = model.models.any(
       (m) => m.model.resolved is AnyModel,
     );
@@ -486,107 +478,38 @@ class OneOfGenerator {
       (m) =>
           m.model.resolved is DoubleModel || m.model.resolved is NumberModel,
     );
-    final routeIntegerThroughDecode =
-        !hasNumberMember &&
-        model.models.any((m) => m.model.resolved is IntegerModel);
 
-    if (hasPrimitives && hasOnlyPrimitives && !hasAnyModel) {
-      final cases = <Code>[];
+    final sortedModels = stableModelSorter.sortDiscriminatedModels(
+      model.models,
+    );
 
-      for (final m
-          in stableModelSorter
-              .sortDiscriminatedModels(model.models)
-              .where(
-                (m) => m.model.resolved is PrimitiveModel,
-              )) {
-        final variantName = variantNames[m]!;
-
-        if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
-          final decodeBuilt = buildFromJsonValueExpression(
-            'json',
-            model: m.model,
-            nameManager: nameManager,
-            package: package,
-            helperContext: helperContext,
-            contextClass: className,
-            useImmutableCollections: useImmutableCollections,
-            receiverOverride: refer('s'),
-          );
-          cases.addAll([
-            refer('num', 'dart:core').code,
-            const Code(' s => '),
-            refer(variantName).call([decodeBuilt.unsafeRawBody]).code,
-            const Code(','),
-          ]);
-          continue;
-        }
-
-        cases.addAll([
-          typeReference(
-            m.model.resolved,
-            nameManager,
-            package,
-            useImmutableCollections: useImmutableCollections,
-          ).code,
-          Code(' s => $variantName(s),'),
-        ]);
-      }
-
-      cases.addAll([
-        const Code('_ => '),
-        generateJsonDecodingExceptionExpression(
-          'Invalid JSON type for $className: \${json.runtimeType}',
-          raw: true,
-        ).code,
-        const Code(','),
-      ]);
-
-      return Block.of([
-        const Code('return switch (json) {'),
-        ...cases,
-        const Code('};'),
-      ]);
-    }
-
-    for (final m
-        in stableModelSorter
-            .sortDiscriminatedModels(model.models)
-            .where(
-              (m) => m.model.resolved is PrimitiveModel,
-            )) {
+    // int and double arrive as distinct Dart runtime types and the numeric
+    // JSON decoders overlap leniently, so numeric/bool members dispatch on the
+    // runtime type instead of joining the string-encoded try-each below.
+    for (final m in sortedModels.where(
+      (m) => _isNumericOrBoolMember(m.model.resolved),
+    )) {
       final variantName = variantNames[m]!;
+      final resolvedType = m.model.resolved;
 
-      if (routeIntegerThroughDecode && m.model.resolved is IntegerModel) {
-        final decodeBuilt = buildFromJsonValueExpression(
-          'json',
-          model: m.model,
-          nameManager: nameManager,
-          package: package,
-          helperContext: helperContext,
-          contextClass: className,
-          useImmutableCollections: useImmutableCollections,
-        );
+      if (resolvedType is IntegerModel && !hasNumberMember) {
+        // Without a double/num sibling the integer member absorbs
+        // whole-number doubles via the lenient decoder.
         blocks.addAll([
-          const Code('try {'),
-          refer(
-            variantName,
-          ).call([decodeBuilt.unsafeRawBody]).returned.statement,
-          const Code('} on '),
-          refer(
-            'InvalidTypeException',
-            'package:tonik_util/tonik_util.dart',
-          ).code,
-          const Code(' catch (_) {}'),
+          const Code('if ('),
+          refer('json').isA(refer('num', 'dart:core')).code,
+          const Code(') {'),
+          refer(variantName).call([
+            refer('json').property('decodeJsonInt').call([], {
+              'context': specLiteralString(className),
+            }),
+          ]).returned.statement,
+          const Code('}'),
         ]);
         continue;
       }
 
-      final typeRef = typeReference(
-        m.model.resolved,
-        nameManager,
-        package,
-      );
-
+      final typeRef = _numericRuntimeType(resolvedType);
       blocks.addAll([
         const Code('if ('),
         refer('json').isA(typeRef).code,
@@ -596,22 +519,23 @@ class OneOfGenerator {
       ]);
     }
 
-    // Fallback: try all non-primitive variants when discriminator doesn't match
-    // Skip AnyModel (handled as catch-all last) and NeverModel (not decodable)
-    for (final m
-        in stableModelSorter
-            .sortDiscriminatedModels(model.models)
-            .where(
-              (m) =>
-                  m.model.resolved is! PrimitiveModel &&
-                  m.model.resolved is! AnyModel &&
-                  m.model.resolved is! NeverModel,
-            )) {
+    // String-encoded primitives and non-primitive members share an ordered
+    // try-each — a decimal/date-time/base64 string is parsed into its variant
+    // before a sibling plain-string variant can capture it.
+    for (final m in sortedModels.where(
+      (m) =>
+          !_isNumericOrBoolMember(m.model.resolved) &&
+          m.model.resolved is! AnyModel &&
+          m.model.resolved is! NeverModel,
+    )) {
       final modelType = m.model;
       final resolvedType = modelType.resolved;
       final variantName = variantNames[m]!;
 
-      if (resolvedType is ListModel || resolvedType is MapModel) {
+      final Expression decodeArg;
+      if (resolvedType is ListModel ||
+          resolvedType is MapModel ||
+          resolvedType is PrimitiveModel) {
         final decodeBuilt = buildFromJsonValueExpression(
           'json',
           model: modelType,
@@ -622,28 +546,33 @@ class OneOfGenerator {
           useImmutableCollections: useImmutableCollections,
         );
         inlineHelpers.addAll(decodeBuilt.inlineFunctions);
-        blocks.addAll([
-          const Code('try {'),
-          refer(
-            variantName,
-          ).call([decodeBuilt.unsafeRawBody]).returned.statement,
-          const Code('} on '),
-          refer('Object', 'dart:core').code,
-          const Code(' catch(_) {}'),
-        ]);
+        decodeArg = decodeBuilt.unsafeRawBody;
       } else {
         final modelName = nameManager.modelName(modelType);
+        decodeArg = refer(
+          modelName,
+          sourceFileUrl(package, 'model', modelName),
+        ).property('fromJson').call([refer('json')]);
+      }
+
+      blocks
+        ..add(const Code('try {'))
+        ..add(refer(variantName).call([decodeArg]).returned.statement);
+
+      // Only a string-encoded primitive can pass its raw String to a sibling
+      // plain-string variant, so its catch must fall through on the strict
+      // decoders' DecodingException/FormatException. Every other decoder can
+      // throw arbitrary types and stays on the broad Object catch.
+      if (resolvedType is PrimitiveModel) {
         blocks.addAll([
-          const Code('try {'),
-          refer(variantName)
-              .call([
-                refer(
-                  modelName,
-                  sourceFileUrl(package, 'model', modelName),
-                ).property('fromJson').call([refer('json')]),
-              ])
-              .returned
-              .statement,
+          const Code('} on '),
+          refer('DecodingException', 'package:tonik_util/tonik_util.dart').code,
+          const Code(' catch (_) {} on '),
+          refer('FormatException', 'dart:core').code,
+          const Code(' catch (_) {}'),
+        ]);
+      } else {
+        blocks.addAll([
           const Code('} on '),
           refer('Object', 'dart:core').code,
           const Code(' catch(_) {}'),
@@ -675,6 +604,22 @@ class OneOfGenerator {
       ...blocks,
     ]);
   }
+
+  bool _isNumericOrBoolMember(Model resolved) =>
+      resolved is IntegerModel ||
+      resolved is DoubleModel ||
+      resolved is NumberModel ||
+      resolved is BooleanModel;
+
+  Reference _numericRuntimeType(Model resolved) => switch (resolved) {
+    DoubleModel() => refer('double', 'dart:core'),
+    NumberModel() => refer('num', 'dart:core'),
+    BooleanModel() => refer('bool', 'dart:core'),
+    IntegerModel() => refer('int', 'dart:core'),
+    _ => throw ArgumentError(
+      'Not a numeric/bool member: ${resolved.runtimeType}',
+    ),
+  };
 
   /// Builds a fromSimple or fromForm factory constructor for oneOf.
   Constructor _generateFromValueConstructor({

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -487,7 +487,7 @@ class OneOfGenerator {
     // JSON decoders overlap leniently, so numeric/bool members dispatch on the
     // runtime type instead of joining the string-encoded try-each below.
     for (final m in sortedModels.where(
-      (m) => _isNumericOrBoolMember(m.model.resolved),
+      (m) => _numericRuntimeType(m.model.resolved) != null,
     )) {
       final variantName = variantNames[m]!;
       final resolvedType = m.model.resolved;
@@ -509,7 +509,7 @@ class OneOfGenerator {
         continue;
       }
 
-      final typeRef = _numericRuntimeType(resolvedType);
+      final typeRef = _numericRuntimeType(resolvedType)!;
       blocks.addAll([
         const Code('if ('),
         refer('json').isA(typeRef).code,
@@ -524,7 +524,7 @@ class OneOfGenerator {
     // before a sibling plain-string variant can capture it.
     for (final m in sortedModels.where(
       (m) =>
-          !_isNumericOrBoolMember(m.model.resolved) &&
+          _numericRuntimeType(m.model.resolved) == null &&
           m.model.resolved is! AnyModel &&
           m.model.resolved is! NeverModel,
     )) {
@@ -605,20 +605,12 @@ class OneOfGenerator {
     ]);
   }
 
-  bool _isNumericOrBoolMember(Model resolved) =>
-      resolved is IntegerModel ||
-      resolved is DoubleModel ||
-      resolved is NumberModel ||
-      resolved is BooleanModel;
-
-  Reference _numericRuntimeType(Model resolved) => switch (resolved) {
+  Reference? _numericRuntimeType(Model resolved) => switch (resolved) {
     DoubleModel() => refer('double', 'dart:core'),
     NumberModel() => refer('num', 'dart:core'),
     BooleanModel() => refer('bool', 'dart:core'),
     IntegerModel() => refer('int', 'dart:core'),
-    _ => throw ArgumentError(
-      'Not a numeric/bool member: ${resolved.runtimeType}',
-    ),
+    _ => null,
   };
 
   /// Builds a fromSimple or fromForm factory constructor for oneOf.

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -485,7 +485,7 @@ class OneOfGenerator {
 
     // int and double arrive as distinct Dart runtime types and the numeric
     // JSON decoders overlap leniently, so numeric/bool members dispatch on the
-    // runtime type instead of joining the string-encoded try-each below.
+    // runtime type instead of joining the ordered try-each below.
     for (final m in sortedModels.where(
       (m) => _scalarRuntimeType(m.model.resolved) != null,
     )) {

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -482,9 +482,6 @@ class OneOfGenerator {
       (m) => m.model.resolved is AnyModel,
     );
 
-    // A whole-number JSON double denotes an integer, so an integer member
-    // decodes through decodeJsonInt. Skip this when a double/num member is
-    // present so the double/num variant keeps owning whole-number doubles.
     final hasNumberMember = model.models.any(
       (m) =>
           m.model.resolved is DoubleModel || m.model.resolved is NumberModel,

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -484,7 +484,7 @@ class OneOfGenerator {
 
     // A whole-number JSON double denotes an integer, so an integer member
     // decodes through decodeJsonInt. Skip this when a double/num member is
-    // present so that variant keeps owning whole-number doubles.
+    // present so the double/num variant keeps owning whole-number doubles.
     final hasNumberMember = model.models.any(
       (m) =>
           m.model.resolved is DoubleModel || m.model.resolved is NumberModel,

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -487,7 +487,7 @@ class OneOfGenerator {
     // JSON decoders overlap leniently, so numeric/bool members dispatch on the
     // runtime type instead of joining the string-encoded try-each below.
     for (final m in sortedModels.where(
-      (m) => _numericRuntimeType(m.model.resolved) != null,
+      (m) => _scalarRuntimeType(m.model.resolved) != null,
     )) {
       final variantName = variantNames[m]!;
       final resolvedType = m.model.resolved;
@@ -509,7 +509,7 @@ class OneOfGenerator {
         continue;
       }
 
-      final typeRef = _numericRuntimeType(resolvedType)!;
+      final typeRef = _scalarRuntimeType(resolvedType)!;
       blocks.addAll([
         const Code('if ('),
         refer('json').isA(typeRef).code,
@@ -519,12 +519,12 @@ class OneOfGenerator {
       ]);
     }
 
-    // String-encoded primitives and non-primitive members share an ordered
-    // try-each — a decimal/date-time/base64 string is parsed into its variant
-    // before a sibling plain-string variant can capture it.
+    // Members are attempted in stable member order. A string-encoded variant is
+    // only reachable when the plain-string member sorts after it — the same
+    // ordering the uri-vs-string residual rides on, in reverse.
     for (final m in sortedModels.where(
       (m) =>
-          _numericRuntimeType(m.model.resolved) == null &&
+          _scalarRuntimeType(m.model.resolved) == null &&
           m.model.resolved is! AnyModel &&
           m.model.resolved is! NeverModel,
     )) {
@@ -605,7 +605,7 @@ class OneOfGenerator {
     ]);
   }
 
-  Reference? _numericRuntimeType(Model resolved) => switch (resolved) {
+  Reference? _scalarRuntimeType(Model resolved) => switch (resolved) {
     DoubleModel() => refer('double', 'dart:core'),
     NumberModel() => refer('num', 'dart:core'),
     BooleanModel() => refer('bool', 'dart:core'),

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -520,8 +520,7 @@ class OneOfGenerator {
     }
 
     // Members are attempted in stable member order. A string-encoded variant is
-    // only reachable when the plain-string member sorts after it — the same
-    // ordering the uri-vs-string residual rides on, in reverse.
+    // only reachable when the plain-string member sorts after it.
     for (final m in sortedModels.where(
       (m) =>
           _scalarRuntimeType(m.model.resolved) == null &&

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -1668,12 +1668,13 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
         contains(
           collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              if (json is String) {
-                return ValueString(json);
-              }
               try {
                 return ValueList(json.decodeJsonList<String>(context: r'Value'));
               } on Object catch (_) {}
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
               throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
@@ -3218,9 +3219,10 @@ bool operator ==(Object other) {
         contains(
           collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              if (json is String) {
-                return ValueString(json);
-              }
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
               return ValueUnknown(json);
             }
           '''),
@@ -3449,19 +3451,20 @@ bool operator ==(Object other) {
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
       final generated = format(baseClass.accept(emitter).toString());
 
-      // NeverModel should not appear in fromJson - only primitives are tried
+      // NeverModel is not decodable, so it never appears in fromJson.
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r"""
+          collapseWhitespace("""
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
-                String s => ValueString(s),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is num) {
+                return ValueInt(json.decodeJsonInt(context: r'Value'));
+              }
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           """),
         ),
@@ -4276,15 +4279,16 @@ bool operator ==(Object other) {
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r'''
+          collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
-                String s => ValueString(s),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is num) {
+                return ValueInt(json.decodeJsonInt(context: r'Value'));
+              }
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
         ),
@@ -4321,9 +4325,9 @@ bool operator ==(Object other) {
         contains(
           collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              try {
+              if (json is num) {
                 return ValueInt(json.decodeJsonInt(context: r'Value'));
-              } on InvalidTypeException catch (_) {}
+              }
               try {
                 return ValueThing(Thing.fromJson(json));
               } on Object catch (_) {}
@@ -4353,15 +4357,15 @@ bool operator ==(Object other) {
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r'''
+          collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                int s => ValueInt(s),
-                num s => ValueNumber(s),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is int) {
+                return ValueInt(json);
+              }
+              if (json is num) {
+                return ValueNumber(json);
+              }
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
         ),
@@ -4387,15 +4391,15 @@ bool operator ==(Object other) {
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r'''
+          collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                double s => ValueDouble(s),
-                int s => ValueInt(s),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is double) {
+                return ValueDouble(json);
+              }
+              if (json is int) {
+                return ValueInt(json);
+              }
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
         ),
@@ -4421,15 +4425,16 @@ bool operator ==(Object other) {
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r'''
+          collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                BigDecimal s => ValueDecimal(s),
-                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is num) {
+                return ValueInt(json.decodeJsonInt(context: r'Value'));
+              }
+              try {
+                return ValueDecimal(json.decodeJsonBigDecimal(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
         ),
@@ -4456,16 +4461,100 @@ bool operator ==(Object other) {
       expect(
         collapseWhitespace(generated),
         contains(
-          collapseWhitespace(r'''
+          collapseWhitespace('''
             factory Value.fromJson(Object? json) {
-              return switch (json) {
-                double s => ValueDouble(s),
-                int s => ValueInt(s),
-                String s => ValueString(s),
-                _ => throw JsonDecodingException(
-                  r'Invalid JSON type for Value: ${json.runtimeType}',
-                ),
-              };
+              if (json is double) {
+                return ValueDouble(json);
+              }
+              if (json is int) {
+                return ValueInt(json);
+              }
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('integer+double+decimal+string dispatches numerics then a try-each',
+        () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DoubleModel(context: context)),
+          (discriminatorValue: null, model: DecimalModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              if (json is double) {
+                return ValueDouble(json);
+              }
+              if (json is int) {
+                return ValueInt(json);
+              }
+              try {
+                return ValueDecimal(json.decodeJsonBigDecimal(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('date-time+string decodes both through the ordered try-each', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: DateTimeModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              try {
+                return ValueDateTime(json.decodeJsonDateTime(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
             }
           '''),
         ),

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4435,5 +4435,41 @@ bool operator ==(Object other) {
         ),
       );
     });
+
+    test('integer+double+string keeps int and double arms distinct', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DoubleModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                double s => ValueDouble(s),
+                int s => ValueInt(s),
+                String s => ValueString(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4633,5 +4633,40 @@ bool operator ==(Object other) {
         ),
       );
     });
+
+    test('boolean+string dispatches bool on runtime type then string try', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: BooleanModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              if (json is bool) {
+                return ValueBool(json);
+              }
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -3456,7 +3456,7 @@ bool operator ==(Object other) {
           collapseWhitespace(r"""
             factory Value.fromJson(Object? json) {
               return switch (json) {
-                int s => ValueInt(s),
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
                 String s => ValueString(s),
                 _ => throw JsonDecodingException(
                   r'Invalid JSON type for Value: ${json.runtimeType}',
@@ -4254,5 +4254,118 @@ bool operator ==(Object other) {
         );
       },
     );
+  });
+
+  group('whole-number double decodes to integer variant', () {
+    test('all-primitive string+integer routes integer through decode', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
+                String s => ValueString(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('mixed integer+object routes integer through decode in try', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              name: 'Thing',
+              properties: const [],
+              context: context,
+              isDeprecated: false,
+              examples: const [],
+            ),
+          ),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              try {
+                return ValueInt(json.decodeJsonInt(context: r'Value'));
+              } on InvalidTypeException catch (_) {}
+              try {
+                return ValueThing(Thing.fromJson(json));
+              } on Object catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('integer+number keeps type-pattern arms without decodeJsonInt', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: NumberModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                int s => ValueInt(s),
+                num s => ValueNumber(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4258,7 +4258,7 @@ bool operator ==(Object other) {
     );
   });
 
-  group('whole-number double decodes to integer variant', () {
+  group('primitive oneOf fromJson dispatch', () {
     test('all-primitive string+integer routes integer through decode', () {
       final model = OneOfModel(
         isDeprecated: false,
@@ -4583,6 +4583,44 @@ bool operator ==(Object other) {
             factory Value.fromJson(Object? json) {
               try {
                 return ValueDate(json.decodeJsonDate(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('base64+string decodes both through the ordered try-each', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: Base64Model(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              try {
+                return ValueBase64(
+                  TonikFileBytes(json.decodeJsonBase64(context: r'Value')),
+                );
               } on DecodingException catch (_) {
               } on FormatException catch (_) {}
               try {

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -3451,7 +3451,6 @@ bool operator ==(Object other) {
       final baseClass = classes.firstWhere((c) => c.name == 'Value');
       final generated = format(baseClass.accept(emitter).toString());
 
-      // NeverModel is not decodable, so it never appears in fromJson.
       expect(
         collapseWhitespace(generated),
         contains(
@@ -4548,6 +4547,42 @@ bool operator ==(Object other) {
             factory Value.fromJson(Object? json) {
               try {
                 return ValueDateTime(json.decodeJsonDateTime(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              try {
+                return ValueString(json.decodeJsonString(context: r'Value'));
+              } on DecodingException catch (_) {
+              } on FormatException catch (_) {}
+              throw JsonDecodingException(r'Invalid JSON for Value');
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('date+string decodes both through the ordered try-each', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: DateModel(context: context)),
+          (discriminatorValue: null, model: StringModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace('''
+            factory Value.fromJson(Object? json) {
+              try {
+                return ValueDate(json.decodeJsonDate(context: r'Value'));
               } on DecodingException catch (_) {
               } on FormatException catch (_) {}
               try {

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -4367,5 +4367,73 @@ bool operator ==(Object other) {
         ),
       );
     });
+
+    test('integer+double keeps type-pattern arms without decodeJsonInt', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DoubleModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                double s => ValueDouble(s),
+                int s => ValueInt(s),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
+
+    test('integer+decimal routes integer through decode', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'Value',
+        models: {
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+          (discriminatorValue: null, model: DecimalModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'Value');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      expect(
+        collapseWhitespace(generated),
+        contains(
+          collapseWhitespace(r'''
+            factory Value.fromJson(Object? json) {
+              return switch (json) {
+                BigDecimal s => ValueDecimal(s),
+                num s => ValueInt(s.decodeJsonInt(context: r'Value')),
+                _ => throw JsonDecodingException(
+                  r'Invalid JSON type for Value: ${json.runtimeType}',
+                ),
+              };
+            }
+          '''),
+        ),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -96,7 +96,7 @@ void main() {
         const expectedMethod = r'''
           factory Result.fromJson(Object? json) {
             return switch (json) {
-              int s => ResultError(s),
+              num s => ResultError(s.decodeJsonInt(context: r'Result')),
               String s => ResultSuccess(s),
               _ => throw JsonDecodingException(
                 r'Invalid JSON type for Result: ${json.runtimeType}',
@@ -1141,7 +1141,7 @@ void main() {
           factory Result.fromJson(Object? json) {
             return switch (json) {
               String s => ResultErrorCode(s),
-              int s => ResultInt(s),
+              num s => ResultInt(s.decodeJsonInt(context: r'Result')),
               _ => throw JsonDecodingException(
                 r'Invalid JSON type for Result: ${json.runtimeType}',
               ),

--- a/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_json_generator_test.dart
@@ -93,15 +93,16 @@ void main() {
         );
 
         final generatedCode = format(baseClass.accept(emitter).toString());
-        const expectedMethod = r'''
+        const expectedMethod = '''
           factory Result.fromJson(Object? json) {
-            return switch (json) {
-              num s => ResultError(s.decodeJsonInt(context: r'Result')),
-              String s => ResultSuccess(s),
-              _ => throw JsonDecodingException(
-                r'Invalid JSON type for Result: ${json.runtimeType}',
-              ),
-            };
+            if (json is num) {
+              return ResultError(json.decodeJsonInt(context: r'Result'));
+            }
+            try {
+              return ResultSuccess(json.decodeJsonString(context: r'Result'));
+            } on DecodingException catch (_) {
+            } on FormatException catch (_) {}
+            throw JsonDecodingException(r'Invalid JSON for Result');
           }''';
 
         expect(
@@ -355,10 +356,6 @@ void main() {
               return _$result;
             }
 
-            if (json is String) {
-              return ResultString(json);
-            }
-
             try {
               return ResultError(Error.fromJson(json));
             } on Object catch (_) {}
@@ -366,6 +363,11 @@ void main() {
             try {
               return ResultSuccess(Success.fromJson(json));
             } on Object catch (_) {}
+
+            try {
+              return ResultString(json.decodeJsonString(context: r'Result'));
+            } on DecodingException catch (_) {
+            } on FormatException catch (_) {}
 
             throw JsonDecodingException(r'Invalid JSON for Result');
           }''';
@@ -1112,7 +1114,7 @@ void main() {
 
     group('with alias-to-primitive types', () {
       test(
-        'fromJson uses primitive switch for only alias-to-primitive types',
+        'fromJson routes alias-to-primitive members through their decoders',
         () {
           final aliasModel = AliasModel(
             name: 'ErrorCode',
@@ -1137,15 +1139,16 @@ void main() {
           final baseClass = classes.firstWhere((c) => c.name == 'Result');
           final generatedCode = format(baseClass.accept(emitter).toString());
 
-          const expectedMethod = r'''
+          const expectedMethod = '''
           factory Result.fromJson(Object? json) {
-            return switch (json) {
-              String s => ResultErrorCode(s),
-              num s => ResultInt(s.decodeJsonInt(context: r'Result')),
-              _ => throw JsonDecodingException(
-                r'Invalid JSON type for Result: ${json.runtimeType}',
-              ),
-            };
+            if (json is num) {
+              return ResultInt(json.decodeJsonInt(context: r'Result'));
+            }
+            try {
+              return ResultErrorCode(json.decodeJsonString(context: r'Result'));
+            } on DecodingException catch (_) {
+            } on FormatException catch (_) {}
+            throw JsonDecodingException(r'Invalid JSON for Result');
           }''';
 
           expect(
@@ -1156,7 +1159,7 @@ void main() {
       );
 
       test(
-        'fromJson uses type check for alias-to-primitive mixed with class',
+        'fromJson tries alias-to-primitive then class in ordered try-each',
         () {
           final aliasModel = AliasModel(
             name: 'ErrorCode',
@@ -1202,9 +1205,10 @@ void main() {
 
           const expectedMethod = '''
           factory Result.fromJson(Object? json) {
-            if (json is String) {
-              return ResultErrorCode(json);
-            }
+            try {
+              return ResultErrorCode(json.decodeJsonString(context: r'Result'));
+            } on DecodingException catch (_) {
+            } on FormatException catch (_) {}
 
             try {
               return ResultTestClass(TestClass.fromJson(json));


### PR DESCRIPTION
## Problem

A `oneOf` whose members include primitives generated a `fromJson` that dispatched on the Dart runtime type of the decoded JSON value. That only works for the types `jsonDecode` produces natively (`int`, `double`, `num`, `bool`, `String`). Every **string-encoded** primitive — `decimal`, `date-time`, `date`, `base64` — arrives as a Dart `String`, so its runtime-type arm was dead and the variant was unreachable: the value was silently captured by a sibling plain `string` variant (or the decode threw). A high-precision decimal string, for example, decoded to the plain string variant and lost the decimal variant entirely.

## Fix

`fromJson` now mirrors the ordered try-each that `fromSimple`/`fromForm` already use:

- **Numeric and `bool` members** keep runtime-type dispatch (`if (json is double | num | bool)`). This is required because JSON delivers `int` and `double` as distinct runtime types and the numeric decoders overlap/are lenient — only runtime-type checks cleanly separate them.
- **The integer member** keeps its whole-number-double guard: it matches strictly as `int` when a `double`/`number` sibling exists, and decodes leniently otherwise (so `42.0` still lands on the integer variant when there is no numeric sibling to claim it).
- **String-encoded and non-primitive members** are attempted in stable order inside a try-each, catching `DecodingException` and `FormatException` to fall through — so a `decimal`/`date-time`/`date`/`base64` string reaches its own variant before the plain `string` catch-all.

The all-primitive `switch (json)` path and the mixed-path `if (json is T)` handling collapse into one unified body.

## Behaviour

Now reachable in any primitive-bearing `oneOf`: `decimal`, `date-time`, `date`, `base64`. A high-precision decimal string round-trips to the decimal variant with full precision.

Preserved unchanged: `[integer, number]` / `[integer, double]` numeric dispatch, and the whole-number-double routing for `[integer, string]` and `[integer, decimal]`.

## Known residual (unchanged, pre-existing across all three decode paths)

Variant selection among string-decodable members follows the stable member order, which is deterministic but not a strict-decoder-priority rule. Two ambiguities remain, both inherent rather than introduced here:

- A plain `string` variant still shadows a `uri` variant, because URI decoding accepts virtually any string — no ordering can separate them.
- When a member that itself accepts a bare string (for example a nested `oneOf` with a string arm) sorts before a sibling plain `string` variant, that member captures a bare string first, so `fromJson(toJson())` does not round-trip to the plain-string variant for that input.

Both are the same shadowing class and are tracked as a follow-up.

## Tests

- Rewrote the primitive-`oneOf` `fromJson` unit goldens to the unified output (full method-body comparisons), including regression goldens for the preserved numeric cases and new goldens for `[integer, double, decimal, string]`, `[date-time, string]`, `[date, string]`, and `[base64, string]`.
- Extended the composition integration suite with date-time-or-string and base64-or-string decode cases proving the string-encoded member is reachable, plus decimal-shaped-but-invalid and non-base64 fall-through-to-string cases, alongside the existing scalar-mix and whole-number-double coverage.