### PR TITLE
Serialize empty object property values in styled parameters per RFC 6570

### DIFF
--- a/integration_test/path_encoding/path_encoding_test/test/label_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/label_test.dart
@@ -219,6 +219,40 @@ void main() {
       );
     });
 
+    test('object with empty property (explode=false) keeps an empty slot',
+        () async {
+      final api = buildLabelApi();
+      final response = await api.testLabelObject(
+        value: const SimpleObject(name: '', count: 5),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/label/object/.name,,count,5',
+      );
+    });
+
+    test('object with empty property (explode=true) keeps trailing equals',
+        () async {
+      final api = buildLabelApi();
+      final response = await api.testLabelObjectExplode(
+        value: const SimpleObject(name: '', count: 5),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/label/object/explode/.name=.count=5',
+      );
+    });
+
     test(
       'composite-list property comma-joins elements and escapes reserved '
       'characters once',

--- a/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/matrix_test.dart
@@ -221,6 +221,40 @@ void main() {
         '/v1/matrix/object/explode/;name=test;count=5',
       );
     });
+
+    test('object with empty property (explode=false) keeps an empty slot',
+        () async {
+      final api = buildMatrixApi();
+      final response = await api.testMatrixObject(
+        value: const SimpleObject(name: '', count: 5),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/matrix/object/;value=name,,count,5',
+      );
+    });
+
+    test('object with empty property (explode=true) encodes name-only pair',
+        () async {
+      final api = buildMatrixApi();
+      final response = await api.testMatrixObjectExplode(
+        value: const SimpleObject(name: '', count: 5),
+      );
+
+      expect(response, isA<TonikSuccess<EchoResponse>>());
+      final success = response as TonikSuccess<EchoResponse>;
+      expect(success.response.statusCode, 200);
+
+      expect(
+        success.response.requestOptions.uri.path,
+        '/v1/matrix/object/explode/;name;count=5',
+      );
+    });
   });
 
   group('Matrix style - Combined', () {

--- a/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
@@ -119,5 +119,43 @@ void main() {
         );
       },
     );
+
+    test(
+      'object with empty property (explode=false) keeps an empty slot',
+      () async {
+        final api = buildSimpleApi();
+        final response = await api.testSimpleSpecialKeys(
+          value: const SpecialKeyObject(myField: '', aEqualsB: 42),
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/simple/special-keys/my.field,,a%3Db,42',
+        );
+      },
+    );
+
+    test(
+      'object with empty property (explode=true) keeps trailing equals',
+      () async {
+        final api = buildSimpleApi();
+        final response = await api.testSimpleSpecialKeysExplode(
+          value: const SpecialKeyObject(myField: '', aEqualsB: 42),
+        );
+
+        expect(response, isA<TonikSuccess<EchoResponse>>());
+        final success = response as TonikSuccess<EchoResponse>;
+        expect(success.response.statusCode, 200);
+
+        expect(
+          success.response.requestOptions.uri.path,
+          '/v1/simple/special-keys/explode/my.field=,a%3Db=42',
+        );
+      },
+    );
   });
 }

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_anyof_complex_test.dart
@@ -79,20 +79,25 @@ void main() {
         expect(success.value.xFlexibleObject!.class1!.name, 'hello world');
       });
 
-      test('Class1 with empty name fails at encoding', () async {
+      test('round-trips Class1 with empty name', () async {
         final result = await api.testHeaderRoundtripAnyOfComplex.call(
           flexibleObject: const AnyOfComplex(class1: Class1(name: '')),
         );
 
         expect(
           result,
-          isA<TonikError<HeadersRoundtripAnyofComplexGet200Response>>(),
+          isA<TonikSuccess<HeadersRoundtripAnyofComplexGet200Response>>(),
         );
-        final error =
-            result as TonikError<HeadersRoundtripAnyofComplexGet200Response>;
+        final success =
+            result as TonikSuccess<HeadersRoundtripAnyofComplexGet200Response>;
 
-        expect(error.type, TonikErrorType.encoding);
-        expect(error.response, isNull);
+        expect(
+          success.response.requestOptions.headers['X-Flexible-Object'],
+          'name,',
+        );
+        expect(success.value.xFlexibleObject, isNotNull);
+        expect(success.value.xFlexibleObject!.class1, isNotNull);
+        expect(success.value.xFlexibleObject!.class1!.name, '');
       });
     });
 

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_oneof_complex_test.dart
@@ -102,22 +102,25 @@ void main() {
         expect(class1.value.name, "O'Brien");
       });
 
-      test('Class1 with empty name fails at encoding', () async {
+      test('round-trips Class1 with empty name', () async {
         final result = await api.testHeaderRoundtripOneOfComplex.call(
           complexUnion: const OneOfComplexClass1(Class1(name: '')),
         );
 
-        // Empty strings throw EmptyValueException during encoding
-        // because allowEmpty is false for headers
         expect(
           result,
-          isA<TonikError<HeadersRoundtripOneofComplexGet200Response>>(),
+          isA<TonikSuccess<HeadersRoundtripOneofComplexGet200Response>>(),
         );
-        final error =
-            result as TonikError<HeadersRoundtripOneofComplexGet200Response>;
+        final success =
+            result as TonikSuccess<HeadersRoundtripOneofComplexGet200Response>;
 
-        expect(error.type, TonikErrorType.encoding);
-        expect(error.response, isNull);
+        expect(
+          success.response.requestOptions.headers['X-Complex-Union'],
+          'name,',
+        );
+        expect(success.value.xComplexUnion, isA<OneOfComplexClass1>());
+        final class1 = success.value.xComplexUnion! as OneOfComplexClass1;
+        expect(class1.value.name, '');
       });
     });
 

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -44,18 +44,6 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
   if (map.isEmpty && !allowEmpty) {
     throw const EmptyValueException();
   }
-  if (allowEmpty) {
-    return;
-  }
-  for (final value in map.values) {
-    final isValueEmpty = switch (value) {
-      ScalarPropertyValue(:final value) => value.isEmpty,
-      ArrayPropertyValue(:final values) => values.isEmpty,
-    };
-    if (isValueEmpty) {
-      throw const EmptyValueException();
-    }
-  }
 }
 
 /// Enforces empty-value and URI-escaping rules for object-valued parameters.
@@ -140,13 +128,18 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return ';$paramName';
     }
     if (explode) {
-      return entries
-          .map(
-            (e) =>
-                ';${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value, literal: false)}',
-          )
-          .join();
+      // Matrix is an RFC 6570 named operator: empty values expand to the
+      // name alone, without '='.
+      return entries.map((e) {
+        final key = Uri.encodeComponent(e.key);
+        final isValueEmpty = switch (e.value) {
+          ScalarPropertyValue(:final value) => value.isEmpty,
+          ArrayPropertyValue(:final values) => values.isEmpty,
+        };
+        return isValueEmpty
+            ? ';$key'
+            : ';$key=${_encodeValue(e.value, literal: false)}';
+      }).join();
     }
     return ';$paramName=${_collapsedPairs(this, literal: false)}';
   }

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -23,6 +23,15 @@ void main() {
         'formula,x/y?z',
       );
     });
+
+    test('empty scalar beside a filled scalar renders with allowEmpty=false',
+        () {
+      const value = {
+        'color': PropertyValue.scalar(''),
+        'size': PropertyValue.scalar('xl'),
+      };
+      expect(value.toUri(allowEmpty: false), 'color,,size,xl');
+    });
   });
 
   group('PropertyValueStyleEncoders.toSimple', () {
@@ -123,19 +132,31 @@ void main() {
       expect(value.toSimple(explode: true, allowEmpty: true), 'k=');
     });
 
-    test('empty scalar throws with allowEmpty=false', () {
+    test('empty scalar renders with allowEmpty=false', () {
       const value = {'k': PropertyValue.scalar('')};
-      expect(
-        () => value.toSimple(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
     });
 
-    test('empty array throws with allowEmpty=false', () {
+    test('empty array renders empty value with allowEmpty=false', () {
       const value = {'k': PropertyValue.array(<String>[])};
+      expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
+    });
+
+    test('empty scalar beside a filled scalar renders with allowEmpty=false',
+        () {
+      const value = {
+        'color': PropertyValue.scalar(''),
+        'size': PropertyValue.scalar('xl'),
+      };
       expect(
-        () => value.toSimple(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        value.toSimple(explode: false, allowEmpty: false),
+        'color,,size,xl',
+      );
+      expect(
+        value.toSimple(explode: true, allowEmpty: false),
+        'color=,size=xl',
       );
     });
 
@@ -268,19 +289,31 @@ void main() {
       expect(value.toLabel(explode: true, allowEmpty: true), '.k=');
     });
 
-    test('empty scalar throws with allowEmpty=false', () {
+    test('empty scalar renders with allowEmpty=false', () {
       const value = {'k': PropertyValue.scalar('')};
-      expect(
-        () => value.toLabel(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(value.toLabel(explode: false, allowEmpty: false), '.k,');
+      expect(value.toLabel(explode: true, allowEmpty: false), '.k=');
     });
 
-    test('empty array throws with allowEmpty=false', () {
+    test('empty array renders empty value with allowEmpty=false', () {
       const value = {'k': PropertyValue.array(<String>[])};
+      expect(value.toLabel(explode: false, allowEmpty: false), '.k,');
+      expect(value.toLabel(explode: true, allowEmpty: false), '.k=');
+    });
+
+    test('empty scalar beside a filled scalar renders with allowEmpty=false',
+        () {
+      const value = {
+        'color': PropertyValue.scalar(''),
+        'size': PropertyValue.scalar('xl'),
+      };
       expect(
-        () => value.toLabel(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        value.toLabel(explode: false, allowEmpty: false),
+        '.color,,size,xl',
+      );
+      expect(
+        value.toLabel(explode: true, allowEmpty: false),
+        '.color=.size=xl',
       );
     });
 
@@ -383,25 +416,40 @@ void main() {
       );
     });
 
-    test('empty scalar renders with allowEmpty=true', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=true',
+        () {
       const value = {'k': PropertyValue.scalar('')};
       expect(value.toMatrix('p', explode: false, allowEmpty: true), ';p=k,');
-      expect(value.toMatrix('p', explode: true, allowEmpty: true), ';k=');
+      expect(value.toMatrix('p', explode: true, allowEmpty: true), ';k');
     });
 
-    test('empty scalar throws with allowEmpty=false', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.scalar('')};
-      expect(
-        () => value.toMatrix('p', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(value.toMatrix('p', explode: false, allowEmpty: false), ';p=k,');
+      expect(value.toMatrix('p', explode: true, allowEmpty: false), ';k');
     });
 
-    test('empty array throws with allowEmpty=false', () {
+    test('empty array renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.array(<String>[])};
+      expect(value.toMatrix('p', explode: false, allowEmpty: false), ';p=k,');
+      expect(value.toMatrix('p', explode: true, allowEmpty: false), ';k');
+    });
+
+    test('empty scalar beside a filled scalar renders with allowEmpty=false',
+        () {
+      const value = {
+        'color': PropertyValue.scalar(''),
+        'size': PropertyValue.scalar('xl'),
+      };
       expect(
-        () => value.toMatrix('p', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        value.toMatrix('filter', explode: false, allowEmpty: false),
+        ';filter=color,,size,xl',
+      );
+      expect(
+        value.toMatrix('filter', explode: true, allowEmpty: false),
+        ';color;size=xl',
       );
     });
 


### PR DESCRIPTION
## Problem

An object parameter with an empty-string property value — e.g. `Filter(color: '', size: 'xl')` as a matrix- or label-style path parameter — threw `EmptyValueException` at encode time, so the request was never sent. The same guard rejected empty property values in simple-style path/header objects and form-style query objects.

Per RFC 6570 §2.3, an empty string is a *defined* value and must expand (matrix non-explode: `;filter=color,,size,xl`; label explode: `.color=.size=xl`). OAS `allowEmptyValue` is defined only for query parameters and governs whole parameter values, never individual object members — so there is no spec basis for rejecting these. The behavior was also internally inconsistent: the same empty string inside an array or as a scalar parameter serialized fine.

## Fix

Runtime-only, in `tonik_util`'s `PropertyValueStyleEncoders`:

- `_guardEmpty` no longer throws for individual empty property values; it only guards a wholly empty map (unchanged behavior).
- `toMatrix` with `explode: true` now emits the RFC 6570 named-operator form for an empty member: `;name` without `=` (`ifemp`), matching the existing scalar matrix encoder. Label and simple styles are unnamed operators and correctly keep `name=` / an empty slot, which the existing code already produced once the guard stopped throwing.

No generator changes; generated code is unaffected.

## Tests

- Unit: the six per-property throw tests now assert serialized output; added empty-scalar/empty-array/mixed-map cases for all four styles, including the matrix name-only form. Whole-map guard tests unchanged.
- Integration (`path_encoding`): new empty-property object cases for matrix, label, and simple styles asserting the exact request path on the wire.
- Integration (`simple_encoding`): the two header round-trip tests that asserted the old encode failure now assert the full round-trip (`name,` on the wire, decoding back to an empty string).
- Full `tonik_util` suite (1422), `path_encoding` (65), `simple_encoding` (301), and `query_parameters` (230) all pass; `dart analyze` clean.