### PR TITLE
Import null-only schemas as nullable Never type

### DIFF
--- a/integration_test/composition/composition_test/test/standalone_null_operation_test.dart
+++ b/integration_test/composition/composition_test/test/standalone_null_operation_test.dart
@@ -1,0 +1,47 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  CompositionApi buildApi(String responseBody) {
+    return CompositionApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Body': responseBody},
+          ),
+        ),
+      ),
+    );
+  }
+
+  group('getStandaloneNull', () {
+    test('decodes a null response body to null', () async {
+      final api = buildApi('null');
+      final result = await api.getStandaloneNull();
+
+      final success = result as TonikSuccess<StandaloneNullEchoGet200Response>;
+      expect(success.value.body, isNull);
+      expect(success.value.xNullHeader, isNull);
+    });
+
+    test('returns a decoding error for a non-null response body', () async {
+      final api = buildApi('{}');
+      final result = await api.getStandaloneNull();
+
+      final error = result as TonikError;
+      expect(error.type, TonikErrorType.decoding);
+    });
+  });
+}

--- a/integration_test/composition/composition_test/test/standalone_null_test.dart
+++ b/integration_test/composition/composition_test/test/standalone_null_test.dart
@@ -1,0 +1,97 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('StandaloneNullHolder', () {
+    test('fromJson decodes null values to null', () {
+      final holder = StandaloneNullHolder.fromJson(const {
+        'viaRef': null,
+        'inline': null,
+        'nullList': [null, null],
+        'nullMap': {'first': null},
+      });
+
+      expect(holder.viaRef, isNull);
+      expect(holder.inline, isNull);
+      expect(holder.nullList, [null, null]);
+      expect(holder.nullMap, {'first': null});
+    });
+
+    test('json roundtrip preserves null values', () {
+      final holder = StandaloneNullHolder.fromJson(const {
+        'viaRef': null,
+        'inline': null,
+        'nullList': [null],
+        'nullMap': {'first': null},
+      });
+
+      expect(holder.toJson(), {
+        'viaRef': null,
+        'inline': null,
+        'nullList': [null],
+        'nullMap': {'first': null},
+      });
+    });
+
+    test('fromJson throws for empty object via ref', () {
+      expect(
+        () => StandaloneNullHolder.fromJson(const {
+          'viaRef': <String, Object?>{},
+          'inline': null,
+          'nullList': <Object?>[],
+          'nullMap': <String, Object?>{},
+        }),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+
+    test('fromJson throws for non-empty object via ref', () {
+      expect(
+        () => StandaloneNullHolder.fromJson(const {
+          'viaRef': {'a': 1},
+          'inline': null,
+          'nullList': <Object?>[],
+          'nullMap': <String, Object?>{},
+        }),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+
+    test('fromJson throws for non-null inline value', () {
+      expect(
+        () => StandaloneNullHolder.fromJson(const {
+          'viaRef': null,
+          'inline': 'value',
+          'nullList': <Object?>[],
+          'nullMap': <String, Object?>{},
+        }),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+
+    test('fromJson throws for non-null list element', () {
+      expect(
+        () => StandaloneNullHolder.fromJson(const {
+          'viaRef': null,
+          'inline': null,
+          'nullList': [1],
+          'nullMap': <String, Object?>{},
+        }),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+
+    test('fromJson throws for non-null map value', () {
+      expect(
+        () => StandaloneNullHolder.fromJson(const {
+          'viaRef': null,
+          'inline': null,
+          'nullList': <Object?>[],
+          'nullMap': {'first': 1},
+        }),
+        throwsA(isA<JsonDecodingException>()),
+      );
+    });
+  });
+}

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -971,3 +971,24 @@ components:
           $ref: '#/components/schemas/OneOfWithNullRef'
         anyOfValue:
           $ref: '#/components/schemas/AnyOfWithNull'
+
+    StandaloneNullHolder:
+      type: object
+      required:
+        - viaRef
+        - inline
+        - nullList
+        - nullMap
+      properties:
+        viaRef:
+          $ref: '#/components/schemas/NullType'
+        inline:
+          type: "null"
+        nullList:
+          type: array
+          items:
+            type: "null"
+        nullMap:
+          type: object
+          additionalProperties:
+            type: "null"

--- a/integration_test/composition/openapi.yaml
+++ b/integration_test/composition/openapi.yaml
@@ -149,6 +149,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/OneOfBase64OrString'
 
+  /standalone-null/echo:
+    get:
+      operationId: getStandaloneNull
+      tags:
+        - composition
+      responses:
+        '200':
+          description: OK
+          headers:
+            X-Null-Header:
+              schema:
+                $ref: '#/components/schemas/NullType'
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NullType'
+
 components:
   schemas:
     Class1:

--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -32,6 +32,7 @@ sealed class Model {
     AllOfModel(:final isNullable) => isNullable,
     OneOfModel(:final isNullable) => isNullable,
     AnyOfModel(:final isNullable) => isNullable,
+    NeverModel(:final isNullable) => isNullable,
     _ => false,
   };
 
@@ -600,7 +601,9 @@ class AnyModel extends Model {
 }
 
 class NeverModel extends Model {
-  NeverModel({required super.context});
+  NeverModel({required super.context, required this.isNullable});
+
+  final bool isNullable;
 
   @override
   EncodingShape get encodingShape => EncodingShape.simple;

--- a/packages/tonik_core/test/src/model/model_test.dart
+++ b/packages/tonik_core/test/src/model/model_test.dart
@@ -141,4 +141,14 @@ void main() {
       );
     });
   });
+
+  group('NeverModel', () {
+    test('isEffectivelyNullable returns isNullable value', () {
+      final nullableNever = NeverModel(context: context, isNullable: true);
+      final nonNullableNever = NeverModel(context: context, isNullable: false);
+
+      expect(nullableNever.isEffectivelyNullable, isTrue);
+      expect(nonNullableNever.isEffectivelyNullable, isFalse);
+    });
+  });
 }

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -680,7 +680,7 @@ class ParseGenerator {
           .firstWhere((entry) => entry.value == norm.header)
           .key;
 
-      if (norm.property.model is NeverModel) {
+      if (norm.property.model.resolved is NeverModel) {
         neverHeaders.add(rawHeaderName);
         continue;
       }

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -484,10 +484,13 @@ BuiltExpression _buildListFromJsonBody(
         'Cannot decode List<NeverModel> - this type does not permit any '
         'value.',
       );
+      final elementExpr = isItemNullable
+          ? refer('e').equalTo(literalNull).conditional(literalNull, throwExpr)
+          : throwExpr;
       final mapFunction = Method(
         (b) => b
           ..requiredParameters.add(Parameter((b) => b..name = 'e'))
-          ..body = throwExpr.code,
+          ..body = elementExpr.code,
       ).closure;
       final listExpr = receiver.property(listDecoder).call(
         [],

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -177,11 +177,13 @@ BuiltExpression _buildSerializationExpression(
 
   switch (model) {
     case NeverModel():
-      return BuiltExpression.simple(
-        generateEncodingExceptionExpression(
-          'Cannot encode NeverModel - this type does not permit any value.',
-        ),
+      final throwExpr = generateEncodingExceptionExpression(
+        'Cannot encode NeverModel - this type does not permit any value.',
       );
+      final body = useNullAware
+          ? receiver.equalTo(literalNull).conditional(literalNull, throwExpr)
+          : throwExpr;
+      return BuiltExpression.simple(body);
     case DateTimeModel():
       return BuiltExpression.simple(callMethod('toTimeZonedIso8601String'));
     case DecimalModel():

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -124,11 +124,11 @@ TypeReference typeReference(
         ..url = 'package:tonik_util/tonik_util.dart'
         ..isNullable = isNullableOverride,
     ),
-    NeverModel _ => TypeReference(
+    final NeverModel m => TypeReference(
       (b) => b
         ..symbol = 'Never'
         ..url = 'dart:core'
-        ..isNullable = isNullableOverride,
+        ..isNullable = isNullableOverride || m.isNullable,
     ),
     AnyModel _ => TypeReference(
       (b) => b

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -3620,7 +3620,10 @@ void wrap() {
         name: 'NeverFilter',
         models: {
           (discriminatorValue: null, model: classModel),
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
         },
         context: context,
         examples: const [],

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -1479,7 +1479,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
             ),
             Property(
               name: 'forbidden',
-              model: NeverModel(context: context),
+              model: NeverModel(context: context, isNullable: false),
               isRequired: true,
               isNullable: false,
               isDeprecated: false,
@@ -1523,7 +1523,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
             ),
             Property(
               name: 'forbidden',
-              model: NeverModel(context: context),
+              model: NeverModel(context: context, isNullable: false),
               isRequired: true,
               isNullable: false,
               isDeprecated: false,

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -91,7 +91,7 @@ void main() {
           Property(
             name: 'corner',
             model: ListModel(
-              content: NeverModel(context: context),
+              content: NeverModel(context: context, isNullable: false),
               context: context,
               examples: const [],
             ),

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -3359,7 +3359,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
         },
         context: context,
@@ -3383,7 +3386,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
         },
         context: context,
@@ -3411,7 +3417,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
         },
         context: context,
@@ -3439,7 +3448,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
           (discriminatorValue: null, model: IntegerModel(context: context)),
         },
@@ -3475,7 +3487,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
         },
         context: context,
@@ -3503,7 +3518,10 @@ bool operator ==(Object other) {
         isDeprecated: false,
         name: 'Value',
         models: {
-          (discriminatorValue: null, model: NeverModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: NeverModel(context: context, isNullable: false),
+          ),
           (discriminatorValue: null, model: StringModel(context: context)),
         },
         context: context,

--- a/packages/tonik_generate/test/src/model/typedef_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/typedef_generator_test.dart
@@ -44,6 +44,40 @@ void main() {
       );
     });
 
+    test('generates typedef for NeverModel', () {
+      final model = AliasModel(
+        name: 'Forbidden',
+        model: NeverModel(context: context, isNullable: false),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final typedef = generator.generateAliasTypedef(model);
+
+      expect(
+        typedef.accept(emitter).toString().trim(),
+        'typedef Forbidden = Never;',
+      );
+    });
+
+    test('generates nullable typedef for nullable NeverModel', () {
+      final model = AliasModel(
+        name: 'Nothing',
+        model: NeverModel(context: context, isNullable: true),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final typedef = generator.generateAliasTypedef(model);
+
+      expect(
+        typedef.accept(emitter).toString().trim(),
+        'typedef Nothing = Never?;',
+      );
+    });
+
     test('generates typedef for list types', () {
       final model = AliasModel(
         name: 'UserIds',

--- a/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
@@ -213,7 +213,7 @@ void main() {
               description: '',
               bodies: {
                 ResponseBody(
-                  model: NeverModel(context: context),
+                  model: NeverModel(context: context, isNullable: false),
                   rawContentType: 'application/json',
                   contentType: ContentType.json,
                   examples: const [],
@@ -342,7 +342,7 @@ Future<TonikResult<Never>> call({CancelToken? cancelToken}) async {
                 ResponseBody(
                   model: AliasModel(
                     isNullable: true,
-                    model: NeverModel(context: context),
+                    model: NeverModel(context: context, isNullable: false),
                     context: context,
                     examples: const [],
                     defaultValue: null,

--- a/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
@@ -308,24 +308,21 @@ Future<TonikResult<Never>> call({CancelToken? cancelToken}) async {
       },
     );
 
-    // `isNeverParseReturn` also guards against `Never?` defensively. The
-    // current `tonik_parse` package does not produce OpenAPI input that
-    // yields a `Never?` parse-response type, but the core model layer
-    // permits the shape (e.g. an anonymous AliasModel with `isNullable: true`
-    // wrapping NeverModel renders as `Never?` via the anonymous-alias branch
-    // in typeReference). The guard prevents the unassigned try/catch branch
-    // from being emitted should such a model ever reach the generator.
+    // `isNeverParseReturn` also guards against `Never?`, the shape an inline
+    // `{type: "null"}` response schema imports as. It can legitimately
+    // complete normally with `null`, so the unassigned try/catch branch must
+    // not be emitted.
     test(
-      'nullable anonymous-alias Never response uses assigned-var shape',
+      'nullable Never response body uses assigned-var shape',
       () {
         final operation = Operation(
-          operationId: 'nullableNeverAliasBodyOp',
+          operationId: 'nullableNeverBodyOp',
           context: context,
           summary: '',
           description: '',
           tags: const {},
           isDeprecated: false,
-          path: '/nullable-never-alias-body',
+          path: '/nullable-never-body',
           method: HttpMethod.get,
           headers: const {},
           queryParameters: const {},
@@ -340,13 +337,7 @@ Future<TonikResult<Never>> call({CancelToken? cancelToken}) async {
               description: '',
               bodies: {
                 ResponseBody(
-                  model: AliasModel(
-                    isNullable: true,
-                    model: NeverModel(context: context, isNullable: false),
-                    context: context,
-                    examples: const [],
-                    defaultValue: null,
-                  ),
+                  model: NeverModel(context: context, isNullable: true),
                   rawContentType: 'application/json',
                   contentType: ContentType.json,
                   examples: const [],

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -1785,7 +1785,7 @@ void main() {
         isRequired: true,
         isDeprecated: false,
         explode: false,
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         encoding: CookieParameterEncoding.form,
         context: context,
         examples: const [],

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2609,7 +2609,7 @@ DateTime _parseResponse(Response<List<int>> response) {
             description: '',
             isRequired: false,
             isDeprecated: false,
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             explode: false,
             encoding: ResponseHeaderEncoding.simple,
             examples: const [],
@@ -2709,7 +2709,7 @@ DateTime _parseResponse(Response<List<int>> response) {
               description: '',
               isRequired: false,
               isDeprecated: false,
-              model: NeverModel(context: context),
+              model: NeverModel(context: context, isNullable: false),
               explode: false,
               encoding: ResponseHeaderEncoding.simple,
               examples: const [],
@@ -2824,7 +2824,7 @@ DateTime _parseResponse(Response<List<int>> response) {
                 bodies: {
                   ResponseBody(
                     model: ListModel(
-                      content: NeverModel(context: context),
+                      content: NeverModel(context: context, isNullable: false),
                       context: context,
                       examples: const [],
                     ),
@@ -2890,7 +2890,7 @@ List<Never> _parseResponse(Response<List<int>> response) {
               description: '',
               bodies: {
                 ResponseBody(
-                  model: NeverModel(context: context),
+                  model: NeverModel(context: context, isNullable: false),
                   rawContentType: 'application/json',
                   contentType: ContentType.json,
                   examples: const [],
@@ -2949,7 +2949,7 @@ Never _parseResponse(Response<List<int>> response) {
                   ResponseBody(
                     model: AliasModel(
                       name: 'NeverAlias',
-                      model: NeverModel(context: context),
+                      model: NeverModel(context: context, isNullable: false),
                       context: context,
                       examples: const [],
                       defaultValue: null,
@@ -3012,7 +3012,7 @@ NeverAlias _parseResponse(Response<List<int>> response) {
                 description: '',
                 bodies: {
                   ResponseBody(
-                    model: NeverModel(context: context),
+                    model: NeverModel(context: context, isNullable: false),
                     rawContentType: 'application/json',
                     contentType: ContentType.json,
                     examples: const [],
@@ -3076,7 +3076,7 @@ MultiNeverBodyOpResponse _parseResponse(Response<List<int>> response) {
               description: '',
               isRequired: false,
               isDeprecated: false,
-              model: NeverModel(context: context),
+              model: NeverModel(context: context, isNullable: false),
               explode: false,
               encoding: ResponseHeaderEncoding.simple,
               examples: const [],
@@ -3103,7 +3103,7 @@ MultiNeverBodyOpResponse _parseResponse(Response<List<int>> response) {
                 description: '',
                 bodies: {
                   ResponseBody(
-                    model: NeverModel(context: context),
+                    model: NeverModel(context: context, isNullable: false),
                     rawContentType: 'application/json',
                     contentType: ContentType.json,
                     examples: const [],
@@ -3155,7 +3155,7 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
               description: '',
               isRequired: false,
               isDeprecated: false,
-              model: NeverModel(context: context),
+              model: NeverModel(context: context, isNullable: false),
               explode: false,
               encoding: ResponseHeaderEncoding.simple,
               examples: const [],
@@ -3182,7 +3182,7 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
                 description: '',
                 bodies: {
                   ResponseBody(
-                    model: NeverModel(context: context),
+                    model: NeverModel(context: context, isNullable: false),
                     rawContentType: 'application/json',
                     contentType: ContentType.json,
                     examples: const [],
@@ -3268,7 +3268,7 @@ MultiNeverBodyHeaderOpResponse _parseResponse(Response<List<int>> response) {
                   ResponseBody(
                     model: AliasModel(
                       name: 'NeverFormAlias',
-                      model: NeverModel(context: context),
+                      model: NeverModel(context: context, isNullable: false),
                       context: context,
                       examples: const [],
                       defaultValue: null,
@@ -3332,7 +3332,7 @@ NeverFormAlias _parseResponse(Response<List<int>> response) {
                 description: '',
                 bodies: {
                   ResponseBody(
-                    model: NeverModel(context: context),
+                    model: NeverModel(context: context, isNullable: false),
                     rawContentType: 'application/x-www-form-urlencoded',
                     contentType: ContentType.form,
                     examples: const [],
@@ -3394,7 +3394,7 @@ Never _parseResponse(Response<List<int>> response) {
                 bodies: {
                   ResponseBody(
                     model: ListModel(
-                      content: NeverModel(context: context),
+                      content: NeverModel(context: context, isNullable: false),
                       context: context,
                       examples: const [],
                     ),
@@ -3466,7 +3466,7 @@ List<Never> _parseResponse(Response<List<int>> response) {
                 bodies: {
                   ResponseBody(
                     model: ListModel(
-                      content: NeverModel(context: context),
+                      content: NeverModel(context: context, isNullable: false),
                       isNullable: true,
                       context: context,
                       examples: const [],

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2682,6 +2682,120 @@ DateTime _parseResponse(Response<List<int>> response) {
         );
       });
 
+      test('generates runtime check for NeverModel header behind an alias',
+          () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'User',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+        final responseHeaders = {
+          'X-Any-Header': ResponseHeaderObject(
+            name: 'X-Any-Header',
+            context: context,
+            description: '',
+            isRequired: false,
+            isDeprecated: false,
+            model: AnyModel(context: context),
+            explode: false,
+            encoding: ResponseHeaderEncoding.simple,
+            examples: const [],
+          ),
+          'X-Never-Header': ResponseHeaderObject(
+            name: 'X-Never-Header',
+            context: context,
+            description: '',
+            isRequired: false,
+            isDeprecated: false,
+            model: AliasModel(
+              name: 'NullType',
+              model: NeverModel(context: context, isNullable: true),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+            explode: false,
+            encoding: ResponseHeaderEncoding.simple,
+            examples: const [],
+          ),
+        };
+        final operation = Operation(
+          operationId: 'neverAliasHeaderOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/never-alias-header',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: responseHeaders,
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: classModel,
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+
+        const expectedMethod = r'''
+        AnonymousResponse _parseResponse(Response<List<int>> response) {
+          final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+            case (200, r'application/json'):
+              if (response.headers.value(r'X-Never-Header') != null) {
+                throw SimpleDecodingException(
+                  r'NeverModel does not permit any value at X-Never-Header',
+                );
+              }
+              final _$json = decodeResponseJson<Object?>(response.data);
+              final _$body = User.fromJson(_$json);
+              return AnonymousResponse(
+                  body: _$body,
+                  xAnyHeader: response.headers.value(r'X-Any-Header'),
+              );
+            default:
+              final _$content = response.headers.value('content-type') ?? 'not specified';
+              final _$matched = _$mediaType ?? 'none';
+              final _$status = response.statusCode;
+              throw ResponseDecodingException(
+                'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
+              );
+          }
+        }
+      ''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(expectedMethod),
+        );
+      });
+
       test(
         'generates runtime check for NeverModel header in multi-response',
         () {
@@ -2972,6 +3086,133 @@ NeverAlias _parseResponse(Response<List<int>> response) {
       throw JsonDecodingException(
         'Cannot decode NeverModel - this type does not permit any value.',
       );
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test('decodes nullable NeverModel JSON body with a null guard', () {
+        final operation = Operation(
+          operationId: 'nullableNeverBodyOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/nullable-never-body',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: NeverModel(context: context, isNullable: true),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+Never? _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json == null
+          ? null
+          : throw JsonDecodingException(
+              'Cannot decode NeverModel - this type does not permit any value.',
+            );
+      return _$body;
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test(
+        'decodes aliased nullable NeverModel JSON body with a null guard',
+        () {
+          final operation = Operation(
+            operationId: 'aliasedNullableNeverBodyOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/aliased-nullable-never-body',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: AliasModel(
+                      name: 'NullType',
+                      model: NeverModel(context: context, isNullable: true),
+                      context: context,
+                      examples: const [],
+                      defaultValue: null,
+                    ),
+                    rawContentType: 'application/json',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
+NullType _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/json'):
+      final _$json = decodeResponseJson<Object?>(response.data);
+      final _$body = _$json == null
+          ? null
+          : throw JsonDecodingException(
+              'Cannot decode NeverModel - this type does not permit any value.',
+            );
+      return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
       final _$matched = _$mediaType ?? 'none';

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -3255,7 +3255,7 @@ void main() {
         isDeprecated: false,
         allowEmptyValue: false,
         explode: false,
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         encoding: PathParameterEncoding.simple,
         context: context,
         examples: const [],
@@ -3351,7 +3351,7 @@ void main() {
         'without concatenation', () {
       final listModel = ListModel(
         context: context,
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         examples: const [],
       );
 
@@ -3465,7 +3465,7 @@ void main() {
         'unwrapping at depth 1', () {
       final aliasModel = AliasModel(
         name: 'NeverAlias',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
         defaultValue: null,
@@ -3533,7 +3533,7 @@ void main() {
         'throw statement unwrapping at depth 2', () {
       final innerAlias = AliasModel(
         name: 'NeverInner',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
         defaultValue: null,

--- a/packages/tonik_generate/test/src/util/flat_value_codec_plan_test.dart
+++ b/packages/tonik_generate/test/src/util/flat_value_codec_plan_test.dart
@@ -398,7 +398,7 @@ void main() {
     });
 
     test('never values are unsupported', () {
-      final plan = encodePlan(NeverModel(context: context));
+      final plan = encodePlan(NeverModel(context: context, isNullable: false));
 
       expect(plan, isA<UnsupportedFlatEncodePlan>());
     });
@@ -539,7 +539,7 @@ void main() {
     });
 
     test('never is unsupported', () {
-      final plan = decodePlan(NeverModel(context: context));
+      final plan = decodePlan(NeverModel(context: context, isNullable: false));
 
       expect(plan, isA<UnsupportedFlatDecodePlan>());
     });

--- a/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
+++ b/packages/tonik_generate/test/src/util/form_entries_expression_builder_test.dart
@@ -591,7 +591,7 @@ void main() {
     test('NeverModel returns null', () {
       final result = buildFormEntriesValueExpression(
         refer('value'),
-        NeverModel(context: context),
+        NeverModel(context: context, isNullable: false),
         paramName: literalString('p'),
         explode: literalBool(true),
         allowEmpty: literalBool(true),
@@ -639,7 +639,7 @@ void main() {
       Base64Model(context: context),
       BinaryModel(context: context),
       AnyModel(context: context),
-      NeverModel(context: context),
+      NeverModel(context: context, isNullable: false),
       EnumModel<String>(
         values: const {},
         isNullable: false,
@@ -770,7 +770,7 @@ void main() {
           context: context,
           examples: const [],
         ),
-        NeverModel(context: context),
+        NeverModel(context: context, isNullable: false),
       ];
 
       for (final model in complex) {

--- a/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
@@ -788,7 +788,7 @@ void main() {
       test('generates throw for required NeverModel', () {
         final expression = buildFromFormValueExpression(
           refer("values['neverField']"),
-          model: NeverModel(context: context),
+          model: NeverModel(context: context, isNullable: false),
           isRequired: true,
           nameManager: nameManager,
           package: 'test_package',
@@ -806,7 +806,7 @@ void main() {
       test('generates null check before throw for optional NeverModel', () {
         final expression = buildFromFormValueExpression(
           refer("values['neverField']"),
-          model: NeverModel(context: context),
+          model: NeverModel(context: context, isNullable: false),
           isRequired: false,
           nameManager: nameManager,
           package: 'test_package',
@@ -828,7 +828,7 @@ void main() {
         final expression = buildFromFormValueExpression(
           refer('formString'),
           model: ListModel(
-            content: NeverModel(context: context),
+            content: NeverModel(context: context, isNullable: false),
             context: context,
             examples: const [],
           ),
@@ -850,7 +850,7 @@ void main() {
           final expression = buildFromFormValueExpression(
             refer('formString'),
             model: ListModel(
-              content: NeverModel(context: context),
+              content: NeverModel(context: context, isNullable: false),
               isNullable: true,
               context: context,
               examples: const [],
@@ -872,7 +872,7 @@ void main() {
         final expression = buildFromFormValueExpression(
           refer('formString'),
           model: ListModel(
-            content: NeverModel(context: context),
+            content: NeverModel(context: context, isNullable: false),
             context: context,
             examples: const [],
           ),
@@ -897,7 +897,7 @@ void main() {
             model: ListModel(
               content: AliasModel(
                 name: 'ForbiddenAlias',
-                model: NeverModel(context: context),
+                model: NeverModel(context: context, isNullable: false),
                 context: context,
                 examples: const [],
                 defaultValue: null,

--- a/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_json_value_expression_generator_test.dart
@@ -1527,7 +1527,7 @@ void main() {
     test('generates throw JsonDecodingException for NeverModel', () {
       final result = buildFromJsonValueExpression(
         'value',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         nameManager: nameManager,
         package: 'my_package',
       ).accept(emitter).toString();
@@ -1540,7 +1540,7 @@ void main() {
     test('generates null check before throw for nullable NeverModel', () {
       final result = buildFromJsonValueExpression(
         'value',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         nameManager: nameManager,
         package: 'my_package',
         isNullable: true,
@@ -1551,10 +1551,23 @@ void main() {
       );
     });
 
+    test('generates null check before throw for nullable NeverModel model', () {
+      final result = buildFromJsonValueExpression(
+        'value',
+        model: NeverModel(context: context, isNullable: true),
+        nameManager: nameManager,
+        package: 'my_package',
+      ).accept(emitter).toString();
+      expect(
+        result,
+        '''value == null ? null : throw  _i1.JsonDecodingException('Cannot decode NeverModel - this type does not permit any value.')''',
+      );
+    });
+
     test('generates throw for AliasModel wrapping NeverModel', () {
       final aliasModel = AliasModel(
         name: 'ForbiddenAlias',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
         defaultValue: null,
@@ -1573,7 +1586,7 @@ void main() {
 
     test('decodes List of NeverModel before rejecting elements', () {
       final listModel = ListModel(
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
       );
@@ -1589,11 +1602,30 @@ void main() {
       );
     });
 
+    test('decodes List of nullable NeverModel elements to null', () {
+      final listModel = ListModel(
+        content: NeverModel(context: context, isNullable: true),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final result = buildFromJsonValueExpression(
+        'value',
+        model: listModel,
+        nameManager: nameManager,
+        package: 'my_package',
+      ).accept(emitter).toString();
+      expect(
+        result,
+        '''value.decodeJsonList<Object?>().map((e) => e == null ? null : throw  _i1.JsonDecodingException('Cannot decode List<NeverModel> - this type does not permit any value.')).toList()''',
+      );
+    });
+
     test(
       'generates null check for List of NeverModel when caller marks nullable',
       () {
         final listModel = ListModel(
-          content: NeverModel(context: context),
+          content: NeverModel(context: context, isNullable: false),
           context: context,
           examples: const [],
         );
@@ -1615,7 +1647,7 @@ void main() {
       'generates null check for ListModel(isNullable: true) of NeverModel',
       () {
         final listModel = ListModel(
-          content: NeverModel(context: context),
+          content: NeverModel(context: context, isNullable: false),
           isNullable: true,
           context: context,
           examples: const [],
@@ -1781,7 +1813,7 @@ void main() {
       'under useImmutableCollections',
       () {
         final listModel = ListModel(
-          content: NeverModel(context: context),
+          content: NeverModel(context: context, isNullable: false),
           isNullable: true,
           context: context,
           examples: const [],
@@ -1804,7 +1836,7 @@ void main() {
       'under useImmutableCollections',
       () {
         final listModel = ListModel(
-          content: NeverModel(context: context),
+          content: NeverModel(context: context, isNullable: false),
           context: context,
           examples: const [],
         );
@@ -1857,7 +1889,7 @@ void main() {
         expect(
           buildFromJsonValueExpression(
             r'_$raw',
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             nameManager: nameManager,
             package: 'my_package',
             isNullable: true,

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -843,7 +843,7 @@ void main() {
         expect(
           buildSimpleValueExpression(
             value,
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             isRequired: true,
             nameManager: nameManager,
             package: 'my_package',
@@ -858,7 +858,7 @@ void main() {
         expect(
           buildSimpleValueExpression(
             value,
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             isRequired: false,
             nameManager: nameManager,
             package: 'my_package',
@@ -874,7 +874,7 @@ void main() {
           buildSimpleValueExpression(
             value,
             model: ListModel(
-              content: NeverModel(context: context),
+              content: NeverModel(context: context, isNullable: false),
               context: context,
               examples: const [],
             ),
@@ -893,7 +893,7 @@ void main() {
           buildSimpleValueExpression(
             value,
             model: ListModel(
-              content: NeverModel(context: context),
+              content: NeverModel(context: context, isNullable: false),
               context: context,
               examples: const [],
             ),

--- a/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_query_parameter_expression_generator_test.dart
@@ -331,7 +331,7 @@ void main() {
         final parameter = createParameter(
           name: 'neverParam',
           rawName: 'neverParam',
-          model: NeverModel(context: context),
+          model: NeverModel(context: context, isNullable: false),
           explode: false,
           allowEmpty: true,
         );
@@ -432,7 +432,7 @@ void main() {
             name: 'neverListParam',
             rawName: 'neverListParam',
             model: ListModel(
-              content: NeverModel(context: context),
+              content: NeverModel(context: context, isNullable: false),
               context: context,
               examples: const [],
             ),

--- a/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_form_value_expression_generator_test.dart
@@ -740,7 +740,7 @@ void main() {
     test('NeverModel body throws an encoding exception', () {
       final result = buildToFormValueExpression(
         'body',
-        NeverModel(context: context),
+        NeverModel(context: context, isNullable: false),
         useQueryComponent: true,
       );
 

--- a/packages/tonik_generate/test/src/util/to_json_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_json_value_expression_generator_test.dart
@@ -1882,7 +1882,7 @@ void main() {
     test('for NeverModel property throws EncodingException', () {
       final property = Property(
         name: 'forbidden',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         isRequired: true,
         isNullable: false,
         isDeprecated: false,
@@ -1901,10 +1901,10 @@ void main() {
       );
     });
 
-    test('for nullable NeverModel property throws EncodingException', () {
+    test('for nullable NeverModel property encodes null before throwing', () {
       final property = Property(
         name: 'forbidden',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         isRequired: false,
         isNullable: true,
         isDeprecated: false,
@@ -1919,13 +1919,39 @@ void main() {
             nameManager: nameManager,
           ),
         ),
-        '''throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
+        '''forbidden == null ? null : throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
       );
     });
 
+    test(
+      'for NeverModel property with nullable model encodes null '
+      'before throwing',
+      () {
+        final property = Property(
+          name: 'forbidden',
+          model: NeverModel(context: context, isNullable: true),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        );
+        expect(
+          scopedEmit(
+            buildToJsonPropertyExpression(
+              'forbidden',
+              property,
+              nameManager: nameManager,
+            ),
+          ),
+          '''forbidden == null ? null : throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
+        );
+      },
+    );
+
     test('for List of NeverModel property throws EncodingException', () {
       final listModel = ListModel(
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
       );
@@ -1950,10 +1976,38 @@ void main() {
       );
     });
 
+    test('for List of nullable NeverModel property encodes null elements', () {
+      final listModel = ListModel(
+        content: NeverModel(context: context, isNullable: true),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final property = Property(
+        name: 'forbiddenList',
+        model: listModel,
+        isRequired: true,
+        isNullable: false,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: null,
+      );
+      expect(
+        scopedEmit(
+          buildToJsonPropertyExpression(
+            'forbiddenList',
+            property,
+            nameManager: nameManager,
+          ),
+        ),
+        '''forbiddenList.map((e) => e == null ? null : throw  _i1.EncodingException('Cannot encode NeverModel - this type does not permit any value.')).toList()''',
+      );
+    });
+
     test('for AliasModel wrapping NeverModel throws EncodingException', () {
       final aliasModel = AliasModel(
         name: 'ForbiddenAlias',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
         defaultValue: null,
@@ -1986,7 +2040,7 @@ void main() {
         name: 'forbidden',
         rawName: 'forbidden',
         description: 'Test path parameter',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         encoding: PathParameterEncoding.simple,
         explode: false,
         allowEmptyValue: false,
@@ -2015,7 +2069,7 @@ void main() {
         name: 'forbidden',
         rawName: 'forbidden',
         description: 'Test query parameter',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         encoding: QueryParameterEncoding.form,
         explode: false,
         allowEmptyValue: false,

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -483,7 +483,7 @@ void main() {
     });
 
     test('generates runtime throw for NeverModel', () {
-      final model = NeverModel(context: context);
+      final model = NeverModel(context: context, isNullable: false);
       final expression = buildLabelParameterExpression(
         refer('value'),
         model,
@@ -499,7 +499,7 @@ void main() {
 
     test('generates runtime throw for List with NeverModel content', () {
       final model = ListModel(
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
       );

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -500,7 +500,7 @@ void main() {
     });
 
     test('generates runtime throw for NeverModel', () {
-      final model = NeverModel(context: context);
+      final model = NeverModel(context: context, isNullable: false);
       final expression = buildMatrixParameterExpression(
         refer('value'),
         model,
@@ -517,7 +517,7 @@ void main() {
 
     test('generates runtime throw for List with NeverModel content', () {
       final model = ListModel(
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
       );

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -651,7 +651,7 @@ void main() {
         properties: [
           Property(
             name: 'impossible',
-            model: NeverModel(context: testContext),
+            model: NeverModel(context: testContext, isNullable: false),
             isRequired: true,
             isNullable: false,
             isDeprecated: false,
@@ -713,7 +713,7 @@ void main() {
           properties: [
             Property(
               name: r'$total',
-              model: NeverModel(context: testContext),
+              model: NeverModel(context: testContext, isNullable: false),
               isRequired: true,
               isNullable: false,
               isDeprecated: false,

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -806,7 +806,7 @@ void main() {
     });
 
     test('generates runtime throw for NeverModel', () {
-      final model = NeverModel(context: context);
+      final model = NeverModel(context: context, isNullable: false);
       final expression = buildSimpleParameterExpression(
         refer('value'),
         model,
@@ -822,7 +822,7 @@ void main() {
 
     test('generates runtime throw for List with NeverModel content', () {
       final model = ListModel(
-        content: NeverModel(context: context),
+        content: NeverModel(context: context, isNullable: false),
         context: context,
         examples: const [],
       );

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -148,7 +148,7 @@ void main() {
         name: 'neverParam',
         rawName: 'neverParam',
         description: 'Never parameter',
-        model: NeverModel(context: context),
+        model: NeverModel(context: context, isNullable: false),
         encoding: PathParameterEncoding.simple,
         explode: false,
         allowEmptyValue: false,
@@ -504,7 +504,7 @@ void main() {
         emit(
           buildToSimpleHeaderParameterExpression(
             'neverHeader',
-            header(NeverModel(context: context)),
+            header(NeverModel(context: context, isNullable: false)),
           ),
         ),
         '''throw  EncodingException('Cannot encode NeverModel - this type does not permit any value.')''',
@@ -599,7 +599,7 @@ void main() {
     });
 
     test('serializes never model as exception', () {
-      final model = NeverModel(context: context);
+      final model = NeverModel(context: context, isNullable: false);
       expect(
         emit(
           buildSimpleValueExpression(
@@ -1862,7 +1862,7 @@ void main() {
 
     test('NeverModel returns never-typed reason', () {
       expectThrowReason(
-        NeverModel(context: context),
+        NeverModel(context: context, isNullable: false),
         label: 'NeverModel',
         containsText: 'never-typed',
       );
@@ -1879,7 +1879,7 @@ void main() {
     test('ListModel<NeverModel> returns unsupported elements reason', () {
       expectThrowReason(
         ListModel(
-          content: NeverModel(context: context),
+          content: NeverModel(context: context, isNullable: false),
           context: context,
           examples: const [],
         ),
@@ -1940,7 +1940,7 @@ void main() {
       expectThrowReason(
         AliasModel(
           name: 'NA',
-          model: NeverModel(context: context),
+          model: NeverModel(context: context, isNullable: false),
           context: context,
           examples: const [],
           defaultValue: null,
@@ -1957,7 +1957,7 @@ void main() {
           name: 'NA2',
           model: AliasModel(
             name: 'NA1',
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             context: context,
             examples: const [],
             defaultValue: null,
@@ -2055,7 +2055,7 @@ void main() {
         ListModel(
           content: AliasModel(
             name: 'NA',
-            model: NeverModel(context: context),
+            model: NeverModel(context: context, isNullable: false),
             context: context,
             examples: const [],
             defaultValue: null,

--- a/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/type_reference_generator_test.dart
@@ -193,6 +193,26 @@ void main() {
         },
       );
 
+      test('returns Never TypeReference for NeverModel', () {
+        final model = NeverModel(context: context, isNullable: false);
+
+        final result = typeReference(model, nameManager, package);
+
+        expect(result.symbol, 'Never');
+        expect(result.url, 'dart:core');
+        expect(result.isNullable, isFalse);
+      });
+
+      test('returns Never? TypeReference for nullable NeverModel', () {
+        final model = NeverModel(context: context, isNullable: true);
+
+        final result = typeReference(model, nameManager, package);
+
+        expect(result.symbol, 'Never');
+        expect(result.url, 'dart:core');
+        expect(result.isNullable, isTrue);
+      });
+
       test('returns TonikFile TypeReference for Base64Model', () {
         final model = Base64Model(context: context);
 

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -109,7 +109,7 @@ class ModelImporter {
     if (schema.isBooleanSchema != null) {
       final model = schema.isBooleanSchema!
           ? AnyModel(context: context)
-          : NeverModel(context: context);
+          : NeverModel(context: context, isNullable: false);
       final aliasModel = AliasModel(
         name: name,
         model: model,
@@ -176,6 +176,21 @@ class ModelImporter {
 
     final hasNullType = schema.type.contains('null');
     final types = schema.type.where((t) => t != 'null').toList();
+
+    if (hasNullType && types.isEmpty) {
+      final aliasModel = AliasModel(
+        name: name,
+        model: NeverModel(context: context, isNullable: true),
+        context: context,
+        description: schema.description,
+        isDeprecated: schema.isDeprecated ?? false,
+        defaultValue: schema.rawDefault,
+        examples: const [],
+      );
+      _logModelAdded(aliasModel);
+      models.add(aliasModel);
+      return;
+    }
 
     if (types.length > 1) {
       // Multi-type becomes OneOfModel — create shell.
@@ -415,6 +430,12 @@ class ModelImporter {
 
     final hasNullType = schema.type.contains('null');
     final types = schema.type.where((t) => t != 'null').toList();
+
+    if (hasNullType && types.isEmpty) {
+      // Already fully populated in pass 1.
+      applyExamples(existingModel, examples);
+      return;
+    }
 
     if (types.length > 1) {
       _populateMultiTypeShell(
@@ -1393,7 +1414,7 @@ class ModelImporter {
     if (schema.isBooleanSchema != null) {
       return schema.isBooleanSchema!
           ? AnyModel(context: context)
-          : NeverModel(context: context);
+          : NeverModel(context: context, isNullable: false);
     }
 
     if (schema.allOf != null) {
@@ -1411,6 +1432,10 @@ class ModelImporter {
     // OpenAPI 3.1 null types become Tonik nullability.
     final hasNullType = schema.type.contains('null');
     final types = schema.type.where((t) => t != 'null').toList();
+
+    if (hasNullType && types.isEmpty) {
+      return NeverModel(context: context, isNullable: true);
+    }
 
     if (types.length > 1) {
       return _parseMultiType(types, schema, hasNullType, context, name);

--- a/packages/tonik_parse/test/model/model_null_only_schema_test.dart
+++ b/packages/tonik_parse/test/model/model_null_only_schema_test.dart
@@ -1,0 +1,143 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+void main() {
+  const fileContent = {
+    'openapi': '3.1.0',
+    'info': {'title': 'Test API', 'version': '1.0.0'},
+    'paths': <String, dynamic>{},
+    'components': {
+      'schemas': {
+        'Nothing': {'type': 'null'},
+        'NothingTypeArray': {
+          'type': ['null'],
+        },
+        'Nope': false,
+        'Holder': {
+          'type': 'object',
+          'properties': {
+            'viaRef': {r'$ref': '#/components/schemas/Nothing'},
+            'inline': {'type': 'null'},
+            'nullItems': {
+              'type': 'array',
+              'items': {'type': 'null'},
+            },
+          },
+          'required': ['viaRef', 'inline', 'nullItems'],
+        },
+        'HolderWithAdditionalProperties': {
+          'type': 'object',
+          'properties': {
+            'name': {'type': 'string'},
+          },
+          'additionalProperties': {'type': 'null'},
+        },
+        'NullValueMap': {
+          'type': 'object',
+          'additionalProperties': {'type': 'null'},
+        },
+      },
+    },
+  };
+
+  Model named(ApiDocument api, String name) =>
+      api.models.firstWhere((m) => m is NamedModel && m.name == name);
+
+  ClassModel holder(ApiDocument api, String name) =>
+      named(api, name) as ClassModel;
+
+  group('named null-only schema', () {
+    test('imports as a named alias of a nullable NeverModel', () {
+      final api = Importer().import(fileContent);
+      final model = named(api, 'Nothing') as AliasModel;
+
+      expect(model.name, 'Nothing');
+      final never = model.model as NeverModel;
+      expect(never.isNullable, isTrue);
+    });
+
+    test('type array form imports as a named alias of a nullable NeverModel',
+        () {
+      final api = Importer().import(fileContent);
+      final model = named(api, 'NothingTypeArray') as AliasModel;
+
+      final never = model.model as NeverModel;
+      expect(never.isNullable, isTrue);
+    });
+
+    test('is effectively nullable', () {
+      final api = Importer().import(fileContent);
+      final model = named(api, 'Nothing');
+
+      expect(model.isEffectivelyNullable, isTrue);
+    });
+
+    test('boolean false schema stays a non-nullable NeverModel', () {
+      final api = Importer().import(fileContent);
+      final model = named(api, 'Nope') as AliasModel;
+
+      final never = model.model as NeverModel;
+      expect(never.isNullable, isFalse);
+    });
+  });
+
+  group('null-only schema in properties', () {
+    test('ref to a null-only component resolves to the named alias', () {
+      final api = Importer().import(fileContent);
+      final property = holder(api, 'Holder').properties.firstWhere(
+        (p) => p.name == 'viaRef',
+      );
+
+      final alias = property.model as AliasModel;
+      expect(alias.name, 'Nothing');
+      expect(alias.isEffectivelyNullable, isTrue);
+    });
+
+    test('inline null-only property imports as a nullable NeverModel', () {
+      final api = Importer().import(fileContent);
+      final property = holder(api, 'Holder').properties.firstWhere(
+        (p) => p.name == 'inline',
+      );
+
+      final never = property.model as NeverModel;
+      expect(never.isNullable, isTrue);
+      expect(property.isNullable, isTrue);
+    });
+  });
+
+  group('null-only schema as list items', () {
+    test('imports as nullable NeverModel content', () {
+      final api = Importer().import(fileContent);
+      final property = holder(api, 'Holder').properties.firstWhere(
+        (p) => p.name == 'nullItems',
+      );
+
+      final list = property.model as ListModel;
+      expect(list.isContentNullable, isTrue);
+      final never = list.content as NeverModel;
+      expect(never.isNullable, isTrue);
+    });
+  });
+
+  group('null-only schema as additionalProperties', () {
+    test('imports as nullable NeverModel policy value without alias wrap', () {
+      final api = Importer().import(fileContent);
+      final model = holder(api, 'HolderWithAdditionalProperties');
+
+      final policy =
+          model.additionalPropertiesPolicy as AllowedAdditionalProperties;
+      final never = policy.valueModel as NeverModel;
+      expect(never.isNullable, isTrue);
+    });
+
+    test('imports as nullable NeverModel map value', () {
+      final api = Importer().import(fileContent);
+      final model = named(api, 'NullValueMap') as MapModel;
+
+      expect(model.isValueNullable, isTrue);
+      final never = model.valueModel as NeverModel;
+      expect(never.isNullable, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

A schema whose only type is `"null"` (OpenAPI 3.1 / JSON Schema 2020-12, where `type: "null"` matches only the JSON literal `null`) previously imported as a **non-nullable empty ClassModel**:

- A `$ref` to such a component decoded JSON `null` into a non-null empty object and re-encoded it as `{}` — silent data corruption.
- Any non-null input (e.g. `{"a": 1}`) was silently accepted instead of rejected.
- Inline uses (property, `items`, `additionalProperties`) generated junk empty model classes.

`NeverModel` now carries its own `isNullable` flag and null-only schemas import as `NeverModel(isNullable: true)` — Dart's `Never?` is exactly "permits only null". Named components become `typedef Name = Never?;` (mirroring how boolean-`false` schemas already alias `Never`).

## Changes

- **tonik_core**: `NeverModel.isNullable` (required, like other model flags); `isEffectivelyNullable` gains a `NeverModel` arm.
- **tonik_parse**: null-only schemas (`type: "null"` or `type: ["null"]`) import as nullable `NeverModel` in both the shell and inline parse paths; named components are alias-wrapped.
- **tonik_generate**:
  - `typeReference` honors the model's own nullability → `Never?` (also fixes typedef emission).
  - JSON encode of an effectively-nullable `Never` emits `null` instead of throwing; non-null still throws `EncodingException`.
  - JSON list decode with nullable `Never` elements null-guards per element; non-null elements still throw `JsonDecodingException`.
- Parameter encoding of null-only properties intentionally keeps throwing (pathological case).

## Tests

- New parse tests covering named components, type-array form, inline property, `items`, `additionalProperties`, and the boolean-`false` guard.
- New/updated generator tests for type references, typedefs, and JSON encode/decode null guards.
- New `composition` integration tests: full JSON round-trip preserves nulls in all four contexts and rejects every non-null input shape.

All unit suites, the composition/boolean_schemas/type_arrays/additional_properties integration suites, and `dart analyze` (packages + integration_test) are green.