### PR TITLE
Preserve reserved map keys in form query encoding

### DIFF
--- a/integration_test/additional_properties/additional_properties_test/test/additional_properties_contract_test.dart
+++ b/integration_test/additional_properties/additional_properties_test/test/additional_properties_contract_test.dart
@@ -18,6 +18,32 @@ void main() {
     });
 
     test(
+      'form allowReserved preserves map keys and values when collapsed',
+      () async {
+        final adapter = _CapturingAdapter();
+        final result = await EncodePureMapFormAllowReservedCollapsed(
+          _capturingDio(adapter),
+        ).call(values: const {'a:b': 'c:d'});
+
+        expect(result, isA<TonikSuccess<void>>());
+        expect(adapter.requestOptions!.uri.query, 'values=a:b,c:d');
+      },
+    );
+
+    test(
+      'form allowReserved preserves map keys and values when exploded',
+      () async {
+        final adapter = _CapturingAdapter();
+        final result = await EncodePureMapFormAllowReservedExploded(
+          _capturingDio(adapter),
+        ).call(values: const {'a:b': 'c:d'});
+
+        expect(result, isA<TonikSuccess<void>>());
+        expect(adapter.requestOptions!.uri.query, 'a:b=c:d');
+      },
+    );
+
+    test(
       'deepObject omits null while preserving empty and scalar values',
       () async {
         final adapter = _CapturingAdapter();

--- a/integration_test/additional_properties/openapi.yaml
+++ b/integration_test/additional_properties/openapi.yaml
@@ -51,6 +51,40 @@ paths:
       responses:
         '204':
           description: Encoded
+  /pure-map-form-allow-reserved-collapsed:
+    get:
+      operationId: encodePureMapFormAllowReservedCollapsed
+      tags:
+        - additional-properties
+      parameters:
+        - name: values
+          in: query
+          required: true
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/StringMap'
+      responses:
+        '204':
+          description: Encoded
+  /pure-map-form-allow-reserved-exploded:
+    get:
+      operationId: encodePureMapFormAllowReservedExploded
+      tags:
+        - additional-properties
+      parameters:
+        - name: values
+          in: query
+          required: true
+          style: form
+          explode: true
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/StringMap'
+      responses:
+        '204':
+          description: Encoded
   /pure-map-deep-object:
     get:
       operationId: encodePureMapDeepObject

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -56,8 +56,9 @@ abstract interface class FormEncodable {
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [useQueryComponent] is true, uses '+' for spaces
   /// (application/x-www-form-urlencoded encoding).
-  /// When [allowReserved] is true, reserved characters in values are kept
-  /// literal except the form delimiters `& = +`.
+  /// When [allowReserved] is true, reserved characters in encoded data,
+  /// including object property names and values, are kept literal except the
+  /// form delimiters `& = +`.
   /// [fieldEncodings], keyed by raw property name, lets individual object
   /// properties override [allowReserved]; other encoders ignore it.
   List<ParameterEntry> toForm(

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -39,9 +39,11 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
   ///
   /// When the map is exploded, per-property [FormFieldEncoding.explode]
   /// controls array assembly and [FormFieldEncoding.allowReserved] applies to
-  /// values only; keys are always component-encoded. In collapse mode
-  /// (object-level `explode` false) [fieldEncodings] is ignored and arrays are
-  /// always comma-joined.
+  /// values only. The object-level [allowReserved] applies to keys and is the
+  /// fallback for values without a field encoding. In collapse mode
+  /// (object-level `explode` false) [fieldEncodings] is ignored,
+  /// [allowReserved] applies to both keys and values, and arrays are always
+  /// comma-joined.
   List<ParameterEntry> toForm(
     String paramName, {
     required bool explode,
@@ -80,7 +82,7 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
       final encodedKey = _encode(
         name,
         useQueryComponent: useQueryComponent,
-        allowReserved: false,
+        allowReserved: allowReserved,
       );
       final encoding = fieldEncodings[name];
       final explodeArray = encoding?.explode ?? false;
@@ -148,7 +150,7 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
           _encode(
             entry.key,
             useQueryComponent: useQueryComponent,
-            allowReserved: false,
+            allowReserved: allowReserved,
           ),
         )
         ..add(

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -261,27 +261,38 @@ void main() {
       );
     });
 
-    test('applies an object-level override to values while component-encoding '
-        'keys when exploded', () {
-      expect(
-        <String, PropertyValue>{
-          'a/1': const PropertyValue.scalar('a/b'),
-          'tags': const PropertyValue.array(['a/b']),
-        }.toForm('p', explode: true, allowEmpty: true, allowReserved: true),
-        const <ParameterEntry>[
-          (name: 'a%2F1', value: 'a/b'),
-          (name: 'tags', value: 'a/b'),
-        ],
-      );
-    });
+    test(
+      'applies an object-level override to keys and values when exploded',
+      () {
+        expect(
+          <String, PropertyValue>{
+            'a:b': const PropertyValue.scalar('c:d'),
+          }.toForm('p', explode: true, allowEmpty: true, allowReserved: true),
+          const <ParameterEntry>[
+            (name: 'a:b', value: 'c:d'),
+          ],
+        );
+      },
+    );
 
-    test('applies an object-level override to values while component-encoding '
-        'keys when collapsed', () {
+    test(
+      'applies an object-level override to keys and values when collapsed',
+      () {
+        expect(
+          <String, PropertyValue>{
+            'a:b': const PropertyValue.scalar('c:d'),
+          }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+          const <ParameterEntry>[(name: 'p', value: 'a:b,c:d')],
+        );
+      },
+    );
+
+    test('component-encodes keys and values when allowReserved is false', () {
       expect(
         <String, PropertyValue>{
-          'k/1': const PropertyValue.scalar('a/b'),
-        }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
-        const <ParameterEntry>[(name: 'p', value: 'k%2F1,a/b')],
+          'a:b': const PropertyValue.scalar('c:d'),
+        }.toForm('p', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'p', value: 'a%3Ab,c%3Ad')],
       );
     });
 
@@ -416,14 +427,15 @@ void main() {
     test('throws on an empty exploded array descriptor when allowEmpty is '
         'false', () {
       expect(
-        () => <String, PropertyValue>{
-          'tags': const PropertyValue.array([]),
-        }.toForm(
-          'p',
-          explode: true,
-          allowEmpty: false,
-          fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
-        ),
+        () =>
+            <String, PropertyValue>{
+              'tags': const PropertyValue.array([]),
+            }.toForm(
+              'p',
+              explode: true,
+              allowEmpty: false,
+              fieldEncodings: const {'tags': FormFieldEncoding(explode: true)},
+            ),
         throwsA(isA<EmptyValueException>()),
       );
     });

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -287,6 +287,60 @@ void main() {
       },
     );
 
+    test('keeps query delimiters encoded in keys when exploded', () {
+      expect(
+        <String, PropertyValue>{
+          'a=b&c': const PropertyValue.scalar('d:e'),
+        }.toForm('p', explode: true, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[
+          (name: 'a%3Db%26c', value: 'd:e'),
+        ],
+      );
+    });
+
+    test('keeps query delimiters encoded in keys when collapsed', () {
+      expect(
+        <String, PropertyValue>{
+          'a=b&c': const PropertyValue.scalar('d:e'),
+        }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: 'a%3Db%26c,d:e')],
+      );
+    });
+
+    test('uses the object-level policy for a key when a field descriptor '
+        'overrides its value', () {
+      expect(
+        <String, PropertyValue>{
+          'a:b': const PropertyValue.scalar('c:d'),
+        }.toForm(
+          'p',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+          fieldEncodings: const {'a:b': FormFieldEncoding()},
+        ),
+        const <ParameterEntry>[(name: 'a:b', value: 'c%3Ad')],
+      );
+    });
+
+    test('keeps reserved characters in collapsed array keys and values', () {
+      expect(
+        <String, PropertyValue>{
+          'k:1': const PropertyValue.array(['a:b', 'c:d']),
+        }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: 'k:1,a:b,c:d')],
+      );
+    });
+
+    test('keeps a key comma literal when collapsing with allowReserved', () {
+      expect(
+        <String, PropertyValue>{
+          'a,b': const PropertyValue.scalar('c:d'),
+        }.toForm('p', explode: false, allowEmpty: true, allowReserved: true),
+        const <ParameterEntry>[(name: 'p', value: 'a,b,c:d')],
+      );
+    });
+
     test('component-encodes keys and values when allowReserved is false', () {
       expect(
         <String, PropertyValue>{


### PR DESCRIPTION
## Summary
- Allow object-level `allowReserved` to apply to form-style map keys as well as values.
- Keep collapsed form maps aligned with reserved-character semantics for both keys and values.
- Add integration coverage for collapsed and exploded query encoding with reserved characters in map entries.

## Testing
- Added unit coverage for exploded and collapsed form-map encoding with `allowReserved: true`.
- Added integration tests validating the generated query string for reserved map keys and values.
- Not run (not requested).