### PR TITLE
Reject JSON integers beyond the representable int range

### DIFF
--- a/packages/tonik_util/lib/src/decoding/json_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/json_decoder.dart
@@ -135,7 +135,8 @@ extension JsonDecoder on Object? {
   /// `jsonDecode` yields a [double] for numbers written in fractional or
   /// exponent form (e.g. `10.0`, `1e1`); such whole-number doubles denote an
   /// integer and are accepted, matching JSON Schema's `integer` definition.
-  /// Throws [InvalidTypeException] if the value is not a valid int or is null.
+  /// Throws [InvalidTypeException] if the value is not a valid int, is null,
+  /// or exceeds the representable [int] range.
   int decodeJsonInt({String? context}) {
     final value = this;
     if (value is int) {
@@ -144,7 +145,12 @@ extension JsonDecoder on Object? {
     if (value is double &&
         value.isFinite &&
         value == value.truncateToDouble()) {
-      return value.toInt();
+      // int.tryParse rejects values outside the platform's int range, where
+      // double.toInt() would silently saturate.
+      final asInt = int.tryParse(value.toStringAsFixed(0));
+      if (asInt != null) {
+        return asInt;
+      }
     }
     throw InvalidTypeException(
       value: value == null ? 'null' : toString(),

--- a/packages/tonik_util/test/src/decoding/json_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/json_decoder_test.dart
@@ -193,6 +193,45 @@ void main() {
         );
       });
 
+      test('decodes large in-range whole-number doubles exactly', () {
+        expect((9.2e18 as Object?).decodeJsonInt(), 9200000000000000000);
+        expect(
+          (-9223372036854775808.0 as Object?).decodeJsonInt(),
+          -9223372036854775808,
+        );
+        expect(
+          (9.2e18 as Object?).decodeJsonNullableInt(),
+          9200000000000000000,
+        );
+      });
+
+      test('throws on whole-number double beyond the int range', () {
+        expect(
+          () => (9223372036854775808.0 as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (1e19 as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (-1e19 as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (1e21 as Object?).decodeJsonInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (9223372036854775808.0 as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+        expect(
+          () => (-1e19 as Object?).decodeJsonNullableInt(),
+          throwsA(isA<InvalidTypeException>()),
+        );
+      });
+
       test('throws on non-finite double', () {
         expect(
           () => (double.nan as Object?).decodeJsonInt(),
@@ -546,6 +585,23 @@ void main() {
       final json = jsonDecode('[1.5]') as Object?;
       expect(
         () => json.decodeJsonList<int>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('throws for int list with an integer beyond the int range', () {
+      final json = jsonDecode('[9223372036854775808]') as Object?;
+      expect(
+        () => json.decodeJsonList<int>(),
+        throwsA(isA<InvalidTypeException>()),
+      );
+    });
+
+    test('throws for nullable int list with an integer beyond the int range',
+        () {
+      final json = jsonDecode('[10000000000000000000]') as Object?;
+      expect(
+        () => json.decodeJsonList<int?>(),
         throwsA(isA<InvalidTypeException>()),
       );
     });


### PR DESCRIPTION
## Summary

A JSON integer that does not fit in Dart's 64-bit `int` (e.g. `10000000000000000000`, or the minimal overflow `9223372036854775808`) is parsed by `jsonDecode` as a `double` on the VM. `decodeJsonInt` accepted any finite whole-number double and called `double.toInt()`, which silently saturates out-of-range values to `9223372036854775807` / `-9223372036854775808` — decoding substituted a different number without any error, and `toJson()` re-emitted the corrupted value.

`decodeJsonInt` now converts whole-number doubles via `int.tryParse(value.toStringAsFixed(0))` and throws `InvalidTypeException` when the parse fails. `int.tryParse` returns `null` for digit strings outside the platform's `int` range, so the platform's own parser defines what fits — no hand-encoded int64 bounds, correct on VM and Wasm by construction, and behavior on the web (where such values already arrive as `int` from `JSON.parse`) is unchanged. This also covers the exponent-notation output `toStringAsFixed` produces for doubles ≥ 1e21. The nullable and list decode paths funnel through the same branch.

Values at the range boundary keep decoding exactly: `-9223372036854775808` (INT64_MIN, representable) is accepted, while `9223372036854775808` (2^63, the minimal overflow) throws — a case a `toInt()`/`toDouble()` round-trip check would miss, since INT64_MAX rounds back up to 2^63 when converted to double.

## Test plan

- New unit tests: scalar and nullable decoders throw on 2^63, ±1e19, and 1e21; large in-range doubles (`9.2e18`, INT64_MIN) still decode exactly; `decodeJsonList<int>` / `<int?>` throw on overflowing wire JSON (`jsonDecode('[9223372036854775808]')`).
- Full tonik_util suite passes (1422 tests), `dart analyze` clean.