### PR TITLE
Fix empty form object query parameters

### DIFF
--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -284,6 +284,12 @@ paths:
           explode: true
           schema:
             $ref: '#/components/schemas/NullableClass'
+        - name: allOptionalFilter
+          in: query
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/AllOptionalFilter'
         - name: deeplyNestedClass
           in: query
           style: form
@@ -1891,6 +1897,13 @@ components:
         age:
           type: integer
           nullable: true
+    AllOptionalFilter:
+      type: object
+      properties:
+        category:
+          type: string
+        label:
+          type: string
     DeeplyNestedClass:
       type: object
       required:

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -808,6 +808,32 @@ void main() {
       );
     });
 
+    test('all-optional empty object drops the whole query', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testFormComplexExplode(
+        allOptionalFilter: const AllOptionalFilter(),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(success.response.requestOptions.uri.query, '');
+    });
+
+    test(
+      'all-optional empty object is dropped beside a populated parameter',
+      () async {
+        final api = buildQueryApi(responseStatus: '204');
+        final response = await api.testFormComplexExplode(
+          allOptionalFilter: const AllOptionalFilter(),
+          integerEnum: PriorityEnum.three,
+        );
+
+        expect(response, isA<TonikSuccess<void>>());
+        final success = response as TonikSuccess<void>;
+        expect(success.response.requestOptions.uri.query, 'integerEnum=3');
+      },
+    );
+
     test('deeplyNestedClass', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormComplexExplode(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -392,7 +392,8 @@ String encodeAnyToForm(
 }
 
 /// Encodes a top-level form query parameter whose runtime value has an unknown
-/// type, omitting an empty list so the parameter is absent from the query.
+/// type, omitting an empty list or map so the parameter is absent from the
+/// query.
 List<ParameterEntry> encodeAnyToFormEntries(
   Object? value, {
   required String name,
@@ -401,7 +402,8 @@ List<ParameterEntry> encodeAnyToFormEntries(
   bool useQueryComponent = false,
   bool allowReserved = false,
 }) {
-  if (value is List && value.isEmpty) {
+  if ((value is List && value.isEmpty) ||
+      (value is Map<String, dynamic> && value.isEmpty)) {
     return const [];
   }
   return [

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -1,5 +1,4 @@
 import 'package:big_decimal/big_decimal.dart';
-import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
@@ -242,6 +241,8 @@ extension FormStringListEncoder on List<String> {
 extension FormStringMapEncoder on Map<String, String> {
   /// Encodes this Map value using form style encoding.
   ///
+  /// An empty map is omitted, regardless of [allowEmpty].
+  ///
   /// The [alreadyEncoded] parameter indicates whether the values are already
   /// URL-encoded, in which case they are not re-encoded to prevent double
   /// encoding.
@@ -253,8 +254,8 @@ extension FormStringMapEncoder on Map<String, String> {
     bool useQueryComponent = false,
     bool allowReserved = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
+    if (isEmpty) {
+      return const [];
     }
 
     if (!explode) {

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -35,6 +35,8 @@ String _joinEncoded(
 extension PropertyValueFormEncoder on Map<String, PropertyValue> {
   /// Encodes this property map using form style encoding.
   ///
+  /// An empty property map is omitted, regardless of [allowEmpty].
+  ///
   /// When the map is exploded, per-property [FormFieldEncoding.explode]
   /// controls array assembly and [FormFieldEncoding.allowReserved] applies to
   /// values only; keys are always component-encoded. In collapse mode
@@ -48,8 +50,8 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
     bool allowReserved = false,
     Map<String, FormFieldEncoding> fieldEncodings = const {},
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
+    if (isEmpty) {
+      return const [];
     }
 
     if (!allowEmpty) {

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -1892,15 +1892,42 @@ void main() {
       );
     });
 
-    test('empty map value throws EmptyValueException', () {
+    test('empty map value yields no entries regardless of encoding flags', () {
       expect(
-        () => encodeAnyToFormEntries(
+        encodeAnyToFormEntries(
+          <String, dynamic>{},
+          name: 'anyValue',
+          explode: false,
+          allowEmpty: true,
+        ),
+        const <ParameterEntry>[],
+      );
+      expect(
+        encodeAnyToFormEntries(
+          <String, dynamic>{},
+          name: 'anyValue',
+          explode: true,
+          allowEmpty: true,
+        ),
+        const <ParameterEntry>[],
+      );
+      expect(
+        encodeAnyToFormEntries(
           <String, dynamic>{},
           name: 'anyValue',
           explode: false,
           allowEmpty: false,
         ),
-        throwsA(isA<EmptyValueException>()),
+        const <ParameterEntry>[],
+      );
+      expect(
+        encodeAnyToFormEntries(
+          <String, dynamic>{},
+          name: 'anyValue',
+          explode: true,
+          allowEmpty: false,
+        ),
+        const <ParameterEntry>[],
       );
     });
   });

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -321,28 +321,22 @@ void main() {
       );
     });
 
-    test('empty map with explode=false yields a single empty-value entry', () {
+    test('empty map is omitted regardless of explode and allowEmpty', () {
       expect(
         <String, String>{}.toForm('p', explode: false, allowEmpty: true),
-        const <ParameterEntry>[(name: 'p', value: '')],
+        const <ParameterEntry>[],
       );
-    });
-
-    test('empty map with explode=true yields no entries', () {
       expect(
         <String, String>{}.toForm('p', explode: true, allowEmpty: true),
         const <ParameterEntry>[],
       );
-    });
-
-    test('empty map throws when allowEmpty=false', () {
       expect(
-        () => <String, String>{}.toForm('p', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String, String>{}.toForm('p', explode: false, allowEmpty: false),
+        const <ParameterEntry>[],
       );
       expect(
-        () => <String, String>{}.toForm('p', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String, String>{}.toForm('p', explode: true, allowEmpty: false),
+        const <ParameterEntry>[],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -312,20 +312,37 @@ void main() {
   });
 
   group('EmptyValueException', () {
-    test('throws on an empty map when allowEmpty is false', () {
+    test('empty map is omitted regardless of explode and allowEmpty', () {
       expect(
-        () => <String, PropertyValue>{}.toForm(
+        <String, PropertyValue>{}.toForm(
+          'p',
+          explode: false,
+          allowEmpty: true,
+        ),
+        const <ParameterEntry>[],
+      );
+      expect(
+        <String, PropertyValue>{}.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+        ),
+        const <ParameterEntry>[],
+      );
+      expect(
+        <String, PropertyValue>{}.toForm(
+          'p',
+          explode: false,
+          allowEmpty: false,
+        ),
+        const <ParameterEntry>[],
+      );
+      expect(
+        <String, PropertyValue>{}.toForm(
           'p',
           explode: true,
           allowEmpty: false,
         ),
-        throwsA(isA<EmptyValueException>()),
-      );
-    });
-
-    test('does not throw on an empty map when allowEmpty is true', () {
-      expect(
-        <String, PropertyValue>{}.toForm('p', explode: true, allowEmpty: true),
         const <ParameterEntry>[],
       );
     });


### PR DESCRIPTION
## Summary

- omit empty map-backed form objects instead of emitting or rejecting an empty query entry
- apply the behavior consistently to string maps, property-value maps, and top-level unknown values
- add unit coverage for encoding flags and literal generated-client query assertions

## Testing

- `fvm dart analyze packages/tonik_util`
- `fvm dart test packages/tonik_util --reporter=compact`
- `melos run test-integration-query-parameters`