### PR TITLE
Combine repeated response header field lines per RFC 9110

### DIFF
--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_duplicate_field_lines_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_duplicate_field_lines_test.dart
@@ -1,0 +1,50 @@
+import 'dart:typed_data';
+
+import 'package:dio/dio.dart';
+import 'package:simple_encoding_api/simple_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('Header Roundtrip Duplicate Field Lines', () {
+    test(
+      'list header sent as two field lines decodes to the combined list',
+      () async {
+        final dio = Dio(BaseOptions(baseUrl: 'https://example.com/v1'))
+          ..httpClientAdapter = _DuplicateFieldLineAdapter();
+
+        final response = await TestHeaderRoundtripSimpleLists(dio).call();
+
+        expect(
+          response,
+          isA<TonikSuccess<HeadersRoundtripListsSimpleGet200Response>>(),
+        );
+        final success =
+            response as TonikSuccess<HeadersRoundtripListsSimpleGet200Response>;
+        expect(success.response.statusCode, 200);
+        expect(success.response.headers['x-string-list'], ['a', 'b']);
+        expect(success.value.xStringList, ['a', 'b']);
+      },
+    );
+  });
+}
+
+class _DuplicateFieldLineAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString(
+      '',
+      200,
+      headers: {
+        'x-string-list': ['a', 'b'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {}
+}

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -615,8 +615,7 @@ class ParseGenerator {
     return neverHeaders.map((headerName) {
       final headerValue = refer('response')
           .property('headers')
-          .property('value')
-          .call([specLiteralString(headerName)]);
+          .index(specLiteralString(headerName));
       return Block.of([
         const Code('if ('),
         headerValue.code,
@@ -680,10 +679,14 @@ class ParseGenerator {
         continue;
       }
 
+      // RFC 9110 combined field value: a header repeated across field
+      // lines is equivalent to the comma-joined single-line form.
       final headerValue = refer('response')
           .property('headers')
-          .property('value')
-          .call([specLiteralString(rawHeaderName)]);
+          .index(specLiteralString(rawHeaderName))
+          .nullSafeProperty('join')
+          .call([literalString(',')])
+          .parenthesized;
       final resolvedHeader = norm.header!.resolve();
       final decode = buildSimpleValueExpression(
         headerValue,

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -730,11 +730,9 @@ String _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return AnonymousResponse(
                   body: _$body,
-                  xRateLimit: response.headers
-                    .value(r'x-rate-limit')
+                  xRateLimit: (response.headers[r'x-rate-limit']?.join(','))
                     .decodeSimpleNullableInt(context: r'x-rate-limit'),
-                  xExpiresAfter: response.headers
-                    .value(r'x-expires-after')
+                  xExpiresAfter: (response.headers[r'x-expires-after']?.join(','))
                     .decodeSimpleNullableDateTime(context: r'x-expires-after'),
               );
             default:
@@ -857,8 +855,7 @@ String _parseResponse(Response<List<int>> response) {
               return CombinedOpResponse200(
                 body: AnonymousResponse(
                   body: _$body,
-                  xRateLimit: response.headers
-                    .value(r'x-rate-limit')
+                  xRateLimit: (response.headers[r'x-rate-limit']?.join(','))
                     .decodeSimpleNullableInt(context: r'x-rate-limit'),
                 ),
               );
@@ -1301,8 +1298,7 @@ String _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return BaseResponse(
                 body: _$body,
-                xUserId: response.headers
-                    .value(r'x-user-id')
+                xUserId: (response.headers[r'x-user-id']?.join(','))
                     .decodeSimpleString(context: r'x-user-id'),
               );
             default:
@@ -1394,8 +1390,7 @@ String _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return HeaderAliasResponse(
                 body: _$body,
-                xUserId: response.headers
-                    .value(r'x-user-id')
+                xUserId: (response.headers[r'x-user-id']?.join(','))
                     .decodeSimpleString(context: r'x-user-id'),
               );
             default:
@@ -1479,8 +1474,7 @@ String _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return BodyHeaderResponse(
                 body2: _$body,
-                body: response.headers
-                    .value(r'body_')
+                body: (response.headers[r'body_']?.join(','))
                     .decodeSimpleString(context: r'body_'),
               );
             default:
@@ -1571,8 +1565,7 @@ String _parseResponse(Response<List<int>> response) {
           contains(
             collapseWhitespace(r'''
               body2: _$body,
-              body: response.headers
-                  .value(r'body_')
+              body: (response.headers[r'body_']?.join(','))
                   .decodeSimpleString(context: r'body_'),
             '''),
           ),
@@ -1717,8 +1710,7 @@ String _parseResponse(Response<List<int>> response) {
               collapseWhitespace('''
                 return $implementation(
                   body2: _\$body,
-                  body: response.headers
-                      .value(r'body_')
+                  body: (response.headers[r'body_']?.join(','))
                       .decodeSimpleString(context: r'body_'),
                 );
               '''),
@@ -2915,7 +2907,7 @@ List<Map<String, String>> _parseResponse(Response<List<int>> response) {
           final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
-              if (response.headers.value(r'X-Never-Header') != null) {
+              if (response.headers[r'X-Never-Header'] != null) {
                 throw SimpleDecodingException(
                   r'NeverModel does not permit any value at X-Never-Header',
                 );
@@ -2924,7 +2916,7 @@ List<Map<String, String>> _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return AnonymousResponse(
                   body: _$body,
-                  xAnyHeader: response.headers.value(r'X-Any-Header'),
+                  xAnyHeader: (response.headers[r'X-Any-Header']?.join(',')),
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
@@ -3029,7 +3021,7 @@ List<Map<String, String>> _parseResponse(Response<List<int>> response) {
           final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
-              if (response.headers.value(r'X-Never-Header') != null) {
+              if (response.headers[r'X-Never-Header'] != null) {
                 throw SimpleDecodingException(
                   r'NeverModel does not permit any value at X-Never-Header',
                 );
@@ -3038,7 +3030,7 @@ List<Map<String, String>> _parseResponse(Response<List<int>> response) {
               final _$body = User.fromJson(_$json);
               return AnonymousResponse(
                   body: _$body,
-                  xAnyHeader: response.headers.value(r'X-Any-Header'),
+                  xAnyHeader: (response.headers[r'X-Any-Header']?.join(',')),
               );
             default:
               final _$content = response.headers.value('content-type') ?? 'not specified';
@@ -3142,7 +3134,7 @@ List<Map<String, String>> _parseResponse(Response<List<int>> response) {
           final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
             case (200, r'application/json'):
-              if (response.headers.value(r'X-Never-Header') != null) {
+              if (response.headers[r'X-Never-Header'] != null) {
                 throw SimpleDecodingException(
                   r'NeverModel does not permit any value at X-Never-Header',
                 );
@@ -3620,7 +3612,7 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
-      if (response.headers.value(r'X-Never-Header') != null) {
+      if (response.headers[r'X-Never-Header'] != null) {
         throw SimpleDecodingException(
           r'NeverModel does not permit any value at X-Never-Header',
         );
@@ -3713,7 +3705,7 @@ MultiNeverBodyHeaderOpResponse _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'application/json'):
-      if (response.headers.value(r'X-Never-Header') != null) {
+      if (response.headers[r'X-Never-Header'] != null) {
         throw SimpleDecodingException(
           r'NeverModel does not permit any value at X-Never-Header',
         );


### PR DESCRIPTION
## Problem

RFC 9110 §5.2 defines the combined field value of a header repeated across field lines as the comma-joined list of the individual field-line values, and §5.3 permits senders to split a list-typed header across multiple lines. A conformant server can therefore send an array-typed response header as:

```
X-Tags: a
X-Tags: b
```

Generated response parsers read declared headers via Dio's `Headers.value(name)`, which **throws** when the header has more than one field line. The result: a conformant response is rejected with a `TonikError(decoding)` and the caller loses the entire response, body included — even though the intended value is simply `["a", "b"]`. The single-line comma form (`X-Tags: a,b`) already decoded correctly, so only the multi-line form was broken.

## Fix

Read `response.headers[name]` (Dio returns `List<String>?`) and join the entries with `','` before handing the value to the simple-style decoder. For a repeated header this is exactly the RFC 9110 combined field value; for a single-line header it is identical to the previous behavior.

- `_decodeHeaders` now emits `(response.headers[r'name']?.join(','))...` instead of `response.headers.value(r'name')...`. The parentheses are required: the `SimpleDecoder` extension is declared `on String?`, and without them Dart null-shorting would skip the decoder call entirely for an absent header, yielding `null` for a required header instead of the proper `SimpleDecodingException`.
- `_generateNeverHeaderChecks` now emits `response.headers[r'name'] != null` for the presence check.

Content-Type reads (`extractMediaType`) are untouched — Content-Type is an RFC 9110 singleton field.

## Out of scope

`Set-Cookie` is the RFC 9110 §5.3 exception that must **not** be comma-joined. A typed `Set-Cookie` response-header declaration would be comma-joined like any other header and could be mangled, but this is no worse than the previous behavior of throwing outright. Typed `Set-Cookie` declarations are rare; special-casing it is left for a follow-up if it ever surfaces.

## Tests

- Updated the expected-code literals in `parse_generator_test.dart` to the new emission.
- Added an integration test in `simple_encoding` that stubs a response with `X-Tags` on two field lines (via a Dio `HttpClientAdapter`, since Imposter overwrites on repeated `withHeader`) and asserts the header decodes to the combined list. The single-line comma form remains covered by the existing header-roundtrip suites.
