### PR TITLE
Percent-encode form parameter names

### DIFF
--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -107,6 +107,29 @@ paths:
         '204':
           description: OK
 
+  /form-special-names:
+    get:
+      operationId: testFormSpecialNames
+      tags:
+        - query
+      summary: Test form query parameters whose names contain reserved characters
+      parameters:
+        - name: q&a
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+        - name: a=b
+          in: query
+          style: form
+          explode: false
+          schema:
+            type: string
+      responses:
+        '204':
+          description: OK
+
   /form-complex:
     get:
       operationId: testFormComplex

--- a/integration_test/query_parameters/query_parameters_test/test/special_names_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/special_names_test.dart
@@ -1,0 +1,66 @@
+import 'package:dio/dio.dart';
+import 'package:query_parameters_api/query_parameters_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  QueryApi buildQueryApi({required String responseStatus}) {
+    return QueryApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Status': responseStatus},
+          ),
+        ),
+      ),
+    );
+  }
+
+  test('ampersand in a parameter name is percent-encoded', () async {
+    final api = buildQueryApi(responseStatus: '204');
+    final response = await api.testFormSpecialNames(qAmpersandA: 'hello');
+
+    expect(response, isA<TonikSuccess<void>>());
+    final success = response as TonikSuccess<void>;
+    expect(success.response.requestOptions.uri.query, 'q%26a=hello');
+  });
+
+  test('equals in a parameter name is percent-encoded', () async {
+    final api = buildQueryApi(responseStatus: '204');
+    final response = await api.testFormSpecialNames(aEqualsB: 'v');
+
+    expect(response, isA<TonikSuccess<void>>());
+    final success = response as TonikSuccess<void>;
+    expect(success.response.requestOptions.uri.query, 'a%3Db=v');
+  });
+
+  test('special names keep their pair structure when parsed by a server',
+      () async {
+    final api = buildQueryApi(responseStatus: '204');
+    final response = await api.testFormSpecialNames(
+      qAmpersandA: 'hello',
+      aEqualsB: 'v',
+    );
+
+    expect(response, isA<TonikSuccess<void>>());
+    final success = response as TonikSuccess<void>;
+    expect(
+      success.response.requestOptions.uri.query,
+      'q%26a=hello&a%3Db=v',
+    );
+    expect(
+      Uri.splitQueryString(success.response.requestOptions.uri.query),
+      {'q&a': 'hello', 'a=b': 'v'},
+    );
+  });
+}

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -30,7 +30,11 @@ extension FormUriEncoder on Uri {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -51,7 +55,11 @@ extension FormStringEncoder on String {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -72,7 +80,11 @@ extension FormIntEncoder on int {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -93,7 +105,11 @@ extension FormDoubleEncoder on double {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -114,7 +130,11 @@ extension FormNumEncoder on num {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -135,7 +155,11 @@ extension FormBoolEncoder on bool {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -156,7 +180,11 @@ extension FormDateTimeEncoder on DateTime {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -177,7 +205,11 @@ extension FormBigDecimalEncoder on BigDecimal {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,
@@ -210,7 +242,11 @@ extension FormStringListEncoder on List<String> {
     if (!explode) {
       return [
         (
-          name: paramName,
+          name: _encodeValue(
+            paramName,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+          ),
           value: uriEncode(
             allowEmpty: allowEmpty,
             alreadyEncoded: alreadyEncoded,
@@ -224,7 +260,11 @@ extension FormStringListEncoder on List<String> {
     return [
       for (final item in this)
         (
-          name: paramName,
+          name: _encodeValue(
+            paramName,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+          ),
           value: alreadyEncoded
               ? item
               : _encodeValue(
@@ -261,7 +301,11 @@ extension FormStringMapEncoder on Map<String, String> {
     if (!explode) {
       return [
         (
-          name: paramName,
+          name: _encodeValue(
+            paramName,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+          ),
           value: uriEncode(
             allowEmpty: allowEmpty,
             alreadyEncoded: alreadyEncoded,
@@ -305,7 +349,11 @@ extension FormBinaryEncoder on List<int> {
     bool allowReserved = false,
   }) => [
     (
-      name: paramName,
+      name: _encodeValue(
+        paramName,
+        useQueryComponent: useQueryComponent,
+        allowReserved: allowReserved,
+      ),
       value: uriEncode(
         allowEmpty: allowEmpty,
         useQueryComponent: useQueryComponent,

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -909,4 +909,95 @@ void main() {
       );
     });
   });
+
+  group('parameter name encoding', () {
+    test('string encoder escapes & in the parameter name', () {
+      expect(
+        'hello'.toForm('q&a', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'q%26a', value: 'hello')],
+      );
+    });
+
+    test('string encoder escapes = in the parameter name', () {
+      expect(
+        'v'.toForm('a=b', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'a%3Db', value: 'v')],
+      );
+    });
+
+    test('string encoder leaves an unreserved parameter name unchanged', () {
+      expect(
+        'v'.toForm('limit', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'limit', value: 'v')],
+      );
+    });
+
+    test('int encoder escapes & in the parameter name', () {
+      expect(
+        42.toForm('q&a', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'q%26a', value: '42')],
+      );
+    });
+
+    test('list explode=false escapes the parameter name', () {
+      expect(
+        ['a', 'b'].toForm('q&a', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'q%26a', value: 'a,b')],
+      );
+    });
+
+    test('list explode=true escapes the parameter name on every entry', () {
+      expect(
+        ['a', 'b'].toForm('q&a', explode: true, allowEmpty: true),
+        const <ParameterEntry>[
+          (name: 'q%26a', value: 'a'),
+          (name: 'q%26a', value: 'b'),
+        ],
+      );
+    });
+
+    test('map explode=false escapes the parameter name', () {
+      expect(
+        {'k': 'v'}.toForm('q&a', explode: false, allowEmpty: true),
+        const <ParameterEntry>[(name: 'q%26a', value: 'k,v')],
+      );
+    });
+
+    test('parameter name renders space as + under useQueryComponent', () {
+      expect(
+        'v'.toForm(
+          'user name',
+          explode: false,
+          allowEmpty: true,
+          useQueryComponent: true,
+        ),
+        const <ParameterEntry>[(name: 'user+name', value: 'v')],
+      );
+    });
+
+    test('parameter name still escapes & under allowReserved', () {
+      expect(
+        'v'.toForm(
+          'a&b',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'a%26b', value: 'v')],
+      );
+    });
+
+    test('parameter name keeps other reserved chars literal under '
+        'allowReserved', () {
+      expect(
+        'v'.toForm(
+          'a:b',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        ),
+        const <ParameterEntry>[(name: 'a:b', value: 'v')],
+      );
+    });
+  });
 }


### PR DESCRIPTION
## Summary
Form-style parameter serialization percent-encoded parameter *values* but passed the parameter *name* through verbatim. A declared parameter name containing a reserved character such as `&` or `=` was emitted raw into the `name=value&name=value` join, silently destroying the pair structure of the query string — a conformant server parses `q&a=hello` as two parameters (`q` and `a`) instead of one parameter named `q&a`. The request still reported success, so the corruption was completely silent.

Values were already safe (`&`→`%26`, `=`→`%3D`), and exploded-object property keys were already encoded; only the top-level parameter name was exempt.

## Fix
In `form_encoder_extensions.dart`, every `toForm` now encodes the parameter name through the same `_encodeValue` helper already used for exploded-object keys, mirroring `useQueryComponent` and `allowReserved`. Because the `allowReserved` path always escapes the structural `& = +`, a name like `q&a` becomes `q%26a` regardless of `allowReserved`, while unreserved names (`limit`) and other reserved characters under `allowReserved` are unchanged. The single encoder change covers query, cookie, and urlencoded-body/multipart serialization since they all build entries through `toForm`.

## Standards
- **RFC 3986 §3.4**: `&` and `=` are valid query sub-delimiters, so no downstream URI normalization can repair the ambiguity once a raw name is joined into the query — the serializer must escape them.
- **`application/x-www-form-urlencoded`** (the convention query strings follow): both the name and value of each pair are percent-escaped so `&` and `=` stay unambiguous delimiters.
- **OpenAPI**: a parameter name is an arbitrary case-sensitive string, and the spec places responsibility on applications to percent-encode characters with special meaning in `application/x-www-form-urlencoded`.

## Tests
- Unit: `form_encoder_extensions_test.dart` → `parameter name encoding` group (String, int, list explode/non-explode, map, `useQueryComponent`, `allowReserved`), including guards that unreserved names and reserved chars under `allowReserved` are left intact.
- Integration: new `/form-special-names` operation in the `query_parameters` suite with parameter names `q&a` and `a=b`, verifying the wire query is `q%26a=hello` / `a%3Db=v` and that a server round-trips the intended names via `Uri.splitQueryString`.
