### PR TITLE
Percent-decode untyped additional properties from form bodies

### DIFF
--- a/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
+++ b/integration_test/form_urlencoded/form_urlencoded_test/imposter/response.groovy
@@ -85,6 +85,15 @@ switch (path) {
         }
         break
 
+    case '/form/untyped-extras-response':
+        def formBody = 'id=1&user_name=caf%C3%A9&note=caf%C3%A9&city=New+York'
+        respond {
+            withStatusCode 200
+            withHeader 'Content-Type', 'application/x-www-form-urlencoded'
+            withContent formBody
+        }
+        break
+
     case '/form/empty-null':
         def formBody = 'emptyString=&nullableString=not+empty'
         respond {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -509,6 +509,35 @@ void main() {
       expect(error.type, TonikErrorType.decoding);
       expect(error.error, isA<FormDecodingException>());
     });
+
+    test('percent-decodes untyped additional properties', () async {
+      final response = await api.getUntypedExtrasResponse();
+
+      expect(response, isA<TonikSuccess<UntypedExtrasForm>>());
+      final data = (response as TonikSuccess<UntypedExtrasForm>).value;
+
+      expect(data.userName, 'café');
+      expect(data.additionalProperties['note'], 'café');
+      expect(data.additionalProperties['city'], 'New York');
+    });
+
+    test('re-encodes untyped additional properties without double '
+        'encoding', () async {
+      final response = await api.getUntypedExtrasResponse();
+      final data = (response as TonikSuccess<UntypedExtrasForm>).value;
+
+      final entries = data.toForm(
+        'item',
+        explode: true,
+        allowEmpty: true,
+        useQueryComponent: true,
+      );
+
+      expect(
+        entries.firstWhere((e) => e.name == 'note').value,
+        'caf%C3%A9',
+      );
+    });
   });
 
   group('Empty and null values', () {

--- a/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
+++ b/integration_test/form_urlencoded/form_urlencoded_test/test/form_encoding_test.dart
@@ -537,6 +537,10 @@ void main() {
         entries.firstWhere((e) => e.name == 'note').value,
         'caf%C3%A9',
       );
+      expect(
+        entries.firstWhere((e) => e.name == 'city').value,
+        'New+York',
+      );
     });
   });
 

--- a/integration_test/form_urlencoded/openapi.yaml
+++ b/integration_test/form_urlencoded/openapi.yaml
@@ -176,6 +176,21 @@ paths:
                 additionalProperties:
                   type: string
 
+  /form/untyped-extras-response:
+    get:
+      operationId: getUntypedExtrasResponse
+      tags:
+        - form
+      summary: Get response with untyped additional properties
+      description: Tests decoding of untyped additionalProperties from form body
+      responses:
+        '200':
+          description: Successful response with declared and untyped extras
+          content:
+            application/x-www-form-urlencoded:
+              schema:
+                $ref: '#/components/schemas/UntypedExtrasForm'
+
   /form/empty-null:
     post:
       operationId: postEmptyNull
@@ -764,6 +779,17 @@ components:
           type: integer
           description: Person age
           example: 30
+
+    UntypedExtrasForm:
+      type: object
+      required:
+        - id
+      properties:
+        id:
+          type: integer
+        user_name:
+          type: string
+      additionalProperties: true
 
     SpecialCharsForm:
       type: object

--- a/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
@@ -88,7 +88,16 @@ Expression _buildFromFormValueExpression(
   final contextParam = _buildContextParam(contextClass, contextProperty);
 
   return switch (model) {
-    StringModel() || AnyModel() =>
+    StringModel() =>
+      value
+          .property(
+            isRequired ? 'decodeFormString' : 'decodeFormNullableString',
+          )
+          .call([], contextParam),
+
+    // urlencoded carries no type information: an untyped value is a string on
+    // the wire, decoded into the Object? slot (JSON keeps AnyModel raw).
+    AnyModel() =>
       value
           .property(
             isRequired ? 'decodeFormString' : 'decodeFormNullableString',

--- a/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_form_value_expression_generator.dart
@@ -88,7 +88,7 @@ Expression _buildFromFormValueExpression(
   final contextParam = _buildContextParam(contextClass, contextProperty);
 
   return switch (model) {
-    StringModel() =>
+    StringModel() || AnyModel() =>
       value
           .property(
             isRequired ? 'decodeFormString' : 'decodeFormNullableString',
@@ -205,8 +205,6 @@ Expression _buildFromFormValueExpression(
     ),
 
     NeverModel() => _buildNeverModelExpression(value, isRequired),
-
-    AnyModel() => value,
 
     MapModel() => generateFormDecodingExceptionExpression(
       _mapFormDecodingMessage,

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -4049,7 +4049,9 @@ class Holder {
     final _$additional = <String, Object?>{};
     for (final _$entry in _$values.entries) {
       if (!_$knownKeys.contains(_$entry.key)) {
-        _$additional[_$entry.key] = _$entry.value;
+        _$additional[_$entry.key] = _$entry.value.decodeFormString(
+          context: r'ExtendedConfig.additionalProperties',
+        );
       }
     }
     return ExtendedConfig(

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -1341,7 +1341,9 @@ void main() {
     final _$additional = <String, Object?>{};
     for (final _$entry in _$values.entries) {
       if (!_$knownKeys.contains(_$entry.key)) {
-        _$additional[_$entry.key] = _$entry.value;
+        _$additional[_$entry.key] = _$entry.value.decodeFormString(
+          context: r'Config.additionalProperties',
+        );
       }
     }
     return Config(

--- a/packages/tonik_generate/test/src/util/additional_properties_builders_test.dart
+++ b/packages/tonik_generate/test/src/util/additional_properties_builders_test.dart
@@ -304,6 +304,72 @@ void main() {
       );
     });
 
+    test('untyped values percent-decode through the form decoder', () {
+      final result = buildApFlatCaptureLoop(
+        AdditionalPropertiesPlan(
+          valueModel: AnyModel(context: context),
+          knownWireKeys: const {'name'},
+        ),
+        format: FlatWireFormat.form,
+        sourceMapVar: r'_$values',
+        nameManager: nameManager,
+        package: 'package:example/api.dart',
+        contextClass: 'Order',
+      );
+
+      const expected = r'''
+        void run() {
+          const _$knownKeys = {r'name'};
+          final _$additional = <String, Object?>{};
+          for (final _$entry in _$values.entries) {
+            if (!_$knownKeys.contains(_$entry.key)) {
+              _$additional[_$entry.key] = _$entry.value.decodeFormString(
+                context: r'Order.additionalProperties',
+              );
+            }
+          }
+        }
+      ''';
+
+      expect(result, isA<CapturingApFlatCapture>());
+      expect(
+        collapseWhitespace(formatCodes(result.codes)),
+        contains(collapseWhitespace(expected)),
+      );
+    });
+
+    test('untyped values stay literal for simple decoding', () {
+      final result = buildApFlatCaptureLoop(
+        AdditionalPropertiesPlan(
+          valueModel: AnyModel(context: context),
+          knownWireKeys: const {'name'},
+        ),
+        format: FlatWireFormat.simple,
+        sourceMapVar: r'_$values',
+        nameManager: nameManager,
+        package: 'package:example/api.dart',
+        contextClass: 'Order',
+      );
+
+      const expected = r'''
+        void run() {
+          const _$knownKeys = {r'name'};
+          final _$additional = <String, Object?>{};
+          for (final _$entry in _$values.entries) {
+            if (!_$knownKeys.contains(_$entry.key)) {
+              _$additional[_$entry.key] = _$entry.value;
+            }
+          }
+        }
+      ''';
+
+      expect(result, isA<CapturingApFlatCapture>());
+      expect(
+        collapseWhitespace(formatCodes(result.codes)),
+        contains(collapseWhitespace(expected)),
+      );
+    });
+
     test('list value models throw on unknown keys because element '
         'boundaries cannot be recovered', () {
       final result = buildApFlatCaptureLoop(

--- a/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_form_value_expression_generator_test.dart
@@ -371,6 +371,47 @@ void main() {
       });
     });
 
+    group('AnyModel', () {
+      test('percent-decodes required value through the form decoder', () {
+        final expression = buildFromFormValueExpression(
+          refer("values['note']"),
+          model: AnyModel(context: context),
+          isRequired: true,
+          nameManager: nameManager,
+          package: 'test_package',
+          contextClass: 'TestClass',
+          contextProperty: 'note',
+        );
+
+        final code = expression.accept(DartEmitter()).toString();
+        expect(
+          code,
+          "values['note'].decodeFormString(context: r'TestClass.note')",
+        );
+      });
+
+      test('percent-decodes optional value through the form decoder', () {
+        final expression = buildFromFormValueExpression(
+          refer("values['note']"),
+          model: AnyModel(context: context),
+          isRequired: false,
+          nameManager: nameManager,
+          package: 'test_package',
+          contextClass: 'TestClass',
+          contextProperty: 'note',
+        );
+
+        final code = expression.accept(DartEmitter()).toString();
+        expect(
+          code,
+          equals(
+            "values['note'].decodeFormNullableString("
+            "context: r'TestClass.note')",
+          ),
+        );
+      });
+    });
+
     group('context handling', () {
       test('handles context with class only', () {
         final expression = buildFromFormValueExpression(


### PR DESCRIPTION
## Summary

When a model with untyped additional properties (`additionalProperties: true`) is decoded from an `application/x-www-form-urlencoded` body, the captured values were stored as the raw wire text — still percent-encoded, with `+` left as a literal plus — while declared properties and typed `additionalProperties: {type: string}` extras on the very same input were percent-decoded correctly.

As a result the same wire byte sequence decoded differently depending only on whether the key was declared, a typed extra, or an untyped extra, and an unchanged decode → re-encode round-trip double-encoded the value (`caf%C3%A9` → `caf%25C3%25A9`).

## Fix

The scalar `AnyModel` case in the form-value decoder returned the value unchanged. It now routes through `decodeFormString` / `decodeFormNullableString` — the same decoding used for declared string values — so the wire decoding of a value no longer depends on whether its schema is typed or untyped. This also covers bare object-typed declared properties decoded from a form body. Simple/header decoding stays literal by design and JSON decoding is unaffected.

## Standard

For `application/x-www-form-urlencoded`, each value is percent-decoded and `+` decodes to a space (WHATWG URL Standard / HTML form serialization). Whether `additionalProperties` is `true` or a typed schema is a validation concern and must not change how the wire bytes decode.

## Tests

- Unit: `AnyModel` now decodes through the form decoder in `buildFromFormValueExpression` and in the additional-properties flat-capture loop (with a companion test pinning that simple decoding stays literal).
- Updated two class/allOf generator tests that had encoded the previous raw-copy output.
- Integration (`form_urlencoded`): new response operation with a declared property plus untyped additional properties; asserts extras are percent-decoded (`café`, `New York`) and that a re-encode round-trip does not double-encode.