### PR TITLE
Fix non-exploded multipart array serialization

### DIFF
--- a/integration_test/multipart/multipart_test/imposter/response.groovy
+++ b/integration_test/multipart/multipart_test/imposter/response.groovy
@@ -264,6 +264,16 @@ switch (path) {
         }
         break
 
+    case '/multipart31/form-non-exploded':
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/json'
+            withHeader 'X-Has-Tags', formParams.containsKey('tags').toString()
+            withHeader 'X-Param-Tags', (formParams['tags'] ?: '')
+            withContent '{"success":true,"message":"form-non-exploded received"}'
+        }
+        break
+
     case '/multipart31/default-explode':
         // Repeated fields: formParams['values'] returns the last value.
         // The test verifies the full set of fields client-side via FormData.

--- a/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
@@ -114,6 +114,26 @@ void main() {
       expect(success.response.headers['x-has-tags']?.first, 'false');
       expect(success.response.headers['x-param-tags']?.first, '');
     });
+
+    test('serializes an empty array as one empty multipart field', () async {
+      const form = FormNonExplodedForm(tags: []);
+
+      final response = await api.postFormNonExploded(body: form);
+
+      expect(response, isA<TonikSuccess<GenericResponse>>());
+
+      final success = response as TonikSuccess<GenericResponse>;
+      final formData = success.response.requestOptions.data as FormData;
+      final tagEntries = formData.fields
+          .where((entry) => entry.key == 'tags')
+          .toList();
+
+      expect(tagEntries, hasLength(1));
+      expect(tagEntries.single.value, '');
+      expect(formData.files.where((entry) => entry.key == 'tags'), isEmpty);
+      expect(success.response.headers['x-has-tags']?.first, 'true');
+      expect(success.response.headers['x-param-tags']?.first, '');
+    });
   });
 
   group('OAS 3.1 array with no encoding specified', () {

--- a/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
@@ -78,6 +78,44 @@ void main() {
     });
   });
 
+  group('OAS 3.1 form encoding with explode=false', () {
+    test('serializes an array as one comma-joined multipart field', () async {
+      const form = FormNonExplodedForm(tags: ['a', 'b', 'c']);
+
+      final response = await api.postFormNonExploded(body: form);
+
+      expect(response, isA<TonikSuccess<GenericResponse>>());
+
+      final success = response as TonikSuccess<GenericResponse>;
+      final formData = success.response.requestOptions.data as FormData;
+      final tagEntries = formData.fields
+          .where((entry) => entry.key == 'tags')
+          .toList();
+
+      expect(tagEntries, hasLength(1));
+      expect(tagEntries.single.value, 'a,b,c');
+      expect(formData.files.where((entry) => entry.key == 'tags'), isEmpty);
+      expect(success.response.headers['x-has-tags']?.first, 'true');
+      expect(success.response.headers['x-param-tags']?.first, 'a,b,c');
+    });
+
+    test('omits the optional array when it is null', () async {
+      const form = FormNonExplodedForm();
+
+      final response = await api.postFormNonExploded(body: form);
+
+      expect(response, isA<TonikSuccess<GenericResponse>>());
+
+      final success = response as TonikSuccess<GenericResponse>;
+      final formData = success.response.requestOptions.data as FormData;
+
+      expect(formData.fields.where((entry) => entry.key == 'tags'), isEmpty);
+      expect(formData.files.where((entry) => entry.key == 'tags'), isEmpty);
+      expect(success.response.headers['x-has-tags']?.first, 'false');
+      expect(success.response.headers['x-param-tags']?.first, '');
+    });
+  });
+
   group('OAS 3.1 array with no encoding specified', () {
     test(
       'serializes array as repeated form fields when no encoding is set',

--- a/integration_test/multipart/openapi_3_1.yaml
+++ b/integration_test/multipart/openapi_3_1.yaml
@@ -42,6 +42,33 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
 
+  /multipart31/form-non-exploded:
+    post:
+      operationId: postFormNonExploded
+      tags:
+        - multipart31
+      summary: Post an array with form style and explode=false
+      description: >-
+        Verifies OAS 3.1 serializes an optional array as one comma-joined
+        multipart field when style is form and explode is false.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/FormNonExplodedForm'
+            encoding:
+              tags:
+                style: form
+                explode: false
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericResponse'
+
   /multipart31/default-explode:
     post:
       operationId: postDefaultExplode
@@ -294,6 +321,15 @@ components:
           items:
             type: string
           description: Array to be serialized with pipe-delimited style
+
+    FormNonExplodedForm:
+      type: object
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+          description: Optional array serialized as one comma-joined field
 
     DefaultExplodeForm:
       type: object

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -667,13 +667,13 @@ Code _buildListFieldAddition(
 
   final explode = propertyEncoding?.explode ?? true;
 
-  // When headers are present, text items must be sent as
-  // MultipartFile.fromString so the headers can be attached.
-  if (headerVarName != null) {
-    final fileItemExpr = refer('MultipartFile', 'package:dio/dio.dart')
-        .property('fromString')
-        .call([itemExpr], {'headers': refer(headerVarName)});
-    if (explode) {
+  if (explode) {
+    // When headers are present, text items must be sent as
+    // MultipartFile.fromString so the headers can be attached.
+    if (headerVarName != null) {
+      final fileItemExpr = refer('MultipartFile', 'package:dio/dio.dart')
+          .property('fromString')
+          .call([itemExpr], {'headers': refer(headerVarName)});
       return _buildListForLoop(
         rawName,
         refer(accessor),
@@ -681,26 +681,7 @@ Code _buildListFieldAddition(
         isFile: true,
       );
     }
-    final encoderExpr = _buildEncoderExpr(
-      accessor,
-      itemExpr,
-      needsMapping: !isIdentity,
-      style: style,
-    );
-    // After the encoder, items are already strings.
-    final encodedFileItemExpr = refer('MultipartFile', 'package:dio/dio.dart')
-        .property('fromString')
-        .call([refer('item')], {'headers': refer(headerVarName)});
-    return _buildListForLoop(
-      rawName,
-      encoderExpr,
-      encodedFileItemExpr,
-      isFile: true,
-    );
-  }
 
-  if (explode) {
-    // explode: true — for-loop adding each item as a separate field.
     return _buildListForLoop(
       rawName,
       refer(accessor),
@@ -709,17 +690,13 @@ Code _buildListFieldAddition(
     );
   }
 
-  final encoderExpr = _buildEncoderExpr(
+  return _buildNonExplodedListAddition(
+    rawName,
     accessor,
     itemExpr,
     needsMapping: !isIdentity,
     style: style,
-  );
-  return _buildListForLoop(
-    rawName,
-    encoderExpr,
-    refer('item'),
-    isFile: false,
+    headerVarName: headerVarName,
   );
 }
 
@@ -865,6 +842,68 @@ Code _buildListForLoop(
   ]);
 }
 
+Code _buildNonExplodedListAddition(
+  String rawName,
+  String accessor,
+  Expression itemExpr, {
+  required bool needsMapping,
+  required EncodingStyle? style,
+  String? headerVarName,
+}) {
+  final listExpr = _buildStringListExpr(
+    accessor,
+    itemExpr,
+    needsMapping: needsMapping,
+  );
+
+  if (style == EncodingStyle.spaceDelimited ||
+      style == EncodingStyle.pipeDelimited) {
+    final encoderMethod = style == EncodingStyle.spaceDelimited
+        ? 'toSpaceDelimited'
+        : 'toPipeDelimited';
+    final namedArgs = <String, Expression>{
+      'explode': literalFalse,
+      'allowEmpty': literalTrue,
+      'alreadyEncoded': literalTrue,
+      if (style == EncodingStyle.spaceDelimited)
+        'percentEncodeDelimiter': literalFalse,
+    };
+    final iterableExpr = listExpr.property(encoderMethod).call([], namedArgs);
+    final itemValue = headerVarName == null
+        ? refer('item')
+        : refer('MultipartFile', 'package:dio/dio.dart')
+              .property('fromString')
+              .call([refer('item')], {'headers': refer(headerVarName)});
+    return _buildListForLoop(
+      rawName,
+      iterableExpr,
+      itemValue,
+      isFile: headerVarName != null,
+    );
+  }
+
+  // Form-style, non-exploded arrays encode to one comma-joined String. That
+  // scalar is one multipart part; unlike the delimited helpers above, it must
+  // not be used as the iterable of a generated for-in loop.
+  final valueExpr = listExpr.property('uriEncode').call([], {
+    'allowEmpty': literalTrue,
+    'alreadyEncoded': literalTrue,
+  });
+  final value = headerVarName == null
+      ? valueExpr
+      : refer('MultipartFile', 'package:dio/dio.dart')
+            .property('fromString')
+            .call([valueExpr], {'headers': refer(headerVarName)});
+  final target = headerVarName == null ? 'fields' : 'files';
+
+  return refer(r'_$formData').property(target).property('add').call([
+    refer('MapEntry', 'dart:core').call([
+      specLiteralString(rawName),
+      value,
+    ]),
+  ]).statement;
+}
+
 /// Builds a for-loop for binary list items, embedding a switch on the
 /// sealed `TonikFile` type inside each iteration.
 Code _buildBinaryListForLoop(
@@ -988,20 +1027,14 @@ Expression _complexItemExpr(
   ], namedArgs);
 }
 
-/// Builds an [Expression] for the encoder call for explode: false arrays.
-///
-/// Maps items to strings via [itemExpr], then calls the appropriate style
-/// encoder. Set [needsMapping] to false when [itemExpr] is identity
-/// (i.e. the item is already a string).
-Expression _buildEncoderExpr(
+/// Builds the string-list input used by non-exploded array encoders.
+Expression _buildStringListExpr(
   String accessor,
   Expression itemExpr, {
   required bool needsMapping,
-  EncodingStyle? style,
 }) {
-  Expression listExpr;
   if (needsMapping) {
-    listExpr = refer(accessor)
+    return refer(accessor)
         .property('map')
         .call([
           Method(
@@ -1013,31 +1046,8 @@ Expression _buildEncoderExpr(
         ])
         .property('toList')
         .call([]);
-  } else {
-    listExpr = refer(accessor);
   }
-
-  final encoderMethod = switch (style) {
-    EncodingStyle.spaceDelimited => 'toSpaceDelimited',
-    EncodingStyle.pipeDelimited => 'toPipeDelimited',
-    _ => 'uriEncode',
-  };
-
-  final isDelimited =
-      style == EncodingStyle.spaceDelimited ||
-      style == EncodingStyle.pipeDelimited;
-
-  final namedArgs = <String, Expression>{
-    if (isDelimited) 'explode': literalFalse,
-    'allowEmpty': literalTrue,
-    'alreadyEncoded': literalTrue,
-  };
-
-  if (style == EncodingStyle.spaceDelimited) {
-    namedArgs['percentEncodeDelimiter'] = literalFalse;
-  }
-
-  return listExpr.property(encoderMethod).call([], namedArgs);
+  return refer(accessor);
 }
 
 Code _buildDeepObjectFileAddition(
@@ -1351,14 +1361,16 @@ Code _buildUrlEncodedObjectFileAddition(
   return Block.of([
     declareFinal(entriesVarName)
         .assign(
-          refer(accessor).property('toForm').call(
-            [specLiteralString(rawName)],
-            {
-              'explode': literalTrue,
-              'allowEmpty': literalTrue,
-              'useQueryComponent': literalTrue,
-            },
-          ),
+          refer(accessor)
+              .property('toForm')
+              .call(
+                [specLiteralString(rawName)],
+                {
+                  'explode': literalTrue,
+                  'allowEmpty': literalTrue,
+                  'useQueryComponent': literalTrue,
+                },
+              ),
         )
         .statement,
     refer(r'_$formData').property('files').property('add').call([
@@ -1399,7 +1411,8 @@ Code _buildRawStylePartsAddition(
     refer(r'_$formData').property('files').property('add').call([
       refer('MapEntry', 'dart:core').call([
         refer(r'_$part').property('name'),
-        refer('MultipartFile', 'package:dio/dio.dart').property('fromString')
+        refer('MultipartFile', 'package:dio/dio.dart')
+            .property('fromString')
             .call(
               [refer(r'_$part').property('value')],
               {if (headerVarName != null) 'headers': refer(headerVarName)},

--- a/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_multipart_expression_generator.dart
@@ -882,9 +882,8 @@ Code _buildNonExplodedListAddition(
     );
   }
 
-  // Form-style, non-exploded arrays encode to one comma-joined String. That
-  // scalar is one multipart part; unlike the delimited helpers above, it must
-  // not be used as the iterable of a generated for-in loop.
+  // Unlike delimited encoders, non-exploded form encoding returns a scalar
+  // String, so it represents one multipart part rather than an iterable.
   final valueExpr = listExpr.property('uriEncode').call([], {
     'allowEmpty': literalTrue,
     'alreadyEncoded': literalTrue,
@@ -1028,6 +1027,8 @@ Expression _complexItemExpr(
 }
 
 /// Builds the string-list input used by non-exploded array encoders.
+///
+/// When [needsMapping] is false, [itemExpr] is ignored.
 Expression _buildStringListExpr(
   String accessor,
   Expression itemExpr, {

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -9144,6 +9144,170 @@ void main() {
       );
     });
 
+    test(
+      'non-exploded space-delimited string list with headers wraps the '
+      'encoded value in MultipartFile.fromString',
+      () {
+        final model = ClassModel(
+          name: 'TestForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: 'tags',
+              model: ListModel(
+                content: StringModel(context: testContext),
+                context: testContext,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          multipartEncoding: _multipartEncoding(model, {
+            'tags': PartEncoding(
+              contentType: ContentType.text,
+              rawContentType: 'text/plain',
+              style: EncodingStyle.spaceDelimited,
+              explode: false,
+              headers: {
+                'X-Custom': ResponseHeaderObject(
+                  name: 'X-Custom',
+                  context: testContext,
+                  description: null,
+                  explode: false,
+                  model: StringModel(context: testContext),
+                  isRequired: true,
+                  isDeprecated: false,
+                  encoding: ResponseHeaderEncoding.simple,
+                  examples: const [],
+                ),
+              },
+              allowReserved: null,
+            ),
+          }),
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+          void test() {
+            final _$formData = FormData();
+            final _$tagsHeaders = <String, List<String>>{};
+            _$tagsHeaders[r'X-Custom'] = [tagsCustom.toSimple(explode: false, allowEmpty: true)];
+            for (final item in body.tags.toSpaceDelimited(explode: false, allowEmpty: true, alreadyEncoded: true, percentEncodeDelimiter: false)) {
+              _$formData.files.add(MapEntry(r'tags', MultipartFile.fromString(item, headers: _$tagsHeaders)));
+            }
+            return _$formData;
+          }
+        '''),
+          ),
+        );
+      },
+    );
+
+    test(
+      'non-exploded pipe-delimited DateTime list with headers maps items and '
+      'wraps the encoded value in MultipartFile.fromString',
+      () {
+        final model = ClassModel(
+          name: 'TestForm',
+          isDeprecated: false,
+          properties: [
+            Property(
+              name: 'dates',
+              model: ListModel(
+                content: DateTimeModel(context: testContext),
+                context: testContext,
+                examples: const [],
+              ),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: testContext,
+          examples: const [],
+        );
+
+        final content = RequestContent(
+          model: model,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          multipartEncoding: _multipartEncoding(model, {
+            'dates': PartEncoding(
+              contentType: ContentType.text,
+              rawContentType: 'text/plain',
+              style: EncodingStyle.pipeDelimited,
+              explode: false,
+              headers: {
+                'X-Custom': ResponseHeaderObject(
+                  name: 'X-Custom',
+                  context: testContext,
+                  description: null,
+                  explode: false,
+                  model: StringModel(context: testContext),
+                  isRequired: true,
+                  isDeprecated: false,
+                  encoding: ResponseHeaderEncoding.simple,
+                  examples: const [],
+                ),
+              },
+              allowReserved: null,
+            ),
+          }),
+          examples: const [],
+        );
+
+        final result = buildMultipartBodyStatements(
+          content,
+          'body',
+          nameManager,
+          'test_package',
+        );
+
+        final code = emitStatements(result);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+          void test() {
+            final _$formData = FormData();
+            final _$datesHeaders = <String, List<String>>{};
+            _$datesHeaders[r'X-Custom'] = [datesCustom.toSimple(explode: false, allowEmpty: true)];
+            for (final item in body.dates.map((item) => item.toTimeZonedIso8601String()).toList().toPipeDelimited(explode: false, allowEmpty: true, alreadyEncoded: true)) {
+              _$formData.files.add(MapEntry(r'dates', MultipartFile.fromString(item, headers: _$datesHeaders)));
+            }
+            return _$formData;
+          }
+        '''),
+          ),
+        );
+      },
+    );
+
     test('exploded binary list with headers passes headers to '
         'MultipartFile.fromBytes', () {
       final model = ClassModel(
@@ -9727,8 +9891,7 @@ void main() {
     );
 
     test(
-      'non-exploded DateTime list with headers uses item directly '
-      'after encoder stringifies',
+      'non-exploded DateTime list with headers sends one mapped encoded part',
       () {
         final model = ClassModel(
           name: 'TestForm',

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -5835,9 +5835,7 @@ void main() {
           format(r'''
           void test() {
             final _$formData = FormData();
-            for (final item in body.tags.uriEncode(allowEmpty: true, alreadyEncoded: true)) {
-              _$formData.fields.add(MapEntry(r'tags', item));
-            }
+            _$formData.fields.add(MapEntry(r'tags', body.tags.uriEncode(allowEmpty: true, alreadyEncoded: true)));
             return _$formData;
           }
         '''),
@@ -6250,9 +6248,7 @@ void main() {
           format(r'''
           void test() {
             final _$formData = FormData();
-            for (final item in body.codes.map((item) => item.uriEncode(allowEmpty: true)).toList().uriEncode(allowEmpty: true, alreadyEncoded: true)) {
-              _$formData.fields.add(MapEntry(r'codes', item));
-            }
+            _$formData.fields.add(MapEntry(r'codes', body.codes.map((item) => item.uriEncode(allowEmpty: true)).toList().uriEncode(allowEmpty: true, alreadyEncoded: true)));
             return _$formData;
           }
         '''),
@@ -6444,9 +6440,7 @@ void main() {
           format(r'''
           void test() {
             final _$formData = FormData();
-            for (final item in body.scores.map((item) => jsonEncode(item)).toList().uriEncode(allowEmpty: true, alreadyEncoded: true)) {
-              _$formData.fields.add(MapEntry(r'scores', item));
-            }
+            _$formData.fields.add(MapEntry(r'scores', body.scores.map((item) => jsonEncode(item)).toList().uriEncode(allowEmpty: true, alreadyEncoded: true)));
             return _$formData;
           }
         '''),
@@ -9142,9 +9136,7 @@ void main() {
             final _$formData = FormData();
             final _$tagsHeaders = <String, List<String>>{};
             _$tagsHeaders[r'X-Custom'] = [tagsCustom.toSimple(explode: false, allowEmpty: true)];
-            for (final item in body.tags.uriEncode(allowEmpty: true, alreadyEncoded: true)) {
-              _$formData.files.add(MapEntry(r'tags', MultipartFile.fromString(item, headers: _$tagsHeaders)));
-            }
+            _$formData.files.add(MapEntry(r'tags', MultipartFile.fromString(body.tags.uriEncode(allowEmpty: true, alreadyEncoded: true), headers: _$tagsHeaders)));
             return _$formData;
           }
         '''),
@@ -9805,9 +9797,7 @@ void main() {
             final _$formData = FormData();
             final _$datesHeaders = <String, List<String>>{};
             _$datesHeaders[r'X-Custom'] = [datesCustom.toSimple(explode: false, allowEmpty: true)];
-            for (final item in body.dates.map((item) => item.toTimeZonedIso8601String()).toList().uriEncode(allowEmpty: true, alreadyEncoded: true)) {
-              _$formData.files.add(MapEntry(r'dates', MultipartFile.fromString(item, headers: _$datesHeaders)));
-            }
+            _$formData.files.add(MapEntry(r'dates', MultipartFile.fromString(body.dates.map((item) => item.toTimeZonedIso8601String()).toList().uriEncode(allowEmpty: true, alreadyEncoded: true), headers: _$datesHeaders)));
             return _$formData;
           }
         '''),


### PR DESCRIPTION
## Summary

- serialize multipart arrays with `style: form` and `explode: false` as one comma-joined part
- preserve repeated-part behavior for exploded arrays and iterable delimited encoders
- cover the optional-array reproduction with OAS 3.1 integration tests

## Root cause

The multipart generator passed the result of `List<String>.uriEncode(...)` to a generated `for-in` loop. That encoder returns a single `String`, which is not iterable in Dart, so the generated client did not compile.

The non-exploded form path now adds that scalar value directly. When per-part headers are present, it creates one `MultipartFile.fromString` instead.

## Impact

Generated clients compile and send one field such as `tags=a,b,c` for non-exploded form arrays. Optional null arrays remain omitted.

## Validation

- `fvm dart analyze` in `packages/tonik_generate`
- focused multipart generator suite: 141 tests
- full generator suite: 3,000 tests
- complete multipart integration package: 41 tests
- regenerated OAS 3.1 client analyzed successfully
- formatting and `git diff --check`
