### PR TITLE
Fix RFC 3339 offset parsing and formatting across DST boundaries

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -52,6 +52,13 @@ jobs:
       - name: Run tests with coverage
         run: melos run coverage-ci
 
+      - name: Run fixed-offset tests in a DST timezone
+        if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'
+        working-directory: packages/tonik_util
+        env:
+          TZ: Europe/Berlin
+        run: dart test test/src/offset_date_time_test.dart
+
       - name: Upload coverage to Codecov
         if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v7

--- a/packages/tonik_util/lib/src/offset_date_time.dart
+++ b/packages/tonik_util/lib/src/offset_date_time.dart
@@ -39,24 +39,21 @@ class OffsetDateTime implements DateTime {
     required String originalInput,
   }) {
     final offsetString = timezoneMatch.group(0)!;
-    final datetimeString = input.substring(
-      0,
-      input.length - offsetString.length,
-    );
-
     final offset = _parseTimezoneOffset(offsetString);
 
-    final DateTime localDateTime;
     try {
-      localDateTime = DateTime.parse(datetimeString);
+      final utcDateTime = DateTime.parse(input).toUtc();
+      return OffsetDateTime._fromUtc(
+        utcDateTime,
+        offset: offset,
+        timeZoneName: _generateTimeZoneName(offset),
+      );
     } on FormatException {
       throw InvalidFormatException(
         value: originalInput,
         format: 'ISO8601 datetime format',
       );
     }
-
-    return OffsetDateTime.from(localDateTime, offset: offset);
   }
 
   /// Parses an ISO8601 datetime string with timezone support.
@@ -169,17 +166,17 @@ class OffsetDateTime implements DateTime {
 
   /// Converts a local DateTime with an offset to UTC DateTime.
   static DateTime _toUtcDateTime(DateTime localDateTime, Duration offset) {
-    final utcMoment = localDateTime.subtract(offset);
-    return DateTime.utc(
-      utcMoment.year,
-      utcMoment.month,
-      utcMoment.day,
-      utcMoment.hour,
-      utcMoment.minute,
-      utcMoment.second,
-      utcMoment.millisecond,
-      utcMoment.microsecond,
+    final localFieldsAsUtc = DateTime.utc(
+      localDateTime.year,
+      localDateTime.month,
+      localDateTime.day,
+      localDateTime.hour,
+      localDateTime.minute,
+      localDateTime.second,
+      localDateTime.millisecond,
+      localDateTime.microsecond,
     );
+    return localFieldsAsUtc.subtract(offset);
   }
 
   /// Generates a timezone name from an offset.
@@ -333,7 +330,7 @@ class OffsetDateTime implements DateTime {
       final offH = _twoDigits(offsetHours);
       final offM = _twoDigits(offsetMinutes);
 
-      return '$y-$m-$d$sep$h:$min:$sec.$ms$us$offsetSign$offH$offM';
+      return '$y-$m-$d$sep$h:$min:$sec.$ms$us$offsetSign$offH:$offM';
     }
   }
 

--- a/packages/tonik_util/test/src/offset_date_time_test.dart
+++ b/packages/tonik_util/test/src/offset_date_time_test.dart
@@ -39,6 +39,22 @@ void main() {
       expect(offsetDateTime.timeZoneName, 'UTC');
       expect(offsetDateTime.isUtc, isTrue);
     });
+
+    test('should not use host DST rules when applying a fixed offset', () {
+      final offsetDateTime = OffsetDateTime.from(
+        DateTime(2025, 3, 29, 17),
+        offset: const Duration(hours: -10),
+      );
+
+      expect(
+        offsetDateTime.microsecondsSinceEpoch,
+        DateTime.utc(2025, 3, 30, 3).microsecondsSinceEpoch,
+      );
+      expect(
+        offsetDateTime.toTimeZonedIso8601String(),
+        '2025-03-29T17:00:00-10:00',
+      );
+    });
   });
 
   group('timezone name generation', () {
@@ -437,8 +453,8 @@ void main() {
       );
       final isoString = offsetDateTime.toIso8601String();
       final toString = offsetDateTime.toString();
-      expect(isoString, '2023-01-15T12:30:45.123+0530');
-      expect(toString, '2023-01-15 12:30:45.123+0530');
+      expect(isoString, '2023-01-15T12:30:45.123+05:30');
+      expect(toString, '2023-01-15 12:30:45.123+05:30');
     });
 
     test('should format negative offset correctly', () {
@@ -447,7 +463,7 @@ void main() {
         offset: const Duration(hours: -8),
       );
       final isoString = offsetDateTime.toIso8601String();
-      expect(isoString, '2023-01-15T12:30:45.123-0800');
+      expect(isoString, '2023-01-15T12:30:45.123-08:00');
     });
 
     test('should handle microseconds in string representation', () {
@@ -456,7 +472,7 @@ void main() {
         offset: const Duration(hours: 2),
       );
       final isoString = offsetDateTime.toIso8601String();
-      expect(isoString, '2023-01-15T12:30:45.123456+0200');
+      expect(isoString, '2023-01-15T12:30:45.123456+02:00');
     });
   });
 
@@ -732,6 +748,18 @@ void main() {
         expect(result.timeZoneOffset.inHours, -7);
         expect(result.millisecond, 123);
         expect(result.microsecond, 456);
+      });
+
+      test('should preserve the instant when crossing host DST', () {
+        const input = '2025-03-29T17:00:00-10:00';
+        final result = OffsetDateTime.parse(input);
+
+        expect(
+          result.microsecondsSinceEpoch,
+          DateTime.utc(2025, 3, 30, 3).microsecondsSinceEpoch,
+        );
+        expect(result.timeZoneOffset, const Duration(hours: -10));
+        expect(result.toTimeZonedIso8601String(), input);
       });
 
       test('should accept lowercase t separator with offset and colon', () {


### PR DESCRIPTION
## Summary
- Parse offset datetimes from the UTC instant produced by `DateTime.parse` so fixed offsets are not distorted by host DST rules
- Format timezone offsets with a colon to match RFC 3339 output
- Add coverage for DST-sensitive parsing and formatting cases in `tonik_util`
- Extend CI to run the offset datetime test under `Europe/Berlin` on stable Ubuntu

## Testing
- Added unit coverage for parsing a fixed-offset timestamp across a host DST transition
- Updated string-format expectations for positive and negative offsets to the colon-separated RFC 3339 form
- CI now exercises the offset datetime test in a DST timezone