### PR TITLE
Omit Content-Type for omitted optional request bodies

### DIFF
--- a/integration_test/composition/composition_test/test/optional_body_content_type_test.dart
+++ b/integration_test/composition/composition_test/test/optional_body_content_type_test.dart
@@ -1,0 +1,47 @@
+import 'package:composition_api/composition_api.dart';
+import 'package:dio/dio.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  CompositionApi buildApi() {
+    return CompositionApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(headers: {'X-Response-Body': '"hello"'}),
+        ),
+      ),
+    );
+  }
+
+  group('optional single-content request body', () {
+    test('omits Content-Type when body is not provided', () async {
+      final result = await buildApi().echoOneOfPrimitive();
+
+      final success = result as TonikSuccess<OneOfPrimitive>;
+      expect(success.response.requestOptions.headers['content-type'], isNull);
+    });
+
+    test('sends Content-Type application/json when body is provided', () async {
+      final result = await buildApi().echoOneOfPrimitive(
+        body: const OneOfPrimitiveString('hello'),
+      );
+
+      final success = result as TonikSuccess<OneOfPrimitive>;
+      expect(
+        success.response.requestOptions.headers['content-type'],
+        'application/json',
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -269,7 +269,7 @@ class OperationGenerator {
         pathExpr,
         queryExpr,
         hasRequestBody,
-        (operation.requestBody?.contentCount ?? 0) > 1,
+        optionsMethodNeedsBody(operation.requestBody),
         headerArgs,
         cookieArgs,
         pathArgs,
@@ -351,7 +351,7 @@ class OperationGenerator {
     Expression pathExpr,
     Expression queryExpr,
     bool hasRequestBody,
-    bool hasVariableContent,
+    bool optionsNeedsBody,
     Map<String, Expression> headerArgs,
     Map<String, Expression> cookieArgs,
     Map<String, Expression> pathArgs,
@@ -427,7 +427,7 @@ class OperationGenerator {
               refer('_options').call([], {
                 ...headerArgs,
                 ...cookieArgs,
-                if (hasVariableContent) 'body': refer('body'),
+                if (optionsNeedsBody) 'body': refer('body'),
               }),
             )
             .statement,

--- a/packages/tonik_generate/lib/src/operation/options_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/options_generator.dart
@@ -98,7 +98,39 @@ class OptionsGenerator {
       if (singleContent.contentType == ContentType.multipart) {
         return literalNull;
       }
-      return specLiteralString(singleContent.rawContentType);
+      if (requestBody.isRequired) {
+        return specLiteralString(singleContent.rawContentType);
+      }
+
+      // Optional bodies omit the Content-Type header when no body is sent.
+      parameters.add(
+        Parameter(
+          (b) => b
+            ..name = 'body'
+            ..type = typeReference(
+              singleContent.model,
+              nameManager,
+              package,
+              isNullableOverride: true,
+              useImmutableCollections: useImmutableCollections,
+            )
+            ..named = true
+            ..required = false,
+        ),
+      );
+      bodyStatements.add(
+        declareFinal(r'_$contentType')
+            .assign(
+              refer('body')
+                  .equalTo(literalNull)
+                  .conditional(
+                    literalNull,
+                    specLiteralString(singleContent.rawContentType),
+                  ),
+            )
+            .statement,
+      );
+      return refer(r'_$contentType');
     }
 
     final (baseName, subclassNames) = nameManager.requestBodyNames(requestBody);
@@ -549,4 +581,22 @@ class OptionsGenerator {
       ..requiredParameters.add(Parameter((b) => b..name = '_'))
       ..body = literalBool(true).code,
   ).closure;
+}
+
+/// Whether the generated `_options` method needs the request body value to
+/// compute the Content-Type header.
+///
+/// True for multi-content bodies (the Content-Type switches on the runtime
+/// value) and for optional non-multipart single-content bodies (Content-Type
+/// is omitted when no body is sent).
+bool optionsMethodNeedsBody(RequestBody? requestBody) {
+  final content = requestBody?.resolvedContent;
+  if (content == null || content.isEmpty) {
+    return false;
+  }
+  if (requestBody!.contentCount > 1) {
+    return true;
+  }
+  return !requestBody.isRequired &&
+      content.first.contentType != ContentType.multipart;
 }

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -777,6 +777,123 @@ Future<TonikResult<void>> call({
       );
 
       test(
+        'passes body to _options for optional single content type body',
+        () {
+          final requestBody = RequestBodyObject(
+            name: 'optionalBody',
+            context: context,
+            description: 'An optional single content type body',
+            isRequired: false,
+            content: {
+              RequestContent(
+                model: StringModel(context: context),
+                contentType: ContentType.json,
+                rawContentType: 'application/json',
+                examples: const [],
+              ),
+            },
+          );
+
+          final operation = Operation(
+            operationId: 'operationWithOptionalBody',
+            context: context,
+            summary: 'Operation with optional body',
+            description: 'An operation that has an optional single body',
+            tags: const {},
+            isDeprecated: false,
+            path: '/optional-body',
+            method: HttpMethod.post,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            requestBody: requestBody,
+            securitySchemes: const {},
+          );
+
+          const normalizedParams = NormalizedRequestParameters(
+            pathParameters: [],
+            cookieParameters: [],
+            queryParameters: [],
+            headers: [],
+          );
+
+          final method = generator.generateCallMethod(
+            operation,
+            normalizedParams,
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  String? body,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(path: _$newPath);
+    _$data = _data(body: body);
+    _$options = _options(body: body);
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
         'generates call method w/ multiple content type request body parameter',
         () {
           final requestBody = RequestBodyObject(

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -1101,6 +1101,151 @@ Future<TonikResult<void>> call({
       );
 
       test(
+        'passes body to _data but not _options for optional multipart body',
+        () {
+          final multipartModel = ClassModel(
+            name: 'UploadForm',
+            isDeprecated: false,
+            properties: [
+              Property(
+                name: 'name',
+                model: StringModel(context: context),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
+            context: context,
+            examples: const [],
+          );
+
+          final requestBody = RequestBodyObject(
+            name: 'upload',
+            context: context,
+            description: null,
+            isRequired: false,
+            content: {
+              RequestContent(
+                model: multipartModel,
+                contentType: ContentType.multipart,
+                rawContentType: 'multipart/form-data',
+                multipartEncoding: _multipartEncoding(multipartModel, {
+                  'name': const PartEncoding(
+                    contentType: ContentType.text,
+                    rawContentType: 'text/plain',
+                    headers: null,
+                    style: EncodingStyle.form,
+                    explode: true,
+                    allowReserved: false,
+                  ),
+                }),
+                examples: const [],
+              ),
+            },
+          );
+
+          final operation = Operation(
+            operationId: 'uploadOptionalForm',
+            context: context,
+            summary: 'Upload optional form',
+            description: 'Upload an optional form',
+            tags: const {},
+            isDeprecated: false,
+            path: '/upload-optional',
+            method: HttpMethod.post,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: const {},
+            requestBody: requestBody,
+            securitySchemes: const {},
+          );
+
+          const normalizedParams = NormalizedRequestParameters(
+            pathParameters: [],
+            cookieParameters: [],
+            queryParameters: [],
+            headers: [],
+          );
+
+          final method = generator.generateCallMethod(
+            operation,
+            normalizedParams,
+          );
+
+          const expectedMethod = r'''
+Future<TonikResult<void>> call({
+  UploadForm? body,
+  CancelToken? cancelToken,
+}) async {
+  late final Uri _$uri;
+  late final Object? _$data;
+  late final Options _$options;
+
+  try {
+    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$pathResult = _path();
+    final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
+    _$uri = _$baseUri.replace(path: _$newPath);
+    _$data = await _data(body: body);
+    _$options = _options();
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  final Response<List<int>> _$response;
+  try {
+    _$response = await _dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+
+  return TonikSuccess(null, _$response);
+}
+''';
+
+          final methodString = format(method.accept(emitter).toString());
+          expect(
+            collapseWhitespace(methodString),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
+      );
+
+      test(
         'prioritizes body parameter for request body with conflicting names',
         () {
           final requestBody = RequestBodyObject(

--- a/packages/tonik_generate/test/src/operation/options_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/options_generator_test.dart
@@ -860,6 +860,63 @@ void main() {
       },
     );
 
+    test('omits contentType when optional single-content body is null', () {
+      final requestBody = RequestBodyObject(
+        name: 'optionalContent',
+        context: context,
+        description: 'Optional request body with single content type',
+        isRequired: false,
+        content: {
+          RequestContent(
+            model: StringModel(context: context),
+            contentType: ContentType.json,
+            rawContentType: 'application/json',
+            examples: const [],
+          ),
+        },
+      );
+
+      final operation = Operation(
+        operationId: 'operationWithOptionalContent',
+        context: context,
+        summary: 'Operation with optional single content',
+        description: 'An operation with an optional single content type body',
+        tags: const {},
+        isDeprecated: false,
+        path: '/optional-content',
+        method: HttpMethod.post,
+        headers: const {},
+        queryParameters: const {},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        requestBody: requestBody,
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = r'''
+        Options _options({String? body}) {
+          final _$contentType = body == null ? null : r'application/json';
+          final _$headers = <String, dynamic>{};
+          _$headers['Accept'] = r'*/*';
+          return Options(
+            method: 'POST',
+            headers: _$headers,
+            contentType: _$contentType,
+            responseType: ResponseType.bytes,
+            validateStatus: (_) => true,
+          );
+        }
+      ''';
+
+      final method = generator.generateOptionsMethod(operation, [], []);
+      final methodString = format(method.accept(emitter).toString());
+      expect(
+        collapseWhitespace(methodString),
+        collapseWhitespace(expectedMethod),
+      );
+    });
+
     test(
       'sets contentType based on body type when body has multiple contents',
       () {
@@ -4472,6 +4529,68 @@ void main() {
           tags: const {},
           isDeprecated: false,
           path: '/upload',
+          method: HttpMethod.post,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          requestBody: requestBody,
+          securitySchemes: const {},
+        );
+
+        const expectedMethod = r'''
+          Options _options() {
+            final _$headers = <String, dynamic>{};
+            _$headers['Accept'] = r'*/*';
+            return Options(
+              method: 'POST',
+              headers: _$headers,
+              contentType: null,
+              responseType: ResponseType.bytes,
+              validateStatus: (_) => true,
+            );
+          }
+        ''';
+
+        final method = generator.generateOptionsMethod(operation, [], []);
+        final methodString = format(method.accept(emitter).toString());
+        expect(
+          collapseWhitespace(methodString),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
+      test('sets contentType to null for optional single multipart body', () {
+        final requestBody = RequestBodyObject(
+          name: 'optionalUploadBody',
+          context: context,
+          description: 'Optional multipart body',
+          isRequired: false,
+          content: {
+            RequestContent(
+              model: ClassModel(
+                name: 'UploadForm',
+                isDeprecated: false,
+                properties: const [],
+                context: context,
+                examples: const [],
+              ),
+              contentType: ContentType.multipart,
+              rawContentType: 'multipart/form-data',
+              examples: const [],
+            ),
+          },
+        );
+
+        final operation = Operation(
+          operationId: 'uploadOptionalFile',
+          context: context,
+          summary: 'Upload optional file',
+          description: 'Upload an optional file',
+          tags: const {},
+          isDeprecated: false,
+          path: '/upload-optional',
           method: HttpMethod.post,
           headers: const {},
           queryParameters: const {},


### PR DESCRIPTION
## Problem

An operation with an optional single-content-type request body (`required: false`) still sent `Content-Type: application/json` even when the caller omitted the body. This labels a zero-length body as JSON, which is self-contradictory — a zero-length document is not valid JSON — so conformant servers (Fastify, Spring MVC, ASP.NET Core) reject the request with 400/415. The generated client had no way to send a well-formed bodiless request, even though the spec declares "no body" as valid.

The multi-content-type path already handled this correctly (it omits the header when the body is null); only the single-content path did not.

## Fix

The single-content branch of `_generateContentType` now mirrors the multi-content behavior. For optional non-multipart bodies it emits:

```dart
final _$contentType = body == null ? null : r'application/json';
```

so the header is present exactly when content is sent. Required bodies (constant string) and multipart bodies (`null`, boundary set by Dio) are unchanged.

A shared `optionsMethodNeedsBody` predicate is the single source of truth for whether `_options` needs the runtime body, keeping the argument-passing site in `operation_generator` in sync with the parameter `_options` declares.

## Tests

- Unit: optional single-content JSON body emits the conditional Content-Type; optional single multipart body still yields `contentType: null` with no `body` parameter; `call()` passes `body` through to `_options`.
- Integration (composition suite): omitting the optional body sends no Content-Type; providing it sends `application/json`.