### PR TITLE
Fix List<Never> property decoding and analysis

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/type_verification_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/type_verification_test.dart
@@ -1,5 +1,6 @@
 import 'package:boolean_schemas_api/boolean_schemas_api.dart';
 import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 void main() {
   group('AnyModel type verification', () {
@@ -53,6 +54,36 @@ void main() {
       final copied = obj.copyWith(name: 'copied');
       expect(copied.name, 'copied');
       expect(copied.neverField, isNull);
+    });
+
+    test('Shape decode factories accept empty List<Never> properties', () {
+      expect(
+        Shape.fromJson(
+          const <String, Object?>{'corner': <Object?>[]},
+        ).corner,
+        isEmpty,
+      );
+      expect(Shape.fromSimple('corner=', explode: true).corner, isEmpty);
+      expect(Shape.fromForm('corner=', explode: true).corner, isEmpty);
+    });
+
+    test('Shape decode factories reject non-empty List<Never> properties', () {
+      expect(
+        () => Shape.fromJson(
+          const <String, Object?>{
+            'corner': <Object?>['forbidden'],
+          },
+        ),
+        throwsA(isA<JsonDecodingException>()),
+      );
+      expect(
+        () => Shape.fromSimple('corner=forbidden', explode: true),
+        throwsA(isA<SimpleDecodingException>()),
+      );
+      expect(
+        () => Shape.fromForm('corner=forbidden', explode: true),
+        throwsA(isA<FormDecodingException>()),
+      );
     });
   });
 }

--- a/integration_test/boolean_schemas/openapi.yaml
+++ b/integration_test/boolean_schemas/openapi.yaml
@@ -1196,6 +1196,15 @@ components:
         neverField:
           $ref: '#/components/schemas/NeverValid'
 
+    Shape:
+      type: object
+      required:
+        - corner
+      properties:
+        corner:
+          type: array
+          items: false
+
     FlexibleArray:
       type: array
       items: true

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -406,20 +406,14 @@ class ParseGenerator {
     return (statements: statements, varName: bodyVar);
   }
 
-  // Mirrors the *non-nullable* `NeverModel` and `ListModel<NeverModel>` arms
-  // in buildFromJsonValueExpression — only those emit a bare
-  // `throw JsonDecodingException(...)`. When the model is nullable the arms
-  // emit `value == null ? null : throw …`, which references `_$json` and so
-  // must NOT short-circuit here. The `!nullable` gates in the switch below
-  // enforce that.
+  // Mirrors the non-nullable `NeverModel` arm in
+  // buildFromJsonValueExpression, which emits a bare throw. Nullable models
+  // reference `_$json` in their null guard and must not short-circuit here.
   bool _isJsonBodyPureThrow(Model model, {bool isNullable = false}) {
     final nullable = isNullable || model.isEffectivelyNullable;
     switch (model) {
       case NeverModel():
         return !nullable;
-      case ListModel(:final content):
-        final unwrapped = content is AliasModel ? content.model : content;
-        return !nullable && unwrapped is NeverModel;
       case AliasModel():
         return _isJsonBodyPureThrow(model.model, isNullable: nullable);
       default:
@@ -427,20 +421,13 @@ class ParseGenerator {
     }
   }
 
-  // Bare `NeverModel` and `ListModel<NeverModel>` both collapse to a pure
-  // throw regardless of nullability, because `_$formString` comes from
-  // `decodeResponseText` and is typed `String` (non-null). Wrapping the throw
-  // in `_$formString == null ? null : throw …` would trip
-  // `unnecessary_null_comparison`. This differs from `_isJsonBodyPureThrow`,
-  // where `_$json` is `Object?` and the nullable arms emit the null-guarded
-  // ternary — see the `!nullable` gates there.
+  // A bare `NeverModel` collapses to a pure throw regardless of nullability,
+  // because `_$formString` comes from `decodeResponseText` and is typed
+  // `String` (non-null).
   bool _isFormBodyPureThrow(Model model) {
     switch (model) {
       case NeverModel():
         return true;
-      case ListModel(:final content):
-        final unwrapped = content is AliasModel ? content.model : content;
-        return unwrapped is NeverModel;
       case AliasModel():
         return _isFormBodyPureThrow(model.model);
       default:

--- a/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
@@ -185,22 +185,22 @@ Expression _buildNeverModelExpression(Expression value, bool isRequired) {
       : value.equalTo(literalNull).conditional(literalNull, throwExpr);
 }
 
-// Wrap the bare throw whenever the surrounding list is nullable or the field
-// is optional so the caller's input local stays referenced; an unwrapped
-// throw on a nested-class form field would orphan the receiver expression
-// and trip unused_local_variable.
 Expression _buildListNeverFormExpression(
-  Expression value, {
-  required bool isRequired,
-  required bool isNullableList,
-}) {
-  final throwExpr = generateFormDecodingExceptionExpression(
-    'Cannot decode List<NeverModel> - this type does not permit any value.',
-  );
-  if (isRequired && !isNullableList) {
-    return throwExpr;
-  }
-  return value.equalTo(literalNull).conditional(literalNull, throwExpr);
+  Expression listDecode,
+  bool isRequired,
+) {
+  final mapFunction = Method(
+    (b) => b
+      ..requiredParameters.add(Parameter((b) => b..name = 'e'))
+      ..body = generateFormDecodingExceptionExpression(
+        'Cannot decode List<NeverModel> - this type does not permit any value.',
+      ).code,
+  ).closure;
+
+  final map = isRequired
+      ? listDecode.property('map')
+      : listDecode.nullSafeProperty('map');
+  return map.call([mapFunction]).property('toList').call([]);
 }
 
 Expression _buildFromFormExpression(
@@ -362,9 +362,8 @@ Expression _buildListFromFormExpression(
       useImmutableCollections: useImmutableCollections,
     ),
     NeverModel() => _buildListNeverFormExpression(
-      value,
-      isRequired: isRequired,
-      isNullableList: model.isEffectivelyNullable,
+      listDecode,
+      isRequired,
     ),
     AnyModel() => listDecode,
     NamedModel() || CompositeModel() => generateFormDecodingExceptionExpression(

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -316,7 +316,7 @@ BuiltExpression _buildListFromJsonBody(
       ? 'decodeJsonNullableList'
       : 'decodeJsonList';
 
-  final unwrappedContent = content is AliasModel ? content.model : content;
+  final unwrappedContent = content.resolved;
   final isItemNullable =
       model.isContentNullable || content.isEffectivelyNullable;
   final inlineFunctions = <InlineHelper>[];
@@ -335,10 +335,9 @@ BuiltExpression _buildListFromJsonBody(
     return Method(
       (b) => b
         ..requiredParameters.add(Parameter((b) => b..name = 'e'))
-        ..body = refer('e')
-            .equalTo(literalNull)
-            .conditional(literalNull, decodeOfE)
-            .code,
+        ..body = refer(
+          'e',
+        ).equalTo(literalNull).conditional(literalNull, decodeOfE).code,
     ).closure;
   }
 
@@ -485,16 +484,17 @@ BuiltExpression _buildListFromJsonBody(
         'Cannot decode List<NeverModel> - this type does not permit any '
         'value.',
       );
-      // Gate on isNullable, not effectiveNullable: useImmutableCollections
-      // must not erase nullable semantics (a `null` payload yields `null`,
-      // not a throw). The non-nullable case stays a bare throw so
-      // _isJsonBodyPureThrow can drop the surrounding _$json / _$body locals.
-      if (isNullable) {
-        return BuiltExpression.simple(
-          receiver.equalTo(literalNull).conditional(literalNull, throwExpr),
-        );
-      }
-      return BuiltExpression.simple(throwExpr);
+      final mapFunction = Method(
+        (b) => b
+          ..requiredParameters.add(Parameter((b) => b..name = 'e'))
+          ..body = throwExpr.code,
+      ).closure;
+      final listExpr = receiver.property(listDecoder).call(
+        [],
+        contextParam,
+        [refer('Object?', 'dart:core')],
+      );
+      result = mapList(listExpr, mapFunction);
 
     default:
       final typeArg = typeReference(
@@ -503,9 +503,7 @@ BuiltExpression _buildListFromJsonBody(
         package,
         isNullableOverride: isItemNullable,
       );
-      result = receiver
-          .property(listDecoder)
-          .call([], contextParam, [typeArg]);
+      result = receiver.property(listDecoder).call([], contextParam, [typeArg]);
   }
 
   if (useImmutableCollections) {

--- a/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
@@ -381,15 +381,28 @@ Expression _buildListFromSimpleExpression(
       contextProperty: contextProperty,
       explode: explode,
     ),
-    NeverModel() => generateSimpleDecodingExceptionExpression(
-      'Cannot decode List<NeverModel> - this type does not permit any value.',
-    ),
+    NeverModel() => _buildNeverList(listDecode, isRequired),
     AnyModel() => listDecode,
     NamedModel() ||
     CompositeModel() => generateSimpleDecodingExceptionExpression(
       'Unsupported model type for simple decoding.',
     ),
   };
+}
+
+Expression _buildNeverList(Expression listDecode, bool isRequired) {
+  final mapFunction = Method(
+    (b) => b
+      ..requiredParameters.add(Parameter((b) => b..name = 'e'))
+      ..body = generateSimpleDecodingExceptionExpression(
+        'Cannot decode List<NeverModel> - this type does not permit any value.',
+      ).code,
+  ).closure;
+
+  final map = isRequired
+      ? listDecode.property('map')
+      : listDecode.nullSafeProperty('map');
+  return map.call([mapFunction]).property('toList').call([]);
 }
 
 Expression _buildPrimitiveList(

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -83,6 +83,109 @@ void main() {
       },
     );
 
+    group('Never property decoding', () {
+      ClassModel buildShape() => ClassModel(
+        isDeprecated: false,
+        name: 'Shape',
+        properties: [
+          Property(
+            name: 'corner',
+            model: ListModel(
+              content: NeverModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+
+      test('validates List<Never> elements after decoding the list', () {
+        final generatedClass = generator.generateClass(buildShape());
+        final constructors = ['fromJson', 'fromSimple', 'fromForm'].map(
+          (name) => generatedClass.constructors.firstWhere(
+            (constructor) => constructor.name == name,
+          ),
+        );
+        final actual = format(
+          Class(
+            (b) => b
+              ..name = 'Shape'
+              ..constructors.addAll(constructors),
+          ).accept(emitter).toString(),
+        );
+
+        const expected = r'''
+          class Shape {
+            factory Shape.fromJson(Object? json) {
+              final _$map = json.decodeMap(context: r'Shape');
+              return Shape(
+                corner: _$map[r'corner']
+                    .decodeJsonList<Object?>(context: r'Shape.corner')
+                    .map(
+                      (e) => throw JsonDecodingException(
+                        'Cannot decode List<NeverModel> - this type does not permit any value.',
+                      ),
+                    )
+                    .toList(),
+              );
+            }
+
+            factory Shape.fromSimple(String? value, {required bool explode}) {
+              final _$values = value.decodeObject(
+                explode: explode,
+                explodeSeparator: ',',
+                expectedKeys: {r'corner'},
+                listKeys: {r'corner'},
+                context: r'Shape',
+              );
+              return Shape(
+                corner: _$values[r'corner']
+                    .decodeSimpleStringList(context: r'Shape.corner')
+                    .map(
+                      (e) => throw SimpleDecodingException(
+                        'Cannot decode List<NeverModel> - this type does not permit any value.',
+                      ),
+                    )
+                    .toList(),
+              );
+            }
+
+            factory Shape.fromForm(String? value, {required bool explode}) {
+              final _$values = value.decodeObject(
+                explode: explode,
+                explodeSeparator: '&',
+                expectedKeys: {r'corner'},
+                listKeys: {r'corner'},
+                context: r'Shape',
+              );
+              return Shape(
+                corner: _$values[r'corner']
+                    .decodeFormStringList(context: r'Shape.corner')
+                    .map(
+                      (e) => throw FormDecodingException(
+                        'Cannot decode List<NeverModel> - this type does not permit any value.',
+                      ),
+                    )
+                    .toList(),
+              );
+            }
+          }
+        ''';
+
+        expect(
+          collapseWhitespace(actual),
+          collapseWhitespace(format(expected)),
+        );
+      });
+    });
+
     group('uriEncode', () {
       test('generates uriEncode that throws for class with properties', () {
         final model = ClassModel(
@@ -2390,8 +2493,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
               ],
               context: context,
               additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+                valueModel: AnyModel(context: context),
+              ),
               examples: const [],
             );
 
@@ -2524,8 +2627,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
             ],
             context: context,
             additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+              valueModel: AnyModel(context: context),
+            ),
             examples: const [],
           );
 
@@ -2661,8 +2764,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
               ],
               context: context,
               additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+                valueModel: AnyModel(context: context),
+              ),
               examples: const [],
             );
 
@@ -2705,8 +2808,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
             ],
             context: context,
             additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+              valueModel: AnyModel(context: context),
+            ),
             examples: const [],
           );
 
@@ -2740,8 +2843,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
             ],
             context: context,
             additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+              valueModel: AnyModel(context: context),
+            ),
             examples: const [],
           );
 
@@ -2784,8 +2887,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
             ],
             context: context,
             additionalPropertiesPolicy: AllowedAdditionalProperties(
-            valueModel: AnyModel(context: context),
-          ),
+              valueModel: AnyModel(context: context),
+            ),
             examples: const [],
           );
 

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2642,51 +2642,60 @@ DateTime _parseResponse(Response<List<int>> response) {
     });
 
     group('NeverModel response bodies', () {
-      test('generates pure throw for ListModel<NeverModel> JSON body', () {
-        final operation = Operation(
-          operationId: 'listNeverOp',
-          context: context,
-          summary: '',
-          description: '',
-          tags: const {},
-          isDeprecated: false,
-          path: '/list-never',
-          method: HttpMethod.get,
-          headers: const {},
-          queryParameters: const {},
-          pathParameters: const {},
-          cookieParameters: const {},
-          responses: {
-            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
-              name: null,
-              context: context,
-              headers: const {},
-              description: '',
-              bodies: {
-                ResponseBody(
-                  model: ListModel(
-                    content: NeverModel(context: context),
-                    context: context,
+      test(
+        'decodes ListModel<NeverModel> JSON body before rejecting items',
+        () {
+          final operation = Operation(
+            operationId: 'listNeverOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/list-never',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: ListModel(
+                      content: NeverModel(context: context),
+                      context: context,
+                      examples: const [],
+                    ),
+                    rawContentType: 'application/json',
+                    contentType: ContentType.json,
                     examples: const [],
                   ),
-                  rawContentType: 'application/json',
-                  contentType: ContentType.json,
-                  examples: const [],
-                ),
-              },
-            ),
-          },
-          securitySchemes: const {},
-        );
-        final method = generator.generateParseResponseMethod(operation);
-        const expectedMethod = r'''
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
 List<Never> _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
-      throw JsonDecodingException(
-        'Cannot decode List<NeverModel> - this type does not permit any value.',
-      );
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json
+          .decodeJsonList<Object?>()
+          .map(
+            (e) => throw JsonDecodingException(
+              'Cannot decode List<NeverModel> - this type does not permit any value.',
+            ),
+          )
+          .toList();
+      return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
       final _$matched = _$mediaType ?? 'none';
@@ -2695,11 +2704,12 @@ List<Never> _parseResponse(Response<List<int>> response) {
   }
 }
 ''';
-        expect(
-          collapseWhitespace(format(method.accept(emitter).toString())),
-          collapseWhitespace(format(expectedMethod)),
-        );
-      });
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
 
       test('generates pure throw for non-nullable NeverModel JSON body', () {
         final operation = Operation(
@@ -3202,7 +3212,7 @@ Never _parseResponse(Response<List<int>> response) {
       );
 
       test(
-        'generates pure throw for required ListModel<NeverModel> '
+        'decodes required ListModel<NeverModel> '
         'form-urlencoded body',
         () {
           final operation = Operation(
@@ -3246,9 +3256,16 @@ List<Never> _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
-      throw FormDecodingException(
-        'Cannot decode List<NeverModel> - this type does not permit any value.',
-      );
+      final _$formString = decodeResponseText(response.data);
+      final _$body = _$formString
+          .decodeFormStringList()
+          .map(
+            (e) => throw FormDecodingException(
+              'Cannot decode List<NeverModel> - this type does not permit any value.',
+            ),
+          )
+          .toList();
+      return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
       final _$matched = _$mediaType ?? 'none';
@@ -3267,8 +3284,8 @@ List<Never> _parseResponse(Response<List<int>> response) {
       );
 
       test(
-        'nullable ListModel<NeverModel> form body emits pure throw without '
-        r'declaring an unused _$formString local',
+        'decodes nullable ListModel<NeverModel> form body before rejecting '
+        'items',
         () {
           final operation = Operation(
             operationId: 'formNullableListNeverBodyOp',
@@ -3312,9 +3329,16 @@ List<Never>? _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/x-www-form-urlencoded'):
-      throw FormDecodingException(
-        'Cannot decode List<NeverModel> - this type does not permit any value.',
-      );
+      final _$formString = decodeResponseText(response.data);
+      final _$body = _$formString
+          .decodeFormStringList()
+          .map(
+            (e) => throw FormDecodingException(
+              'Cannot decode List<NeverModel> - this type does not permit any value.',
+            ),
+          )
+          .toList();
+      return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
       final _$matched = _$mediaType ?? 'none';

--- a/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
@@ -824,7 +824,7 @@ void main() {
     });
 
     group('List of NeverModel', () {
-      test('generates bare throw for required non-nullable list', () {
+      test('decodes required non-nullable list before rejecting elements', () {
         final expression = buildFromFormValueExpression(
           refer('formString'),
           model: ListModel(
@@ -840,13 +840,12 @@ void main() {
         final code = expression.accept(DartEmitter()).toString();
         expect(
           code,
-          """throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')""",
+          """formString.decodeFormStringList().map((e) => throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
         );
       });
 
       test(
-        'generates null-guarded throw for required nullable list so the '
-        'caller-supplied local stays referenced',
+        'decodes required nullable list before rejecting elements',
         () {
           final expression = buildFromFormValueExpression(
             refer('formString'),
@@ -864,12 +863,12 @@ void main() {
           final code = expression.accept(DartEmitter()).toString();
           expect(
             code,
-            """formString == null ? null : throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')""",
+            """formString.decodeFormStringList().map((e) => throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
           );
         },
       );
 
-      test('generates null-guarded throw for optional non-nullable list', () {
+      test('decodes optional non-nullable list before rejecting elements', () {
         final expression = buildFromFormValueExpression(
           refer('formString'),
           model: ListModel(
@@ -885,7 +884,7 @@ void main() {
         final code = expression.accept(DartEmitter()).toString();
         expect(
           code,
-          """formString == null ? null : throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')""",
+          """formString.decodeFormNullableStringList()?.map((e) => throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
         );
       });
 
@@ -915,7 +914,7 @@ void main() {
           final code = expression.accept(DartEmitter()).toString();
           expect(
             code,
-            """formString == null ? null : throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')""",
+            """formString.decodeFormStringList().map((e) => throw  FormDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
           );
         },
       );

--- a/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
@@ -1571,7 +1571,7 @@ void main() {
       );
     });
 
-    test('generates throw for List of NeverModel', () {
+    test('decodes List of NeverModel before rejecting elements', () {
       final listModel = ListModel(
         content: NeverModel(context: context),
         context: context,
@@ -1585,7 +1585,7 @@ void main() {
       ).accept(emitter).toString();
       expect(
         result,
-        '''throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')''',
+        '''value.decodeJsonList<Object?>().map((e) => throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()''',
       );
     });
 
@@ -1606,7 +1606,7 @@ void main() {
         ).accept(emitter).toString();
         expect(
           result,
-          '''value == null ? null : throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')''',
+          '''value.decodeJsonNullableList<Object?>()?.map((e) => throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()''',
         );
       },
     );
@@ -1628,7 +1628,7 @@ void main() {
         ).accept(emitter).toString();
         expect(
           result,
-          '''value == null ? null : throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')''',
+          '''value.decodeJsonNullableList<Object?>()?.map((e) => throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()''',
         );
       },
     );
@@ -1777,7 +1777,7 @@ void main() {
     });
 
     test(
-      'nullable List of NeverModel still emits null-guarded throw '
+      'nullable List of NeverModel validates elements '
       'under useImmutableCollections',
       () {
         final listModel = ListModel(
@@ -1794,13 +1794,13 @@ void main() {
             package: 'my_package',
             useImmutableCollections: true,
           ).accept(emitter).toString(),
-          '''value == null ? null : throw  JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')''',
+          '''value == null ? null : IList(value.decodeJsonList<Object?>().map((e) => throw  JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList())''',
         );
       },
     );
 
     test(
-      'non-nullable List of NeverModel emits bare throw '
+      'non-nullable List of NeverModel validates elements '
       'under useImmutableCollections',
       () {
         final listModel = ListModel(
@@ -1816,7 +1816,7 @@ void main() {
             package: 'my_package',
             useImmutableCollections: true,
           ).accept(emitter).toString(),
-          '''throw  JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')''',
+          '''IList(value.decodeJsonList<Object?>().map((e) => throw  JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList())''',
         );
       },
     );

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -867,6 +867,44 @@ void main() {
           """value == null ? null : throw  _i1.SimpleDecodingException('Cannot decode NeverModel - this type does not permit any value.')""",
         );
       });
+
+      test('decodes required List<Never> before rejecting elements', () {
+        final value = refer('value');
+        expect(
+          buildSimpleValueExpression(
+            value,
+            model: ListModel(
+              content: NeverModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            nameManager: nameManager,
+            package: 'my_package',
+            explode: literalBool(false),
+          ).accept(scopedEmitter).toString(),
+          """value.decodeSimpleStringList().map((e) => throw  _i1.SimpleDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
+        );
+      });
+
+      test('decodes optional List<Never> before rejecting elements', () {
+        final value = refer('value');
+        expect(
+          buildSimpleValueExpression(
+            value,
+            model: ListModel(
+              content: NeverModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: false,
+            nameManager: nameManager,
+            package: 'my_package',
+            explode: literalBool(false),
+          ).accept(scopedEmitter).toString(),
+          """value.decodeSimpleNullableStringList()?.map((e) => throw  _i1.SimpleDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()""",
+        );
+      });
     });
 
     group('unsupported model types generate runtime throws', () {


### PR DESCRIPTION
## Summary

- decode List<Never> by validating actual elements, so empty arrays succeed and non-empty arrays fail
- use the normal class decode setup path, which consumes the generated map/value locals without a special suppression heuristic
- apply the corrected behavior to JSON, simple, form, and response-body decoders
- add OpenAPI 3.1 items: false integration coverage for both valid empty and invalid non-empty values, exercised by the generated-code analyzer

## Testing

- fvm dart test in packages/tonik_generate (2,987 tests)
- fvm dart analyze in packages/tonik_generate
- fvm dart analyze in integration_test/boolean_schemas/boolean_schemas_api
- fvm dart analyze in integration_test/boolean_schemas/boolean_schemas_test
- fvm dart test test/type_verification_test.dart in integration_test/boolean_schemas/boolean_schemas_test