### PR TITLE
Fix positive exponent query encoding

### DIFF
--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -43,7 +43,6 @@ paths:
           explode: false
           schema:
             type: number
-            format: number
         - name: string
           in: query
           style: form

--- a/integration_test/query_parameters/query_parameters_test/test/form_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/form_test.dart
@@ -48,17 +48,19 @@ void main() {
       expect(success.response.requestOptions.uri.query, 'double=1.0');
     });
 
-    test('number', () async {
+    test('number percent-encodes plus in a positive exponent', () async {
       final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testFormPrimitive(number: 1.0);
+      final response = await api.testFormPrimitive(number: 6.022e23);
 
       expect(response, isA<TonikSuccess<void>>());
 
       final success = response as TonikSuccess<void>;
-      expect(success.response.requestOptions.uri.query, 'number=1.0');
+      final uri = success.response.requestOptions.uri;
+      expect(uri.query, 'number=6.022e%2B23');
+      expect(uri.queryParameters['number'], '6.022e+23');
     });
 
-    test('number', () async {
+    test('number without exponent', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testFormPrimitive(number: 1.0);
 

--- a/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/uri_encoder_extensions.dart
@@ -54,7 +54,8 @@ extension StringUriEncoder on String {
 extension IntUriEncoder on int {
   /// URI encodes this int value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -64,9 +65,11 @@ extension IntUriEncoder on int {
     if (literal) {
       return toString();
     }
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : toString();
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 
@@ -97,7 +100,8 @@ extension DoubleUriEncoder on double {
 extension NumUriEncoder on num {
   /// URI encodes this num value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -107,9 +111,11 @@ extension NumUriEncoder on num {
     if (literal) {
       return toString();
     }
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : toString();
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 
@@ -117,7 +123,8 @@ extension NumUriEncoder on num {
 extension BoolUriEncoder on bool {
   /// URI encodes this bool value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -127,9 +134,11 @@ extension BoolUriEncoder on bool {
     if (literal) {
       return toString();
     }
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : toString();
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 
@@ -160,7 +169,8 @@ extension DateTimeUriEncoder on DateTime {
 extension BigDecimalUriEncoder on BigDecimal {
   /// URI encodes this BigDecimal value.
   ///
-  /// [literal] returns the value unencoded, overriding [useQueryComponent].
+  /// [literal] returns the value unencoded, overriding [useQueryComponent] and
+  /// [allowReserved].
   String uriEncode({
     required bool allowEmpty,
     bool useQueryComponent = false,
@@ -170,9 +180,11 @@ extension BigDecimalUriEncoder on BigDecimal {
     if (literal) {
       return toString();
     }
-    return useQueryComponent
-        ? Uri.encodeQueryComponent(toString())
-        : toString();
+    return encodeUriValue(
+      toString(),
+      allowReserved: allowReserved,
+      useQueryComponent: useQueryComponent,
+    );
   }
 }
 

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -138,6 +138,15 @@ void main() {
         const <ParameterEntry>[(name: 'p', value: '3.14')],
       );
     });
+
+    test('percent-encodes plus in a positive exponent', () {
+      const num value = 6.022e23;
+
+      expect(
+        value.toForm('p', explode: true, allowEmpty: true),
+        const <ParameterEntry>[(name: 'p', value: '6.022e%2B23')],
+      );
+    });
   });
 
   group('FormBoolEncoder', () {
@@ -182,6 +191,15 @@ void main() {
       expect(
         BigDecimal.parse('-42.5').toForm('p', explode: false, allowEmpty: true),
         const <ParameterEntry>[(name: 'p', value: '-42.5')],
+      );
+    });
+
+    test('percent-encodes plus in a positive exponent', () {
+      final value = BigDecimal.parse('1.23E+10');
+
+      expect(
+        value.toForm('p', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'p', value: '1.23e%2B10')],
       );
     });
   });
@@ -646,7 +664,7 @@ void main() {
       );
     });
 
-    test('numeric and bool encoders accept the flag as a no-op', () {
+    test('numeric and bool safe values are unchanged', () {
       expect(
         42.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
         const <ParameterEntry>[(name: 'p', value: '42')],

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -525,6 +525,15 @@ void main() {
       );
     });
 
+    test('percent-encodes plus in a positive exponent', () {
+      const num value = 6.022e23;
+
+      expect(
+        value.toSimple(explode: false, allowEmpty: true),
+        '6.022e%2B23',
+      );
+    });
+
     test('explode parameter has no effect on num encoding', () {
       const num value = 123.45;
       expect(
@@ -693,7 +702,7 @@ void main() {
       final value = BigDecimal.parse('1.23E+10');
       expect(
         value.toSimple(explode: false, allowEmpty: true),
-        value.toString(),
+        '1.23e%2B10',
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/uri_encoder_extensions_test.dart
@@ -79,6 +79,16 @@ void main() {
       expect((3.14 as num).uriEncode(allowEmpty: true), '3.14');
     });
 
+    test('percent-encodes plus in a positive exponent', () {
+      const num value = 6.022e23;
+
+      expect(value.uriEncode(allowEmpty: true), '6.022e%2B23');
+      expect(
+        value.uriEncode(allowEmpty: true, allowReserved: true),
+        '6.022e%2B23',
+      );
+    });
+
     test('encodes num values with allowEmpty false', () {
       expect((42 as num).uriEncode(allowEmpty: false), '42');
     });
@@ -120,6 +130,16 @@ void main() {
     test('encodes BigDecimal values', () {
       final bigDecimal = BigDecimal.parse('123.456');
       expect(bigDecimal.uriEncode(allowEmpty: true), '123.456');
+    });
+
+    test('percent-encodes plus in a positive exponent', () {
+      final value = BigDecimal.parse('1.23E+10');
+
+      expect(value.uriEncode(allowEmpty: true), '1.23e%2B10');
+      expect(
+        value.uriEncode(allowEmpty: true, allowReserved: true),
+        '1.23e%2B10',
+      );
     });
 
     test('encodes BigDecimal values with allowEmpty false', () {
@@ -364,7 +384,7 @@ void main() {
       );
     });
 
-    test('numeric and bool types accept the flag as a no-op', () {
+    test('numeric and bool safe values are unchanged', () {
       expect(42.uriEncode(allowEmpty: true, allowReserved: true), '42');
       expect(
         (3.14 as num).uriEncode(allowEmpty: true, allowReserved: true),
@@ -570,7 +590,10 @@ void main() {
     });
 
     test('num uses plain string form', () {
-      expect((3.14 as num).uriEncode(allowEmpty: true, literal: true), '3.14');
+      expect(
+        (6.022e23 as num).uriEncode(allowEmpty: true, literal: true),
+        '6.022e+23',
+      );
     });
 
     test('bool uses plain string form', () {
@@ -579,8 +602,10 @@ void main() {
 
     test('BigDecimal uses plain string form', () {
       expect(
-        BigDecimal.parse('123.456').uriEncode(allowEmpty: true, literal: true),
-        '123.456',
+        BigDecimal.parse(
+          '1.23E+10',
+        ).uriEncode(allowEmpty: true, literal: true),
+        '1.23e+10',
       );
     });
 


### PR DESCRIPTION
## Summary

- route scalar URI encoding through the shared encoder
- percent-encode the plus sign in positive numeric exponents, including query parameters
- add exact URI, form, simple, and integration regression coverage

## Testing

- fvm dart test test/src/encoding/uri_encoder_extensions_test.dart test/src/encoding/form_encoder_extensions_test.dart test/src/encoding/simple_encoder_extensions_test.dart
- melos run test-integration-query-parameters
- melos exec -- dart analyze --fatal-infos
- melos run test
- ./scripts/setup_integration_tests.sh