### PR TITLE
Handle hostile OpenAPI names

### DIFF
--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -12,7 +12,9 @@ import 'package:naming_api/src/model/object_method_collider.dart';
 import 'package:naming_api/src/model/self_referencer.dart';
 import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/weird_property_names.dart';
+import 'package:naming_api/src/operation/get_hostile_query_names.dart';
 import 'package:naming_api/src/operation/get_param_counter_collision.dart';
+import 'package:naming_api/src/operation/get_suffix_induced_collision.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_cookie.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_header.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_path.dart';
@@ -420,5 +422,73 @@ void main() {
         );
       },
     );
+  });
+
+  group('hostile but valid query parameter names', () {
+    test('uses valid Dart names while preserving the wire names', () async {
+      final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+      Uri? capturedUri;
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            capturedUri = options.uri;
+            handler.reject(
+              DioException(
+                requestOptions: options,
+                type: DioExceptionType.cancel,
+              ),
+            );
+          },
+        ),
+      );
+
+      await GetHostileQueryNames(dio).call(
+        parameter: 'love',
+        parameter2: 'cache-buster',
+        expand: 'customer',
+        metaLessThanFieldGreaterThanLessThanOperatorGreaterThan: 'value',
+      );
+
+      expect(capturedUri, isNotNull);
+      expect(capturedUri!.queryParameters, {
+        '❤️': 'love',
+        '_': 'cache-buster',
+        'expand[]': 'customer',
+        'meta.<field>[<operator>]': 'value',
+      });
+    });
+  });
+
+  group('location suffix induced collisions', () {
+    test('keeps all generated Dart parameters and wire names unique', () async {
+      final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+      Uri? capturedUri;
+      dio.interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            capturedUri = options.uri;
+            handler.reject(
+              DioException(
+                requestOptions: options,
+                type: DioExceptionType.cancel,
+              ),
+            );
+          },
+        ),
+      );
+
+      await GetSuffixInducedCollision(dio).call(
+        idPath: 'path-id',
+        idQuery: 'query-id',
+        idPathQuery: 'literal-id-path',
+      );
+
+      expect(capturedUri, isNotNull);
+      expect(capturedUri!.path, '/suffix-induced-collision/path-id');
+      expect(capturedUri!.queryParameters, {
+        'id': 'query-id',
+        'idPath': 'literal-id-path',
+      });
+    });
   });
 }

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -470,9 +470,9 @@ void main() {
         field2: 'two-value',
         apiVersion: 'first-version',
         apiVersion2: 'second-version',
-        baseUrl2: 'base-value',
-        serverConfig2: 'config-value',
-        dio2: 'dio-value',
+        $baseUrl: 'base-value',
+        $serverConfig: 'config-value',
+        $dio: 'dio-value',
       );
 
       expect(

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -1,3 +1,5 @@
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:naming_api/src/api_client/default_api2.dart';
 import 'package:naming_api/src/model/_function.dart';
@@ -8,19 +10,21 @@ import 'package:naming_api/src/model/error.dart' as naming;
 import 'package:naming_api/src/model/generated_method_collider.dart';
 import 'package:naming_api/src/model/keyword_enum.dart';
 import 'package:naming_api/src/model/keyword_property_names.dart';
+import 'package:naming_api/src/model/multipart_name_collision_form.dart';
 import 'package:naming_api/src/model/object_method_collider.dart';
 import 'package:naming_api/src/model/self_referencer.dart';
 import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/weird_property_names.dart';
 import 'package:naming_api/src/operation/get_hostile_query_names.dart';
 import 'package:naming_api/src/operation/get_param_counter_collision.dart';
-import 'package:naming_api/src/operation/get_suffix_induced_collision.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_cookie.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_header.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_path.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_query.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_sanitized.dart';
+import 'package:naming_api/src/operation/post_multipart_name_collisions.dart';
 import 'package:naming_api/src/operation/post_with_cancel_token_and_body.dart';
+import 'package:naming_api/src/server/server.dart';
 import 'package:test/test.dart';
 import 'package:test_helpers/test_helpers.dart';
 import 'package:tonik_util/tonik_util.dart';
@@ -459,14 +463,34 @@ void main() {
     });
   });
 
-  group('location suffix induced collisions', () {
-    test('keeps all generated Dart parameters and wire names unique', () async {
+  group('hostile server variable names', () {
+    test('keeps every variable independently configurable', () {
+      final server = BdBe29Da4Efb88F7DServer(
+        field: 'one-value',
+        field2: 'two-value',
+        apiVersion: 'first-version',
+        apiVersion2: 'second-version',
+        baseUrl2: 'base-value',
+        serverConfig2: 'config-value',
+        dio2: 'dio-value',
+      );
+
+      expect(
+        server.baseUrl,
+        'https://one-value.two-value.example.com/'
+        'first-version/second-version/base-value/config-value/dio-value',
+      );
+    });
+  });
+
+  group('multipart header name collisions', () {
+    test('uses every distinct argument for its original wire header', () async {
       final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
-      Uri? capturedUri;
+      RequestOptions? capturedRequest;
       dio.interceptors.add(
         InterceptorsWrapper(
           onRequest: (options, handler) {
-            capturedUri = options.uri;
+            capturedRequest = options;
             handler.reject(
               DioException(
                 requestOptions: options,
@@ -477,17 +501,26 @@ void main() {
         ),
       );
 
-      await GetSuffixInducedCollision(dio).call(
-        idPath: 'path-id',
-        idQuery: 'query-id',
-        idPathQuery: 'literal-id-path',
+      await PostMultipartNameCollisions(dio).call(
+        body: MultipartNameCollisionForm(
+          file: TonikFileBytes(Uint8List.fromList([1, 2, 3])),
+        ),
+        fileCustom: 'query-value',
+        fileTraceId: 'first-header',
+        fileTraceIdPartHeader: 'second-header',
+        fileTraceIdPartHeader2: 'third-header',
       );
 
-      expect(capturedUri, isNotNull);
-      expect(capturedUri!.path, '/suffix-induced-collision/path-id');
-      expect(capturedUri!.queryParameters, {
-        'id': 'query-id',
-        'idPath': 'literal-id-path',
+      expect(capturedRequest, isNotNull);
+      expect(capturedRequest!.uri.queryParameters, {
+        'file_custom': 'query-value',
+      });
+      final formData = capturedRequest!.data as FormData;
+      final headers = formData.files.single.value.headers;
+      expect(headers, {
+        'X-Trace-Id': ['first-header'],
+        'Trace-Id': ['second-header'],
+        'Trace_Id': ['third-header'],
       });
     });
   });

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -14,6 +14,24 @@ servers:
           - staging
       default:
         default: v1
+  - url: >-
+      https://{_}.{❤️}.example.com/{api-version}/{api_version}/{baseUrl}/{serverConfig}/{dio}
+    description: Server with hostile variable names
+    variables:
+      _:
+        default: one
+      "❤️":
+        default: two
+      api-version:
+        default: v1
+      api_version:
+        default: v2
+      baseUrl:
+        default: base
+      serverConfig:
+        default: config
+      dio:
+        default: client
 
 paths:
   /keyword/switch:
@@ -1044,31 +1062,50 @@ paths:
         '200':
           description: OK
 
-  /suffix-induced-collision/{id}:
-    get:
-      operationId: getSuffixInducedCollision
+  /multipart-name-collisions:
+    post:
+      operationId: postMultipartNameCollisions
       parameters:
-        - name: id
-          in: path
-          required: true
-          schema:
-            type: string
-        - name: id
+        - name: file_custom
           in: query
-          required: true
           schema:
             type: string
-        - name: idPath
-          in: query
-          required: true
-          schema:
-            type: string
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MultipartNameCollisionForm'
+            encoding:
+              file:
+                headers:
+                  X-Trace-Id:
+                    required: true
+                    schema:
+                      type: string
+                  Trace-Id:
+                    required: true
+                    schema:
+                      type: string
+                  Trace_Id:
+                    required: true
+                    schema:
+                      type: string
       responses:
-        '200':
+        '204':
           description: OK
 
 components:
   schemas:
+    MultipartNameCollisionForm:
+      type: object
+      required:
+        - file
+      properties:
+        file:
+          type: string
+          format: binary
+
     SimpleResult:
       type: object
       required:

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -1014,6 +1014,59 @@ paths:
               schema:
                 $ref: '#/components/schemas/SelfNamedProperty'
 
+  /hostile-query-names:
+    get:
+      operationId: getHostileQueryNames
+      parameters:
+        # OpenAPI 3.0.4 Appendix C.4.4 uses this exact parameter name.
+        - name: "❤️"
+          in: query
+          required: true
+          schema:
+            type: string
+        # jQuery uses this parameter for cache-busting timestamps.
+        - name: _
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: expand[]
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: meta.<field>[<operator>]
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
+  /suffix-induced-collision/{id}:
+    get:
+      operationId: getSuffixInducedCollision
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          required: true
+          schema:
+            type: string
+        - name: idPath
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     SimpleResult:

--- a/packages/tonik_generate/lib/src/naming/name_utils.dart
+++ b/packages/tonik_generate/lib/src/naming/name_utils.dart
@@ -388,7 +388,8 @@ String normalizeSingle(String name, {bool preserveNumbers = false}) {
 
   // If it's just a number, spell it out (e.g. "600" -> "sixHundred")
   if (RegExp(r'^\d+$').hasMatch(processedName)) {
-    final number = int.parse(processedName);
+    final number = int.tryParse(processedName);
+    if (number == null) return '\$$processedName';
     final words = _numberToWords(number);
     return _normalizeText(words).toCamelCase();
   }
@@ -410,7 +411,10 @@ String normalizeSingle(String name, {bool preserveNumbers = false}) {
 String normalizeEnumValueName(String value) {
   // Only spell out numbers if the entire value is just a number (no prefix)
   if (RegExp(r'^-?\d+$').hasMatch(value)) {
-    final number = int.parse(value);
+    final number = int.tryParse(value);
+    if (number == null) {
+      return value.startsWith('-') ? 'minus${value.substring(1)}' : '\$$value';
+    }
     final words = number < 0
         ? 'minus ${_numberToWords(number.abs())}'
         : _numberToWords(number);
@@ -426,7 +430,10 @@ String normalizeEnumValueName(String value) {
 
     final segments = versionPart.split('.');
     final spelled = segments
-        .map((s) => _numberToWords(int.parse(s)))
+        .map((s) {
+          final number = int.tryParse(s);
+          return number == null ? s : _numberToWords(number);
+        })
         .join(' dot ');
 
     final fullSpelled = suffix.isNotEmpty ? '$spelled $suffix' : spelled;

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -144,39 +144,11 @@ NormalizedRequestParameters normalizeRequestParameters({
   final uniqueHeaderParams = _ensureUniquenessInGroup(resolvedHeaderParams);
   final uniqueCookieParams = _ensureUniquenessInGroup(resolvedCookieParams);
 
-  final usedNames = <String>{};
-  List<({String normalizedName, T parameter})> ensureGlobalUniqueness<T>(
-    List<({String normalizedName, T parameter})> parameters,
-    String locationSuffix,
-  ) {
-    return parameters.map((item) {
-      var name = item.normalizedName;
-      var lowerName = name.toLowerCase();
-      if (usedNames.contains(lowerName)) {
-        final baseName = '$name$locationSuffix';
-        name = baseName;
-        lowerName = name.toLowerCase();
-        var counter = 2;
-        while (usedNames.contains(lowerName)) {
-          name = '$baseName$counter';
-          lowerName = name.toLowerCase();
-          counter++;
-        }
-      }
-
-      usedNames.add(lowerName);
-      return (normalizedName: name, parameter: item.parameter);
-    }).toList();
-  }
-
   return NormalizedRequestParameters(
-    pathParameters: ensureGlobalUniqueness(uniquePathParams, _pathSuffix),
-    queryParameters: ensureGlobalUniqueness(uniqueQueryParams, _querySuffix),
-    headers: ensureGlobalUniqueness(uniqueHeaderParams, _headerSuffix),
-    cookieParameters: ensureGlobalUniqueness(
-      uniqueCookieParams,
-      _cookieSuffix,
-    ),
+    pathParameters: uniquePathParams,
+    queryParameters: uniqueQueryParams,
+    headers: uniqueHeaderParams,
+    cookieParameters: uniqueCookieParams,
   );
 }
 

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -5,6 +5,7 @@ const _pathSuffix = 'Path';
 const _querySuffix = 'Query';
 const _headerSuffix = 'Header';
 const _cookieSuffix = 'Cookie';
+const _defaultParameterPrefix = 'parameter';
 
 /// `cancelToken` is reserved because the generated `call(...)` method
 /// always declares a built-in `CancelToken? cancelToken` parameter.
@@ -143,11 +144,39 @@ NormalizedRequestParameters normalizeRequestParameters({
   final uniqueHeaderParams = _ensureUniquenessInGroup(resolvedHeaderParams);
   final uniqueCookieParams = _ensureUniquenessInGroup(resolvedCookieParams);
 
+  final usedNames = <String>{};
+  List<({String normalizedName, T parameter})> ensureGlobalUniqueness<T>(
+    List<({String normalizedName, T parameter})> parameters,
+    String locationSuffix,
+  ) {
+    return parameters.map((item) {
+      var name = item.normalizedName;
+      var lowerName = name.toLowerCase();
+      if (usedNames.contains(lowerName)) {
+        final baseName = '$name$locationSuffix';
+        name = baseName;
+        lowerName = name.toLowerCase();
+        var counter = 2;
+        while (usedNames.contains(lowerName)) {
+          name = '$baseName$counter';
+          lowerName = name.toLowerCase();
+          counter++;
+        }
+      }
+
+      usedNames.add(lowerName);
+      return (normalizedName: name, parameter: item.parameter);
+    }).toList();
+  }
+
   return NormalizedRequestParameters(
-    pathParameters: uniquePathParams,
-    queryParameters: uniqueQueryParams,
-    headers: uniqueHeaderParams,
-    cookieParameters: uniqueCookieParams,
+    pathParameters: ensureGlobalUniqueness(uniquePathParams, _pathSuffix),
+    queryParameters: ensureGlobalUniqueness(uniqueQueryParams, _querySuffix),
+    headers: ensureGlobalUniqueness(uniqueHeaderParams, _headerSuffix),
+    cookieParameters: ensureGlobalUniqueness(
+      uniqueCookieParams,
+      _cookieSuffix,
+    ),
   );
 }
 
@@ -288,5 +317,6 @@ String normalizeMultipartHeaderName(
 
 /// Normalizes a single parameter name.
 String _normalizeName(String name) {
-  return normalizeSingle(name, preserveNumbers: true);
+  final normalized = normalizeSingle(name, preserveNumbers: true);
+  return normalized.isEmpty ? _defaultParameterPrefix : normalized;
 }

--- a/packages/tonik_generate/lib/src/operation/data_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/data_generator.dart
@@ -38,6 +38,9 @@ class DataGenerator {
     final content = requestBody.resolvedContent;
     final hasMultipleContent = content.length > 1;
     final isRequired = requestBody.isRequired;
+    final multipartHeaderInfo = extractOperationMultipartHeaderParamInfo(
+      operation,
+    );
 
     final helperContext = InlineHelperContext(nameManager: nameManager);
     final inlineHelpers = <InlineHelper>[];
@@ -144,6 +147,9 @@ class DataGenerator {
                   'value.value',
                   nameManager,
                   package,
+                  headerParameters: multipartHeaderInfo
+                      .where((info) => identical(info.content, c))
+                      .toList(),
                 ).code,
               )
               ..add(const Code(','));
@@ -151,26 +157,22 @@ class DataGenerator {
       }
 
       final multipartHeaderParams = <Parameter>[];
-      for (final c in content) {
-        if (c.contentType == ContentType.multipart) {
-          for (final info in extractMultipartHeaderParamInfo(c)) {
-            multipartHeaderParams.add(
-              Parameter(
-                (b) => b
-                  ..name = info.name
-                  ..type = typeReference(
-                    info.model,
-                    nameManager,
-                    package,
-                    isNullableOverride: !info.isRequired,
-                    useImmutableCollections: useImmutableCollections,
-                  )
-                  ..named = true
-                  ..required = info.isRequired,
-              ),
-            );
-          }
-        }
+      for (final info in multipartHeaderInfo) {
+        multipartHeaderParams.add(
+          Parameter(
+            (b) => b
+              ..name = info.name
+              ..type = typeReference(
+                info.model,
+                nameManager,
+                package,
+                isNullableOverride: !info.isRequired,
+                useImmutableCollections: useImmutableCollections,
+              )
+              ..named = true
+              ..required = info.isRequired,
+          ),
+        );
       }
 
       return Method(
@@ -312,6 +314,7 @@ class DataGenerator {
               'body',
               nameManager,
               package,
+              headerParameters: multipartHeaderInfo,
             ).statements,
           ]);
     }
@@ -319,7 +322,7 @@ class DataGenerator {
     // Collect multipart header params for single-content multipart bodies.
     final multipartHeaderParams = <Parameter>[];
     if (contentType == ContentType.multipart) {
-      for (final info in extractMultipartHeaderParamInfo(content.first)) {
+      for (final info in multipartHeaderInfo) {
         multipartHeaderParams.add(
           Parameter(
             (b) => b

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -413,12 +413,10 @@ class OperationGenerator {
               if (hasRequestBody)
                 ...() {
                   final args = <String, Expression>{};
-                  for (final c in operation.requestBody!.resolvedContent) {
-                    if (c.contentType == ContentType.multipart) {
-                      for (final info in extractMultipartHeaderParamInfo(c)) {
-                        args[info.name] = refer(info.name);
-                      }
-                    }
+                  for (final info in extractOperationMultipartHeaderParamInfo(
+                    operation,
+                  )) {
+                    args[info.name] = refer(info.name);
                   }
                   return args;
                 }(),

--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -11,6 +11,8 @@ import 'package:tonik_generate/src/util/doc_comment_formatter.dart';
 import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 
+const _baseServerMemberNames = {'baseUrl', 'serverConfig', 'dio'};
+
 /// Generates server classes for API client.
 class ServerGenerator {
   /// Creates a new ServerGenerator.
@@ -154,7 +156,7 @@ class ServerGenerator {
           ),
           Field(
             (f) => f
-              ..name = '_dio'
+              ..name = r'_$dio'
               ..type = dioNullableType,
           ),
         ])
@@ -186,13 +188,13 @@ class ServerGenerator {
               ..type = MethodType.getter
               ..returns = dioType
               ..body = Block.of([
-                const Code('if (_dio == null) {'),
-                Code.scope((a) => '  _dio = ${a(dioType)}();'),
+                const Code(r'if (_$dio == null) {'),
+                Code.scope((a) => '  _\$dio = ${a(dioType)}();'),
                 const Code(
-                  '  serverConfig.configureDio(_dio!, baseUrl);',
+                  r'  serverConfig.configureDio(_$dio!, baseUrl);',
                 ),
                 const Code('}'),
-                const Code('return _dio!;'),
+                const Code(r'return _$dio!;'),
               ]),
           ),
         ),
@@ -274,24 +276,24 @@ class ServerGenerator {
     final variableParams = <Parameter>[];
     final variableFields = <Field>[];
 
-    final normalizedVariables =
-        ensureUniqueness<ServerVariable?>([
-          for (final name in const ['baseUrl', 'serverConfig', 'dio'])
-            (normalizedName: name, originalValue: null),
-          for (final variable in server.variables)
-            (
-              normalizedName: normalizeSingle(
-                variable.name,
-                preserveNumbers: true,
-              ),
-              originalValue: variable,
-            ),
-        ], defaultPrefix: defaultFieldPrefix).where((item) {
-          return item.originalValue != null;
-        });
+    final normalizedVariables = ensureUniqueness([
+      for (final variable in server.variables)
+        () {
+          final normalized = normalizeSingle(
+            variable.name,
+            preserveNumbers: true,
+          );
+          return (
+            normalizedName: _baseServerMemberNames.contains(normalized)
+                ? '\$$normalized'
+                : normalized,
+            originalValue: variable,
+          );
+        }(),
+    ], defaultPrefix: defaultFieldPrefix);
     final variableNameMap = {
       for (final item in normalizedVariables)
-        item.originalValue!: item.normalizedName,
+        item.originalValue: item.normalizedName,
     };
 
     for (final variable in server.variables) {

--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -274,15 +274,30 @@ class ServerGenerator {
     final variableParams = <Parameter>[];
     final variableFields = <Field>[];
 
-    // Map from original variable name to sanitized Dart identifier,
-    // used by _buildBaseUrlExpression for URL interpolation.
-    final variableNameMap = <String, String>{};
+    final normalizedVariables =
+        ensureUniqueness<ServerVariable?>([
+          for (final name in const ['baseUrl', 'serverConfig', 'dio'])
+            (normalizedName: name, originalValue: null),
+          for (final variable in server.variables)
+            (
+              normalizedName: normalizeSingle(
+                variable.name,
+                preserveNumbers: true,
+              ),
+              originalValue: variable,
+            ),
+        ], defaultPrefix: defaultFieldPrefix).where((item) {
+          return item.originalValue != null;
+        });
+    final variableNameMap = {
+      for (final item in normalizedVariables)
+        item.originalValue!: item.normalizedName,
+    };
 
     for (final variable in server.variables) {
       final hasEnum =
           variable.enumValues != null && variable.enumValues!.isNotEmpty;
-      final fieldName = normalizeSingle(variable.name, preserveNumbers: true);
-      variableNameMap[variable.name] = fieldName;
+      final fieldName = variableNameMap[variable]!;
 
       if (hasEnum) {
         final enumName = nameManager.serverVariableEnumName(
@@ -377,7 +392,7 @@ class ServerGenerator {
   String _buildUrlExpression(
     String urlTemplate,
     List<ServerVariable> variables,
-    Map<String, String> variableNameMap,
+    Map<ServerVariable, String> variableNameMap,
   ) {
     // Split the template at variable placeholders so each literal segment
     // can be escaped independently, preserving Dart interpolation expressions.
@@ -408,7 +423,7 @@ class ServerGenerator {
       }
 
       final placeholder = '{${earliestVariable.name}}';
-      final dartName = variableNameMap[earliestVariable.name]!;
+      final dartName = variableNameMap[earliestVariable]!;
       final hasEnum =
           earliestVariable.enumValues != null &&
           earliestVariable.enumValues!.isNotEmpty;

--- a/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
+++ b/packages/tonik_generate/lib/src/util/operation_parameter_generator.dart
@@ -2,9 +2,9 @@ import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/naming/parameter_name_normalizer.dart';
-import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
 import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
+import 'package:tonik_generate/src/util/to_multipart_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 /// Generates the `call()` parameters for an operation.
@@ -196,7 +196,7 @@ List<Parameter> generateParameters({
   if (hasRequestBody) {
     _addMultipartHeaderParameters(
       parameters: parameters,
-      requestBody: operation.requestBody!,
+      operation: operation,
       nameManager: nameManager,
       package: package,
     );
@@ -209,87 +209,38 @@ List<Parameter> generateParameters({
 /// Per OAS spec, `encoding.headers` defines per-part MIME headers. Each header
 /// becomes a method parameter so callers can provide header values at runtime.
 ///
-/// Names are deduplicated against already-added parameters by appending
-/// a `PartHeader` suffix when a collision is detected.
 void _addMultipartHeaderParameters({
   required List<Parameter> parameters,
-  required RequestBody requestBody,
+  required Operation operation,
   required NameManager nameManager,
   required String package,
 }) {
-  final usedNames = <String>{
-    for (final p in parameters) p.name.toLowerCase(),
-  };
+  for (final info in extractOperationMultipartHeaderParamInfo(operation)) {
+    final parameterType = typeReference(
+      info.model,
+      nameManager,
+      package,
+      isNullableOverride: !info.isRequired,
+    );
 
-  for (final content in requestBody.resolvedContent) {
-    if (content.contentType != ContentType.multipart) continue;
+    parameters.add(
+      Parameter(
+        (b) {
+          b
+            ..name = info.name
+            ..type = parameterType
+            ..named = true
+            ..required = info.isRequired;
 
-    final encoding = content.multipartEncoding;
-    if (encoding == null) continue;
-
-    // Resolve the model to get properties.
-    final model = content.model.resolved;
-    if (model is! ClassModel) continue;
-
-    final writeProperties = model.properties
-        .where((p) => !p.isReadOnly)
-        .toList();
-    final normalizedProps = normalizeProperties(writeProperties);
-
-    for (final (:normalizedName, :property) in normalizedProps) {
-      final propertyEncoding = encoding[property];
-      final headers = propertyEncoding?.headers;
-      if (headers == null || headers.isEmpty) continue;
-
-      final isPropertyOptional = !property.isRequired || property.isNullable;
-
-      for (final entry in headers.entries) {
-        final rawHeaderName = entry.key;
-        final header = entry.value;
-
-        final resolved = header.resolve(name: rawHeaderName);
-
-        // Parameter is required only if both property and header are required.
-        final isRequired = !isPropertyOptional && resolved.isRequired;
-
-        final parameterType = typeReference(
-          resolved.model,
-          nameManager,
-          package,
-          isNullableOverride: !isRequired,
-        );
-
-        final paramName = normalizeMultipartHeaderName(
-          normalizedName,
-          rawHeaderName,
-        );
-
-        // Deduplicate against existing parameter names.
-        final uniqueName = usedNames.contains(paramName.toLowerCase())
-            ? '${paramName}PartHeader'
-            : paramName;
-        usedNames.add(uniqueName.toLowerCase());
-
-        parameters.add(
-          Parameter(
-            (b) {
-              b
-                ..name = uniqueName
-                ..type = parameterType
-                ..named = true
-                ..required = isRequired;
-
-              if (resolved.isDeprecated) {
-                b.annotations.add(
-                  refer('Deprecated', 'dart:core').call([
-                    literalString('This parameter is deprecated.'),
-                  ]),
-                );
-              }
-            },
-          ),
-        );
-      }
-    }
+          if (info.isDeprecated) {
+            b.annotations.add(
+              refer('Deprecated', 'dart:core').call([
+                literalString('This parameter is deprecated.'),
+              ]),
+            );
+          }
+        },
+      ),
+    );
   }
 }

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -13,10 +13,17 @@ BuiltStatements buildMultipartBodyStatements(
   RequestContent content,
   String bodyAccessor,
   NameManager nameManager,
-  String package,
-) {
+  String package, {
+  List<MultipartHeaderParamInfo>? headerParameters,
+}) {
   return BuiltStatements.simple(
-    _buildMultipartFields(content, bodyAccessor, nameManager, package),
+    _buildMultipartFields(
+      content,
+      bodyAccessor,
+      nameManager,
+      package,
+      headerParameters: headerParameters,
+    ),
   );
 }
 
@@ -27,13 +34,15 @@ BuiltExpression buildMultipartBodyExpression(
   RequestContent content,
   String bodyAccessor,
   NameManager nameManager,
-  String package,
-) {
+  String package, {
+  List<MultipartHeaderParamInfo>? headerParameters,
+}) {
   final statements = _buildMultipartFields(
     content,
     bodyAccessor,
     nameManager,
     package,
+    headerParameters: headerParameters,
   );
 
   return BuiltExpression.simple(
@@ -50,8 +59,9 @@ List<Code> _buildMultipartFields(
   RequestContent content,
   String bodyAccessor,
   NameManager nameManager,
-  String package,
-) {
+  String package, {
+  List<MultipartHeaderParamInfo>? headerParameters,
+}) {
   final statements = <Code>[];
 
   // Resolve through alias chains.
@@ -84,6 +94,8 @@ List<Code> _buildMultipartFields(
   final writeProperties = model.properties.where((p) => !p.isReadOnly).toList();
 
   final normalizedProps = normalizeProperties(writeProperties);
+  final normalizedHeaderParameters =
+      headerParameters ?? extractMultipartHeaderParamInfo(content);
 
   for (final (:normalizedName, :property) in normalizedProps) {
     final rawName = property.name;
@@ -96,6 +108,7 @@ List<Code> _buildMultipartFields(
       normalizedName,
       isNullable,
       encoding: content.multipartEncoding?[property],
+      headerParameters: normalizedHeaderParameters,
     );
 
     if (fieldCode == null) continue;
@@ -121,6 +134,7 @@ Code? _buildFieldCode(
   String bodyAccessor,
   String normalizedName,
   bool isNullable, {
+  required List<MultipartHeaderParamInfo> headerParameters,
   PartEncoding? encoding,
 }) {
   final accessor = '$bodyAccessor.$normalizedName${isNullable ? '!' : ''}';
@@ -132,6 +146,7 @@ Code? _buildFieldCode(
   final headerResult = _buildHeaderMapStatements(
     normalizedName,
     encoding,
+    headerParameters: headerParameters,
     isPropertyOptional: isNullable,
   );
 
@@ -247,6 +262,7 @@ Code? _buildFieldCode(
       normalizedName,
       isNullable,
       encoding: encoding,
+      headerParameters: headerParameters,
     ),
 
     _ => generateEncodingExceptionExpression(
@@ -274,6 +290,7 @@ class _HeaderMapResult {
 _HeaderMapResult? _buildHeaderMapStatements(
   String normalizedPropertyName,
   PartEncoding? encoding, {
+  required List<MultipartHeaderParamInfo> headerParameters,
   bool isPropertyOptional = false,
 }) {
   final headers = encoding?.headers;
@@ -308,10 +325,13 @@ _HeaderMapResult? _buildHeaderMapStatements(
   for (final entry in filteredEntries) {
     final rawHeaderName = entry.key;
     final header = entry.value.resolve();
-    final paramName = normalizeMultipartHeaderName(
-      normalizedPropertyName,
-      rawHeaderName,
-    );
+    final paramName = headerParameters
+        .firstWhere(
+          (parameter) =>
+              parameter.normalizedPropertyName == normalizedPropertyName &&
+              parameter.rawHeaderName == rawHeaderName,
+        )
+        .name;
 
     // When the property is optional, required header params are nullable
     // at the method level but must be non-null here.
@@ -1381,18 +1401,22 @@ Code _buildUrlEncodedObjectFileAddition(
 
 /// Information about a per-part header parameter in multipart encoding.
 typedef MultipartHeaderParamInfo = ({
+  RequestContent content,
   String name,
+  String normalizedPropertyName,
+  String rawHeaderName,
   Model model,
   bool isRequired,
+  bool isDeprecated,
 });
 
 /// Extracts per-part header parameters from a multipart request content.
 ///
 /// Returns info needed to generate method parameters or call arguments.
-/// Content-Type headers are filtered per OAS spec.
 List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
-  RequestContent content,
-) {
+  RequestContent content, {
+  Set<String> reservedNames = const {},
+}) {
   final encoding = content.multipartEncoding;
   if (encoding == null) return const [];
 
@@ -1403,6 +1427,7 @@ List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
   final normalizedProps = normalizeProperties(writeProperties);
 
   final result = <MultipartHeaderParamInfo>[];
+  final usedNames = reservedNames.map((name) => name.toLowerCase()).toSet();
 
   for (final (:normalizedName, :property) in normalizedProps) {
     final propertyEncoding = encoding[property];
@@ -1411,27 +1436,87 @@ List<MultipartHeaderParamInfo> extractMultipartHeaderParamInfo(
 
     final isPropertyOptional = !property.isRequired || property.isNullable;
 
-    final filteredEntries = headers.entries
-        .where((e) => e.key.toLowerCase() != 'content-type')
-        .toList();
-
-    for (final entry in filteredEntries) {
+    for (final entry in headers.entries) {
       final rawHeaderName = entry.key;
       final header = entry.value.resolve(name: rawHeaderName);
       final isRequired = !isPropertyOptional && header.isRequired;
 
-      final paramName = normalizeMultipartHeaderName(
+      final baseName = normalizeMultipartHeaderName(
         normalizedName,
         rawHeaderName,
       );
+      final paramName = _uniqueMultipartHeaderParameterName(
+        baseName,
+        usedNames,
+      );
 
       result.add((
+        content: content,
         name: paramName,
+        normalizedPropertyName: normalizedName,
+        rawHeaderName: rawHeaderName,
         model: header.model,
         isRequired: isRequired,
+        isDeprecated: header.isDeprecated,
       ));
     }
   }
 
   return result;
+}
+
+/// Extracts all per-part header parameters using names scoped to one operation.
+List<MultipartHeaderParamInfo> extractOperationMultipartHeaderParamInfo(
+  Operation operation,
+) {
+  final hasRequestBody =
+      operation.requestBody?.resolvedContent.isNotEmpty ?? false;
+  if (!hasRequestBody) return const [];
+
+  final normalized = normalizeRequestParameters(
+    pathParameters: operation.pathParameters.map((p) => p.resolve()).toSet(),
+    queryParameters: operation.queryParameters.map((p) => p.resolve()).toSet(),
+    headers: operation.headers.map((p) => p.resolve()).toSet(),
+    cookieParameters: operation.cookieParameters
+        .map((p) => p.resolve())
+        .toSet(),
+    reservedNames: operationReservedParameterNames(hasRequestBody: true),
+  );
+  final usedNames = <String>{
+    'body',
+    'cancelToken',
+    ...normalized.pathParameters.map((p) => p.normalizedName),
+    ...normalized.queryParameters.map((p) => p.normalizedName),
+    ...normalized.headers.map((p) => p.normalizedName),
+    ...normalized.cookieParameters.map((p) => p.normalizedName),
+  };
+  final result = <MultipartHeaderParamInfo>[];
+
+  for (final content in operation.requestBody!.resolvedContent) {
+    if (content.contentType != ContentType.multipart) continue;
+    final parameters = extractMultipartHeaderParamInfo(
+      content,
+      reservedNames: usedNames,
+    );
+    result.addAll(parameters);
+    usedNames.addAll(parameters.map((parameter) => parameter.name));
+  }
+
+  return result;
+}
+
+String _uniqueMultipartHeaderParameterName(
+  String baseName,
+  Set<String> usedNames,
+) {
+  if (usedNames.add(baseName.toLowerCase())) return baseName;
+
+  final suffixedBase = '${baseName}PartHeader';
+  var candidate = suffixedBase;
+  var counter = 2;
+  while (!usedNames.add(candidate.toLowerCase())) {
+    candidate = '$suffixedBase$counter';
+    counter++;
+  }
+  return candidate;
 }

--- a/packages/tonik_generate/test/src/naming/name_utils_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_utils_test.dart
@@ -76,6 +76,13 @@ void main() {
         );
       });
 
+      test('keeps numeric strings larger than Dart integers valid', () {
+        expect(
+          normalizeEnumValueName('18446744073709551616'),
+          r'$18446744073709551616',
+        );
+      });
+
       test('produces camelCase identifiers', () {
         // Based on existing test expectations
         expect(normalizeEnumValueName('1'), 'one');
@@ -170,6 +177,13 @@ void main() {
       test('handles two-segment version strings', () {
         expect(normalizeEnumValueName('1.0'), 'oneDotZero');
       });
+
+      test('keeps segments larger than Dart integers valid', () {
+        expect(
+          normalizeEnumValueName('18446744073709551616.1'),
+          r'$18446744073709551616DotOne',
+        );
+      });
     });
 
     group('dotted enum values', () {
@@ -229,6 +243,13 @@ void main() {
       expect(normalizeSingle('1'), 'one');
       expect(normalizeSingle('600'), 'sixHundred');
       expect(normalizeSingle('1000'), 'oneThousand');
+    });
+
+    test('keeps numeric strings larger than Dart integers valid', () {
+      expect(
+        normalizeSingle('18446744073709551616'),
+        r'$18446744073709551616',
+      );
     });
   });
 

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -37,6 +37,22 @@ void main() {
       ]);
     });
 
+    test('uses fallback names when normalization removes every character', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {},
+        queryParameters: {
+          createQueryParameter('❤️'),
+          createQueryParameter('_'),
+        },
+        headers: {},
+      );
+
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'parameter',
+        'parameter2',
+      ]);
+    });
+
     test('normalizes header parameters and removes x- prefix', () {
       final result = normalizeRequestParameters(
         pathParameters: {},
@@ -76,6 +92,25 @@ void main() {
         ]);
       },
     );
+
+    test('resolves collisions introduced by location suffixes', () {
+      final result = normalizeRequestParameters(
+        pathParameters: {createPathParameter('id')},
+        queryParameters: {
+          createQueryParameter('id'),
+          createQueryParameter('idPath'),
+        },
+        headers: {},
+      );
+
+      expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
+        'idPath',
+      ]);
+      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+        'idQuery',
+        'idPathQuery',
+      ]);
+    });
 
     test('handles Dart keywords', () {
       final result = normalizeRequestParameters(

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -93,25 +93,6 @@ void main() {
       },
     );
 
-    test('resolves collisions introduced by location suffixes', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {createPathParameter('id')},
-        queryParameters: {
-          createQueryParameter('id'),
-          createQueryParameter('idPath'),
-        },
-        headers: {},
-      );
-
-      expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
-        'idPath',
-      ]);
-      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
-        'idQuery',
-        'idPathQuery',
-      ]);
-    });
-
     test('handles Dart keywords', () {
       final result = normalizeRequestParameters(
         pathParameters: {createPathParameter('class')},

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -2709,6 +2709,108 @@ void main() {
         },
       );
 
+      test('uses the operation-scoped name for multipart header values', () {
+        final uploadModel = ClassModel(
+          name: 'UploadForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: 'file',
+              model: BinaryModel(context: testContext),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+        final queryParameter = QueryParameterObject(
+          name: null,
+          rawName: 'file_custom',
+          description: null,
+          isRequired: false,
+          isDeprecated: false,
+          allowEmptyValue: false,
+          allowReserved: false,
+          explode: false,
+          model: StringModel(context: testContext),
+          encoding: QueryParameterEncoding.form,
+          context: testContext,
+          examples: const [],
+          defaultValue: null,
+        );
+        final operation = Operation(
+          operationId: 'uploadFile',
+          path: '/uploads',
+          method: HttpMethod.post,
+          requestBody: RequestBodyObject(
+            name: 'uploadFile',
+            context: testContext,
+            description: null,
+            isRequired: true,
+            content: {
+              RequestContent(
+                model: uploadModel,
+                contentType: ContentType.multipart,
+                rawContentType: 'multipart/form-data',
+                multipartEncoding: _multipartEncodingByName(uploadModel, {
+                  'file': PartEncoding(
+                    contentType: ContentType.bytes,
+                    rawContentType: 'application/octet-stream',
+                    style: null,
+                    explode: null,
+                    allowReserved: null,
+                    headers: {
+                      'X-Custom': ResponseHeaderObject(
+                        name: 'X-Custom',
+                        context: testContext,
+                        description: null,
+                        explode: false,
+                        model: StringModel(context: testContext),
+                        isRequired: true,
+                        isDeprecated: false,
+                        encoding: ResponseHeaderEncoding.simple,
+                        examples: const [],
+                      ),
+                    },
+                  ),
+                }),
+                examples: const [],
+              ),
+            },
+          ),
+          responses: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          queryParameters: {queryParameter},
+          headers: const {},
+          context: testContext,
+          tags: const {},
+          isDeprecated: false,
+          securitySchemes: const {},
+        );
+
+        final method = generator.generateDataMethod(operation);
+        final methodString = format(method.accept(emitter).toString());
+
+        expect(
+          method.optionalParameters.map((parameter) => parameter.name),
+          ['body', 'fileCustomPartHeader'],
+        );
+        expect(
+          collapseWhitespace(methodString),
+          contains(
+            collapseWhitespace(
+              'fileCustomPartHeader.toSimple('
+              'explode: false, allowEmpty: true)',
+            ),
+          ),
+        );
+      });
+
       test('generates _data method for multi-content including multipart', () {
         final jsonModel = ClassModel(
           name: 'JsonPayload',

--- a/packages/tonik_generate/test/src/server/server_generator_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_test.dart
@@ -60,16 +60,15 @@ void main() {
       );
       expect(serverConfigField.modifier, FieldModifier.final$);
 
-      final dioField = fields.firstWhere((f) => f.name == '_dio');
+      final dioField = fields.firstWhere((f) => f.name == r'_$dio');
       expect(dioField.type?.accept(emitter).toString(), 'Dio?');
-      // _dio should not be final because it needs to be initialized lazily
+      // The Dio field cannot be final because it is initialized lazily.
       expect(dioField.modifier, isNot(FieldModifier.final$));
     });
 
     test('generates constructor with named parameters', () {
       final constructor = baseClass.constructors.first;
-      // Constructor should not be const since _dio is not final
-      // and initialized later
+      // The constructor cannot be const because Dio is initialized lazily.
       expect(constructor.constant, isFalse);
       expect(constructor.optionalParameters.length, 2);
 
@@ -92,9 +91,9 @@ void main() {
       expect(dioGetter.returns?.accept(emitter).toString(), 'Dio');
 
       final bodyCode = dioGetter.body!.accept(emitter).toString();
-      expect(bodyCode, contains('if (_dio == null)'));
+      expect(bodyCode, contains(r'if (_$dio == null)'));
       expect(bodyCode, contains('serverConfig.configureDio'));
-      expect(bodyCode, contains('return _dio!'));
+      expect(bodyCode, contains(r'return _$dio!'));
     });
   });
 

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -530,15 +530,13 @@ void main() {
           .map((parameter) => parameter.name)
           .toList();
 
-      expect(
-        fieldNames,
-        isNot(contains(anyOf('baseUrl', 'serverConfig', 'dio'))),
-      );
-      expect(parameterNames.toSet(), hasLength(parameterNames.length));
-      expect(
-        parameterNames.where((name) => name == 'serverConfig'),
-        hasLength(1),
-      );
+      expect(fieldNames, [r'$baseUrl', r'$serverConfig', r'$dio']);
+      expect(parameterNames, [
+        r'$baseUrl',
+        r'$serverConfig',
+        r'$dio',
+        'serverConfig',
+      ]);
     });
   });
 

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -484,6 +484,64 @@ void main() {
     });
   });
 
+  group('hostile variable names', () {
+    test('uses unique fallback and normalized names within one server', () {
+      final servers = [
+        const Server(
+          url: 'https://{_}.{❤️}.example.com/{api-version}/{api_version}',
+          description: 'Hostile variable server',
+          variables: [
+            ServerVariable(name: '_', defaultValue: 'one'),
+            ServerVariable(name: '❤️', defaultValue: 'two'),
+            ServerVariable(name: 'api-version', defaultValue: 'v1'),
+            ServerVariable(name: 'api_version', defaultValue: 'v2'),
+          ],
+        ),
+      ];
+
+      final serverClass = generator.generateClasses(servers)[1];
+      final fieldNames = serverClass.fields.map((field) => field.name).toList();
+
+      expect(fieldNames, ['field', 'field2', 'apiVersion', 'apiVersion2']);
+      expect(
+        serverClass.constructors.single.optionalParameters
+            .map((parameter) => parameter.name)
+            .toList(),
+        [...fieldNames, 'serverConfig'],
+      );
+    });
+
+    test('does not shadow members of the generated base server', () {
+      final servers = [
+        const Server(
+          url: 'https://{baseUrl}.{serverConfig}.example.com/{dio}',
+          description: 'Inherited member collision server',
+          variables: [
+            ServerVariable(name: 'baseUrl', defaultValue: 'base'),
+            ServerVariable(name: 'serverConfig', defaultValue: 'config'),
+            ServerVariable(name: 'dio', defaultValue: 'client'),
+          ],
+        ),
+      ];
+
+      final serverClass = generator.generateClasses(servers)[1];
+      final fieldNames = serverClass.fields.map((field) => field.name).toList();
+      final parameterNames = serverClass.constructors.single.optionalParameters
+          .map((parameter) => parameter.name)
+          .toList();
+
+      expect(
+        fieldNames,
+        isNot(contains(anyOf('baseUrl', 'serverConfig', 'dio'))),
+      );
+      expect(parameterNames.toSet(), hasLength(parameterNames.length));
+      expect(
+        parameterNames.where((name) => name == 'serverConfig'),
+        hasLength(1),
+      );
+    });
+  });
+
   group('ServerGenerator templated URLs with empty url template', () {
     test('emits empty baseUrl literal when no placeholders are present', () {
       // An empty url combined with any variables means no placeholders match

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -444,22 +444,22 @@ void main() {
   group('multipart per-part header parameters', () {
     test('generates parameter for property with one header', () {
       final partModel1 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'file',
-                  model: BinaryModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -531,22 +531,22 @@ void main() {
 
     test('generates multiple header parameters for multiple headers', () {
       final partModel2 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'file',
-                  model: BinaryModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -637,22 +637,22 @@ void main() {
       'optional property with required header produces optional parameter',
       () {
         final partModel3 = ClassModel(
-                name: 'UploadForm',
-                properties: [
-                  Property(
-                    name: 'avatar',
-                    model: BinaryModel(context: context),
-                    isRequired: false,
-                    isNullable: false,
-                    isDeprecated: false,
-                    examples: const [],
-                    defaultValue: null,
-                  ),
-                ],
-                context: context,
-                isDeprecated: false,
-                examples: const [],
-              );
+          name: 'UploadForm',
+          properties: [
+            Property(
+              name: 'avatar',
+              model: BinaryModel(context: context),
+              isRequired: false,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        );
         final requestBody = RequestBodyObject(
           name: 'uploadBody',
           context: context,
@@ -723,22 +723,22 @@ void main() {
 
     test('does not filter out Content-Type header', () {
       final partModel4 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'file',
-                  model: BinaryModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -819,22 +819,22 @@ void main() {
 
     test('no extra parameters for property without headers', () {
       final partModel5 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'name',
-                  model: StringModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'name',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -893,22 +893,22 @@ void main() {
       // Multipart header "X-Custom" on property "file" also normalizes to
       // "fileCustom". We need unique names.
       final partModel6 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'file',
-                  model: BinaryModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -996,24 +996,111 @@ void main() {
       );
     });
 
+    test('multipart headers remain unique after repeated normalization '
+        'collisions', () {
+      final model = ClassModel(
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final headers = {
+        for (final rawName in ['X-Trace-Id', 'Trace-Id', 'Trace_Id'])
+          rawName: ResponseHeaderObject(
+            name: rawName,
+            context: context,
+            description: null,
+            explode: false,
+            model: StringModel(context: context),
+            isRequired: true,
+            isDeprecated: false,
+            encoding: ResponseHeaderEncoding.simple,
+            examples: const [],
+          ),
+      };
+      final requestBody = RequestBodyObject(
+        name: 'uploadBody',
+        context: context,
+        description: null,
+        isRequired: true,
+        content: {
+          RequestContent(
+            model: model,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            multipartEncoding: _multipartEncoding(model, {
+              'file': PartEncoding(
+                contentType: ContentType.bytes,
+                rawContentType: 'application/octet-stream',
+                headers: headers,
+                style: null,
+                explode: null,
+                allowReserved: null,
+              ),
+            }),
+            examples: const [],
+          ),
+        },
+      );
+      final operation = Operation(
+        operationId: 'upload',
+        context: context,
+        tags: const {},
+        isDeprecated: false,
+        path: '/upload',
+        method: HttpMethod.post,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        requestBody: requestBody,
+        securitySchemes: const {},
+      );
+
+      final parameterNames = generateParameters(
+        operation: operation,
+        nameManager: nameManager,
+        package: 'api',
+      ).map((parameter) => parameter.name).toList();
+
+      expect(parameterNames, [
+        'body',
+        'fileTraceId',
+        'fileTraceIdPartHeader',
+        'fileTraceIdPartHeader2',
+      ]);
+    });
+
     test('generates deprecated annotation for deprecated multipart header', () {
       final partModel7 = ClassModel(
-              name: 'UploadForm',
-              properties: [
-                Property(
-                  name: 'file',
-                  model: BinaryModel(context: context),
-                  isRequired: true,
-                  isNullable: false,
-                  isDeprecated: false,
-                  examples: const [],
-                  defaultValue: null,
-                ),
-              ],
-              context: context,
-              isDeprecated: false,
-              examples: const [],
-            );
+        name: 'UploadForm',
+        properties: [
+          Property(
+            name: 'file',
+            model: BinaryModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
       final requestBody = RequestBodyObject(
         name: 'uploadBody',
         context: context,
@@ -1192,22 +1279,22 @@ void main() {
         );
 
         final partModel8 = ClassModel(
-                name: 'UploadForm',
-                properties: [
-                  Property(
-                    name: 'file',
-                    model: BinaryModel(context: context),
-                    isRequired: true,
-                    isNullable: false,
-                    isDeprecated: false,
-                    examples: const [],
-                    defaultValue: null,
-                  ),
-                ],
-                context: context,
-                isDeprecated: false,
-                examples: const [],
-              );
+          name: 'UploadForm',
+          properties: [
+            Property(
+              name: 'file',
+              model: BinaryModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        );
         final requestBody = RequestBodyObject(
           name: 'uploadBody',
           context: context,
@@ -2197,7 +2284,6 @@ void main() {
         expect(param.type?.accept(emitter).toString(), 'DateTime?');
       },
     );
-
   });
 }
 

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -4509,6 +4509,75 @@ void main() {
           );
         },
       );
+
+      test('colliding per-part header names use their distinct parameters', () {
+        final model = ClassModel(
+          name: 'UploadForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: 'file',
+              model: BinaryModel(context: testContext),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+        final headers = {
+          for (final rawName in ['X-Trace-Id', 'Trace-Id'])
+            rawName: ResponseHeaderObject(
+              name: rawName,
+              description: null,
+              isRequired: true,
+              isDeprecated: false,
+              explode: false,
+              model: StringModel(context: testContext),
+              context: testContext,
+              encoding: ResponseHeaderEncoding.simple,
+              examples: const [],
+            ),
+        };
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          multipartEncoding: _multipartEncoding(model, {
+            'file': PartEncoding(
+              contentType: ContentType.bytes,
+              rawContentType: 'application/octet-stream',
+              headers: headers,
+              style: null,
+              explode: null,
+              allowReserved: null,
+            ),
+          }),
+          examples: const [],
+        );
+
+        final code = emitStatements(
+          buildMultipartBodyStatements(
+            content,
+            'body',
+            nameManager,
+            'test_package',
+          ),
+        );
+
+        expect(
+          collapseWhitespace(code),
+          contains(
+            collapseWhitespace(
+              'fileTraceIdPartHeader.toSimple('
+              'explode: false, allowEmpty: true)',
+            ),
+          ),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Summary
- generate stable fallback identifiers for parameter names that normalize to empty strings
- preserve numeric names and enum values that exceed Dart integer bounds
- escape server-variable collisions with the generated dollar namespace and use underscore-dollar names for generator internals
- use one operation-scoped name for multipart header signatures, forwarding, and wire serialization
- expand naming integration coverage with hostile query, server-variable, and multipart-header names

## Verification
- fvm dart test packages/tonik_generate (2,969 tests)
- fvm dart analyze packages/tonik_generate
- fvm dart analyze in integration_test/naming/naming_api
- fvm dart analyze in integration_test/naming/naming_test
- scripts/setup_integration_tests.sh

The naming runtime suite cannot start in the current environment because Imposter reports that no Java runtime is installed.