### PR TITLE
Handle nullable base64 list elements in parameter label generation

### DIFF
--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -125,6 +125,13 @@ Expression _buildListLabelExpression(
       ? refer('e').equalTo(literalNull).conditional(literalString(''), encoded)
       : encoded;
 
+  Expression base64Encode() => isContentNullable
+      ? refer('e')
+          .nullSafeProperty('toBase64String')
+          .call([])
+          .ifNullThen(literalString(''))
+      : refer('e').property('toBase64String').call([]);
+
   return switch (contentModel) {
     StringModel() when !isContentNullable => listPropertyAccess.call(
       [],
@@ -209,7 +216,7 @@ Expression _buildListLabelExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = base64Encode().code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -43,6 +43,19 @@ Expression _buildToLabelPathParameterExpression(
     final isContentNullable =
         model.isContentNullable || content.isEffectivelyNullable;
 
+    Expression nullGuard(Expression encoded) => isContentNullable
+        ? refer('e')
+            .equalTo(literalNull)
+            .conditional(literalString(''), encoded)
+        : encoded;
+
+    Expression base64Encode() => isContentNullable
+        ? refer('e')
+            .nullSafeProperty('toBase64String')
+            .call([])
+            .ifNullThen(literalString(''))
+        : refer('e').property('toBase64String').call([]);
+
     if (contentModel is StringModel && !isContentNullable) {
       return valueRef.property('toLabel').call([], {
         'explode': explode,
@@ -59,15 +72,11 @@ Expression _buildToLabelPathParameterExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e')
-                    .equalTo(literalNull)
-                    .conditional(
-                      literalString(''),
-                      refer('e').property('uriEncode').call([], {
-                        'allowEmpty': allowEmpty,
-                      }),
-                    )
-                    .code,
+                ..body = nullGuard(
+                  refer('e').property('uriEncode').call([], {
+                    'allowEmpty': allowEmpty,
+                  }),
+                ).code,
             ).closure,
           ])
           .property('toList')
@@ -92,7 +101,7 @@ Expression _buildToLabelPathParameterExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = base64Encode().code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -179,6 +179,13 @@ Expression _buildListMatrixExpression(
       ? refer('e').equalTo(literalNull).conditional(literalString(''), encoded)
       : encoded;
 
+  Expression base64Encode() => isContentNullable
+      ? refer('e')
+          .nullSafeProperty('toBase64String')
+          .call([])
+          .ifNullThen(literalString(''))
+      : refer('e').property('toBase64String').call([]);
+
   return switch (contentModel) {
     StringModel() when !isContentNullable => listPropertyAccess.call(
       [paramName],
@@ -280,7 +287,7 @@ Expression _buildListMatrixExpression(
                   ..requiredParameters.add(
                     Parameter((b) => b..name = 'e'),
                   )
-                  ..body = refer('e').property('toBase64String').call([]).code,
+                  ..body = base64Encode().code,
               ).closure,
             ],
             {},

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -140,6 +140,13 @@ Expression _buildListSimpleExpression(
       ? refer('e').equalTo(literalNull).conditional(literalString(''), encoded)
       : encoded;
 
+  Expression base64Encode() => isContentNullable
+      ? refer('e')
+          .nullSafeProperty('toBase64String')
+          .call([])
+          .ifNullThen(literalString(''))
+      : refer('e').property('toBase64String').call([]);
+
   return switch (contentModel) {
     StringModel() when !isContentNullable => listPropertyAccess.call(
       [],
@@ -239,7 +246,7 @@ Expression _buildListSimpleExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = base64Encode().code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -291,6 +291,13 @@ Expression _handleListExpression(
       ? refer('e').equalTo(literalNull).conditional(literalString(''), encoded)
       : encoded;
 
+  Expression base64Encode() => isContentNullable
+      ? refer('e')
+          .nullSafeProperty('toBase64String')
+          .call([])
+          .ifNullThen(literalString(''))
+      : refer('e').property('toBase64String').call([]);
+
   Expression mappedList(Expression body) => mapAccess()
       .call([
         Method(
@@ -368,7 +375,7 @@ Expression _handleListExpression(
 
     AnyModel() => callToSimpleOnList(receiver),
     Base64Model() => mappedList(
-      refer('e').property('toBase64String').call([]),
+      base64Encode(),
     ).property('toSimple').call([], {
       ...toSimpleArgs,
       'alreadyEncoded': literalBool(true),

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -699,6 +699,48 @@ void main() {
       );
     });
 
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal(
+            'result',
+          ).assign(expression.expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((e) => e?.toBase64String() ?? '')
+              .toList()
+              .toLabel(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
     test('generates list-of-map encoding for List<Map<String, int>>', () {
       final model = ListModel(
         content: MapModel(

--- a/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
@@ -1023,6 +1023,41 @@ void main() {
         ),
       );
     });
+
+    test('List of nullable Base64Model null-guards each element', () {
+      final parameter = PathParameterObject(
+        name: 'files',
+        rawName: 'files',
+        description: 'List of nullable base64 files',
+        model: ListModel(
+          context: context,
+          content: Base64Model(context: context),
+          isContentNullable: true,
+          examples: const [],
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final result = emit(
+        buildToLabelPathParameterExpression('files', parameter),
+      );
+      expect(
+        collapseWhitespace(result),
+        collapseWhitespace(
+          [
+            "files.map((e) => e?.toBase64String() ?? '').toList()",
+            '.toLabel(explode: false, ',
+            'allowEmpty: false, alreadyEncoded: true, )',
+          ].join(),
+        ),
+      );
+    });
   });
 
   group('nullable model support', () {

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -729,6 +729,50 @@ void main() {
       );
     });
 
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal(
+            'result',
+          ).assign(expression.expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map<String>((e) => e?.toBase64String() ?? '')
+              .toList()
+              .toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
     test('generates list-of-map encoding for List<Map<String, int>>', () {
       final model = ListModel(
         content: MapModel(

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -707,6 +707,48 @@ void main() {
       );
     });
 
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal(
+            'result',
+          ).assign(expression.expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      final expected = format('''
+        test() {
+          final result = value
+              .map((e) => e?.toBase64String() ?? '')
+              .toList()
+              .toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''');
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(expected),
+      );
+    });
+
     test('generates list-of-map encoding for List<Map<String, int>>', () {
       final model = ListModel(
         content: MapModel(

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -1159,6 +1159,48 @@ void main() {
           );
         },
       );
+
+      test('null-guards each element for List<Base64Model?>', () {
+        final model = ListModel(
+          content: Base64Model(context: context),
+          isContentNullable: true,
+          context: context,
+          examples: const [],
+        );
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final method = Method(
+          (b) => b
+            ..name = 'test'
+            ..body = declareFinal(
+              'result',
+            ).assign(expression.expression).statement,
+        );
+
+        final generated = format(method.accept(emitter).toString());
+        final expected = format('''
+          test() {
+            final result = value
+                .map((e) => e?.toBase64String() ?? '')
+                .toList()
+                .toSimple(
+                  explode: false,
+                  allowEmpty: true,
+                  alreadyEncoded: true,
+                );
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
+        );
+      });
     });
 
     group('List<MapModel>', () {


### PR DESCRIPTION
## Summary
- Null-guard `List<Base64Model?>` element encoding across label, path, matrix, and simple parameter generators
- Reuse shared base64 encoding logic so nullable elements emit `''` instead of crashing on `null`
- Add regression tests covering the affected list encoders

## Testing
- Added unit coverage for nullable base64 list element generation in all updated parameter expression builders
- Not run (not requested)