### PR TITLE
Keep rawValue available as an enum case

### DIFF
--- a/integration_test/additional_properties/additional_properties_test/test/additional_properties_test.dart
+++ b/integration_test/additional_properties/additional_properties_test/test/additional_properties_test.dart
@@ -91,7 +91,7 @@ void main() {
     test('enum values are correct', () {
       expect(EnumValueMapModel.values, hasLength(3));
       expect(
-        EnumValueMapModel.values.map((e) => e.rawValue),
+        EnumValueMapModel.values.map((e) => e.toJson()),
         containsAll(['low', 'medium', 'high']),
       );
     });

--- a/integration_test/music_streaming/music_streaming_test/test/albums_test.dart
+++ b/integration_test/music_streaming/music_streaming_test/test/albums_test.dart
@@ -43,7 +43,7 @@ void main() {
 
       expect(albumBase, isA<AlbumBase>());
       expect(albumBase.albumType, isA<AlbumBaseAlbumTypeModel>());
-      expect(AlbumBaseAlbumTypeModel.values.map((v) => v.rawValue), [
+      expect(AlbumBaseAlbumTypeModel.values.map((v) => v.toJson()), [
         'album',
         'single',
         'compilation',
@@ -61,14 +61,14 @@ void main() {
         albumBase.releaseDatePrecision,
         isA<AlbumBaseReleaseDatePrecisionModel>(),
       );
-      expect(AlbumBaseReleaseDatePrecisionModel.values.map((v) => v.rawValue), [
+      expect(AlbumBaseReleaseDatePrecisionModel.values.map((v) => v.toJson()), [
         'year',
         'month',
         'day',
       ]);
       expect(albumBase.restrictions, isA<AlbumBaseRestrictionsAllOfModel?>());
       expect(albumBase.$type, isA<AlbumBaseTypeModel>());
-      expect(AlbumBaseTypeModel.values.map((v) => v.rawValue), ['album']);
+      expect(AlbumBaseTypeModel.values.map((v) => v.toJson()), ['album']);
       expect(albumBase.uri, isA<String>());
 
       final externalUrls = albumBase.externalUrls.externalUrlObject;
@@ -85,7 +85,7 @@ void main() {
         releaseDatePrecision?.reason,
         isA<AlbumRestrictionObjectReasonModel>(),
       );
-      expect(AlbumRestrictionObjectReasonModel.values.map((v) => v.rawValue), [
+      expect(AlbumRestrictionObjectReasonModel.values.map((v) => v.toJson()), [
         'market',
         'product',
         'explicit',
@@ -110,7 +110,7 @@ void main() {
       expect(artist?.id, isA<String?>());
       expect(artist?.name, isA<String?>());
       expect(artist?.$type, isA<SimplifiedArtistObjectTypeModel?>());
-      expect(SimplifiedArtistObjectTypeModel.values.map((v) => v.rawValue), [
+      expect(SimplifiedArtistObjectTypeModel.values.map((v) => v.toJson()), [
         'artist',
       ]);
       expect(artist?.uri, isA<String?>());

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -6,6 +6,7 @@ import 'package:naming_api/src/model/_function.dart';
 import 'package:naming_api/src/model/camel_case_collider.dart';
 import 'package:naming_api/src/model/duration.dart' as naming;
 import 'package:naming_api/src/model/enum.dart' as naming;
+import 'package:naming_api/src/model/enum_reserved_names.dart';
 import 'package:naming_api/src/model/error.dart' as naming;
 import 'package:naming_api/src/model/generated_method_collider.dart';
 import 'package:naming_api/src/model/keyword_enum.dart';
@@ -320,13 +321,23 @@ void main() {
 
   group('keyword enum values', () {
     test('KeywordEnum has escaped values', () {
-      expect(KeywordEnum.$switch.rawValue, 'switch');
-      expect(KeywordEnum.$class.rawValue, 'class');
-      expect(KeywordEnum.$return.rawValue, 'return');
-      expect(KeywordEnum.$void.rawValue, 'void');
-      expect(KeywordEnum.$null.rawValue, 'null');
-      expect(KeywordEnum.$true.rawValue, 'true');
-      expect(KeywordEnum.$false.rawValue, 'false');
+      expect(KeywordEnum.$switch.toJson(), 'switch');
+      expect(KeywordEnum.$class.toJson(), 'class');
+      expect(KeywordEnum.$return.toJson(), 'return');
+      expect(KeywordEnum.$void.toJson(), 'void');
+      expect(KeywordEnum.$null.toJson(), 'null');
+      expect(KeywordEnum.$true.toJson(), 'true');
+      expect(KeywordEnum.$false.toJson(), 'false');
+    });
+  });
+
+  group('generated enum storage names', () {
+    test('keeps rawValue as the enum case name', () {
+      expect(EnumReservedNames.rawValue.toJson(), 'rawValue');
+      expect(
+        EnumReservedNames.fromJson('rawValue'),
+        EnumReservedNames.rawValue,
+      );
     });
   });
 

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -1554,6 +1554,7 @@ components:
         - index
         - values
         - name
+        - rawValue
         - normal
         - hashCode
         - toString

--- a/integration_test/petstore_config/petstore_test/test/order_status_model_test.dart
+++ b/integration_test/petstore_config/petstore_test/test/order_status_model_test.dart
@@ -62,7 +62,7 @@ void main() {
 
     test('base: enum values do not include reservedForFutureUse rawValue', () {
       final hasReserved = base.OrderStatusModel.values.any(
-        (e) => e.rawValue == 'reservedForFutureUse',
+        (e) => e.toJson() == 'reservedForFutureUse',
       );
       expect(hasReserved, isFalse);
     });

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -11,6 +11,8 @@ import 'package:tonik_generate/src/util/format_with_header.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
+const _rawValueFieldName = r'_$rawValue';
+
 /// A generator for creating Dart enum files from enum model definitions.
 @immutable
 class EnumGenerator {
@@ -113,7 +115,7 @@ class EnumGenerator {
                 ..requiredParameters.add(
                   Parameter(
                     (b) => b
-                      ..name = 'rawValue'
+                      ..name = _rawValueFieldName
                       ..toThis = true,
                   ),
                 ),
@@ -188,7 +190,7 @@ class EnumGenerator {
           ..fields.add(
             Field(
               (b) => b
-                ..name = 'rawValue'
+                ..name = _rawValueFieldName
                 ..modifier = FieldModifier.final$
                 ..type = refer(T.toString(), 'dart:core'),
             ),
@@ -383,7 +385,10 @@ class EnumGenerator {
                       )
                       ..body = refer(
                         'e',
-                      ).property('rawValue').equalTo(refer(matchVariable)).code,
+                      )
+                          .property(_rawValueFieldName)
+                          .equalTo(refer(matchVariable))
+                          .code,
                   ).closure,
                 ],
                 {'orElse': orElse},
@@ -405,7 +410,7 @@ class EnumGenerator {
           ..name = 'toJson'
           ..returns = refer(T.toString(), 'dart:core')
           ..lambda = true
-          ..body = const Code('rawValue'),
+          ..body = refer(_rawValueFieldName).code,
       );
     }
 
@@ -422,7 +427,7 @@ class EnumGenerator {
             raw: true,
           ).statement,
           const Code('}'),
-          const Code('return rawValue;'),
+          refer(_rawValueFieldName).returned.statement,
         ]),
     );
   }
@@ -440,7 +445,8 @@ class EnumGenerator {
           ..lambda = true
           ..optionalParameters.addAll(buildSimpleEncodingParameters())
           ..body = const Code(
-            'rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, '
+            '$_rawValueFieldName.toSimple(explode: explode, '
+            'allowEmpty: allowEmpty, '
             'literal: literal)',
           ),
       );
@@ -461,9 +467,8 @@ class EnumGenerator {
           ).statement,
           const Code('}'),
           const Code(
-            '''
-return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
-''',
+            'return $_rawValueFieldName.toSimple(explode: explode, '
+            'allowEmpty: allowEmpty, literal: literal);',
           ),
         ]),
     );
@@ -489,7 +494,7 @@ return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: lite
           )
           ..optionalParameters.addAll(buildFormEncodingParameters())
           ..body = const Code(
-            'rawValue.toForm(paramName, explode: explode, '
+            '$_rawValueFieldName.toForm(paramName, explode: explode, '
             'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
             'allowReserved: allowReserved)',
           ),
@@ -518,9 +523,9 @@ return rawValue.toSimple(explode: explode, allowEmpty: allowEmpty, literal: lite
           ).statement,
           const Code('}'),
           const Code(
-            '''
-return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
-''',
+            'return $_rawValueFieldName.toForm(paramName, explode: explode, '
+            'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
+            'allowReserved: allowReserved);',
           ),
         ]),
     );
@@ -539,7 +544,8 @@ return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQ
           ..lambda = true
           ..optionalParameters.addAll(buildEncodingParameters())
           ..body = const Code(
-            'rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
+            '$_rawValueFieldName.toLabel(explode: explode, '
+            'allowEmpty: allowEmpty)',
           ),
       );
     }
@@ -559,9 +565,8 @@ return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQ
           ).statement,
           const Code('}'),
           const Code(
-            '''
-return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
-''',
+            'return $_rawValueFieldName.toLabel(explode: explode, '
+            'allowEmpty: allowEmpty);',
           ),
         ]),
     );
@@ -580,7 +585,7 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           ..lambda = true
           ..optionalParameters.addAll(buildUriEncodeParameters())
           ..body = const Code(
-            'rawValue.uriEncode(allowEmpty: allowEmpty, '
+            '$_rawValueFieldName.uriEncode(allowEmpty: allowEmpty, '
             'useQueryComponent: useQueryComponent, '
             'allowReserved: allowReserved)',
           ),
@@ -602,7 +607,7 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           ).statement,
           const Code('}'),
           const Code(
-            'return rawValue.uriEncode(allowEmpty: allowEmpty, '
+            'return $_rawValueFieldName.uriEncode(allowEmpty: allowEmpty, '
             'useQueryComponent: useQueryComponent, '
             'allowReserved: allowReserved);',
           ),
@@ -630,7 +635,8 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           )
           ..optionalParameters.addAll(buildEncodingParameters())
           ..body = const Code(
-            '''rawValue.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty)''',
+            '$_rawValueFieldName.toMatrix(paramName, explode: explode, '
+            'allowEmpty: allowEmpty)',
           ),
       );
     }
@@ -657,9 +663,8 @@ return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
           ).statement,
           const Code('}'),
           const Code(
-            '''
-return rawValue.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
-''',
+            'return $_rawValueFieldName.toMatrix(paramName, '
+            'explode: explode, allowEmpty: allowEmpty);',
           ),
         ]),
     );

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -131,7 +131,7 @@ void main() {
       );
 
       final rawValueField = generated.enumValue.fields.firstWhere(
-        (f) => f.name == 'rawValue',
+        (f) => f.name == r'_$rawValue',
       );
       expect(rawValueField.modifier, FieldModifier.final$);
       expect(
@@ -144,8 +144,42 @@ void main() {
       );
       expect(mainConstructor.constant, isTrue);
       expect(mainConstructor.requiredParameters, hasLength(1));
-      expect(mainConstructor.requiredParameters[0].name, 'rawValue');
+      expect(mainConstructor.requiredParameters[0].name, r'_$rawValue');
       expect(mainConstructor.requiredParameters[0].toThis, isTrue);
+    });
+
+    test('keeps rawValue as an enum case and uses private storage', () {
+      final model = EnumModel<String>(
+        isDeprecated: false,
+        name: 'Status',
+        values: {const EnumEntry(value: 'rawValue')},
+        isNullable: false,
+        context: Context.initial(),
+        examples: const [],
+      );
+
+      final generated = generator.generateEnum(model, 'Status');
+
+      expect(generated.enumValue.values.single.name, 'rawValue');
+      expect(
+        generated.enumValue.values.single.arguments.single
+            .accept(DartEmitter())
+            .toString(),
+        "r'rawValue'",
+      );
+      expect(generated.enumValue.fields.single.name, r'_$rawValue');
+      expect(
+        generated.enumValue.constructors.first.requiredParameters.single.name,
+        r'_$rawValue',
+      );
+
+      final toJson = generated.enumValue.methods.firstWhere(
+        (method) => method.name == 'toJson',
+      );
+      expect(
+        toJson.body?.accept(DartEmitter()).toString(),
+        r'_$rawValue',
+      );
     });
 
     test('generates nullable enum code', () {
@@ -290,7 +324,7 @@ void main() {
       );
 
       final rawValueField = generated.enumValue.fields.firstWhere(
-        (f) => f.name == 'rawValue',
+        (f) => f.name == r'_$rawValue',
       );
       expect(rawValueField.modifier, FieldModifier.final$);
       expect(
@@ -303,7 +337,7 @@ void main() {
       );
       expect(mainConstructor.constant, isTrue);
       expect(mainConstructor.requiredParameters, hasLength(1));
-      expect(mainConstructor.requiredParameters[0].name, 'rawValue');
+      expect(mainConstructor.requiredParameters[0].name, r'_$rawValue');
       expect(mainConstructor.requiredParameters[0].toThis, isTrue);
     });
 
@@ -355,7 +389,7 @@ void main() {
         );
 
         final rawValueField = generated.enumValue.fields.firstWhere(
-          (f) => f.name == 'rawValue',
+          (f) => f.name == r'_$rawValue',
         );
         expect(rawValueField.modifier, FieldModifier.final$);
         expect(
@@ -368,7 +402,7 @@ void main() {
         );
         expect(mainConstructor.constant, isTrue);
         expect(mainConstructor.requiredParameters, hasLength(1));
-        expect(mainConstructor.requiredParameters[0].name, 'rawValue');
+        expect(mainConstructor.requiredParameters[0].name, r'_$rawValue');
         expect(mainConstructor.requiredParameters[0].toThis, isTrue);
       },
     );
@@ -648,7 +682,7 @@ void main() {
         );
 
         final body = toJson.body?.accept(DartEmitter()).toString() ?? '';
-        expect(body, 'rawValue');
+        expect(body, r'_$rawValue');
         expect(toJson.returns?.accept(DartEmitter()).toString(), 'String');
       });
 
@@ -688,7 +722,7 @@ void main() {
               );
             }
             return values.firstWhere(
-              (e) => e.rawValue == value,
+              (e) => e._$rawValue == value,
               orElse: () =>
                   throw JsonDecodingException(r'No matching Color for value: $value'),
             );
@@ -732,7 +766,7 @@ void main() {
           factory Status.fromJson(dynamic value) {
             final decoded = (value as Object?).decodeJsonInt(context: r'Status');
             return values.firstWhere(
-              (e) => e.rawValue == decoded,
+              (e) => e._$rawValue == decoded,
               orElse: () => throw JsonDecodingException(
                 r'No matching Status for value: $decoded',
               ),
@@ -772,7 +806,7 @@ void main() {
               );
             }
             return values.firstWhere(
-              (e) => e.rawValue == value,
+              (e) => e._$rawValue == value,
               orElse: () =>
                   throw JsonDecodingException(r'No matching $2fa for value: $value'),
             );
@@ -807,7 +841,7 @@ void main() {
           factory $2fa.fromJson(dynamic value) {
             final decoded = (value as Object?).decodeJsonInt(context: r'$2fa');
             return values.firstWhere(
-              (e) => e.rawValue == decoded,
+              (e) => e._$rawValue == decoded,
               orElse: () =>
                   throw JsonDecodingException(r'No matching $2fa for value: $decoded'),
             );
@@ -854,7 +888,7 @@ void main() {
               );
             }
             return values.firstWhere(
-              (e) => e.rawValue == value,
+              (e) => e._$rawValue == value,
               orElse: () =>
                   throw JsonDecodingException(r'No matching Status for value: $value'),
             );
@@ -1066,14 +1100,14 @@ void main() {
         expect(allowEmptyParam.named, isTrue);
         expect(allowEmptyParam.required, isTrue);
 
-        const expected = '''
+        const expected = r'''
           class Status {
             @override
             String toSimple({
               required bool explode,
               required bool allowEmpty,
               bool literal = false,
-            }) => rawValue.toSimple(
+            }) => _$rawValue.toSimple(
               explode: explode,
               allowEmpty: allowEmpty,
               literal: literal,
@@ -1109,14 +1143,14 @@ void main() {
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
         expect(toSimple.optionalParameters, hasLength(3));
 
-        const expected = '''
+        const expected = r'''
           class Status {
             @override
             String toSimple({
               required bool explode,
               required bool allowEmpty,
               bool literal = false,
-            }) => rawValue.toSimple(
+            }) => _$rawValue.toSimple(
               explode: explode,
               allowEmpty: allowEmpty,
               literal: literal,
@@ -1151,14 +1185,14 @@ void main() {
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
         expect(toSimple.optionalParameters, hasLength(3));
 
-        const expected = '''
+        const expected = r'''
           class Status {
             @override
             String toSimple({
               required bool explode,
               required bool allowEmpty,
               bool literal = false,
-            }) => rawValue.toSimple(
+            }) => _$rawValue.toSimple(
               explode: explode,
               allowEmpty: allowEmpty,
               literal: literal,
@@ -1194,14 +1228,14 @@ void main() {
         expect(toSimple.returns?.accept(DartEmitter()).toString(), 'String');
         expect(toSimple.optionalParameters, hasLength(3));
 
-        const expected = '''
+        const expected = r'''
           class Status {
             @override
             String toSimple({
               required bool explode,
               required bool allowEmpty,
               bool literal = false,
-            }) => rawValue.toSimple(
+            }) => _$rawValue.toSimple(
               explode: explode,
               allowEmpty: allowEmpty,
               literal: literal,
@@ -1437,7 +1471,7 @@ void main() {
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toForm(paramName, explode: explode, '
+          r'_$rawValue.toForm(paramName, explode: explode, '
           'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
           'allowReserved: allowReserved)',
         );
@@ -1473,7 +1507,7 @@ void main() {
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toForm(paramName, explode: explode, '
+          r'_$rawValue.toForm(paramName, explode: explode, '
           'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
           'allowReserved: allowReserved)',
         );
@@ -1508,7 +1542,7 @@ void main() {
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toForm(paramName, explode: explode, '
+          r'_$rawValue.toForm(paramName, explode: explode, '
           'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
           'allowReserved: allowReserved)',
         );
@@ -1544,7 +1578,7 @@ void main() {
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toForm(paramName, explode: explode, '
+          r'_$rawValue.toForm(paramName, explode: explode, '
           'allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, '
           'allowReserved: allowReserved)',
         );
@@ -1592,7 +1626,7 @@ void main() {
         final body = toLabel.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
+          r'_$rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
         );
       });
 
@@ -1621,7 +1655,7 @@ void main() {
         final body = toLabel.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
+          r'_$rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
         );
       });
 
@@ -1650,7 +1684,7 @@ void main() {
         final body = toLabel.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
+          r'_$rawValue.toLabel(explode: explode, allowEmpty: allowEmpty)',
         );
       });
     });
@@ -1703,7 +1737,7 @@ void main() {
         final body = toMatrix.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toMatrix(paramName, explode: explode, '
+          r'_$rawValue.toMatrix(paramName, explode: explode, '
           'allowEmpty: allowEmpty)',
         );
         expect(toMatrix.lambda, isTrue);
@@ -1742,7 +1776,7 @@ void main() {
         final body = toMatrix.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toMatrix(paramName, explode: explode, '
+          r'_$rawValue.toMatrix(paramName, explode: explode, '
           'allowEmpty: allowEmpty)',
         );
         expect(toMatrix.lambda, isTrue);
@@ -1780,7 +1814,7 @@ void main() {
         final body = toMatrix.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toMatrix(paramName, explode: explode, '
+          r'_$rawValue.toMatrix(paramName, explode: explode, '
           'allowEmpty: allowEmpty)',
         );
         expect(toMatrix.lambda, isTrue);
@@ -1819,7 +1853,7 @@ void main() {
         final body = toMatrix.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.toMatrix(paramName, explode: explode, '
+          r'_$rawValue.toMatrix(paramName, explode: explode, '
           'allowEmpty: allowEmpty)',
         );
         expect(toMatrix.lambda, isTrue);
@@ -1873,7 +1907,7 @@ void main() {
         final body = uriEncode.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.uriEncode(allowEmpty: allowEmpty, '
+          r'_$rawValue.uriEncode(allowEmpty: allowEmpty, '
           'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
@@ -1918,7 +1952,7 @@ void main() {
         final body = uriEncode.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.uriEncode(allowEmpty: allowEmpty, '
+          r'_$rawValue.uriEncode(allowEmpty: allowEmpty, '
           'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
@@ -1962,7 +1996,7 @@ void main() {
         final body = uriEncode.body?.accept(DartEmitter()).toString() ?? '';
         expect(
           body,
-          'rawValue.uriEncode(allowEmpty: allowEmpty, '
+          r'_$rawValue.uriEncode(allowEmpty: allowEmpty, '
           'useQueryComponent: useQueryComponent, allowReserved: allowReserved)',
         );
         expect(uriEncode.lambda, isTrue);
@@ -2008,7 +2042,7 @@ void main() {
                 );
               }
               return values.firstWhere(
-                (e) => e.rawValue == value,
+                (e) => e._$rawValue == value,
                 orElse: () => Status.unknown,
               );
             }
@@ -2088,7 +2122,7 @@ void main() {
               );
             }
             return values.firstWhere(
-              (e) => e.rawValue == value,
+              (e) => e._$rawValue == value,
               orElse: () => Status.unknown,
             );
           }
@@ -2130,11 +2164,11 @@ void main() {
         );
 
         final formatted = formatConstructor(fromJson, 'Code');
-        const expectedFactory = '''
+        const expectedFactory = r'''
           factory Code.fromJson(dynamic value) {
             final decoded = (value as Object?).decodeJsonInt(context: r'Code');
             return values.firstWhere(
-              (e) => e.rawValue == decoded,
+              (e) => e._$rawValue == decoded,
               orElse: () => Code.unknown,
             );
           }
@@ -2168,11 +2202,11 @@ void main() {
         expect(toJson.lambda, isFalse);
 
         final body = toJson.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
+        const expectedBody = r'''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue;
+          return _$rawValue;
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2200,7 +2234,7 @@ void main() {
         expect(toSimple.lambda, isFalse);
         expect(toSimple.optionalParameters, hasLength(3));
 
-        const expected = '''
+        const expected = r'''
           class Status {
             @override
             String toSimple({
@@ -2211,7 +2245,7 @@ void main() {
               if (this == Status.unknown) {
                 throw EncodingException(r'Cannot encode unknown enum value');
               }
-              return rawValue.toSimple(
+              return _$rawValue.toSimple(
                 explode: explode,
                 allowEmpty: allowEmpty,
                 literal: literal,
@@ -2253,11 +2287,11 @@ void main() {
         expect(toForm.optionalParameters, hasLength(5));
 
         final body = toForm.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
+        const expectedBody = r'''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
+          return _$rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2332,11 +2366,11 @@ void main() {
         expect(toLabel.optionalParameters, hasLength(2));
 
         final body = toLabel.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
+        const expectedBody = r'''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
+          return _$rawValue.toLabel(explode: explode, allowEmpty: allowEmpty);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2386,11 +2420,11 @@ void main() {
         );
 
         final body = uriEncode.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
+        const expectedBody = r'''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
+          return _$rawValue.uriEncode(allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2420,11 +2454,11 @@ void main() {
         expect(toMatrix.optionalParameters, hasLength(2));
 
         final body = toMatrix.body?.accept(DartEmitter()).toString() ?? '';
-        const expectedBody = '''
+        const expectedBody = r'''
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return rawValue.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
+          return _$rawValue.toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
         ''';
         expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
       });
@@ -2455,7 +2489,7 @@ void main() {
               );
             }
             return values.firstWhere(
-              (e) => e.rawValue == value,
+              (e) => e._$rawValue == value,
               orElse: () =>
                   throw JsonDecodingException(r'No matching Status for value: $value'),
             );
@@ -2605,7 +2639,7 @@ void main() {
                 );
               }
               return values.firstWhere(
-                (e) => e.rawValue == value,
+                (e) => e._$rawValue == value,
                 orElse: () => Status.fallback,
               );
             }
@@ -2669,7 +2703,7 @@ void main() {
                 );
               }
               return values.firstWhere(
-                (e) => e.rawValue == value,
+                (e) => e._$rawValue == value,
                 orElse: () => Status.fallbackUnknown,
               );
             }
@@ -2706,11 +2740,11 @@ void main() {
           );
 
           final body = toJson.body?.accept(DartEmitter()).toString() ?? '';
-          const expectedBody = '''
+          const expectedBody = r'''
             if (this == Status.unknown2) {
               throw EncodingException(r'Cannot encode unknown enum value');
             }
-            return rawValue;
+            return _$rawValue;
           ''';
           expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
         },
@@ -2944,11 +2978,11 @@ void main() {
           );
 
           final body = toJson.body?.accept(DartEmitter()).toString() ?? '';
-          const expectedBody = '''
+          const expectedBody = r'''
             if (this == Status.unKnown) {
               throw EncodingException(r'Cannot encode unknown enum value');
             }
-            return rawValue;
+            return _$rawValue;
           ''';
           expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
         },

--- a/packages/tonik_generate/test/src/naming/name_utils_test.dart
+++ b/packages/tonik_generate/test/src/naming/name_utils_test.dart
@@ -222,6 +222,12 @@ void main() {
         expect(normalizeEnumValueName('VALUES'), r'$values');
       });
 
+      test('keeps rawValue available as an enum case name', () {
+        expect(normalizeEnumValueName('rawValue'), 'rawValue');
+        expect(normalizeEnumValueName('RAW_VALUE'), 'rawValue');
+        expect(normalizeEnumValueName('raw_value'), 'rawValue');
+      });
+
       test('does not escape words that contain reserved names', () {
         expect(normalizeEnumValueName('reindex'), 'reindex');
         expect(normalizeEnumValueName('indexing'), 'indexing');


### PR DESCRIPTION
## Summary

- preserve `rawValue` as the generated enum case for matching schema values
- move the generated backing storage to the private `_$rawValue` field
- update internal encoder access, integration callers, and regression coverage

## Testing

- `fvm dart analyze --fatal-infos` in `packages/tonik_generate`
- `fvm dart test` in `packages/tonik_generate` (2,981 tests)
- focused enum generator and naming tests (134 tests)
- generated naming client analysis and runtime tests (28 tests)
- affected integration analyses and runtime suites (97, 4, and 108 tests)
- `git diff --check`