### PR TITLE
Emit bare throw for form response bodies that cannot be form-decoded

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -75,7 +75,16 @@ switch (path) {
             withContent formBody
         }
         break
-        
+
+    case '/form/map-response':
+        def formBody = 'key=value&other=data'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
     case '/form/empty-null':
         def formBody = 'emptyString=&nullableString=not+empty'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -500,6 +500,15 @@ void main() {
       expect(data.name, 'John Doe');
       expect(data.age, 30);
     });
+
+    test('reports decoding error for form-urlencoded map response', () async {
+      final response = await api.getMapResponse();
+
+      expect(response, isA<TonikError<Map<String, String>>>());
+      final error = response as TonikError<Map<String, String>>;
+      expect(error.type, TonikErrorType.decoding);
+      expect(error.error, isA<FormDecodingException>());
+    });
   });
 
   group('Empty and null values', () {

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -159,6 +159,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/SimpleForm'
 
+  /form/map-response:
+    get:
+      operationId: getMapResponse
+      tags:
+        - form
+      summary: Get map response as form-urlencoded
+      description: Tests response body handling for a free-form object
+      responses:
+        '200':
+          description: Successful response with form-urlencoded map body
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+
   /form/empty-null:
     post:
       operationId: postEmptyNull

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -364,12 +364,11 @@ class ParseGenerator {
   ({List<Code> statements, String? varName}) _createFormBodyDecode(
     ResponseBody responseBody,
   ) {
-    if (_isFormBodyPureThrow(responseBody.model)) {
+    final pureThrowMessage = formDecodingPureThrowMessage(responseBody.model);
+    if (pureThrowMessage != null) {
       return (
         statements: [
-          generateFormDecodingExceptionExpression(
-            _neverPureThrowMessage(responseBody.model),
-          ).statement,
+          generateFormDecodingExceptionExpression(pureThrowMessage).statement,
         ],
         varName: null,
       );
@@ -416,20 +415,6 @@ class ParseGenerator {
         return !nullable;
       case AliasModel():
         return _isJsonBodyPureThrow(model.model, isNullable: nullable);
-      default:
-        return false;
-    }
-  }
-
-  // A bare `NeverModel` collapses to a pure throw regardless of nullability,
-  // because `_$formString` comes from `decodeResponseText` and is typed
-  // `String` (non-null).
-  bool _isFormBodyPureThrow(Model model) {
-    switch (model) {
-      case NeverModel():
-        return true;
-      case AliasModel():
-        return _isFormBodyPureThrow(model.model);
       default:
         return false;
     }

--- a/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
@@ -32,6 +32,48 @@ BuiltExpression buildFromFormValueExpression(
   );
 }
 
+/// Message of the pure `throw` that [buildFromFormValueExpression] collapses
+/// to for a non-null input value, or null when the built expression
+/// references the value.
+String? formDecodingPureThrowMessage(Model model) => switch (model) {
+  AliasModel() => formDecodingPureThrowMessage(model.model),
+  NeverModel() => _neverFormDecodingMessage,
+  MapModel() => _mapFormDecodingMessage,
+  ListModel() => _listContentPureThrowMessage(model.content),
+  PrimitiveModel() ||
+  EnumModel() ||
+  ClassModel() ||
+  AllOfModel() ||
+  OneOfModel() ||
+  AnyOfModel() ||
+  AnyModel() => null,
+  NamedModel() || CompositeModel() => _unsupportedFormDecodingMessage,
+};
+
+String? _listContentPureThrowMessage(Model content) => switch (content) {
+  AliasModel() => _listContentPureThrowMessage(content.model),
+  ClassModel() => _classInListFormDecodingMessage,
+  ListModel() => _nestedListFormDecodingMessage,
+  PrimitiveModel() ||
+  EnumModel() ||
+  AllOfModel() ||
+  OneOfModel() ||
+  AnyOfModel() ||
+  AnyModel() ||
+  NeverModel() => null,
+  NamedModel() || CompositeModel() => _unsupportedFormDecodingMessage,
+};
+
+const _neverFormDecodingMessage =
+    'Cannot decode NeverModel - this type does not permit any value.';
+const _mapFormDecodingMessage = 'Map types cannot be form-decoded.';
+const _classInListFormDecodingMessage =
+    'ClassModel is not supported in lists for form decoding.';
+const _nestedListFormDecodingMessage =
+    'Nested lists are not supported in form decoding.';
+const _unsupportedFormDecodingMessage =
+    'Unsupported model type for form decoding.';
+
 Expression _buildFromFormValueExpression(
   Expression value, {
   required Model model,
@@ -167,18 +209,18 @@ Expression _buildFromFormValueExpression(
     AnyModel() => value,
 
     MapModel() => generateFormDecodingExceptionExpression(
-      'Map types cannot be form-decoded.',
+      _mapFormDecodingMessage,
     ),
 
     _ => generateFormDecodingExceptionExpression(
-      'Unsupported model type for form decoding.',
+      _unsupportedFormDecodingMessage,
     ),
   };
 }
 
 Expression _buildNeverModelExpression(Expression value, bool isRequired) {
   final throwExpr = generateFormDecodingExceptionExpression(
-    'Cannot decode NeverModel - this type does not permit any value.',
+    _neverFormDecodingMessage,
   );
   return isRequired
       ? throwExpr
@@ -327,7 +369,7 @@ Expression _buildListFromFormExpression(
       contextParam: contextParam,
     ),
     ClassModel() => generateFormDecodingExceptionExpression(
-      'ClassModel is not supported in lists for form decoding.',
+      _classInListFormDecodingMessage,
     ),
     EnumModel() ||
     AllOfModel() ||
@@ -343,7 +385,7 @@ Expression _buildListFromFormExpression(
       explode: explode,
     ),
     ListModel() => generateFormDecodingExceptionExpression(
-      'Nested lists are not supported in form decoding.',
+      _nestedListFormDecodingMessage,
     ),
     AliasModel() => _buildListFromFormExpression(
       value,
@@ -367,7 +409,7 @@ Expression _buildListFromFormExpression(
     ),
     AnyModel() => listDecode,
     NamedModel() || CompositeModel() => generateFormDecodingExceptionExpression(
-      'Unsupported model type for form decoding.',
+      _unsupportedFormDecodingMessage,
     ),
   };
 

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -2570,6 +2570,266 @@ DateTime _parseResponse(Response<List<int>> response) {
           collapseWhitespace(format(expectedMethod)),
         );
       });
+
+      test('generates pure throw for map form response', () {
+        final operation = Operation(
+          operationId: 'formMapOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/form-map',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: MapModel(
+                    valueModel: StringModel(context: context),
+                    context: context,
+                    examples: const [],
+                  ),
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  contentType: ContentType.form,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+Map<String, String> _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/x-www-form-urlencoded'):
+      throw FormDecodingException('Map types cannot be form-decoded.');
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test(
+        'generates pure throw for AliasModel resolving to map form response',
+        () {
+          final operation = Operation(
+            operationId: 'formAliasMapOp',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/form-alias-map',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: AliasModel(
+                      name: 'SessionMeta',
+                      model: MapModel(
+                        valueModel: StringModel(context: context),
+                        context: context,
+                        examples: const [],
+                      ),
+                      context: context,
+                      examples: const [],
+                      defaultValue: null,
+                    ),
+                    rawContentType: 'application/x-www-form-urlencoded',
+                    contentType: ContentType.form,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+          final method = generator.generateParseResponseMethod(operation);
+          const expectedMethod = r'''
+SessionMeta _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/x-www-form-urlencoded'):
+      throw FormDecodingException('Map types cannot be form-decoded.');
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+          expect(
+            collapseWhitespace(format(method.accept(emitter).toString())),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test('generates pure throw for list of class form response', () {
+        final classModel = ClassModel(
+          isDeprecated: false,
+          name: 'FormItem',
+          properties: [
+            Property(
+              name: 'name',
+              model: StringModel(context: context),
+              isRequired: true,
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ],
+          context: context,
+          examples: const [],
+        );
+
+        final operation = Operation(
+          operationId: 'formListClassOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/form-list-class',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: ListModel(
+                    content: classModel,
+                    context: context,
+                    examples: const [],
+                  ),
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  contentType: ContentType.form,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+List<FormItem> _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/x-www-form-urlencoded'):
+      throw FormDecodingException('ClassModel is not supported in lists for form decoding.');
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('generates pure throw for list of map form response', () {
+        final operation = Operation(
+          operationId: 'formListMapOp',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/form-list-map',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: ListModel(
+                    content: MapModel(
+                      valueModel: StringModel(context: context),
+                      context: context,
+                      examples: const [],
+                    ),
+                    context: context,
+                    examples: const [],
+                  ),
+                  rawContentType: 'application/x-www-form-urlencoded',
+                  contentType: ContentType.form,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+        final method = generator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+List<Map<String, String>> _parseResponse(Response<List<int>> response) {
+  final _$mediaType = extractMediaType(response.headers.value('content-type'));
+          switch ((response.statusCode, _$mediaType)) {
+    case (200, r'application/x-www-form-urlencoded'):
+      throw FormDecodingException('Unsupported model type for form decoding.');
+    default:
+      final _$content = response.headers.value('content-type') ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException('Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}');
+  }
+}
+''';
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
     });
 
     group('NeverModel response headers', () {

--- a/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
@@ -996,4 +996,162 @@ void main() {
       );
     });
   });
+
+  group('formDecodingPureThrowMessage', () {
+    late Context context;
+
+    setUp(() {
+      context = Context.initial();
+    });
+
+    ClassModel classModel() => ClassModel(
+      name: 'TestClass',
+      properties: const [],
+      context: context,
+      isDeprecated: false,
+      examples: const [],
+    );
+
+    MapModel mapModel() => MapModel(
+      valueModel: StringModel(context: context),
+      context: context,
+      examples: const [],
+    );
+
+    test('returns message for MapModel', () {
+      expect(
+        formDecodingPureThrowMessage(mapModel()),
+        'Map types cannot be form-decoded.',
+      );
+    });
+
+    test('returns message for AliasModel resolving to MapModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          AliasModel(
+            name: 'MapAlias',
+            model: mapModel(),
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ),
+        'Map types cannot be form-decoded.',
+      );
+    });
+
+    test('returns message for NeverModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          NeverModel(context: context, isNullable: false),
+        ),
+        'Cannot decode NeverModel - this type does not permit any value.',
+      );
+    });
+
+    test('returns message for List of ClassModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(
+            content: classModel(),
+            context: context,
+            examples: const [],
+          ),
+        ),
+        'ClassModel is not supported in lists for form decoding.',
+      );
+    });
+
+    test('returns message for List of AliasModel resolving to ClassModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(
+            content: AliasModel(
+              name: 'ClassAlias',
+              model: classModel(),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+            context: context,
+            examples: const [],
+          ),
+        ),
+        'ClassModel is not supported in lists for form decoding.',
+      );
+    });
+
+    test('returns message for nested List', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(
+            content: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+          ),
+        ),
+        'Nested lists are not supported in form decoding.',
+      );
+    });
+
+    test('returns message for List of MapModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(content: mapModel(), context: context, examples: const []),
+        ),
+        'Unsupported model type for form decoding.',
+      );
+    });
+
+    test('returns null for StringModel', () {
+      expect(
+        formDecodingPureThrowMessage(StringModel(context: context)),
+        isNull,
+      );
+    });
+
+    test('returns null for ClassModel', () {
+      expect(formDecodingPureThrowMessage(classModel()), isNull);
+    });
+
+    test('returns null for List of NeverModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(
+            content: NeverModel(context: context, isNullable: false),
+            context: context,
+            examples: const [],
+          ),
+        ),
+        isNull,
+      );
+    });
+
+    test('returns null for List of EnumModel', () {
+      expect(
+        formDecodingPureThrowMessage(
+          ListModel(
+            content: EnumModel<String>(
+              name: 'Color',
+              values: {
+                const EnumEntry<String>(value: 'red'),
+                const EnumEntry<String>(value: 'green'),
+              },
+              isNullable: false,
+              isDeprecated: false,
+              examples: const [],
+              context: context,
+            ),
+            context: context,
+            examples: const [],
+          ),
+        ),
+        isNull,
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary

A `application/x-www-form-urlencoded` response whose schema the form decoder cannot handle (a free-form object, a list of objects, a nested list) generated an unused `_$formString` declaration next to a pure `throw FormDecodingException(...)`:

```dart
case (200, r'application/x-www-form-urlencoded'):
  final _$formString = decodeResponseText(response.data);
  final _$body = throw FormDecodingException(
    'Map types cannot be form-decoded.',
  );
  return _$body;
```

`dart analyze` reported `unused_local_variable` and exited with code 2, so the generated package failed analysis out of the box. The existing short-circuit in `_createFormBodyDecode` only knew about `NeverModel`, while `buildFromFormValueExpression` also collapses to a value-ignoring throw for top-level maps, lists of classes, nested lists, and lists of maps.

## Changes

- Added `formDecodingPureThrowMessage(Model)`, exported from the form decode builder, returning the throw message whenever the built expression ignores its input value. The switches are exhaustive over the sealed `Model` hierarchy (no default arms), so adding a model subtype forces a compile-time revisit, and the message constants are shared with the builder's throw arms so the two cannot drift.
- `_createFormBodyDecode` now consults the predicate and emits a bare throw without the `_$formString` declaration; the `NeverModel`-only `_isFormBodyPureThrow` is gone. The JSON path is unchanged.

## Testing

- New parse generator tests for map, alias-to-map, list-of-class, and list-of-map form responses asserting the bare-throw output.
- New unit tests for `formDecodingPureThrowMessage`, including null for models whose expression does reference the value (`List<NeverModel>`, enums in lists).
- New integration endpoint `GET /form/map-response` (additionalProperties-only object) with a test asserting the call yields a `TonikError` of type `decoding` wrapping `FormDecodingException`; the regenerated package now passes analysis.
- Full `tonik_generate` suite, repo-wide `dart analyze`, and the form_urlencoded integration suite are green.