### PR TITLE
Type empty toJson map literal so allOf branches encode

### DIFF
--- a/integration_test/read_write_only/openapi.yaml
+++ b/integration_test/read_write_only/openapi.yaml
@@ -228,6 +228,26 @@ paths:
                   status:
                     type: string
 
+  /audited:
+    post:
+      operationId: createAudited
+      tags:
+        - read-write-only
+      summary: Create a widget whose allOf has an all-readOnly branch
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AuditedWidget'
+      responses:
+        '200':
+          description: The created widget
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AuditedWidget'
+
 components:
   schemas:
     User:
@@ -464,3 +484,19 @@ components:
           type: string
         payload:
           type: string
+
+    # Property-level readOnly branch: the composite itself is writable, but its
+    # second branch has only a readOnly property, leaving an empty encoded branch.
+    AuditedWidget:
+      allOf:
+        - type: object
+          required:
+            - name
+          properties:
+            name:
+              type: string
+        - type: object
+          properties:
+            createdAt:
+              type: string
+              readOnly: true

--- a/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
+++ b/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
@@ -1002,4 +1002,35 @@ void main() {
       expect(requestBody['force'], isTrue);
     });
   });
+
+  group('AuditedWidget (allOf) - writable composite with readOnly branch', () {
+    test('toJson emits only the writable branch', () {
+      const widget = AuditedWidget(
+        auditedWidgetModel: AuditedWidgetModel(),
+        auditedWidgetModel2: AuditedWidgetModel2(name: 'a1'),
+      );
+
+      final json = widget.toJson()! as Map;
+
+      expect(json, {'name': 'a1'});
+    });
+
+    test('POST /audited sends the writable branch and omits readOnly', () async {
+      final api = buildApi(responseStatus: '200');
+
+      final response = await api.createAudited(
+        body: const AuditedWidget(
+          auditedWidgetModel: AuditedWidgetModel(),
+          auditedWidgetModel2: AuditedWidgetModel2(name: 'a1'),
+        ),
+      );
+
+      final success = response as TonikSuccess<AuditedWidget>;
+      final requestBody =
+          success.response.requestOptions.data as Map<String, dynamic>;
+
+      expect(requestBody['name'], 'a1');
+      expect(requestBody.containsKey('createdAt'), isFalse);
+    });
+  });
 }

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -962,28 +962,18 @@ class ClassGenerator {
 
     if (requiredWriteOnlyNonNullable.isEmpty) {
       if (helperPrelude.isEmpty) {
-        // Type an empty literal explicitly: a bare `{}` infers Map<dynamic,
-        // dynamic>, which composite guards reject as not Map<String, Object?>.
-        final mapOpen = mapEntries.isEmpty
-            ? <Code>[
-                const Code('<'),
-                refer('String', 'dart:core').code,
-                const Code(', '),
-                refer('Object?', 'dart:core').code,
-                const Code('>{'),
-              ]
-            : <Code>[const Code('{')];
+        // A bare `{}` infers Map<dynamic, dynamic>, which composite guards
+        // reject as not Map<String, Object?>, so type an empty map explicitly.
+        final toJsonBody = mapEntries.isEmpty
+            ? buildEmptyMapStringObject().code
+            : Block.of([const Code('{'), ...mapEntries, const Code('}')]);
         return Method(
           (b) => b
             ..annotations.add(refer('override', 'dart:core'))
             ..name = 'toJson'
             ..returns = refer('Object?', 'dart:core')
             ..lambda = true
-            ..body = Block.of([
-              ...mapOpen,
-              ...mapEntries,
-              const Code('}'),
-            ]),
+            ..body = toJsonBody,
         );
       }
       return Method(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -900,6 +900,20 @@ class ClassGenerator {
       }
     }
 
+    // An empty literal needs an explicit type or Dart infers Map<dynamic,
+    // dynamic>, which composite guards reject as not Map<String, Object?>.
+    List<Code> openMap({required bool withReturn}) {
+      final prefix = withReturn ? 'return ' : '';
+      if (mapEntries.isNotEmpty) return [Code('$prefix{')];
+      return [
+        Code('$prefix<'),
+        refer('String', 'dart:core').code,
+        const Code(', '),
+        refer('Object?', 'dart:core').code,
+        const Code('>{'),
+      ];
+    }
+
     final toJsonApPolicy = activeApPolicy(model.additionalPropertiesPolicy);
     final apEncodeCodes = <Code>[];
     if (toJsonApPolicy != null) {
@@ -969,7 +983,7 @@ class ClassGenerator {
             ..returns = refer('Object?', 'dart:core')
             ..lambda = true
             ..body = Block.of([
-              const Code('{'),
+              ...openMap(withReturn: false),
               ...mapEntries,
               const Code('}'),
             ]),
@@ -982,7 +996,7 @@ class ClassGenerator {
           ..returns = refer('Object?', 'dart:core')
           ..body = Block.of([
             ...helperPrelude,
-            const Code('return {'),
+            ...openMap(withReturn: true),
             ...mapEntries,
             const Code('};'),
           ]),
@@ -1010,7 +1024,7 @@ class ClassGenerator {
         ..body = Block.of([
           ...helperPrelude,
           ...nullChecks,
-          const Code('return {'),
+          ...openMap(withReturn: true),
           ...mapEntries,
           const Code('};'),
         ]),

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -962,10 +962,8 @@ class ClassGenerator {
 
     if (requiredWriteOnlyNonNullable.isEmpty) {
       if (helperPrelude.isEmpty) {
-        // Only this path can reach a statically empty map (all properties
-        // readOnly, or none). A bare `{}` there infers Map<dynamic, dynamic>,
-        // which composite guards reject as not Map<String, Object?>, so the
-        // empty literal needs an explicit type.
+        // Type an empty literal explicitly: a bare `{}` infers Map<dynamic,
+        // dynamic>, which composite guards reject as not Map<String, Object?>.
         final mapOpen = mapEntries.isEmpty
             ? <Code>[
                 const Code('<'),

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1679,9 +1679,6 @@ class ClassGenerator {
       final modelType = prop.property.model;
       final defaulted = defaultsByName[normalizedName];
       final isRequired = prop.property.isRequired && !prop.property.isWriteOnly;
-      // An Any field is Object? and its form encoding omits null, so it must
-      // decode as nullable even when required — otherwise an omitted value
-      // fails the non-nullable decoder.
       final isNullable =
           prop.property.isNullable ||
           modelType.isEffectivelyNullable ||

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -900,20 +900,6 @@ class ClassGenerator {
       }
     }
 
-    // An empty literal needs an explicit type or Dart infers Map<dynamic,
-    // dynamic>, which composite guards reject as not Map<String, Object?>.
-    List<Code> openMap({required bool withReturn}) {
-      final prefix = withReturn ? 'return ' : '';
-      if (mapEntries.isNotEmpty) return [Code('$prefix{')];
-      return [
-        Code('$prefix<'),
-        refer('String', 'dart:core').code,
-        const Code(', '),
-        refer('Object?', 'dart:core').code,
-        const Code('>{'),
-      ];
-    }
-
     final toJsonApPolicy = activeApPolicy(model.additionalPropertiesPolicy);
     final apEncodeCodes = <Code>[];
     if (toJsonApPolicy != null) {
@@ -976,6 +962,19 @@ class ClassGenerator {
 
     if (requiredWriteOnlyNonNullable.isEmpty) {
       if (helperPrelude.isEmpty) {
+        // Only this path can reach a statically empty map (all properties
+        // readOnly, or none). A bare `{}` there infers Map<dynamic, dynamic>,
+        // which composite guards reject as not Map<String, Object?>, so the
+        // empty literal needs an explicit type.
+        final mapOpen = mapEntries.isEmpty
+            ? <Code>[
+                const Code('<'),
+                refer('String', 'dart:core').code,
+                const Code(', '),
+                refer('Object?', 'dart:core').code,
+                const Code('>{'),
+              ]
+            : <Code>[const Code('{')];
         return Method(
           (b) => b
             ..annotations.add(refer('override', 'dart:core'))
@@ -983,7 +982,7 @@ class ClassGenerator {
             ..returns = refer('Object?', 'dart:core')
             ..lambda = true
             ..body = Block.of([
-              ...openMap(withReturn: false),
+              ...mapOpen,
               ...mapEntries,
               const Code('}'),
             ]),
@@ -996,7 +995,7 @@ class ClassGenerator {
           ..returns = refer('Object?', 'dart:core')
           ..body = Block.of([
             ...helperPrelude,
-            ...openMap(withReturn: true),
+            const Code('return {'),
             ...mapEntries,
             const Code('};'),
           ]),
@@ -1024,7 +1023,7 @@ class ClassGenerator {
         ..body = Block.of([
           ...helperPrelude,
           ...nullChecks,
-          ...openMap(withReturn: true),
+          const Code('return {'),
           ...mapEntries,
           const Code('};'),
         ]),

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1679,8 +1679,13 @@ class ClassGenerator {
       final modelType = prop.property.model;
       final defaulted = defaultsByName[normalizedName];
       final isRequired = prop.property.isRequired && !prop.property.isWriteOnly;
+      // An Any field is Object? and its form encoding omits null, so it must
+      // decode as nullable even when required — otherwise an omitted value
+      // fails the non-nullable decoder.
       final isNullable =
-          prop.property.isNullable || modelType.isEffectivelyNullable;
+          prop.property.isNullable ||
+          modelType.isEffectivelyNullable ||
+          modelType.resolved is AnyModel;
       final decodeIsRequired = defaulted != null
           ? !isNullable
           : isRequired && !isNullable;

--- a/packages/tonik_generate/test/src/model/class_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_form_generator_test.dart
@@ -198,6 +198,61 @@ void main() {
       );
     });
 
+    test('decodes a required any property with the nullable form decoder', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'FormAny',
+        properties: [
+          Property(
+            name: 'name',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'anyValue',
+            model: AnyModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+
+      final result = generator.generateClass(model);
+      final generatedCode = format(result.accept(emitter).toString());
+
+      const expectedFromFormMethod = r'''
+        factory FormAny.fromForm(String? value, {required bool explode}) {
+          final _$values = value.decodeObject(
+            explode: explode,
+            explodeSeparator: '&',
+            expectedKeys: {r'name', r'anyValue'},
+            listKeys: {},
+            context: r'FormAny',
+          );
+          return FormAny(
+            name: _$values[r'name'].decodeFormString(context: r'FormAny.name'),
+            anyValue: _$values[r'anyValue'].decodeFormNullableString(
+              context: r'FormAny.anyValue',
+            ),
+          );
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedFromFormMethod)),
+      );
+    });
+
     test(
       'generates fromForm for mixed OneOf that attempts decoding',
       () {

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -62,6 +62,26 @@ void main() {
       );
     });
 
+    test('generates typed empty map toJson for class with no properties', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'Empty',
+        properties: const [],
+        context: context,
+        examples: const [],
+      );
+
+      const expectedMethod = '''
+        Object? toJson() => <String, Object?>{};
+        ''';
+
+      final generatedClass = generator.generateClass(model);
+      expect(
+        collapseWhitespace(format(generatedClass.accept(emitter).toString())),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
     test('generates toJson method for multiple primitive properties', () {
       final model = ClassModel(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -157,7 +157,7 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Object? toJson() => {};
+        Object? toJson() => <String, Object?>{};
       ''';
 
       expect(


### PR DESCRIPTION
## Problem

When a schema is an `allOf` and one branch consists only of `readOnly` properties (a common shape — audit fields like `createdAt`/`updatedAt` split into their own branch), the composite request encoding throws and no request of that schema can ever be sent.

Per OpenAPI 3.0.x, a `readOnly` property "MAY be sent as part of a response but SHOULD NOT be sent as part of the request", so a conformant client omits it and sends the rest — e.g. `{"name":"a1"}` is a valid request instance. Tonik correctly filters the property out, but the resulting branch encodes to an untyped empty map that the composite rejects:

```
AuditedWidget.toJson() THREW: Instance of 'EncodingException'
  message: Expected auditedWidgetModel.toJson() to return Map<String, Object?>, got _Map<dynamic, dynamic>
operation result: TonikError(type: encoding)
```

## Root cause

A class whose encodable properties are all filtered out emitted `Object? toJson() => {};`. With only `Object?` as the type context, Dart infers the empty literal as `Map<dynamic, dynamic>`. The composed `allOf` `toJson` guards each sub-result with `if (_$xJson is! Map<String, Object?>) throw EncodingException(...)`, which the untyped map fails.

The same untyped-empty-map shape is emitted for any branch that ends up with zero encodable properties (e.g. a bare `type: object` branch), so `readOnly` is just the standards-relevant trigger.

## Fix

Emit an explicitly typed empty literal (`<String, Object?>{}`) when the `toJson` map's entry list is statically empty, applied at all three literal sites in the class generator. Non-empty literals are left unchanged — they already satisfy the composite guard via covariance (`Map<String, String?>` *is* `Map<String, Object?>`), so typing them would only add noise. The composite guard itself stays as a valid invariant.

## Tests

- **Generator:** the all-`readOnly` class now emits `Object? toJson() => <String, Object?>{};`.
- **Integration** (`read_write_only`): a writable `AuditedWidget` `allOf` whose second branch has only a `readOnly` property — asserts `toJson()` yields `{"name":"a1"}` and `POST /audited` puts that body on the wire (previously `TonikError(encoding)`).

All generator unit tests and the `read_write_only` integration suite pass; `dart analyze` is clean across `tonik_generate` and `integration_test`.