### PR TITLE
Handle empty enums during parsing

### DIFF
--- a/packages/tonik_generate/test/src/generator/generator_models_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_models_test.dart
@@ -10,6 +10,22 @@ void main() {
     late Directory tempDir;
     late Context ctx;
 
+    ApiDocument documentWithModels(Set<Model> models) => ApiDocument(
+      title: 'Test',
+      version: '0.0.1',
+      description: 'Test',
+      models: models,
+      responseHeaders: const {},
+      requestHeaders: const {},
+      servers: const {},
+      operations: const {},
+      responses: const <Response>{},
+      queryParameters: const {},
+      pathParameters: const {},
+      cookieParameters: const {},
+      requestBodies: const {},
+    );
+
     setUp(() {
       tempDir = Directory.systemTemp.createTempSync();
       ctx = Context.initial();
@@ -89,21 +105,7 @@ void main() {
           ),
         };
 
-        final apiDoc = ApiDocument(
-          title: 'Test',
-          version: '0.0.1',
-          description: 'Test',
-          models: models,
-          responseHeaders: const {},
-          requestHeaders: const {},
-          servers: const {},
-          operations: const {},
-          responses: const <Response>{},
-          queryParameters: const {},
-          pathParameters: const {},
-          cookieParameters: const {},
-          requestBodies: const {},
-        );
+        final apiDoc = documentWithModels(models);
 
         const packageName = 'test_package';
         await const Generator().generate(
@@ -134,5 +136,41 @@ void main() {
         }
       },
     );
+
+    test('generates a valid file for an empty enum', () async {
+      final apiDoc = documentWithModels({
+        EnumModel<String>(
+          isDeprecated: false,
+          name: 'Color',
+          values: {},
+          isNullable: false,
+          context: ctx.pushAll(['components', 'schemas', 'Color']),
+          fallbackValue: const EnumEntry(
+            value: 'unknown',
+            nameOverride: 'unknown',
+          ),
+          examples: const [],
+        ),
+      });
+
+      const packageName = 'test_package';
+      await const Generator().generate(
+        apiDocument: apiDoc,
+        outputDirectory: tempDir.path,
+        package: packageName,
+      );
+
+      final generatedFile = File(
+        path.join(
+          tempDir.path,
+          packageName,
+          'lib',
+          'src',
+          'model',
+          'color.dart',
+        ),
+      );
+      expect(generatedFile.existsSync(), isTrue);
+    });
   });
 }

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -1970,6 +1970,53 @@ void main() {
     });
 
     group('fallback/unknown case', () {
+      test('generates a fallback-only string enum', () {
+        final model = EnumModel<String>(
+          isDeprecated: false,
+          name: 'Status',
+          values: {},
+          isNullable: false,
+          context: Context.initial().push('Status'),
+          fallbackValue: const EnumEntry(
+            value: 'unknown',
+            nameOverride: 'unknown',
+          ),
+          examples: const [],
+        );
+
+        final generated = generator.generateEnum(model, 'Status');
+
+        expect(generated.enumValue.values, hasLength(1));
+        expect(generated.enumValue.values.single.name, 'unknown');
+        expect(
+          generated.enumValue.values.single.arguments.single
+              .accept(DartEmitter())
+              .toString(),
+          "r'unknown'",
+        );
+
+        final fromJson = generated.enumValue.constructors.firstWhere(
+          (c) => c.name == 'fromJson',
+        );
+        final formatted = formatConstructor(fromJson, 'Status');
+        final expected = format(r'''
+          class Status {
+            factory Status.fromJson(dynamic value) {
+              if (value is! String) {
+                throw JsonDecodingException(
+                  r'Expected String for Status, got ${value.runtimeType}',
+                );
+              }
+              return values.firstWhere(
+                (e) => e.rawValue == value,
+                orElse: () => Status.unknown,
+              );
+            }
+          }
+        ''');
+        expect(collapseWhitespace(formatted), collapseWhitespace(expected));
+      });
+
       test('includes fallback enum value when fallbackValue is set', () {
         final model = EnumModel<String>(
           isDeprecated: false,

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -31,6 +31,8 @@ class ModelImporter {
   late Set<Model> models;
   final log = Logger('ModelImporter');
 
+  static const _unknownEnumCaseName = 'unknown';
+
   static Context get rootContext =>
       Context.initial().pushAll(['components', 'schemas']);
 
@@ -1458,6 +1460,7 @@ class ModelImporter {
         schema.enumerated!,
         schema.isNullable ?? hasNullType,
         context,
+        emptyFallbackValue: _unknownEnumCaseName,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
         isReadOnly: schema.isReadOnly ?? false,
@@ -1474,6 +1477,7 @@ class ModelImporter {
         schema.enumerated!,
         schema.isNullable ?? hasNullType,
         context,
+        emptyFallbackValue: -1,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
         isReadOnly: schema.isReadOnly ?? false,
@@ -1967,6 +1971,7 @@ class ModelImporter {
     List<dynamic> values,
     bool isNullable,
     Context context, {
+    required T emptyFallbackValue,
     required String? description,
     required bool isDeprecated,
     required List<Example> examples,
@@ -1975,6 +1980,11 @@ class ModelImporter {
     List<String>? xDartEnum,
   }) {
     log.fine('Parsing enum $name<$T> for $context with values $values');
+    final location = switch (name) {
+      final name? when name.isNotEmpty => context.push(name).toString(),
+      _ when context.path.isNotEmpty => context.toString(),
+      _ => '<anonymous>',
+    };
 
     final typedValues = values.whereType<T>().toSet();
     final hasNull = values.any((value) => value == null);
@@ -1983,7 +1993,7 @@ class ModelImporter {
     if (!hasNull && typedValues.length != values.length ||
         hasNull && (typedValues.length + 1) != values.length) {
       log.warning(
-        'Found non-matching values in enum for $context. '
+        'Found non-matching values in enum for $location. '
         'Ignoring non-matching values.',
       );
     }
@@ -2002,6 +2012,17 @@ class ModelImporter {
       enumValues.add(EnumEntry<T>(value: value, nameOverride: nameOverride));
     }
 
+    EnumEntry<T>? fallbackValue;
+    if (enumValues.isEmpty) {
+      log.warning(
+        'Enum $location has no values. Adding an unknown fallback case.',
+      );
+      fallbackValue = EnumEntry<T>(
+        value: emptyFallbackValue,
+        nameOverride: _unknownEnumCaseName,
+      );
+    }
+
     final model = EnumModel<T>(
       isDeprecated: isDeprecated,
       values: enumValues,
@@ -2012,6 +2033,7 @@ class ModelImporter {
       isReadOnly: isReadOnly,
       isWriteOnly: isWriteOnly,
       examples: examples,
+      fallbackValue: fallbackValue,
     );
 
     if (name == null || models.none((m) => m is NamedModel && m.name == name)) {

--- a/packages/tonik_parse/test/model/model_enum_test.dart
+++ b/packages/tonik_parse/test/model/model_enum_test.dart
@@ -1,3 +1,4 @@
+import 'package:logging/logging.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_parse/tonik_parse.dart';
@@ -106,6 +107,118 @@ void main() {
     );
     expect(required, isA<EnumModel<String>>());
     expect((required as EnumModel).isNullable, isFalse);
+  });
+
+  group('empty enum', () {
+    test('adds typed fallback cases and warns', () {
+      final logs = <LogRecord>[];
+      final subscription = Logger('ModelImporter').onRecord.listen(logs.add);
+      addTearDown(subscription.cancel);
+
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'EmptyString': {'type': 'string', 'enum': <String>[]},
+            'EmptyInteger': {'type': 'integer', 'enum': <int>[]},
+            'EmptyNullable': {
+              'type': 'string',
+              'enum': <String>[],
+              'nullable': true,
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+      final emptyString =
+          api.models.firstWhere(
+                (model) => model is NamedModel && model.name == 'EmptyString',
+              )
+              as EnumModel<String>;
+      final emptyInteger =
+          api.models.firstWhere(
+                (model) => model is NamedModel && model.name == 'EmptyInteger',
+              )
+              as EnumModel<int>;
+      final emptyNullable =
+          api.models.firstWhere(
+                (model) => model is NamedModel && model.name == 'EmptyNullable',
+              )
+              as EnumModel<String>;
+
+      expect(emptyString.values, isEmpty);
+      expect(
+        emptyString.fallbackValue,
+        const EnumEntry(value: 'unknown', nameOverride: 'unknown'),
+      );
+      expect(emptyInteger.values, isEmpty);
+      expect(
+        emptyInteger.fallbackValue,
+        const EnumEntry(value: -1, nameOverride: 'unknown'),
+      );
+      expect(emptyNullable.values, isEmpty);
+      expect(emptyNullable.isNullable, isTrue);
+      expect(
+        emptyNullable.fallbackValue,
+        const EnumEntry(value: 'unknown', nameOverride: 'unknown'),
+      );
+
+      expect(
+        logs
+            .where((record) => record.level == Level.WARNING)
+            .map((record) => record.message),
+        [
+          'Enum components/schemas/EmptyString has no values. Adding an unknown fallback case.',
+          'Enum components/schemas/EmptyInteger has no values. Adding an unknown fallback case.',
+          'Enum components/schemas/EmptyNullable has no values. Adding an unknown fallback case.',
+        ],
+      );
+    });
+
+    test('adds a fallback when type filtering removes every value', () {
+      final logs = <LogRecord>[];
+      final subscription = Logger('ModelImporter').onRecord.listen(logs.add);
+      addTearDown(subscription.cancel);
+
+      const spec = {
+        'openapi': '3.0.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'InvalidString': {
+              'type': 'string',
+              'enum': [1, 2],
+            },
+          },
+        },
+      };
+
+      final api = Importer().import(spec);
+      final model =
+          api.models.firstWhere(
+                (model) => model is NamedModel && model.name == 'InvalidString',
+              )
+              as EnumModel<String>;
+
+      expect(model.values, isEmpty);
+      expect(
+        model.fallbackValue,
+        const EnumEntry(value: 'unknown', nameOverride: 'unknown'),
+      );
+      expect(
+        logs
+            .where((record) => record.level == Level.WARNING)
+            .map((record) => record.message),
+        [
+          'Found non-matching values in enum for components/schemas/InvalidString. Ignoring non-matching values.',
+          'Enum components/schemas/InvalidString has no values. Adding an unknown fallback case.',
+        ],
+      );
+    });
   });
 
   group('description', () {


### PR DESCRIPTION
## Summary

- normalize empty or fully filtered enums in the parser with a typed `unknown` fallback
- log a warning with the enum schema path when recovery is required
- keep the generator generic by rendering the parser-provided fallback
- cover string, integer, nullable, filtered-value, and full-file generation paths

## Testing

- `fvm dart test test/model/model_enum_test.dart`
- `fvm dart test test/src/model/enum_generator_test.dart test/src/generator/generator_models_test.dart`
- `dart analyze` for `tonik_parse` and `tonik_generate` using the pinned SDK
- `./scripts/setup_integration_tests.sh`
- `melos run test`