### PR TITLE
Avoid generated model file name collisions

### DIFF
--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -1529,11 +1529,7 @@ class AnyOfGenerator {
           AnyOfModel() =>
             refer(
                   nameManager.modelName(modelType),
-                  sourceFileUrl(
-                    package,
-                    'model',
-                    nameManager.modelName(modelType),
-                  ),
+                  modelSourceFileUrl(package, nameManager, modelType),
                 )
                 .property(constructorName)
                 .call(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1,4 +1,3 @@
-import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:logging/logging.dart';
@@ -55,7 +54,6 @@ class ClassGenerator {
       useNullSafetySyntax: true,
     );
 
-    final snakeCaseName = nameManager.modelName(model).toSnakeCase();
     final generatedClasses = generateClasses(model);
 
     final library = Library((b) {
@@ -68,7 +66,7 @@ class ClassGenerator {
 
     final code = formatter.formatWithHeader(library.accept(emitter).toString());
 
-    return (code: code, filename: '$snakeCaseName.dart');
+    return (code: code, filename: nameManager.modelFileName(model));
   }
 
   @visibleForTesting
@@ -1914,5 +1912,4 @@ class ClassGenerator {
         raw: true,
       ).statement,
   );
-
 }

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -1,4 +1,3 @@
-import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:meta/meta.dart';
@@ -30,7 +29,6 @@ class EnumGenerator {
     );
 
     final publicEnumName = nameManager.modelName(model);
-    final snakeCaseName = publicEnumName.toSnakeCase();
 
     final library = Library((b) {
       final generated = generateEnum(model, publicEnumName);
@@ -46,7 +44,7 @@ class EnumGenerator {
 
     final code = formatter.formatWithHeader(library.accept(emitter).toString());
 
-    return (code: code, filename: '$snakeCaseName.dart');
+    return (code: code, filename: nameManager.modelFileName(model));
   }
 
   @visibleForTesting
@@ -383,12 +381,13 @@ class EnumGenerator {
                       ..requiredParameters.add(
                         Parameter((pb) => pb..name = 'e'),
                       )
-                      ..body = refer(
-                        'e',
-                      )
-                          .property(_rawValueFieldName)
-                          .equalTo(refer(matchVariable))
-                          .code,
+                      ..body =
+                          refer(
+                                'e',
+                              )
+                              .property(_rawValueFieldName)
+                              .equalTo(refer(matchVariable))
+                              .code,
                   ).closure,
                 ],
                 {'orElse': orElse},

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -446,11 +446,7 @@ class OneOfGenerator {
           refer(variantName).call([
             refer(
               nameManager.modelName(m.model),
-              sourceFileUrl(
-                package,
-                'model',
-                nameManager.modelName(m.model),
-              ),
+              modelSourceFileUrl(package, nameManager, m.model),
             ).property('fromJson').call([refer('json')]),
           ]).code,
           const Code(','),
@@ -475,8 +471,7 @@ class OneOfGenerator {
     );
 
     final hasNumberMember = model.models.any(
-      (m) =>
-          m.model.resolved is DoubleModel || m.model.resolved is NumberModel,
+      (m) => m.model.resolved is DoubleModel || m.model.resolved is NumberModel,
     );
 
     final sortedModels = stableModelSorter.sortDiscriminatedModels(
@@ -499,11 +494,14 @@ class OneOfGenerator {
           const Code('if ('),
           refer('json').isA(refer('num', 'dart:core')).code,
           const Code(') {'),
-          refer(variantName).call([
-            refer('json').property('decodeJsonInt').call([], {
-              'context': specLiteralString(className),
-            }),
-          ]).returned.statement,
+          refer(variantName)
+              .call([
+                refer('json').property('decodeJsonInt').call([], {
+                  'context': specLiteralString(className),
+                }),
+              ])
+              .returned
+              .statement,
           const Code('}'),
         ]);
         continue;
@@ -550,7 +548,7 @@ class OneOfGenerator {
         final modelName = nameManager.modelName(modelType);
         decodeArg = refer(
           modelName,
-          sourceFileUrl(package, 'model', modelName),
+          modelSourceFileUrl(package, nameManager, modelType),
         ).property('fromJson').call([refer('json')]);
       }
 
@@ -709,11 +707,7 @@ class OneOfGenerator {
             refer(variantName).call([
               refer(
                     nameManager.modelName(modelType),
-                    sourceFileUrl(
-                      package,
-                      'model',
-                      nameManager.modelName(modelType),
-                    ),
+                    modelSourceFileUrl(package, nameManager, modelType),
                   )
                   .property(constructorName)
                   .call(
@@ -817,11 +811,7 @@ class OneOfGenerator {
         final innerDecode =
             refer(
                   nameManager.modelName(modelType),
-                  sourceFileUrl(
-                    package,
-                    'model',
-                    nameManager.modelName(modelType),
-                  ),
+                  modelSourceFileUrl(package, nameManager, modelType),
                 )
                 .property(constructorName)
                 .call([refer('value')], {'explode': refer('explode')});

--- a/packages/tonik_generate/lib/src/model/typedef_generator.dart
+++ b/packages/tonik_generate/lib/src/model/typedef_generator.dart
@@ -1,4 +1,3 @@
-import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:meta/meta.dart';
@@ -25,13 +24,13 @@ class TypedefGenerator {
   final bool useImmutableCollections;
 
   ({String code, String filename}) generateAlias(AliasModel model) =>
-      _generateFile(generateAliasTypedef(model));
+      _generateFile(generateAliasTypedef(model), model);
 
   ({String code, String filename}) generateList(ListModel model) =>
-      _generateFile(generateListTypedef(model));
+      _generateFile(generateListTypedef(model), model);
 
   ({String code, String filename}) generateMap(MapModel model) =>
-      _generateFile(generateMapTypedef(model));
+      _generateFile(generateMapTypedef(model), model);
 
   @visibleForTesting
   TypeDef generateAliasTypedef(AliasModel model) {
@@ -163,14 +162,16 @@ class TypedefGenerator {
     return walk(start);
   }
 
-  ({String code, String filename}) _generateFile(TypeDef typedef) {
+  ({String code, String filename}) _generateFile(
+    TypeDef typedef,
+    Model model,
+  ) {
     final emitter = DartEmitter(
       allocator: CorePrefixedAllocator(),
       orderDirectives: true,
       useNullSafetySyntax: true,
     );
 
-    final snakeCaseName = typedef.name.toSnakeCase();
     final library = Library((b) => b.body.add(typedef));
 
     final formatter = DartFormatter(
@@ -179,6 +180,6 @@ class TypedefGenerator {
 
     final code = formatter.formatWithHeader(library.accept(emitter).toString());
 
-    return (code: code, filename: '$snakeCaseName.dart');
+    return (code: code, filename: nameManager.modelFileName(model));
   }
 }

--- a/packages/tonik_generate/lib/src/naming/name_manager.dart
+++ b/packages/tonik_generate/lib/src/naming/name_manager.dart
@@ -15,6 +15,10 @@ class NameManager {
 
   final modelNames = <Model, String>{};
 
+  final modelFileNames = <Model, String>{};
+
+  final _usedModelFileNames = <String>{};
+
   final operationNames = <Operation, String>{};
 
   final tagNames = <Tag, String>{};
@@ -111,6 +115,11 @@ class NameManager {
       _logModelName(name, model);
     }
 
+    // File names must be claimed in the same stable order as class names.
+    // Different Dart identifiers can collapse to the same snake_case path
+    // (for example, `$User` and `$$User` both become `_user.dart`).
+    sortedModels.where(_hasGeneratedModelFile).forEach(modelFileName);
+
     for (final response in responses) {
       if (response.hasHeaders || response.bodyCount > 1) {
         final (:baseName, :implementationNames) = responseNames(response);
@@ -144,6 +153,38 @@ class NameManager {
       return generator.generateModelName(model);
     });
   }
+
+  /// Gets a cached, globally unique file name for a generated model.
+  ///
+  /// Class names remain unchanged when their snake_case representations
+  /// collide. Numeric suffixes are applied only to the generated file path.
+  String modelFileName(Model model) {
+    return modelFileNames.putIfAbsent(model, () {
+      final baseName = modelName(model).toSnakeCase();
+      var fileName = '$baseName.dart';
+      var counter = 2;
+
+      while (_usedModelFileNames.contains(fileName)) {
+        fileName = '$baseName$counter.dart';
+        counter++;
+      }
+
+      _usedModelFileNames.add(fileName);
+      return fileName;
+    });
+  }
+
+  bool _hasGeneratedModelFile(Model model) => switch (model) {
+    ClassModel() ||
+    EnumModel() ||
+    AnyOfModel() ||
+    OneOfModel() ||
+    AllOfModel() ||
+    AliasModel() ||
+    ListModel() ||
+    MapModel() => true,
+    _ => false,
+  };
 
   /// Gets a cached or generates a new unique response class
   /// name and implementation names.

--- a/packages/tonik_generate/lib/src/util/composite_library_builder.dart
+++ b/packages/tonik_generate/lib/src/util/composite_library_builder.dart
@@ -1,4 +1,3 @@
-import 'package:change_case/change_case.dart';
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:tonik_core/tonik_core.dart';
@@ -23,7 +22,6 @@ import 'package:tonik_generate/src/util/format_with_header.dart';
   );
 
   final publicClassName = nameManager.modelName(model);
-  final snakeCaseName = publicClassName.toSnakeCase();
 
   final actualClassName = isNullable
       ? nameManager.modelName(
@@ -59,5 +57,5 @@ import 'package:tonik_generate/src/util/format_with_header.dart';
 
   final code = formatter.formatWithHeader(library.accept(emitter).toString());
 
-  return (code: code, filename: '$snakeCaseName.dart');
+  return (code: code, filename: nameManager.modelFileName(model));
 }

--- a/packages/tonik_generate/lib/src/util/default_value_materialiser.dart
+++ b/packages/tonik_generate/lib/src/util/default_value_materialiser.dart
@@ -75,7 +75,7 @@ Expression? _materialiseEnumDefault({
       .enumVariantNames(model)
       .valueNames[matchedIndex];
   final enumName = nameManager.modelName(model);
-  final url = sourceFileUrl(package, 'model', enumName);
+  final url = modelSourceFileUrl(package, nameManager, model);
   return refer('$enumName.$variantName', url);
 }
 

--- a/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
@@ -215,7 +215,9 @@ Expression _buildFromFormExpression(
 }) {
   final name = nameManager.modelName(model);
   final explodeParam = {'explode': explode ?? literalBool(true)};
-  final url = package != null ? sourceFileUrl(package, 'model', name) : null;
+  final url = package != null
+      ? modelSourceFileUrl(package, nameManager, model)
+      : null;
 
   return isRequired
       ? refer(name, url).property('fromForm').call([value], explodeParam)
@@ -422,7 +424,9 @@ Expression _buildClassList(
 }) {
   final name = nameManager.modelName(content);
   final explodeParam = {'explode': explode ?? literalBool(true)};
-  final url = package != null ? sourceFileUrl(package, 'model', name) : null;
+  final url = package != null
+      ? modelSourceFileUrl(package, nameManager, content)
+      : null;
 
   final mapFunction = Method(
     (b) => b

--- a/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_json_value_expression_generator.dart
@@ -194,7 +194,7 @@ BuiltExpression _buildFromJson(
       final className = nameManager.modelName(model);
       final expr = refer(
         className,
-        sourceFileUrl(package, 'model', className),
+        modelSourceFileUrl(package, nameManager, model),
       ).property('fromJson').call([receiver]);
       final body = nullable
           ? receiver.equalTo(literalNull).conditional(literalNull, expr)
@@ -204,7 +204,7 @@ BuiltExpression _buildFromJson(
       final className = nameManager.modelName(model);
       final expr = refer(
         className,
-        sourceFileUrl(package, 'model', className),
+        modelSourceFileUrl(package, nameManager, model),
       ).property('fromJson').call([receiver]);
       final body = nullable
           ? receiver.equalTo(literalNull).conditional(literalNull, expr)
@@ -396,7 +396,7 @@ BuiltExpression _buildListFromJsonBody(
       final className = nameManager.modelName(unwrappedContent);
       final fromJson = refer(
         className,
-        sourceFileUrl(package, 'model', className),
+        modelSourceFileUrl(package, nameManager, unwrappedContent),
       ).property('fromJson');
       final mapFunction = isItemNullable
           ? elementClosure(fromJson.call([refer('e')]))
@@ -640,7 +640,7 @@ BuiltExpression _buildNamedTypedefHelperCall({
 }) {
   final named = model as NamedModel;
   final typedefName = nameManager.modelName(model);
-  final typedefUrl = sourceFileUrl(package, 'model', typedefName);
+  final typedefUrl = modelSourceFileUrl(package, nameManager, model);
   final helperName = helperContext.helperName(named, _decodePrefix);
   final receiver = receiverOverride ?? refer(value);
 

--- a/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
@@ -224,7 +224,9 @@ Expression _buildFromSimpleExpression(
   final name = nameManager.modelName(model);
   final explodeParam = {'explode': explode};
 
-  final url = package != null ? sourceFileUrl(package, 'model', name) : null;
+  final url = package != null
+      ? modelSourceFileUrl(package, nameManager, model)
+      : null;
 
   return isRequired
       ? refer(name, url).property('fromSimple').call([value], explodeParam)
@@ -447,7 +449,7 @@ Expression _buildClassList(
   final explodeParam = {'explode': explode};
 
   final url = package != null
-      ? sourceFileUrl(package, 'model', className)
+      ? modelSourceFileUrl(package, nameManager, content)
       : null;
   final mapFunction = Method(
     (b) => b

--- a/packages/tonik_generate/lib/src/util/source_file_url.dart
+++ b/packages/tonik_generate/lib/src/util/source_file_url.dart
@@ -1,4 +1,6 @@
 import 'package:change_case/change_case.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
 
 /// Computes the targeted import URL for a generated source file.
 ///
@@ -7,5 +9,27 @@ import 'package:change_case/change_case.dart';
 /// returns a package URL like
 /// `'package:my_api/src/model/my_class.dart'`.
 String sourceFileUrl(String packageName, String category, String className) {
-  return 'package:$packageName/src/$category/${className.toSnakeCase()}.dart';
+  return sourceFileUrlFromFileName(
+    packageName,
+    category,
+    '${className.toSnakeCase()}.dart',
+  );
 }
+
+/// Computes an import URL from an already generated source [fileName].
+String sourceFileUrlFromFileName(
+  String packageName,
+  String category,
+  String fileName,
+) => 'package:$packageName/src/$category/$fileName';
+
+/// Computes the import URL for a generated [model] file.
+String modelSourceFileUrl(
+  String packageName,
+  NameManager nameManager,
+  Model model,
+) => sourceFileUrlFromFileName(
+  packageName,
+  'model',
+  nameManager.modelFileName(model),
+);

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -61,7 +61,7 @@ TypeReference typeReference(
     final NamedModel m => TypeReference(
       (b) => b
         ..symbol = nameManager.modelName(m)
-        ..url = sourceFileUrl(package, 'model', nameManager.modelName(m))
+        ..url = modelSourceFileUrl(package, nameManager, m)
         ..isNullable = isNullableOverride || ((m is EnumModel) && m.isNullable),
     ),
     StringModel _ => TypeReference(
@@ -139,7 +139,7 @@ TypeReference typeReference(
     final CompositeModel m => TypeReference(
       (b) => b
         ..symbol = nameManager.modelName(m)
-        ..url = sourceFileUrl(package, 'model', nameManager.modelName(m))
+        ..url = modelSourceFileUrl(package, nameManager, m)
         ..isNullable = isNullableOverride,
     ),
   };

--- a/packages/tonik_generate/test/src/generator/generator_models_test.dart
+++ b/packages/tonik_generate/test/src/generator/generator_models_test.dart
@@ -172,5 +172,100 @@ void main() {
       );
       expect(generatedFile.existsSync(), isTrue);
     });
+
+    test(
+      r'generates distinct files and imports for $-only name differences',
+      () async {
+        final singleDollarUser = ClassModel(
+          isDeprecated: false,
+          name: r'$User',
+          properties: const [],
+          context: ctx.pushAll(['components', 'schemas', r'$User']),
+          examples: const [],
+        );
+        final doubleDollarUser = ClassModel(
+          isDeprecated: false,
+          name: r'$$User',
+          properties: const [],
+          context: ctx.pushAll(['components', 'schemas', r'$$User']),
+          examples: const [],
+        );
+        final holder = ClassModel(
+          isDeprecated: false,
+          name: 'Holder',
+          properties: [
+            Property(
+              name: 'first',
+              model: singleDollarUser,
+              isRequired: false,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+            Property(
+              name: 'second',
+              model: doubleDollarUser,
+              isRequired: false,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: ctx.pushAll(['components', 'schemas', 'Holder']),
+          examples: const [],
+        );
+        final apiDoc = documentWithModels({
+          singleDollarUser,
+          doubleDollarUser,
+          holder,
+        });
+
+        const packageName = 'test_package';
+        await const Generator().generate(
+          apiDocument: apiDoc,
+          outputDirectory: tempDir.path,
+          package: packageName,
+        );
+
+        final modelDir = path.join(
+          tempDir.path,
+          packageName,
+          'lib',
+          'src',
+          'model',
+        );
+        final generatedFiles = Directory(
+          modelDir,
+        ).listSync().whereType<File>().toList();
+        final singleDollarFile = generatedFiles.singleWhere(
+          (file) => file.readAsStringSync().contains(r'class $User'),
+        );
+        final doubleDollarFile = generatedFiles.singleWhere(
+          (file) => file.readAsStringSync().contains(r'class $$User'),
+        );
+
+        expect(singleDollarFile.path, isNot(doubleDollarFile.path));
+
+        final holderCode = File(
+          path.join(modelDir, 'holder.dart'),
+        ).readAsStringSync();
+        expect(
+          holderCode,
+          contains(
+            'package:$packageName/src/model/'
+            '${path.basename(singleDollarFile.path)}',
+          ),
+        );
+        expect(
+          holderCode,
+          contains(
+            'package:$packageName/src/model/'
+            '${path.basename(doubleDollarFile.path)}',
+          ),
+        );
+      },
+    );
   });
 }


### PR DESCRIPTION
## Summary
- Route all generated model imports through `NameManager`-backed file names instead of recomputing snake_case paths
- Add stable unique file naming for generated model files when different Dart identifiers collapse to the same path
- Update generators and helpers to use the resolved file name for imports, references, and typedef output
- Add coverage for `$`-only name differences to verify distinct files and correct imports

## Testing
- Added generator test coverage for colliding model names
- Validated the generated `holder.dart` import paths point to the distinct model files