### PR TITLE
Fold null type members of oneOf and anyOf into nullability

### DIFF
--- a/integration_test/composition/composition_test/test/null_member_test.dart
+++ b/integration_test/composition/composition_test/test/null_member_test.dart
@@ -1,0 +1,95 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('NullMemberHolder', () {
+    test('fromJson decodes null members to null', () {
+      final holder = NullMemberHolder.fromJson(const {
+        'oneOfValue': null,
+        'oneOfRefValue': null,
+        'anyOfValue': null,
+      });
+
+      expect(holder.oneOfValue, isNull);
+      expect(holder.oneOfRefValue, isNull);
+      expect(holder.anyOfValue, isNull);
+    });
+
+    test('json roundtrip preserves null members', () {
+      final holder = NullMemberHolder.fromJson(const {
+        'oneOfValue': null,
+        'oneOfRefValue': null,
+        'anyOfValue': null,
+      });
+
+      expect(holder.toJson(), {
+        'oneOfValue': null,
+        'oneOfRefValue': null,
+        'anyOfValue': null,
+      });
+    });
+
+    test('fromJson decodes non-null members to variants', () {
+      final holder = NullMemberHolder.fromJson(const {
+        'oneOfValue': {'name': 'Kate'},
+        'oneOfRefValue': {'name': 'Mark'},
+        'anyOfValue': {'name': 'Lena'},
+      });
+
+      expect(
+        holder.oneOfValue,
+        const $RawOneOfWithNullClass1(Class1(name: 'Kate')),
+      );
+      expect(
+        holder.oneOfRefValue,
+        const $RawOneOfWithNullRefClass1(Class1(name: 'Mark')),
+      );
+      expect(
+        holder.anyOfValue,
+        const $RawAnyOfWithNull(class1: Class1(name: 'Lena')),
+      );
+    });
+
+    test('json roundtrip preserves non-null members', () {
+      final holder = NullMemberHolder.fromJson(const {
+        'oneOfValue': {'name': 'Kate'},
+        'oneOfRefValue': {'name': 'Mark'},
+        'anyOfValue': {'name': 'Lena'},
+      });
+
+      expect(holder.toJson(), {
+        'oneOfValue': {'name': 'Kate'},
+        'oneOfRefValue': {'name': 'Mark'},
+        'anyOfValue': {'name': 'Lena'},
+      });
+    });
+  });
+
+  group('OneOfWithNull', () {
+    test('fromJson throws when no variant matches', () {
+      expect(
+        () => $RawOneOfWithNull.fromJson(const {'wings': 2}),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+  });
+
+  group('OneOfWithNullRef', () {
+    test('fromJson throws when no variant matches', () {
+      expect(
+        () => $RawOneOfWithNullRef.fromJson(const {'wings': 2}),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+  });
+
+  group('AnyOfWithNull', () {
+    test('fromJson throws when no variant matches', () {
+      expect(
+        () => $RawAnyOfWithNull.fromJson(const {'wings': 2}),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+  });
+}

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -939,3 +939,35 @@ components:
       anyOf:
         - true
         - $ref: '#/components/schemas/Class1'
+
+    NullType:
+      type: "null"
+
+    OneOfWithNull:
+      oneOf:
+        - $ref: '#/components/schemas/Class1'
+        - type: "null"
+
+    OneOfWithNullRef:
+      oneOf:
+        - $ref: '#/components/schemas/Class1'
+        - $ref: '#/components/schemas/NullType'
+
+    AnyOfWithNull:
+      anyOf:
+        - $ref: '#/components/schemas/Class1'
+        - type: "null"
+
+    NullMemberHolder:
+      type: object
+      required:
+        - oneOfValue
+        - oneOfRefValue
+        - anyOfValue
+      properties:
+        oneOfValue:
+          $ref: '#/components/schemas/OneOfWithNull'
+        oneOfRefValue:
+          $ref: '#/components/schemas/OneOfWithNullRef'
+        anyOfValue:
+          $ref: '#/components/schemas/AnyOfWithNull'

--- a/integration_test/totem/totem_test/imposter/response.groovy
+++ b/integration_test/totem/totem_test/imposter/response.groovy
@@ -26,6 +26,49 @@ if (context.request.method == 'DELETE') {
     return
 }
 
+// Imposter's spec-generated examples emit invalid `{}` for
+// anyOf-nullable properties, so these endpoints serve static bodies.
+
+def path = context.request.path
+
+if (path == '/api/mobile/protected/users/current') {
+    respond {
+        withStatusCode 200
+        withHeader 'Content-Type', 'application/json'
+        withContent '''{
+            "profile_avatar_type": "TD",
+            "circle_count": 42,
+            "name": "Test User",
+            "slug": null,
+            "is_staff": false,
+            "api_key": "d864e295-213e-4bf0-b27a-81e6d5583cdf",
+            "profile_avatar_seed": "0bff137a-4255-460f-a3da-bc6b0d9c2a34",
+            "profile_image": null,
+            "email": "user@example.com",
+            "date_created": "2026-07-14T18:11:14Z"
+        }'''
+    }
+    return
+}
+
+if (path.startsWith('/api/mobile/protected/users/profile/')) {
+    respond {
+        withStatusCode 200
+        withHeader 'Content-Type', 'application/json'
+        withContent '''{
+            "profile_avatar_type": "TD",
+            "circle_count": null,
+            "name": null,
+            "slug": "test-user",
+            "is_staff": false,
+            "profile_avatar_seed": "0bff137a-4255-460f-a3da-bc6b0d9c2a34",
+            "profile_image": null,
+            "date_created": "2026-07-14T18:11:14Z"
+        }'''
+    }
+    return
+}
+
 // ── Default: let Imposter generate responses from the spec ─────────────
 
 respond()

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -678,6 +678,10 @@ class ModelImporter {
 
     final resolvedModels = <DiscriminatedModel>{};
     for (final oneOfSchema in alternatives) {
+      if (_isNullOnlySchema(oneOfSchema)) {
+        shell.isNullable = true;
+        continue;
+      }
       final model = _resolveCompositeSubModel(
         oneOfSchema,
         modelContext,
@@ -720,6 +724,10 @@ class ModelImporter {
 
     final resolvedModels = <DiscriminatedModel>{};
     for (final anyOfSchema in alternatives) {
+      if (_isNullOnlySchema(anyOfSchema)) {
+        shell.isNullable = true;
+        continue;
+      }
       final model = _resolveCompositeSubModel(
         anyOfSchema,
         modelContext,
@@ -1695,17 +1703,22 @@ class ModelImporter {
       models.add(oneOfModel);
     }
 
-    final resolvedModels = alternatives.map(
-      (oneOfSchema) => (
+    final resolvedModels = <DiscriminatedModel>{};
+    for (final oneOfSchema in alternatives) {
+      if (_isNullOnlySchema(oneOfSchema)) {
+        oneOfModel.isNullable = true;
+        continue;
+      }
+      resolvedModels.add((
         discriminatorValue: _getDiscriminatorValue(
           discriminator: effectiveDiscriminator,
           innerSchema: oneOfSchema,
         ),
         model: _resolveSchemaRef(null, oneOfSchema, modelContext),
-      ),
-    );
+      ));
+    }
 
-    oneOfModel.models = resolvedModels.toSet();
+    oneOfModel.models = resolvedModels;
 
     // Nested composite members enter the global model set after resolution.
     for (final nestedModel in oneOfModel.models) {
@@ -1742,17 +1755,22 @@ class ModelImporter {
       models.add(anyOfModel);
     }
 
-    final resolvedModels = alternatives.map(
-      (anyOfSchema) => (
+    final resolvedModels = <DiscriminatedModel>{};
+    for (final anyOfSchema in alternatives) {
+      if (_isNullOnlySchema(anyOfSchema)) {
+        anyOfModel.isNullable = true;
+        continue;
+      }
+      resolvedModels.add((
         discriminatorValue: _getDiscriminatorValue(
           discriminator: effectiveDiscriminator,
           innerSchema: anyOfSchema,
         ),
         model: _resolveSchemaRef(null, anyOfSchema, modelContext),
-      ),
-    );
+      ));
+    }
 
-    anyOfModel.models = resolvedModels.toSet();
+    anyOfModel.models = resolvedModels;
 
     return anyOfModel;
   }
@@ -1821,6 +1839,24 @@ class ModelImporter {
     }
 
     return null;
+  }
+
+  /// Returns true if [schema] permits only the JSON literal `null`,
+  /// i.e. its type — possibly behind `$ref`s — is exactly `"null"`.
+  bool _isNullOnlySchema(Schema schema) {
+    var current = schema;
+    final seenRefs = <String>{};
+    while (current.ref != null) {
+      if (!seenRefs.add(current.ref!)) {
+        return false;
+      }
+      final resolved = _resolveSchemaToSchema(current);
+      if (resolved == null) {
+        return false;
+      }
+      current = resolved;
+    }
+    return current.type.isNotEmpty && current.type.every((t) => t == 'null');
   }
 
   Schema? _resolveSchemaToSchema(Schema schema) {

--- a/packages/tonik_parse/test/model/model_composite_null_member_test.dart
+++ b/packages/tonik_parse/test/model/model_composite_null_member_test.dart
@@ -1,0 +1,207 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+void main() {
+  const fileContent = {
+    'openapi': '3.1.0',
+    'info': {'title': 'Test API', 'version': '1.0.0'},
+    'paths': <String, dynamic>{},
+    'components': {
+      'schemas': {
+        'Cat': {
+          'type': 'object',
+          'properties': {
+            'meow': {'type': 'string'},
+          },
+          'required': ['meow'],
+        },
+        'Dog': {
+          'type': 'object',
+          'properties': {
+            'bark': {'type': 'string'},
+          },
+          'required': ['bark'],
+        },
+        'Nothing': {'type': 'null'},
+        'OneOfWithInlineNull': {
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Dog'},
+            {'type': 'null'},
+          ],
+        },
+        'OneOfWithNullRef': {
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Nothing'},
+          ],
+        },
+        'OneOfWithNullTypeArray': {
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {
+              'type': ['null'],
+            },
+          ],
+        },
+        'OneOfOnlyNull': {
+          'oneOf': [
+            {'type': 'null'},
+          ],
+        },
+        'OneOfWithoutNull': {
+          'oneOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Dog'},
+          ],
+        },
+        'AnyOfWithInlineNull': {
+          'anyOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {'type': 'null'},
+          ],
+        },
+        'AnyOfWithNullRef': {
+          'anyOf': [
+            {r'$ref': '#/components/schemas/Cat'},
+            {r'$ref': '#/components/schemas/Nothing'},
+          ],
+        },
+        'HolderWithInlineComposites': {
+          'type': 'object',
+          'properties': {
+            'oneOfValue': {
+              'oneOf': [
+                {'type': 'string'},
+                {'type': 'null'},
+              ],
+            },
+            'anyOfValue': {
+              'anyOf': [
+                {'type': 'string'},
+                {'type': 'null'},
+              ],
+            },
+          },
+        },
+      },
+    },
+  };
+
+  OneOfModel oneOf(ApiDocument api, String name) =>
+      api.models.firstWhere((m) => m is NamedModel && m.name == name)
+          as OneOfModel;
+
+  AnyOfModel anyOf(ApiDocument api, String name) =>
+      api.models.firstWhere((m) => m is NamedModel && m.name == name)
+          as AnyOfModel;
+
+  group('oneOf with null type member', () {
+    test('inline null member is folded into isNullable', () {
+      final api = Importer().import(fileContent);
+      final model = oneOf(api, 'OneOfWithInlineNull');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(2));
+      expect(
+        model.models.map((m) => (m.model as ClassModel).name),
+        unorderedEquals(['Cat', 'Dog']),
+      );
+    });
+
+    test('null member referenced via ref is folded into isNullable', () {
+      final api = Importer().import(fileContent);
+      final model = oneOf(api, 'OneOfWithNullRef');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect((model.models.single.model as ClassModel).name, 'Cat');
+    });
+
+    test('null member in type array form is folded into isNullable', () {
+      final api = Importer().import(fileContent);
+      final model = oneOf(api, 'OneOfWithNullTypeArray');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect((model.models.single.model as ClassModel).name, 'Cat');
+    });
+
+    test('oneOf with only a null member keeps an empty model set', () {
+      final api = Importer().import(fileContent);
+      final model = oneOf(api, 'OneOfOnlyNull');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, isEmpty);
+    });
+
+    test('oneOf without null member stays non-nullable', () {
+      final api = Importer().import(fileContent);
+      final model = oneOf(api, 'OneOfWithoutNull');
+
+      expect(model.isNullable, isFalse);
+      expect(model.models, hasLength(2));
+    });
+
+    test('inline oneOf property with null member is folded', () {
+      final api = Importer().import(fileContent);
+      final holder =
+          api.models.firstWhere(
+                (m) =>
+                    m is NamedModel &&
+                    m.name == 'HolderWithInlineComposites',
+              )
+              as ClassModel;
+
+      final property = holder.properties.firstWhere(
+        (p) => p.name == 'oneOfValue',
+      );
+      final model = property.model as OneOfModel;
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect(model.models.single.model, isA<StringModel>());
+    });
+  });
+
+  group('anyOf with null type member', () {
+    test('inline null member is folded into isNullable', () {
+      final api = Importer().import(fileContent);
+      final model = anyOf(api, 'AnyOfWithInlineNull');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect((model.models.single.model as ClassModel).name, 'Cat');
+    });
+
+    test('null member referenced via ref is folded into isNullable', () {
+      final api = Importer().import(fileContent);
+      final model = anyOf(api, 'AnyOfWithNullRef');
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect((model.models.single.model as ClassModel).name, 'Cat');
+    });
+
+    test('inline anyOf property with null member is folded', () {
+      final api = Importer().import(fileContent);
+      final holder =
+          api.models.firstWhere(
+                (m) =>
+                    m is NamedModel &&
+                    m.name == 'HolderWithInlineComposites',
+              )
+              as ClassModel;
+
+      final property = holder.properties.firstWhere(
+        (p) => p.name == 'anyOfValue',
+      );
+      final model = property.model as AnyOfModel;
+
+      expect(model.isNullable, isTrue);
+      expect(model.models, hasLength(1));
+      expect(model.models.single.model, isA<StringModel>());
+    });
+  });
+}


### PR DESCRIPTION
## Problem

In OpenAPI 3.1, a `{type: "null"}` member is the JSON-Schema-conformant way to make a `oneOf`/`anyOf` accept the JSON literal `null`. Tonik imported such a member as an empty free-form class model, which caused two defects:

- **Null was not representable**: JSON `null` decoded to a non-null empty object and re-encoded as `{}`, silently corrupting data on round-trip.
- **Validation was defeated**: the empty class's `fromJson` accepts any input, so it acted as a catch-all. For `oneOf`, any value matching no real variant was silently accepted instead of rejected. For `anyOf`, the "all variants failed" check could never fire, and the junk member also polluted decoding of valid values, breaking equality and re-encoding.

## Fix

The parser now folds a null-only member (its `type` is exactly `"null"`, directly, in array form, or behind `$ref`s) into `isNullable` on the composite model and drops it from the member set, at all four member-resolution sites (named shell population and inline parsing, for both `oneOf` and `anyOf`).

This mirrors how the importer already handles the equivalent short forms: multi-type schemas like `type: ["string", "null"]` and enums containing a `null` entry both fold into `isNullable`. Downstream, the existing nullable-composite generation applies: use sites become nullable, `null` round-trips as `null`, and unmatched input throws a decoding exception.

## Tests

- Parser tests covering the fold for `oneOf` and `anyOf`: inline members, `type: ["null"]` array form, `$ref` to a null-only component, inline property composites, a composite with only a null member, and a guard that composites without a null member stay non-nullable.
- Integration tests in the composition suite: `null` and non-null values round-trip correctly through a holder object for `oneOf`, `oneOf` via `$ref`, and `anyOf`; unmatched input now throws `JsonDecodingException` for all three.
