### PR TITLE
Support unquoted null in OpenAPI 3.1 type arrays

### DIFF
--- a/integration_test/type_arrays/openapi.yaml
+++ b/integration_test/type_arrays/openapi.yaml
@@ -236,6 +236,8 @@ components:
           type: [string, number, 'null']
         nullableMultiType:
           type: [string, integer, boolean, 'null']
+        unquotedNullable:
+          type: [string, null]
         requiredNullable:
           type: [string, 'null']
       required:

--- a/integration_test/type_arrays/type_arrays_test/test/type_arrays_api_test.dart
+++ b/integration_test/type_arrays/type_arrays_test/test/type_arrays_api_test.dart
@@ -381,6 +381,7 @@ void main() {
         nullableMultiType: NullableTypeArraysNullableMultiTypeOneOfModelInt(
           777,
         ),
+        unquotedNullable: 'unquoted-value',
       );
 
       final result = await api.testNullableTypes(body: input);
@@ -396,6 +397,7 @@ void main() {
       expect(requestData['nullableBoolean'], true);
       expect(requestData['nullableStringOrNumber'], 'mixed-string');
       expect(requestData['nullableMultiType'], 777);
+      expect(requestData['unquotedNullable'], 'unquoted-value');
 
       final output = success.value;
       expect(output.requiredNullable, 'required-value');
@@ -422,6 +424,7 @@ void main() {
             .value,
         777,
       );
+      expect(output.unquotedNullable, 'unquoted-value');
     });
 
     test('all fields null', () async {
@@ -444,6 +447,7 @@ void main() {
       expect(requestData['nullableBoolean'], isNull);
       expect(requestData['nullableStringOrNumber'], isNull);
       expect(requestData['nullableMultiType'], isNull);
+      expect(requestData['unquotedNullable'], isNull);
 
       final output = success.value;
       expect(output.requiredNullable, isNull);
@@ -452,6 +456,7 @@ void main() {
       expect(output.nullableBoolean, isNull);
       expect(output.nullableStringOrNumber, isNull);
       expect(output.nullableMultiType, isNull);
+      expect(output.unquotedNullable, isNull);
     });
 
     test('nullableStringOrNumber: string variant', () async {

--- a/packages/tonik_parse/lib/src/model/schema.dart
+++ b/packages/tonik_parse/lib/src/model/schema.dart
@@ -136,7 +136,10 @@ class Schema {
   }
 
   final String? ref;
-  final List<String> type;
+
+  /// Declared types, verbatim from the document. Unquoted `null` in a YAML
+  /// type array parses as a null scalar and is kept as a null element.
+  final List<String?> type;
   final String? format;
   final List<String>? required;
   final List<dynamic>? enumerated;
@@ -177,6 +180,14 @@ class Schema {
   /// - `null`: Not a boolean schema (standard object schema)
   final bool? isBooleanSchema;
 
+  /// Whether the declared types include the `null` type, spelled either as
+  /// the string `'null'` or as an unquoted YAML null scalar.
+  bool get hasNullType => type.any((t) => t == null || t == 'null');
+
+  /// Declared types without the `null` type in either spelling.
+  List<String> get nonNullTypes =>
+      type.nonNulls.where((t) => t != 'null').toList();
+
   // We ignore externalDocs, xml, title, multipleOf, maximum,
   // exclusiveMaximum, minimum, exclusiveMinimum, maxLength, minLength, pattern,
   // maxItems, minItems, maxProperties, minProperties.
@@ -211,10 +222,19 @@ class _AdditionalPropertiesConverter {
 class _SchemaTypeConverter {
   const _SchemaTypeConverter();
 
-  List<String> fromJson(dynamic json) {
+  List<String?> fromJson(dynamic json) {
     if (json == null) return [];
     if (json is String) return [json];
-    if (json is List) return json.cast<String>();
+    if (json is List) {
+      return [
+        for (final element in json)
+          switch (element) {
+            null => null,
+            final String type => type,
+            _ => throw FormatException('Invalid type value: $json'),
+          },
+      ];
+    }
     throw FormatException('Invalid type value: $json');
   }
 }

--- a/packages/tonik_parse/lib/src/model/schema.dart
+++ b/packages/tonik_parse/lib/src/model/schema.dart
@@ -136,9 +136,6 @@ class Schema {
   }
 
   final String? ref;
-
-  /// Declared types, verbatim from the document. Unquoted `null` in a YAML
-  /// type array parses as a null scalar and is kept as a null element.
   final List<String?> type;
   final String? format;
   final List<String>? required;
@@ -180,11 +177,8 @@ class Schema {
   /// - `null`: Not a boolean schema (standard object schema)
   final bool? isBooleanSchema;
 
-  /// Whether the declared types include the `null` type, spelled either as
-  /// the string `'null'` or as an unquoted YAML null scalar.
   bool get hasNullType => type.any((t) => t == null || t == 'null');
 
-  /// Declared types without the `null` type in either spelling.
   List<String> get nonNullTypes =>
       type.nonNulls.where((t) => t != 'null').toList();
 

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -97,7 +97,7 @@ class ModelImporter {
         context: context,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
-        isNullable: schema.isNullable ?? schema.type.contains('null'),
+        isNullable: schema.isNullable ?? schema.hasNullType,
         defaultValue: schema.rawDefault,
         examples: const [],
       );
@@ -174,8 +174,8 @@ class ModelImporter {
       return;
     }
 
-    final hasNullType = schema.type.contains('null');
-    final types = schema.type.where((t) => t != 'null').toList();
+    final hasNullType = schema.hasNullType;
+    final types = schema.nonNullTypes;
 
     if (hasNullType && types.isEmpty) {
       final aliasModel = AliasModel(
@@ -428,8 +428,8 @@ class ModelImporter {
       return;
     }
 
-    final hasNullType = schema.type.contains('null');
-    final types = schema.type.where((t) => t != 'null').toList();
+    final hasNullType = schema.hasNullType;
+    final types = schema.nonNullTypes;
 
     if (hasNullType && types.isEmpty) {
       // Already fully populated in pass 1.
@@ -560,7 +560,7 @@ class ModelImporter {
       shell
         ..description = schema.description
         ..isDeprecated = (schema.isDeprecated ?? false)
-        ..isNullable = (schema.isNullable ?? schema.type.contains('null'));
+        ..isNullable = (schema.isNullable ?? schema.hasNullType);
       return;
     }
 
@@ -568,7 +568,7 @@ class ModelImporter {
       ..model = refModel
       ..description = schema.description
       ..isDeprecated = (schema.isDeprecated ?? false)
-      ..isNullable = (schema.isNullable ?? schema.type.contains('null'));
+      ..isNullable = (schema.isNullable ?? schema.hasNullType);
   }
 
   /// Attaches schema-level [examples] to an already-constructed [model].
@@ -840,7 +840,7 @@ class ModelImporter {
     // Remove the shell so _parseMultiType can create the real model.
     models.remove(shell);
     final oneOfModel = _parseMultiType(
-      schema.type.where((t) => t != 'null').toList(),
+      schema.nonNullTypes,
       schema,
       hasNullType,
       context,
@@ -870,7 +870,7 @@ class ModelImporter {
     if (ap is Schema && !_isEmptySchema(ap)) {
       shell
         ..valueModel = _resolveSchemaRef(null, ap, mapContext)
-        ..isValueNullable = ap.isNullable ?? ap.type.contains('null');
+        ..isValueNullable = ap.isNullable ?? ap.hasNullType;
     } else {
       shell.valueModel = AnyModel(context: mapContext);
     }
@@ -902,7 +902,7 @@ class ModelImporter {
 
     shell
       ..content = _resolveSchemaRef(null, items, modelContext)
-      ..isContentNullable = items.isNullable ?? items.type.contains('null');
+      ..isContentNullable = items.isNullable ?? items.hasNullType;
   }
 
   /// Populates a ClassModel shell.
@@ -930,7 +930,7 @@ class ModelImporter {
     for (final MapEntry(key: propertyName, value: propertySchema)
         in schemaProperties.entries) {
       final isNullable =
-          propertySchema.isNullable ?? propertySchema.type.contains('null');
+          propertySchema.isNullable ?? propertySchema.hasNullType;
       final isDeprecated = propertySchema.isDeprecated ?? false;
       final isReadOnly = propertySchema.isReadOnly ?? false;
       final isWriteOnly = propertySchema.isWriteOnly ?? false;
@@ -1005,7 +1005,7 @@ class ModelImporter {
           context: context,
           description: schema.description,
           isDeprecated: schema.isDeprecated ?? false,
-          isNullable: schema.isNullable ?? schema.type.contains('null'),
+          isNullable: schema.isNullable ?? schema.hasNullType,
           defaultValue: schema.rawDefault,
           examples: exampleImporter.fromSchema(schema),
         );
@@ -1189,7 +1189,7 @@ class ModelImporter {
         context: context,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
-        isNullable: schema.isNullable ?? schema.type.contains('null'),
+        isNullable: schema.isNullable ?? schema.hasNullType,
         defaultValue: schema.rawDefault,
         examples: exampleImporter.fromSchema(schema),
       );
@@ -1273,7 +1273,7 @@ class ModelImporter {
     return schema.description != null ||
         (schema.isDeprecated ?? false) ||
         (schema.isNullable ?? false) ||
-        schema.type.contains('null') ||
+        schema.hasNullType ||
         schema.rawDefault != null;
   }
 
@@ -1343,7 +1343,7 @@ class ModelImporter {
         context: context,
         description: schema.description,
         isDeprecated: schema.isDeprecated ?? false,
-        isNullable: schema.isNullable ?? schema.type.contains('null'),
+        isNullable: schema.isNullable ?? schema.hasNullType,
         defaultValue: schema.rawDefault,
         examples: exampleImporter.fromSchema(schema),
       );
@@ -1393,7 +1393,7 @@ class ModelImporter {
       context: modelContext,
       description: schema.description,
       isDeprecated: schema.isDeprecated ?? false,
-      isNullable: schema.isNullable ?? schema.type.contains('null'),
+      isNullable: schema.isNullable ?? schema.hasNullType,
       isReadOnly: schema.isReadOnly ?? false,
       isWriteOnly: schema.isWriteOnly ?? false,
       examples: exampleImporter.fromSchema(schema),
@@ -1430,8 +1430,8 @@ class ModelImporter {
     }
 
     // OpenAPI 3.1 null types become Tonik nullability.
-    final hasNullType = schema.type.contains('null');
-    final types = schema.type.where((t) => t != 'null').toList();
+    final hasNullType = schema.hasNullType;
+    final types = schema.nonNullTypes;
 
     if (hasNullType && types.isEmpty) {
       return NeverModel(context: context, isNullable: true);
@@ -1448,7 +1448,7 @@ class ModelImporter {
       var isValueNullable = false;
       if (ap is Schema && !_isEmptySchema(ap)) {
         valueModel = _resolveSchemaRef(null, ap, mapContext);
-        isValueNullable = ap.isNullable ?? ap.type.contains('null');
+        isValueNullable = ap.isNullable ?? ap.hasNullType;
       } else {
         valueModel = AnyModel(context: mapContext);
       }
@@ -1650,7 +1650,7 @@ class ModelImporter {
 
     listModel
       ..content = _resolveSchemaRef(null, items, modelContext)
-      ..isContentNullable = items.isNullable ?? items.type.contains('null');
+      ..isContentNullable = items.isNullable ?? items.hasNullType;
 
     return listModel;
   }
@@ -1885,7 +1885,7 @@ class ModelImporter {
       }
       current = resolved;
     }
-    return current.type.isNotEmpty && current.type.every((t) => t == 'null');
+    return current.type.isNotEmpty && current.nonNullTypes.isEmpty;
   }
 
   Schema? _resolveSchemaToSchema(Schema schema) {
@@ -1912,7 +1912,7 @@ class ModelImporter {
     if (ap == false) return const ForbiddenAdditionalProperties();
     if (ap is Schema && !_isEmptySchema(ap)) {
       var valueModel = _resolveSchemaRef(null, ap, context);
-      final isNullable = ap.isNullable ?? ap.type.contains('null');
+      final isNullable = ap.isNullable ?? ap.hasNullType;
       if (isNullable && !valueModel.isEffectivelyNullable) {
         valueModel = AliasModel(
           model: valueModel,
@@ -1963,7 +1963,7 @@ class ModelImporter {
       additionalPropertiesPolicy: _resolveAdditionalProperties(schema, context),
       isNullable:
           schema.isNullable ??
-          (schema.type.contains('object') && schema.type.contains('null')),
+          (schema.type.contains('object') && schema.hasNullType),
       isReadOnly: schema.isReadOnly ?? false,
       isWriteOnly: schema.isWriteOnly ?? false,
       examples: exampleImporter.fromSchema(schema),
@@ -1986,7 +1986,7 @@ class ModelImporter {
     for (final MapEntry(key: propertyName, value: propertySchema)
         in schemaProperties.entries) {
       final isNullable =
-          propertySchema.isNullable ?? propertySchema.type.contains('null');
+          propertySchema.isNullable ?? propertySchema.hasNullType;
       final isDeprecated = propertySchema.isDeprecated ?? false;
       final isReadOnly = propertySchema.isReadOnly ?? false;
       final isWriteOnly = propertySchema.isWriteOnly ?? false;

--- a/packages/tonik_parse/test/model/model_multiple_types_test.dart
+++ b/packages/tonik_parse/test/model/model_multiple_types_test.dart
@@ -244,6 +244,79 @@ void main() {
     expect(api.models.contains(oneOfModel), isTrue);
   });
 
+  test('imports top-level schema with unquoted null type as nullable', () {
+    const spec = {
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Name': {
+            'type': ['string', null],
+          },
+        },
+      },
+    };
+
+    final api = Importer().import(spec);
+
+    final model = api.models.firstWhere(
+      (m) => m is NamedModel && m.name == 'Name',
+    );
+    expect(model, isA<AliasModel>());
+    final aliasModel = model as AliasModel;
+    expect(aliasModel.isNullable, isTrue);
+    expect(aliasModel.model, isA<StringModel>());
+  });
+
+  test('imports property with unquoted null type as nullable', () {
+    const spec = {
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Person': {
+            'type': 'object',
+            'properties': {
+              'name': {
+                'type': ['string', null],
+              },
+            },
+          },
+        },
+      },
+    };
+
+    final api = Importer().import(spec);
+
+    final model =
+        api.models.firstWhere(
+              (m) => m is ClassModel && m.name == 'Person',
+            )
+            as ClassModel;
+    final name = model.properties.firstWhere((p) => p.name == 'name');
+    expect(name.model, isA<StringModel>());
+    expect(name.isNullable, isTrue);
+  });
+
+  test('throws FormatException for non-string type array element', () {
+    const spec = {
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Name': {
+            'type': ['string', 123],
+          },
+        },
+      },
+    };
+
+    expect(() => Importer().import(spec), throwsFormatException);
+  });
+
   test('adds nested inline type array OneOfModel to models set', () {
     final api = Importer().import(fileContent);
 


### PR DESCRIPTION
## Problem

In a YAML spec, `type: [string, null]` with an unquoted `null` — one of the most common idioms in real-world 3.1 specs — parses as a YAML null scalar rather than the string `"null"`. The schema type converter used a lazy `json.cast<String>()`, so the null element survived until the first `schema.type.contains('null')` call and then detonated as an internal crash:

```
type 'Null' is not a subtype of type 'String' in type cast
#0      _CastListBase.[] (dart:_internal/cast.dart:102)
#1      ListBase.contains (dart:collection/list.dart:92)
#2      ModelImporter._createShell (package:tonik_parse/src/model_importer.dart:177)
```

with a "please report this issue" message instead of either tolerating the idiom or naming the offending value.

## Fix

The parse model stays verbatim: `Schema.type` is now `List<String?>`, preserving the null scalar as a null element. The converter validates eagerly — a non-string, non-null element throws `FormatException('Invalid type value: ...')` at parse time instead of a bare `TypeError` at some arbitrary later point.

The interpretation lives where nullability is decided: two semantic getters on `Schema` — `hasNullType` (true for the `null` type in either spelling) and `nonNullTypes` (declared types minus the null type) — now back every null-type check and effective-type extraction in the model importer.

A schema like `type: [string, null]` generates the same code as the spec-compliant `type: [string, 'null']`.

## Testing

- New unit tests: top-level schema and property position with an unquoted null type import as nullable; a non-string type element fails with an eager `FormatException`.
- Integration: `NullableTypeArrays` in the type_arrays suite gained an `unquotedNullable` property using the unquoted spelling; round-trip tests cover value and null.
- Full test suites, integration regeneration, and `dart analyze` are clean.