### PR TITLE
Guard multipart default content-type resolution against recursive schemas

### DIFF
--- a/integration_test/multipart/multipart_test/imposter/response.groovy
+++ b/integration_test/multipart/multipart_test/imposter/response.groovy
@@ -150,6 +150,17 @@ switch (path) {
         }
         break
 
+    case '/multipart/recursive':
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/json'
+            withHeader 'X-Has-Name', formParams.containsKey('name').toString()
+            withHeader 'X-Has-Tree', formParams.containsKey('tree').toString()
+            withHeader 'X-Param-Name', (formParams['name'] ?: '')
+            withContent '{"success":true,"message":"recursive form received"}'
+        }
+        break
+
     case '/custom/multipart':
         def requestContentType = context.request.headers['Content-Type'] ?: 'unknown'
         respond {

--- a/integration_test/multipart/multipart_test/test/multipart_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_test.dart
@@ -701,4 +701,41 @@ void main() {
       expect(octetSuccess.body, isA<TonikFile>());
     });
   });
+
+  group('Recursive array', () {
+    test('posts the form when the recursive array field is omitted', () async {
+      const form = RecursiveArrayForm(name: 'root');
+
+      final response = await api.postRecursiveArray(body: form);
+
+      expect(response, isA<TonikSuccess<GenericResponse>>());
+
+      final success = response as TonikSuccess<GenericResponse>;
+      final requestData = success.response.requestOptions.data;
+      expect(requestData, isA<FormData>());
+
+      final formData = requestData as FormData;
+      expect(formData.files.any((e) => e.key == 'name'), isTrue);
+      expect(formData.files.any((e) => e.key == 'tree'), isFalse);
+
+      expect(success.response.headers['x-has-name']?.first, 'true');
+      expect(success.response.headers['x-param-name']?.first, 'root');
+      expect(success.value.success, true);
+    });
+
+    test(
+      'returns encoding error when the recursive array field is set',
+      () async {
+        const form = RecursiveArrayForm(name: 'root', tree: [<Object?>[]]);
+
+        final response = await api.postRecursiveArray(body: form);
+
+        expect(response, isA<TonikError<GenericResponse>>());
+
+        final error = response as TonikError<GenericResponse>;
+        expect(error.type, TonikErrorType.encoding);
+        expect(error.error, isA<EncodingException>());
+      },
+    );
+  });
 }

--- a/integration_test/multipart/openapi.yaml
+++ b/integration_test/multipart/openapi.yaml
@@ -414,6 +414,32 @@ paths:
                 type: string
                 format: binary
 
+  /multipart/recursive:
+    post:
+      operationId: postRecursiveArray
+      tags:
+        - multipart
+      summary: Post a multipart form with a self-recursive array property
+      description: >-
+        Tests a property whose schema is a self-recursive array (an array
+        whose items are the array itself). Nested arrays are not supported
+        in multipart encoding, so the generated method throws
+        EncodingException when the property is set and succeeds when it is
+        omitted.
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/RecursiveArrayForm'
+      responses:
+        '200':
+          description: Successful response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenericResponse'
+
   /custom/multipart:
     post:
       operationId: postCustomMultipart
@@ -760,6 +786,22 @@ components:
           description: >-
             Optional key-value metadata. This is a Map<String, String> in
             generated code, NOT a model class, so .toJson() must not be called.
+
+    RecursiveList:
+      type: array
+      items:
+        $ref: '#/components/schemas/RecursiveList'
+
+    RecursiveArrayForm:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          description: A simple text label
+        tree:
+          $ref: '#/components/schemas/RecursiveList'
 
     GenericResponse:
       type: object

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -228,9 +228,13 @@ class RequestBodyImporter {
       if (property.isReadOnly) continue;
 
       final existing = explicitEncoding?[property.name];
-      final defaultContentType = _resolveDefaultContentType(property.model);
+      final defaultContentType = _resolveDefaultContentType(
+        property.model,
+        <core.Model>{},
+      );
       final defaultRawContentType = _resolveDefaultRawContentType(
         property.model,
+        <core.Model>{},
       );
 
       final isStyleBased = existing?.isStyleBased ?? false;
@@ -251,10 +255,16 @@ class RequestBodyImporter {
     return result;
   }
 
-  static core.ContentType _resolveDefaultContentType(core.Model model) {
+  /// A recursive model has no leaf to inspect; only complex structures can
+  /// recurse, so a cycle defaults to JSON.
+  static core.ContentType _resolveDefaultContentType(
+    core.Model model,
+    Set<core.Model> visited,
+  ) {
+    if (!visited.add(model)) return core.ContentType.json;
     return switch (model) {
-      core.AliasModel() => _resolveDefaultContentType(model.resolved),
-      core.ListModel() => _resolveDefaultContentType(model.content),
+      core.AliasModel() => _resolveDefaultContentType(model.resolved, visited),
+      core.ListModel() => _resolveDefaultContentType(model.content, visited),
       core.ClassModel() => core.ContentType.json,
       core.AllOfModel() => core.ContentType.json,
       core.OneOfModel() => core.ContentType.json,
@@ -266,10 +276,16 @@ class RequestBodyImporter {
     };
   }
 
-  static String _resolveDefaultRawContentType(core.Model model) {
+  static String _resolveDefaultRawContentType(
+    core.Model model,
+    Set<core.Model> visited,
+  ) {
+    if (!visited.add(model)) return 'application/json';
     return switch (model) {
-      core.AliasModel() => _resolveDefaultRawContentType(model.resolved),
-      core.ListModel() => _resolveDefaultRawContentType(model.content),
+      core.AliasModel() =>
+        _resolveDefaultRawContentType(model.resolved, visited),
+      core.ListModel() =>
+        _resolveDefaultRawContentType(model.content, visited),
       core.ClassModel() => 'application/json',
       core.AllOfModel() => 'application/json',
       core.OneOfModel() => 'application/json',

--- a/packages/tonik_parse/lib/src/request_body_importer.dart
+++ b/packages/tonik_parse/lib/src/request_body_importer.dart
@@ -231,6 +231,7 @@ class RequestBodyImporter {
       final defaultContentType = _resolveDefaultContentType(
         property.model,
         <core.Model>{},
+        property.name,
       );
       final defaultRawContentType = _resolveDefaultRawContentType(
         property.model,
@@ -257,14 +258,29 @@ class RequestBodyImporter {
 
   /// A recursive model has no leaf to inspect; only complex structures can
   /// recurse, so a cycle defaults to JSON.
-  static core.ContentType _resolveDefaultContentType(
+  core.ContentType _resolveDefaultContentType(
     core.Model model,
     Set<core.Model> visited,
+    String propertyName,
   ) {
-    if (!visited.add(model)) return core.ContentType.json;
+    if (!visited.add(model)) {
+      log.warning(
+        'Multipart property "$propertyName" has a recursive schema with no '
+        'terminal type. Defaulting part content type to application/json.',
+      );
+      return core.ContentType.json;
+    }
     return switch (model) {
-      core.AliasModel() => _resolveDefaultContentType(model.resolved, visited),
-      core.ListModel() => _resolveDefaultContentType(model.content, visited),
+      core.AliasModel() => _resolveDefaultContentType(
+        model.resolved,
+        visited,
+        propertyName,
+      ),
+      core.ListModel() => _resolveDefaultContentType(
+        model.content,
+        visited,
+        propertyName,
+      ),
       core.ClassModel() => core.ContentType.json,
       core.AllOfModel() => core.ContentType.json,
       core.OneOfModel() => core.ContentType.json,

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -1345,7 +1345,13 @@ void main() {
         expect(encoding.rawContentType, 'text/plain');
       });
 
-      test('self-recursive array property gets application/json default', () {
+      test('self-recursive array property gets application/json default '
+          'and logs warning', () {
+        final logs = <LogRecord>[];
+        final sub = Logger.root.onRecord.listen(logs.add);
+
+        addTearDown(sub.cancel);
+
         final content = importMultipartContent(
           multipartSpec(
             properties: {
@@ -1363,6 +1369,12 @@ void main() {
         final encoding = partEncodingFor(content, 'tree')!;
         expect(encoding.contentType, ContentType.json);
         expect(encoding.rawContentType, 'application/json');
+        expect(
+          logs.any(
+            (r) => r.level == Level.WARNING && r.message.contains('"tree"'),
+          ),
+          isTrue,
+        );
       });
 
       test(

--- a/packages/tonik_parse/test/request_body_importer_test.dart
+++ b/packages/tonik_parse/test/request_body_importer_test.dart
@@ -1345,6 +1345,53 @@ void main() {
         expect(encoding.rawContentType, 'text/plain');
       });
 
+      test('self-recursive array property gets application/json default', () {
+        final content = importMultipartContent(
+          multipartSpec(
+            properties: {
+              'tree': {r'$ref': '#/components/schemas/RecursiveList'},
+            },
+            schemas: {
+              'RecursiveList': {
+                'type': 'array',
+                'items': {r'$ref': '#/components/schemas/RecursiveList'},
+              },
+            },
+          ),
+        );
+
+        final encoding = partEncodingFor(content, 'tree')!;
+        expect(encoding.contentType, ContentType.json);
+        expect(encoding.rawContentType, 'application/json');
+      });
+
+      test(
+        'mutually recursive array property gets application/json default',
+        () {
+          final content = importMultipartContent(
+            multipartSpec(
+              properties: {
+                'chain': {r'$ref': '#/components/schemas/LinkA'},
+              },
+              schemas: {
+                'LinkA': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/LinkB'},
+                },
+                'LinkB': {
+                  'type': 'array',
+                  'items': {r'$ref': '#/components/schemas/LinkA'},
+                },
+              },
+            ),
+          );
+
+          final encoding = partEncodingFor(content, 'chain')!;
+          expect(encoding.contentType, ContentType.json);
+          expect(encoding.rawContentType, 'application/json');
+        },
+      );
+
       test('array of AnyModel gets application/json default', () {
         // See AnyModel test above — AnyModel is OAS 3.1 only.
         final content = importMultipartContent(


### PR DESCRIPTION
## Problem

A `multipart/form-data` request body with a property whose schema is a self-recursive array crashes parsing with a stack overflow, so generation never starts:

```yaml
components:
  schemas:
    RecursiveList:
      type: array
      items:
        $ref: '#/components/schemas/RecursiveList'
```

`RequestBodyImporter._resolveDefaultContentType` and `_resolveDefaultRawContentType` recurse through `AliasModel.resolved` and `ListModel.content` with no cycle detection. For a self-recursive list the content is the list itself, so the recursion never terminates. Relying on `AliasModel.resolved` being cycle-guarded is not enough: it breaks alias cycles by returning the alias itself, which would re-enter the same switch arm forever.

The same recursive schema works everywhere else (JSON bodies, parameters, headers, urlencoded bodies, class properties); only the multipart per-part default content-type resolution lacked a guard.

## Fix

Track visited models in both resolvers and treat a revisit as JSON (`ContentType.json` / `application/json`) — only complex structures can recurse, so a cycle has no simple leaf to inspect. This mirrors the visited-set pattern already used by `AliasModel._resolveDefault`.

Downstream behavior is already well-defined: a recursive array property lands in the existing arrays-of-arrays multipart limitation, so the generated method throws `EncodingException` when the property is set and works normally when it is omitted.

## Tests

- Unit: self-recursive and mutually recursive array properties get the `application/json` part default.
- Integration (multipart suite): new `/multipart/recursive` operation; posting with the recursive field omitted round-trips successfully, posting with it set returns a `TonikError` with `EncodingException` — the first integration coverage of the arrays-of-arrays multipart throw.