### PR TITLE
Handle server variable default outside enum values

### DIFF
--- a/integration_test/server_variables/openapi.yaml
+++ b/integration_test/server_variables/openapi.yaml
@@ -50,6 +50,18 @@ servers:
           - '8443'
         description: Server port
 
+  # Server with enum-constrained variable whose default is not a member
+  - url: https://{zone}.fallback.example.com/api/v1
+    description: Zone server with default outside the enum
+    variables:
+      zone:
+        default: staging
+        enum:
+          - us-east
+          - eu-west
+          - ap-south
+        description: Deployment zone
+
 tags:
   - name: health
     description: Health check operations

--- a/integration_test/server_variables/server_variables_test/test/server_test.dart
+++ b/integration_test/server_variables/server_variables_test/test/server_test.dart
@@ -128,6 +128,30 @@ void main() {
     });
   });
 
+  group('Server with enum variable whose default is not a member', () {
+    test('Server6 builds URL from explicitly provided zone', () {
+      expect(
+        Server6(zone: Server6Zone.usEast).baseUrl,
+        'https://us-east.fallback.example.com/api/v1',
+      );
+      expect(
+        Server6(zone: Server6Zone.euWest).baseUrl,
+        'https://eu-west.fallback.example.com/api/v1',
+      );
+      expect(
+        Server6(zone: Server6Zone.apSouth).baseUrl,
+        'https://ap-south.fallback.example.com/api/v1',
+      );
+    });
+
+    test('Server6Zone has only the declared values', () {
+      expect(Server6Zone.values, hasLength(3));
+      expect(Server6Zone.usEast.value, 'us-east');
+      expect(Server6Zone.euWest.value, 'eu-west');
+      expect(Server6Zone.apSouth.value, 'ap-south');
+    });
+  });
+
   group('CustomServer', () {
     test('CustomServer can use any base URL', () {
       final server = CustomServer(baseUrl: 'https://custom.example.com/api');
@@ -146,6 +170,7 @@ void main() {
       expect(Server3(), isA<Server>());
       expect(Server4(), isA<Server>());
       expect(Server5(), isA<Server>());
+      expect(Server6(zone: Server6Zone.usEast), isA<Server>());
       expect(CustomServer(baseUrl: 'https://test.com'), isA<Server>());
     });
   });

--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -1,5 +1,6 @@
 import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
+import 'package:collection/collection.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:meta/meta.dart';
 import 'package:tonik_core/tonik_core.dart';
@@ -120,13 +121,14 @@ class ServerGenerator {
     );
   }
 
-  /// Returns the normalized enum value name for the given value.
+  /// Returns the normalized enum value name for the given value, or null
+  /// when the value is not among the enum values.
   @visibleForTesting
-  String getNormalizedEnumValueName(ServerVariable variable, String value) {
+  String? getNormalizedEnumValueName(ServerVariable variable, String value) {
     final normalizedValues = normalizeEnumValues(variable.enumValues!);
     return normalizedValues
-        .firstWhere((n) => n.originalValue == value)
-        .normalizedName;
+        .firstWhereOrNull((n) => n.originalValue == value)
+        ?.normalizedName;
   }
 
   Class _generateBaseClass(String className) {
@@ -312,13 +314,17 @@ class ServerGenerator {
         );
 
         variableParams.add(
-          Parameter(
-            (p) => p
+          Parameter((p) {
+            p
               ..name = fieldName
               ..named = true
-              ..toThis = true
-              ..defaultTo = Code('$enumName.$defaultEnumValue'),
-          ),
+              ..toThis = true;
+            if (defaultEnumValue == null) {
+              p.required = true;
+            } else {
+              p.defaultTo = Code('$enumName.$defaultEnumValue');
+            }
+          }),
         );
 
         variableFields.add(

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -334,6 +334,114 @@ void main() {
     });
   });
 
+  group('ServerGenerator enum variable with default not in enum values', () {
+    late List<Server> servers;
+
+    setUp(() {
+      servers = [
+        const Server(
+          url: 'https://regional.example.com/{region}',
+          description: 'Regional server',
+          variables: [
+            ServerVariable(
+              name: 'region',
+              defaultValue: 'staging',
+              enumValues: ['us-east', 'us-west', 'eu-central'],
+            ),
+          ],
+        ),
+      ];
+    });
+
+    test('generates server class with required enum parameter', () {
+      final serverClass = generator.generateClasses(servers)[1];
+
+      const expectedClass = r'''
+        /// Regional server - https://regional.example.com/{region}
+        class RegionalServer extends Server {
+          RegionalServer({
+            required this.region,
+            super.serverConfig = const ServerConfig(),
+          }) : super(
+            baseUrl: r'https://regional.example.com/' '${region.value}',
+          );
+
+          final RegionalServerRegion region;
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(format(serverClass.accept(emitter).toString())),
+        collapseWhitespace(format(expectedClass)),
+      );
+    });
+
+    test('generates enum with declared values only', () {
+      final regionEnum = generator.generateEnums(servers).single;
+
+      const expectedEnum = '''
+        /// Allowed values for the region variable.
+        enum RegionalServerRegion {
+          usEast(r'us-east'),
+          usWest(r'us-west'),
+          euCentral(r'eu-central');
+
+          const RegionalServerRegion(this.value);
+          final String value;
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(format(regionEnum.accept(emitter).toString())),
+        collapseWhitespace(format(expectedEnum)),
+      );
+    });
+
+    test('keeps default for sibling enum variable with member default', () {
+      final mixedServers = [
+        const Server(
+          url: 'https://mixed.example.com/{region}:{port}',
+          description: 'Mixed server',
+          variables: [
+            ServerVariable(
+              name: 'region',
+              defaultValue: 'staging',
+              enumValues: ['us-east', 'us-west'],
+            ),
+            ServerVariable(
+              name: 'port',
+              defaultValue: '443',
+              enumValues: ['443', '8443'],
+            ),
+          ],
+        ),
+      ];
+
+      final serverClass = generator.generateClasses(mixedServers)[1];
+
+      const expectedClass = r'''
+        /// Mixed server - https://mixed.example.com/{region}:{port}
+        class MixedServer extends Server {
+          MixedServer({
+            required this.region,
+            this.port = MixedServerPort.fourHundredFortyThree,
+            super.serverConfig = const ServerConfig(),
+          }) : super(
+            baseUrl: r'https://mixed.example.com/' '${region.value}' r':' '${port.value}',
+          );
+
+          final MixedServerRegion region;
+          final MixedServerPort port;
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(format(serverClass.accept(emitter).toString())),
+        collapseWhitespace(format(expectedClass)),
+      );
+    });
+  });
+
   group('ServerGenerator mixed templated and static servers', () {
     late List<Server> servers;
     late List<Class> classes;


### PR DESCRIPTION
## Problem

A server variable that declares an `enum` together with a `default` that is not one of the enum values crashed code generation with `Bad state: No element`, aborting the entire run. OpenAPI 3.1 only says the default *SHOULD* be among the enum values, so such documents are valid.

```yaml
variables:
  region:
    default: staging
    enum:
      - us-east
      - eu-west
      - ap-south
```

## Fix

`ServerGenerator.getNormalizedEnumValueName` now looks up the default with `firstWhereOrNull` instead of `firstWhere`. When the default is not an enum member, the generated server constructor takes the variable as a `required` parameter with no default value:

```dart
Server6({
  required this.zone,
  super.serverConfig = const ServerConfig(),
}) : super(baseUrl: 'https://' '${zone.value}' '.fallback.example.com/api/v1');
```

The generated enum is unchanged and contains exactly the declared values — the stray default is never added as a synthetic member. Variables whose default is a valid member keep their default parameter as before.

## Tests

- Unit tests pinning the generated class for a variable with a non-member default, the generated enum, and a mixed server where a sibling variable's valid default is preserved.
- Integration: new server in the `server_variables` suite with a non-member default; tests verify URL construction from explicitly passed enum values and the enum's member set.
