### PR TITLE
Strip carriage returns from generated doc comments

### DIFF
--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -273,11 +273,13 @@ components:
 
     BasicObject:
       type: object
+      description: "first line\rsecond line"
       required:
         - name
       properties:
         name:
           type: string
+          description: "name line one\r\nname line two"
 
     # 1g. Property name with single quote on an any-typed property
     # The class needs a mix of simple + mixed encoding shapes to trigger

--- a/packages/tonik_generate/lib/src/util/doc_comment_formatter.dart
+++ b/packages/tonik_generate/lib/src/util/doc_comment_formatter.dart
@@ -3,12 +3,14 @@
 /// If the string is multiline, each line will be prefixed with '/// '.
 /// Returns an empty list if the input is null or empty.
 List<String> formatDocComment(String? text) {
-  if (text == null || text.isEmpty) {
+  // Dart treats a lone CR as a line terminator, so any CR surviving into a
+  // doc-comment line lets the rest of the text escape the `///` prefix.
+  final normalized = text?.replaceAll('\r', '');
+  if (normalized == null || normalized.isEmpty) {
     return [];
   }
 
-  // Split by newlines and prefix each line with '/// '
-  return text.split('\n').map((line) => '/// $line').toList();
+  return normalized.split('\n').map((line) => '/// $line').toList();
 }
 
 /// Formats a string as a doc comment with a prefix on the first line.
@@ -17,8 +19,9 @@ List<String> formatDocComment(String? text) {
 /// multiline, continuation lines get the `/// ` prefix without [prefix].
 /// Returns an empty list if [text] is null or empty.
 List<String> formatDocCommentWithPrefix(String prefix, String? text) {
-  if (text == null || text.isEmpty) return [];
-  final lines = text.split('\n');
+  final normalized = text?.replaceAll('\r', '');
+  if (normalized == null || normalized.isEmpty) return [];
+  final lines = normalized.split('\n');
   return [
     '/// $prefix${lines.first}',
     for (var i = 1; i < lines.length; i++) '/// ${lines[i]}',

--- a/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
+++ b/packages/tonik_generate/lib/src/util/example_doc_formatter.dart
@@ -38,18 +38,28 @@ List<String> formatExamplesAsDocs(List<Example> examples) {
 }
 
 List<String>? _formatExample(Example example) {
-  final hasSummary = example.summary != null && example.summary!.isNotEmpty;
-  final hasDescription =
-      example.description != null && example.description!.isNotEmpty;
-  final hasHeadingContent =
-      example.name != null || hasSummary || hasDescription;
+  // Lone CRs would let text escape the `///` prefix; see formatDocComment.
+  final name = example.name?.replaceAll('\r', '');
+  final summary = switch (example.summary?.replaceAll('\r', '')) {
+    null || '' => null,
+    final s => s,
+  };
+  final description = switch (example.description?.replaceAll('\r', '')) {
+    null || '' => null,
+    final s => s,
+  };
 
-  if (example.value == null && !hasHeadingContent) return null;
+  if (example.value == null &&
+      name == null &&
+      summary == null &&
+      description == null) {
+    return null;
+  }
 
-  final lines = <String>[_heading(example, hasSummary: hasSummary)];
+  final lines = <String>[_heading(name: name, summary: summary)];
 
-  if (hasDescription) {
-    for (final line in example.description!.split('\n')) {
+  if (description != null) {
+    for (final line in description.split('\n')) {
       if (line.isEmpty) {
         lines.add('///');
       } else {
@@ -66,22 +76,28 @@ List<String>? _formatExample(Example example) {
   return lines;
 }
 
-String _heading(Example example, {required bool hasSummary}) {
+String _heading({required String? name, required String? summary}) {
   final buf = StringBuffer('/// **Example**');
-  if (example.name != null) {
-    buf.write(' "${example.name}"');
+  if (name != null) {
+    buf.write(' "$name"');
   }
-  if (hasSummary) {
-    buf.write(' — ${example.summary}');
+  if (summary != null) {
+    buf.write(' — $summary');
   }
   buf.write(':');
   return buf.toString();
 }
 
 List<String> _renderValue(Object? value) {
-  final isString = value is String;
-  final payload = isString ? value : _jsonEncoder.convert(value);
-  final fenceLang = isString ? '' : 'json';
+  final String payload;
+  final String fenceLang;
+  if (value is String) {
+    payload = value.replaceAll('\r', '');
+    fenceLang = '';
+  } else {
+    payload = _jsonEncoder.convert(value);
+    fenceLang = 'json';
+  }
 
   final fenceLen = _maxBacktickRun(payload) + 1;
   final fence = '`' * (fenceLen < 3 ? 3 : fenceLen);

--- a/packages/tonik_generate/test/src/util/doc_comment_formatter_test.dart
+++ b/packages/tonik_generate/test/src/util/doc_comment_formatter_test.dart
@@ -23,6 +23,24 @@ void main() {
       expect(result[2], '/// with three lines');
     });
 
+    test('removes lone carriage returns within the text', () {
+      final result = formatDocComment('first line\rsecond line');
+
+      expect(result, ['/// first linesecond line']);
+    });
+
+    test('treats CRLF line endings as single line breaks', () {
+      final result = formatDocComment('first line\r\nsecond line');
+
+      expect(result, ['/// first line', '/// second line']);
+    });
+
+    test('returns empty list for carriage-return-only string', () {
+      final result = formatDocComment('\r');
+
+      expect(result, isEmpty);
+    });
+
     test('returns empty list for null string', () {
       final result = formatDocComment(null);
 
@@ -116,6 +134,27 @@ void main() {
         '/// Line two',
         '/// Line three',
       ]);
+    });
+
+    test('removes lone carriage returns within the text', () {
+      final result = formatDocCommentWithPrefix('[param] ', 'first\rsecond');
+
+      expect(result, ['/// [param] firstsecond']);
+    });
+
+    test('treats CRLF line endings as single line breaks', () {
+      final result = formatDocCommentWithPrefix(
+        '[param] ',
+        'first line\r\nsecond line',
+      );
+
+      expect(result, ['/// [param] first line', '/// second line']);
+    });
+
+    test('returns empty list for carriage-return-only text', () {
+      final result = formatDocCommentWithPrefix('[param] ', '\r');
+
+      expect(result, isEmpty);
     });
 
     test('returns empty list for null text', () {

--- a/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
+++ b/packages/tonik_generate/test/src/util/example_doc_formatter_test.dart
@@ -84,6 +84,19 @@ void main() {
         expect(result.first, '/// **Example** "admin":');
       });
 
+      test('removes carriage returns from name and summary', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: 'ad\rmin',
+            summary: 'an admin\ruser',
+            description: null,
+            value: 1,
+          ),
+        ]);
+
+        expect(result.first, '/// **Example** "admin" — an adminuser:');
+      });
+
       test('passes through markdown-special chars in name and summary', () {
         final result = formatExamplesAsDocs([
           const Example(
@@ -128,6 +141,48 @@ void main() {
             name: null,
             summary: null,
             description: 'line one\nline two',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// line one',
+          '/// line two',
+          '///',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('removes lone carriage returns within a description line', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: 'line one\rstill line one\nline two',
+            value: 1,
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// line onestill line one',
+          '/// line two',
+          '///',
+          '/// ```json',
+          '/// 1',
+          '/// ```',
+        ]);
+      });
+
+      test('treats CRLF in description as a single line break', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: 'line one\r\nline two',
             value: 1,
           ),
         ]);
@@ -219,6 +274,24 @@ void main() {
           '/// ```',
           '/// first',
           '/// second',
+          '/// ```',
+        ]);
+      });
+
+      test('removes carriage returns from string values', () {
+        final result = formatExamplesAsDocs([
+          const Example(
+            name: null,
+            summary: null,
+            description: null,
+            value: 'first\rsecond',
+          ),
+        ]);
+
+        expect(result, [
+          '/// **Example**:',
+          '/// ```',
+          '/// firstsecond',
           '/// ```',
         ]);
       });


### PR DESCRIPTION
## Problem

A schema, property, operation, or parameter `description` containing a lone carriage return (`\r`, U+000D) was emitted verbatim into `///` doc comments. Dart's lexer treats a lone CR as a line terminator, so the text after it landed on a line without the `///` prefix and became bare code — `DartFormatter` threw and generation aborted with "Unexpected error while generating code". Lone CRs are valid in YAML double-quoted scalars and JSON strings, so such specs are valid OpenAPI.

## Fix

Strip all `\r` characters from text before it is rendered into doc comments (CRLF thereby collapses to a normal line break):

- `formatDocComment` / `formatDocCommentWithPrefix` normalize before the empty-check and line split, so a CR-only description produces no doc comment.
- The example doc formatter strips CRs from example name, summary, description, and raw string example values. JSON-encoded example values were already safe via `JsonEncoder` escaping.

String-literal positions (enum values, property keys, defaults) were already safe: they are emitted through `specLiteralString`, which escapes `\r`. Dart treats only `\n` and `\r` as line terminators (NEL, U+2028/U+2029, and other control characters cannot escape a doc comment), so stripping CR closes the gap for these rendering paths.

## Tests

- Unit tests for lone CR, CRLF, and CR-only inputs across both doc-comment helpers and the example formatter (name/summary, description, raw string values).
- The `adversarial_strings` integration spec now carries a lone-CR schema description and a CRLF property description on `BasicObject`; generating that suite crashed before this change and is the regression gate.