### PR TITLE
Fix empty form property serialization

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -312,6 +312,20 @@ void main() {
       expect(requestData, 'tags=a,b');
     });
 
+    test('omits an empty array property with explicit explode false', () async {
+      const form = ArrayExplodeForm(tags: []);
+
+      final response = await api.postArrayExplodeFalseForm(body: form);
+
+      expect(response, isA<TonikSuccess<ArrayExplodeForm>>());
+
+      final requestData = (response as TonikSuccess<ArrayExplodeForm>)
+          .response
+          .requestOptions
+          .data;
+      expect(requestData, '');
+    });
+
     test('comma-joins a spaceDelimited array property with explode omitted',
         () async {
       const form = ArrayExplodeForm(tags: ['a', 'b']);

--- a/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/byte_object_test.dart
@@ -44,6 +44,23 @@ void main() {
       );
     });
 
+    test('sends an empty string property as a named empty value', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormByteObject(
+        filter: const Filter(
+          signature: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),
+          label: '',
+        ),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'signature=3q2%2B7w%3D%3D&label=',
+      );
+    });
+
     test('decoder round-trips the encoder output for a byte property', () {
       const filter = Filter(
         signature: TonikFileBytes([0xDE, 0xAD, 0xBE, 0xEF]),

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -54,11 +54,11 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
 
     if (!allowEmpty) {
       for (final value in values) {
-        final isValueEmpty = switch (value) {
-          ScalarPropertyValue(:final value) => value.isEmpty,
+        final isEmptyCollection = switch (value) {
+          ScalarPropertyValue() => false,
           ArrayPropertyValue(:final values) => values.isEmpty,
         };
-        if (isValueEmpty) {
+        if (isEmptyCollection) {
           throw const EmptyValueException();
         }
       }

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -104,6 +104,10 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
             ),
           ));
         case ArrayPropertyValue(:final values):
+          if (values.isEmpty) {
+            continue;
+          }
+
           if (explodeArray) {
             for (final element in values) {
               result.add((

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -218,6 +218,16 @@ void main() {
         const <ParameterEntry>[(name: 'p', value: 'colors,')],
       );
     });
+
+    test('collapses a scalar empty string when allowEmpty is false', () {
+      expect(
+        <String, PropertyValue>{
+          'a': const PropertyValue.scalar(''),
+          'b': const PropertyValue.scalar('ok'),
+        }.toForm('filter', explode: false, allowEmpty: false),
+        const <ParameterEntry>[(name: 'filter', value: 'a,,b,ok')],
+      );
+    });
   });
 
   group('allowReserved', () {
@@ -330,12 +340,16 @@ void main() {
       );
     });
 
-    test('throws on a scalar empty string when allowEmpty is false', () {
+    test('encodes a scalar empty string when allowEmpty is false', () {
       expect(
-        () => <String, PropertyValue>{
-          'key': const PropertyValue.scalar(''),
-        }.toForm('p', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String, PropertyValue>{
+          'a': const PropertyValue.scalar(''),
+          'b': const PropertyValue.scalar('ok'),
+        }.toForm('filter', explode: true, allowEmpty: false),
+        const <ParameterEntry>[
+          (name: 'a', value: ''),
+          (name: 'b', value: 'ok'),
+        ],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -86,10 +86,21 @@ void main() {
       );
     });
 
-    test('emits one empty-value entry for a non-exploded empty array', () {
+    test('omits a non-exploded empty array beside a scalar', () {
       expect(
         <String, PropertyValue>{
+          'name': const PropertyValue.scalar('John'),
           'tags': const PropertyValue.array([]),
+        }.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'name', value: 'John')],
+      );
+    });
+
+    test('emits one empty-value entry for a non-exploded single empty-string '
+        'element', () {
+      expect(
+        <String, PropertyValue>{
+          'tags': const PropertyValue.array(['']),
         }.toForm('p', explode: true, allowEmpty: true),
         const <ParameterEntry>[(name: 'tags', value: '')],
       );


### PR DESCRIPTION
## Summary

- serialize defined empty-string object properties when allowEmpty is false
- omit zero-element array properties from form-urlencoded bodies instead of emitting an empty field
- preserve empty-string array elements as empty fields and the existing empty-collection validation
- add unit and integration regressions with literal wire assertions

## Validation

- fvm dart test packages/tonik_util/test
- fvm dart analyze packages/tonik_util
- ./scripts/setup_integration_tests.sh
- melos run test-integration-form-urlencoded
