### PR TITLE
Null-guard nullable byte array elements in path parameter encoding

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1370,6 +1370,81 @@ paths:
               schema:
                 $ref: '#/components/schemas/EchoResponse'
 
+  /label/array/nullable-base64/{values}:
+    get:
+      operationId: testLabelArrayNullableBase64
+      tags: [label]
+      summary: Label-style nullable-base64 array path parameter (explode=false)
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: label
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: byte
+              nullable: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/array/nullable-base64/{values}:
+    get:
+      operationId: testMatrixArrayNullableBase64
+      tags: [matrix]
+      summary: Matrix-style nullable-base64 array path parameter (explode=false)
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: matrix
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: byte
+              nullable: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /simple/array/nullable-base64/{values}:
+    get:
+      operationId: testSimpleArrayNullableBase64
+      tags: [simple]
+      summary: Simple-style nullable-base64 array path parameter (explode=false)
+      parameters:
+        - name: values
+          in: path
+          required: true
+          style: simple
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+              format: byte
+              nullable: true
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
   # =============================================================================
   # SIMPLE STYLE - LITERAL SUFFIX AFTER THROW-PRODUCING PARAMETERS
   # =============================================================================

--- a/integration_test/path_encoding/path_encoding_test/test/label_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/label_test.dart
@@ -116,6 +116,29 @@ void main() {
       },
     );
 
+    test(
+      'nullable-base64 array base64-encodes elements and empties null',
+      () async {
+        final api = buildLabelApi();
+        final response = await api.testLabelArrayNullableBase64(
+          values: const [
+            TonikFileBytes([1, 2, 3]),
+            null,
+            TonikFileBytes([4, 5, 6]),
+          ],
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/label/array/nullable-base64/.AQID,,BAUG',
+        );
+      },
+    );
+
     test('string array (explode=false) encodes as .val1,val2,val3', () async {
       final api = buildLabelApi();
       final response = await api.testLabelArrayString(

--- a/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
@@ -116,6 +116,29 @@ void main() {
       },
     );
 
+    test(
+      'nullable-base64 array base64-encodes elements and empties null',
+      () async {
+        final api = buildMatrixApi();
+        final response = await api.testMatrixArrayNullableBase64(
+          values: const [
+            TonikFileBytes([1, 2, 3]),
+            null,
+            TonikFileBytes([4, 5, 6]),
+          ],
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/matrix/array/nullable-base64/;values=AQID,,BAUG',
+        );
+      },
+    );
+
     test('string array (explode=false) encodes as ;param=v1,v2,v3', () async {
       final api = buildMatrixApi();
       final response = await api.testMatrixArrayString(

--- a/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
@@ -54,6 +54,31 @@ void main() {
     });
   });
 
+  group('Simple style - Arrays', () {
+    test(
+      'nullable-base64 array base64-encodes elements and empties null',
+      () async {
+        final api = buildSimpleApi();
+        final response = await api.testSimpleArrayNullableBase64(
+          values: const [
+            TonikFileBytes([1, 2, 3]),
+            null,
+            TonikFileBytes([4, 5, 6]),
+          ],
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/simple/array/nullable-base64/AQID,,BAUG',
+        );
+      },
+    );
+  });
+
   group('Simple style - Special character property names', () {
     test(
       'special keys (explode=false) encodes keys with URI encoding',

--- a/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_parameter_expression_generator.dart
@@ -209,7 +209,13 @@ Expression _buildListLabelExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = isContentNullable
+                    ? refer('e')
+                          .nullSafeProperty('toBase64String')
+                          .call([])
+                          .ifNullThen(literalString(''))
+                          .code
+                    : refer('e').property('toBase64String').call([]).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_label_path_parameter_expression_generator.dart
@@ -92,7 +92,13 @@ Expression _buildToLabelPathParameterExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = isContentNullable
+                    ? refer('e')
+                          .nullSafeProperty('toBase64String')
+                          .call([])
+                          .ifNullThen(literalString(''))
+                          .code
+                    : refer('e').property('toBase64String').call([]).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_matrix_parameter_expression_generator.dart
@@ -280,7 +280,13 @@ Expression _buildListMatrixExpression(
                   ..requiredParameters.add(
                     Parameter((b) => b..name = 'e'),
                   )
-                  ..body = refer('e').property('toBase64String').call([]).code,
+                  ..body = isContentNullable
+                      ? refer('e')
+                            .nullSafeProperty('toBase64String')
+                            .call([])
+                            .ifNullThen(literalString(''))
+                            .code
+                      : refer('e').property('toBase64String').call([]).code,
               ).closure,
             ],
             {},

--- a/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_parameter_expression_generator.dart
@@ -239,7 +239,13 @@ Expression _buildListSimpleExpression(
                 ..requiredParameters.add(
                   Parameter((b) => b..name = 'e'),
                 )
-                ..body = refer('e').property('toBase64String').call([]).code,
+                ..body = isContentNullable
+                    ? refer('e')
+                          .nullSafeProperty('toBase64String')
+                          .call([])
+                          .ifNullThen(literalString(''))
+                          .code
+                    : refer('e').property('toBase64String').call([]).code,
             ).closure,
           ])
           .property('toList')

--- a/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_simple_value_expression_generator.dart
@@ -368,7 +368,12 @@ Expression _handleListExpression(
 
     AnyModel() => callToSimpleOnList(receiver),
     Base64Model() => mappedList(
-      refer('e').property('toBase64String').call([]),
+      isContentNullable
+          ? refer('e')
+                .nullSafeProperty('toBase64String')
+                .call([])
+                .ifNullThen(literalString(''))
+          : refer('e').property('toBase64String').call([]),
     ).property('toSimple').call([], {
       ...toSimpleArgs,
       'alreadyEncoded': literalBool(true),

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -268,6 +268,31 @@ void main() {
       );
     });
 
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildLabelParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.map((e) => e?.toBase64String() ?? '').toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test('generates map and toLabel call for List<Enum>', () {
       final enumModel = EnumModel(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_path_parameter_expression_generator_test.dart
@@ -1023,6 +1023,41 @@ void main() {
         ),
       );
     });
+
+    test('null-guards each element for list of nullable Base64Model', () {
+      final parameter = PathParameterObject(
+        name: 'files',
+        rawName: 'files',
+        description: 'List of base64 files',
+        model: ListModel(
+          context: context,
+          content: Base64Model(context: context),
+          isContentNullable: true,
+          examples: const [],
+        ),
+        encoding: PathParameterEncoding.label,
+        explode: false,
+        allowEmptyValue: false,
+        isRequired: true,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final result = emit(
+        buildToLabelPathParameterExpression('files', parameter),
+      );
+      expect(
+        collapseWhitespace(result),
+        collapseWhitespace(
+          [
+            "files.map((e) => e?.toBase64String() ?? '').toList()",
+            '.toLabel(explode: false, ',
+            'allowEmpty: false, alreadyEncoded: true, )',
+          ].join(),
+        ),
+      );
+    });
   });
 
   group('nullable model support', () {

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -278,6 +278,32 @@ void main() {
       );
     });
 
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildMatrixParameterExpression(
+        refer('value'),
+        model,
+        paramName: refer('paramName'),
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final generated = format('final result = ${expression.accept(emitter)};');
+      const expected = '''
+        final result = value.map<String>((e) => e?.toBase64String() ?? '').toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test('generates map and toMatrix call for List<Enum>', () {
       final enumModel = EnumModel(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_parameter_expression_generator_test.dart
@@ -1111,5 +1111,47 @@ void main() {
         collapseWhitespace(format(expected)),
       );
     });
+
+    test('null-guards each element for List<Base64Model?>', () {
+      final model = ListModel(
+        content: Base64Model(context: context),
+        isContentNullable: true,
+        context: context,
+        examples: const [],
+      );
+      final expression = buildSimpleParameterExpression(
+        refer('value'),
+        model,
+        explode: refer('explode'),
+        allowEmpty: refer('allowEmpty'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'test'
+          ..body = declareFinal(
+            'result',
+          ).assign(expression.expression).statement,
+      );
+
+      final generated = format(method.accept(emitter).toString());
+      const expected = '''
+        test() {
+          final result = value
+              .map((e) => e?.toBase64String() ?? '')
+              .toList()
+              .toSimple(
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generated),
+        collapseWhitespace(format(expected)),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_simple_value_expression_generator_test.dart
@@ -1461,6 +1461,45 @@ void main() {
           collapseWhitespace(expected),
         );
       });
+
+      test('null-guards each element for List<Base64Model?>', () {
+        final model = ListModel(
+          content: Base64Model(context: context),
+          isContentNullable: true,
+          context: context,
+          examples: const [],
+        );
+
+        final expression = buildSimpleValueExpression(
+          refer('value'),
+          model,
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final method = Method(
+          (b) => b
+            ..name = 'test'
+            ..body = declareFinal(
+              'result',
+            ).assign(expression.expression).statement,
+        );
+
+        final generated = format(method.accept(emitter).toString());
+        final expected = format('''
+          test() {
+            final result = value
+                .map((e) => e?.toBase64String() ?? '')
+                .toList()
+                .toSimple(explode: false, allowEmpty: true, alreadyEncoded: true);
+          }
+        ''');
+
+        expect(
+          collapseWhitespace(generated),
+          collapseWhitespace(expected),
+        );
+      });
     });
   });
 


### PR DESCRIPTION
## Problem

A path (or any simple/label/matrix-styled) parameter whose schema is an array of nullable `type: string, format: byte` items generated an encoding closure that called `e.toBase64String()` on a nullable element without a null guard:

```dart
payload
    .map((e) => e.toBase64String())   // e is TonikFile? — no null guard
    .toList()
    .toSimple(explode: false, allowEmpty: false, alreadyEncoded: true)
```

This fails analysis of the generated package with `unchecked_use_of_nullable_value`, once per affected style. Every other primitive content type (String, int, Date, Enum, …) already null-guards its per-element encode when the list content is nullable; only the `Base64Model` list branches were missed.

## Fix

The `Base64Model` list-content branches in the simple, label, label-path, and matrix parameter expression generators now emit

```dart
(e) => e?.toBase64String() ?? ''
```

when the list content is nullable, so null elements encode to the empty string — consistent with all other nullable primitive list content. Non-nullable output is unchanged.

## Testing

- New unit tests for nullable Base64 list content in all five affected expression generators.
- New `path_encoding` integration coverage: simple-, label-, and matrix-style path parameters typed as arrays of nullable `format: byte` items, asserting `[bytes, null, bytes]` encodes as `AQID,,BAUG` on the request path. Regenerating this suite reproduced the analyzer errors before the fix.
- Full `tonik_generate` suite (3018 tests), `dart analyze` over `packages` and `integration_test`, and the `path_encoding` integration suite all pass.