### PR TITLE
Fix location-suffix parameter name collisions

### DIFF
--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -18,6 +18,7 @@ import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/weird_property_names.dart';
 import 'package:naming_api/src/operation/get_hostile_query_names.dart';
 import 'package:naming_api/src/operation/get_param_counter_collision.dart';
+import 'package:naming_api/src/operation/get_param_suffix_collision.dart';
 import 'package:naming_api/src/operation/get_with_call_query.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_cookie.dart';
 import 'package:naming_api/src/operation/get_with_cancel_token_header.dart';
@@ -474,6 +475,68 @@ void main() {
       },
     );
   });
+
+  group(
+    'location-suffix collision with declared name (GetParamSuffixCollision)',
+    () {
+      test(
+        'exposes three distinct Dart parameter names — idPath2, idQuery, '
+        'idPath — and each serialises under its declared wire key',
+        () async {
+          final dio = Dio(BaseOptions(baseUrl: 'http://localhost'));
+          Uri? capturedUri;
+          dio.interceptors.add(
+            InterceptorsWrapper(
+              onRequest: (options, handler) {
+                capturedUri = options.uri;
+                handler.reject(
+                  DioException(
+                    requestOptions: options,
+                    type: DioExceptionType.cancel,
+                  ),
+                );
+              },
+            ),
+          );
+
+          final operation = GetParamSuffixCollision(dio);
+
+          await operation.call(
+            idPath2: 'P',
+            idQuery: 42,
+            idPath: true,
+          );
+
+          expect(capturedUri, isNotNull);
+          final uri = capturedUri!;
+
+          expect(uri.path, contains('/param-suffix-collision/P'));
+
+          final params = uri.queryParametersAll;
+
+          expect(
+            params['id'],
+            ['42'],
+            reason: 'idQuery must serialise under wire key "id".',
+          );
+          expect(
+            params['idPath'],
+            ['true'],
+            reason:
+                'The declared idPath parameter keeps both its Dart name and '
+                'its wire key "idPath".',
+          );
+          expect(
+            params.containsKey('idPath2'),
+            isFalse,
+            reason:
+                'No query key should adopt the renamed Dart identifier — that '
+                'would corrupt the outgoing request.',
+          );
+        },
+      );
+    },
+  );
 
   group('hostile but valid query parameter names', () {
     test('uses valid Dart names while preserving the wire names', () async {

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -686,6 +686,31 @@ paths:
               schema:
                 $ref: '#/components/schemas/SimpleResult'
 
+  /param-suffix-collision/{id}:
+    get:
+      operationId: getParamSuffixCollision
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: id
+          in: query
+          schema:
+            type: integer
+        - name: idPath
+          in: query
+          schema:
+            type: boolean
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SimpleResult'
+
   /param-duplicates/{id}:
     get:
       operationId: getWithDuplicateParams

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -93,108 +93,101 @@ NormalizedRequestParameters normalizeRequestParameters({
   }
 
   // Parameters that collide across locations get a location suffix.
-  final resolvedPathParams = normalizedPathParams.map((item) {
-    final lowerName = item.normalizedName.toLowerCase();
-    if (nameInTypes[lowerName]!.length > 1) {
-      return (
-        normalizedName: '${item.normalizedName}$_pathSuffix',
-        parameter: item.parameter,
-      );
-    }
-    return item;
-  }).toList();
-
-  final resolvedQueryParams = normalizedQueryParams.map((item) {
-    final lowerName = item.normalizedName.toLowerCase();
-    if (nameInTypes[lowerName]!.length > 1) {
-      return (
-        normalizedName: '${item.normalizedName}$_querySuffix',
-        parameter: item.parameter,
-      );
-    }
-    return item;
-  }).toList();
-
-  final resolvedHeaderParams = normalizedHeaders.map((item) {
-    final lowerName = item.normalizedName.toLowerCase();
-    if (nameInTypes[lowerName]!.length > 1) {
-      return (
-        normalizedName: '${item.normalizedName}$_headerSuffix',
-        parameter: item.parameter,
-      );
-    }
-    return item;
-  }).toList();
-
-  final resolvedCookieParams = normalizedCookies
-      .map<({String normalizedName, CookieParameterObject parameter})>((item) {
-        final lowerName = item.normalizedName.toLowerCase();
-        if (nameInTypes[lowerName]!.length > 1) {
-          return (
-            normalizedName: '${item.normalizedName}$_cookieSuffix',
-            parameter: item.parameter,
-          );
-        }
-        return item;
-      })
+  final resolvedPathParams = normalizedPathParams
+      .map((item) => _applySuffix(item, nameInTypes, _pathSuffix))
       .toList();
 
-  final uniquePathParams = _ensureUniquenessInGroup(resolvedPathParams);
-  final uniqueQueryParams = _ensureUniquenessInGroup(resolvedQueryParams);
-  final uniqueHeaderParams = _ensureUniquenessInGroup(resolvedHeaderParams);
-  final uniqueCookieParams = _ensureUniquenessInGroup(resolvedCookieParams);
+  final resolvedQueryParams = normalizedQueryParams
+      .map((item) => _applySuffix(item, nameInTypes, _querySuffix))
+      .toList();
+
+  final resolvedHeaderParams = normalizedHeaders
+      .map((item) => _applySuffix(item, nameInTypes, _headerSuffix))
+      .toList();
+
+  final resolvedCookieParams = normalizedCookies
+      .map((item) => _applySuffix(item, nameInTypes, _cookieSuffix))
+      .toList();
+
+  final assigner = _NameAssigner(
+    totalParameterCount:
+        resolvedPathParams.length +
+        resolvedQueryParams.length +
+        resolvedHeaderParams.length +
+        resolvedCookieParams.length,
+    reservedNames: reservedNames,
+  );
+
+  final pathNames = List<String?>.filled(resolvedPathParams.length, null);
+  final queryNames = List<String?>.filled(resolvedQueryParams.length, null);
+  final headerNames = List<String?>.filled(resolvedHeaderParams.length, null);
+  final cookieNames = List<String?>.filled(resolvedCookieParams.length, null);
+
+  // Unsuffixed names are claimed across all locations first so a declared
+  // parameter keeps its own name; a synthesized (suffixed) name that lands
+  // on a declared one disambiguates further with a counter.
+  for (final suffixedPass in [false, true]) {
+    assigner
+      ..claimInto(resolvedPathParams, pathNames, suffixedPass: suffixedPass)
+      ..claimInto(resolvedQueryParams, queryNames, suffixedPass: suffixedPass)
+      ..claimInto(resolvedHeaderParams, headerNames, suffixedPass: suffixedPass)
+      ..claimInto(
+        resolvedCookieParams,
+        cookieNames,
+        suffixedPass: suffixedPass,
+      );
+  }
 
   return NormalizedRequestParameters(
-    pathParameters: uniquePathParams,
-    queryParameters: uniqueQueryParams,
-    headers: uniqueHeaderParams,
-    cookieParameters: uniqueCookieParams,
+    pathParameters: [
+      for (var i = 0; i < resolvedPathParams.length; i++)
+        (
+          normalizedName: pathNames[i]!,
+          parameter: resolvedPathParams[i].parameter,
+        ),
+    ],
+    queryParameters: [
+      for (var i = 0; i < resolvedQueryParams.length; i++)
+        (
+          normalizedName: queryNames[i]!,
+          parameter: resolvedQueryParams[i].parameter,
+        ),
+    ],
+    headers: [
+      for (var i = 0; i < resolvedHeaderParams.length; i++)
+        (
+          normalizedName: headerNames[i]!,
+          parameter: resolvedHeaderParams[i].parameter,
+        ),
+    ],
+    cookieParameters: [
+      for (var i = 0; i < resolvedCookieParams.length; i++)
+        (
+          normalizedName: cookieNames[i]!,
+          parameter: resolvedCookieParams[i].parameter,
+        ),
+    ],
   );
 }
 
-List<({String normalizedName, T parameter})> _ensureUniquenessInGroup<T>(
-  List<({String normalizedName, T parameter})> parameters,
+({String normalizedName, bool wasSuffixed, T parameter}) _applySuffix<T>(
+  ({String normalizedName, T parameter}) item,
+  Map<String, Set<String>> nameInTypes,
+  String suffix,
 ) {
-  final result = <({String normalizedName, T parameter})>[];
-  final usedNames = <String>{};
-  final nameCounters = <String, int>{};
-
-  // Worst case: all N parameters share the same base, so the maximum
-  // counter value reached is N. The +2 buffer gives headroom and matches
-  // the initial counter value of 2.
-  final convergenceBound = parameters.length + 2;
-
-  for (final item in parameters) {
-    final baseName = item.normalizedName;
-    final baseLowerName = baseName.toLowerCase();
-
-    var name = baseName;
-    var lowerName = baseLowerName;
-
-    nameCounters.putIfAbsent(baseLowerName, () => 2);
-
-    // Loop (not single increment) because a counter-generated candidate may
-    // itself collide with an earlier entry: group [tokenQuery, tokenQuery2,
-    // tokenQuery] — naive increment yields tokenQuery2, which already exists.
-    while (usedNames.contains(lowerName)) {
-      final counter = nameCounters[baseLowerName]!;
-      if (counter > convergenceBound) {
-        throw StateError(
-          'Counter for "$baseName" exceeded parameters.length + 2 '
-          '($convergenceBound); _ensureUniquenessInGroup is not '
-          'converging — counter increment is broken.',
-        );
-      }
-      name = '$baseName$counter';
-      lowerName = name.toLowerCase();
-      nameCounters[baseLowerName] = counter + 1;
-    }
-
-    usedNames.add(lowerName);
-    result.add((normalizedName: name, parameter: item.parameter));
+  final lowerName = item.normalizedName.toLowerCase();
+  if (nameInTypes[lowerName]!.length > 1) {
+    return (
+      normalizedName: '${item.normalizedName}$suffix',
+      wasSuffixed: true,
+      parameter: item.parameter,
+    );
   }
-
-  return result;
+  return (
+    normalizedName: item.normalizedName,
+    wasSuffixed: false,
+    parameter: item.parameter,
+  );
 }
 
 /// Normalizes path parameter names.
@@ -291,4 +284,64 @@ String normalizeMultipartHeaderName(
 String _normalizeName(String name) {
   final normalized = normalizeSingle(name, preserveNumbers: true);
   return normalized.isEmpty ? _defaultParameterPrefix : normalized;
+}
+
+/// Assigns final parameter names, unique (case-insensitively) across all
+/// locations and reserved names.
+class _NameAssigner {
+  _NameAssigner({
+    required int totalParameterCount,
+    required Set<String> reservedNames,
+  }) : _convergenceBound = totalParameterCount + reservedNames.length + 2 {
+    _usedNames.addAll(reservedNames.map((name) => name.toLowerCase()));
+  }
+
+  final Set<String> _usedNames = <String>{};
+  final Map<String, int> _nameCounters = <String, int>{};
+
+  // Worst case: all names share the same base, so the maximum counter value
+  // reached is the total name count. The +2 buffer gives headroom and matches
+  // the initial counter value of 2.
+  final int _convergenceBound;
+
+  void claimInto<T>(
+    List<({String normalizedName, bool wasSuffixed, T parameter})> group,
+    List<String?> names, {
+    required bool suffixedPass,
+  }) {
+    for (var i = 0; i < group.length; i++) {
+      if (group[i].wasSuffixed == suffixedPass) {
+        names[i] = _claim(group[i].normalizedName);
+      }
+    }
+  }
+
+  String _claim(String baseName) {
+    final baseLowerName = baseName.toLowerCase();
+
+    var name = baseName;
+    var lowerName = baseLowerName;
+
+    _nameCounters.putIfAbsent(baseLowerName, () => 2);
+
+    // Loop (not single increment) because a counter-generated candidate may
+    // itself collide with an earlier entry: [tokenQuery, tokenQuery2,
+    // tokenQuery] — naive increment yields tokenQuery2, which already exists.
+    while (_usedNames.contains(lowerName)) {
+      final counter = _nameCounters[baseLowerName]!;
+      if (counter > _convergenceBound) {
+        throw StateError(
+          'Counter for "$baseName" exceeded the total name count + 2 '
+          '($_convergenceBound); _NameAssigner is not converging — '
+          'counter increment is broken.',
+        );
+      }
+      name = '$baseName$counter';
+      lowerName = name.toLowerCase();
+      _nameCounters[baseLowerName] = counter + 1;
+    }
+
+    _usedNames.add(lowerName);
+    return name;
+  }
 }

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -93,6 +93,74 @@ void main() {
       },
     );
 
+    test(
+      'renames suffixed parameter with counter when a declared parameter '
+      'already has the suffixed name',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {createPathParameter('id')},
+          queryParameters: {
+            createQueryParameter('id'),
+            createQueryParameter('idPath'),
+          },
+          headers: {},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
+          'idPath2',
+        ]);
+        expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+          'idQuery',
+          'idPath',
+        ]);
+      },
+    );
+
+    test(
+      'skips counter values already taken by declared parameter names',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {createPathParameter('id')},
+          queryParameters: {
+            createQueryParameter('id'),
+            createQueryParameter('idPath'),
+            createQueryParameter('idPath2'),
+          },
+          headers: {},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
+          'idPath3',
+        ]);
+        expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+          'idQuery',
+          'idPath',
+          'idPath2',
+        ]);
+      },
+    );
+
+    test(
+      'keeps declared header-suffixed name and renames the synthesized one',
+      () {
+        final result = normalizeRequestParameters(
+          pathParameters: {createPathParameter('id')},
+          queryParameters: {createQueryParameter('idHeader')},
+          headers: {createHeader('id')},
+        );
+
+        expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
+          'idPath',
+        ]);
+        expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
+          'idHeader',
+        ]);
+        expect(result.headers.map((r) => r.normalizedName).toList(), [
+          'idHeader2',
+        ]);
+      },
+    );
+
     test('handles Dart keywords', () {
       final result = normalizeRequestParameters(
         pathParameters: {createPathParameter('class')},


### PR DESCRIPTION
## Summary

When an operation has same-named parameters in different locations (e.g. path `id` + query `id`), the normalizer disambiguates them with location suffixes (`idPath`, `idQuery`). Those synthesized names were never checked against the rest of the parameter set, so a parameter literally named `idPath` collided with the synthesized one: two named parameters collapsed to the same Dart identifier (`duplicate_definition` in both the operation class and the api client), and the api client's argument-forwarding map silently dropped one value.

```yaml
parameters:
  - name: id
    in: path
    required: true
  - name: id
    in: query
  - name: idPath
    in: query
```

## Fix

`normalizeRequestParameters` now assigns final names in a single pass that is unique across all locations (and reserved names), instead of enforcing uniqueness per location group:

- Names left untouched by the location-suffix step are claimed first, so a declared parameter always keeps its own name.
- Synthesized (suffixed) names that land on a taken name disambiguate further with the existing counter fallback: path `id` → `idPath2` when `idPath` is declared.
- Wire names are unaffected; only the Dart-side identifiers change.

All generators consume the normalizer, so the operation class and api client stay consistent and the forwarding map can no longer drop an argument.

## Testing

- New unit tests covering the collision, counter skipping (`idPath2` also declared → `idPath3`), and the header-suffix variant.
- New integration operation `/param-suffix-collision/{id}` in the naming suite; the generated package previously failed analysis with `duplicate_definition`, now analyzes clean, and a wire-key test asserts each parameter serialises under its declared name.
- Full `tonik_generate` suite, naming integration suite, and `dart analyze` over `tonik_generate` + `integration_test` all pass.
