### PR TITLE
Serialize pipeDelimited/spaceDelimited object query parameters

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/query_parameters_test.dart
@@ -124,7 +124,7 @@ void main() {
     );
 
     test(
-      'getQuerySpaceDelimitedAny with list returns TonikError',
+      'getQuerySpaceDelimitedAny with list encodes as space-delimited',
       () async {
         final api = buildApi();
         final result = await api.getQuerySpaceDelimitedAny(
@@ -132,11 +132,34 @@ void main() {
         );
         expect(
           result,
-          isA<TonikError<QuerySpaceDelimitedAnyGet200BodyModel>>(),
+          isA<TonikSuccess<QuerySpaceDelimitedAnyGet200BodyModel>>(),
         );
-        final error =
-            result as TonikError<QuerySpaceDelimitedAnyGet200BodyModel>;
-        expect(error.error, isA<EncodingException>());
+        final success =
+            result as TonikSuccess<QuerySpaceDelimitedAnyGet200BodyModel>;
+        expect(
+          success.response.requestOptions.uri.query,
+          'anyValue=a%20b%20c',
+        );
+      },
+    );
+
+    test(
+      'getQuerySpaceDelimitedAny with map encodes as space-delimited',
+      () async {
+        final api = buildApi();
+        final result = await api.getQuerySpaceDelimitedAny(
+          anyValue: <String, dynamic>{'a': 1, 'b': 2},
+        );
+        expect(
+          result,
+          isA<TonikSuccess<QuerySpaceDelimitedAnyGet200BodyModel>>(),
+        );
+        final success =
+            result as TonikSuccess<QuerySpaceDelimitedAnyGet200BodyModel>;
+        expect(
+          success.response.requestOptions.uri.query,
+          'anyValue=a%201%20b%202',
+        );
       },
     );
 
@@ -191,16 +214,42 @@ void main() {
     );
 
     test(
-      'getQueryPipeDelimitedAny with list returns TonikError',
+      'getQueryPipeDelimitedAny with list encodes as pipe-delimited',
       () async {
         final api = buildApi();
         final result = await api.getQueryPipeDelimitedAny(
           anyValue: ['one', 'two', 'three'],
         );
-        expect(result, isA<TonikError<QueryPipeDelimitedAnyGet200BodyModel>>());
-        final error =
-            result as TonikError<QueryPipeDelimitedAnyGet200BodyModel>;
-        expect(error.error, isA<EncodingException>());
+        expect(
+          result,
+          isA<TonikSuccess<QueryPipeDelimitedAnyGet200BodyModel>>(),
+        );
+        final success =
+            result as TonikSuccess<QueryPipeDelimitedAnyGet200BodyModel>;
+        expect(
+          success.response.requestOptions.uri.query,
+          'anyValue=one%7Ctwo%7Cthree',
+        );
+      },
+    );
+
+    test(
+      'getQueryPipeDelimitedAny with map encodes as pipe-delimited',
+      () async {
+        final api = buildApi();
+        final result = await api.getQueryPipeDelimitedAny(
+          anyValue: <String, dynamic>{'a': 1, 'b': 2},
+        );
+        expect(
+          result,
+          isA<TonikSuccess<QueryPipeDelimitedAnyGet200BodyModel>>(),
+        );
+        final success =
+            result as TonikSuccess<QueryPipeDelimitedAnyGet200BodyModel>;
+        expect(
+          success.response.requestOptions.uri.query,
+          'anyValue=a%7C1%7Cb%7C2',
+        );
       },
     );
 

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -624,10 +624,35 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/PriorityEnum'
+        - name: freeFormMap
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: anyValue
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema: true
+        - name: aliasList
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            $ref: '#/components/schemas/TagList'
+        - name: mixedComposite
+          in: query
+          style: spaceDelimited
+          explode: false
+          schema:
+            $ref: '#/components/schemas/StringOrClass'
       responses:
         '204':
           description: OK
-  
+
   /spaceDelimited-complex-explode:
     get:
       operationId: testSpaceDelimitedComplexExplode
@@ -1011,10 +1036,35 @@ paths:
           explode: false
           schema:
             $ref: '#/components/schemas/PriorityEnum'
+        - name: freeFormMap
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+        - name: anyValue
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema: true
+        - name: aliasList
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            $ref: '#/components/schemas/TagList'
+        - name: mixedComposite
+          in: query
+          style: pipeDelimited
+          explode: false
+          schema:
+            $ref: '#/components/schemas/StringOrClass'
       responses:
         '204':
           description: OK
-  
+
   /pipeDelimited-complex-explode:
     get:
       operationId: testPipeDelimitedComplexExplode
@@ -1988,3 +2038,11 @@ components:
             oneOf:
               - type: string
               - type: integer
+    TagList:
+      type: array
+      items:
+        type: string
+    StringOrClass:
+      oneOf:
+        - type: string
+        - $ref: '#/components/schemas/Class'

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.0.4
+openapi: 3.1.0
 info:
   title: Query Parameters API
   description: OpenAPI specification showcasing query parameters

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -1,4 +1,4 @@
-openapi: 3.1.0
+openapi: 3.0.4
 info:
   title: Query Parameters API
   description: OpenAPI specification showcasing query parameters
@@ -632,11 +632,6 @@ paths:
             type: object
             additionalProperties:
               type: string
-        - name: anyValue
-          in: query
-          style: spaceDelimited
-          explode: false
-          schema: true
         - name: aliasList
           in: query
           style: spaceDelimited
@@ -1044,11 +1039,6 @@ paths:
             type: object
             additionalProperties:
               type: string
-        - name: anyValue
-          in: query
-          style: pipeDelimited
-          explode: false
-          schema: true
         - name: aliasList
           in: query
           style: pipeDelimited

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -781,48 +781,6 @@ void main() {
       );
     });
 
-    test('any holding a map flattens key/value pairs', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testPipeDelimitedComplex(
-        anyValue: const <String, String>{'a': '1', 'b': '2'},
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=a%7C1%7Cb%7C2',
-      );
-    });
-
-    test('any holding a list joins elements', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testPipeDelimitedComplex(
-        anyValue: const ['blue', 'black', 'brown'],
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=blue%7Cblack%7Cbrown',
-      );
-    });
-
-    test('any holding a dynamic map flattens numeric values', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testPipeDelimitedComplex(
-        anyValue: const <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=R%7C100%7CG%7C200%7CB%7C150',
-      );
-    });
-
     test('alias to array encodes identically to an inline array', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testPipeDelimitedComplex(

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -795,6 +795,34 @@ void main() {
       );
     });
 
+    test('any holding a list joins elements', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        anyValue: const ['blue', 'black', 'brown'],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=blue%7Cblack%7Cbrown',
+      );
+    });
+
+    test('any holding a dynamic map flattens numeric values', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        anyValue: const <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=R%7C100%7CG%7C200%7CB%7C150',
+      );
+    });
+
     test('alias to array encodes identically to an inline array', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testPipeDelimitedComplex(

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -765,4 +765,73 @@ void main() {
       expect(error.type, TonikErrorType.encoding);
     });
   });
+
+  group('complex - object shapes', () {
+    test('free-form map flattens key/value pairs', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        freeFormMap: const {'k1': 'v1', 'k2': 'v2'},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'freeFormMap=k1%7Cv1%7Ck2%7Cv2',
+      );
+    });
+
+    test('any holding a map flattens key/value pairs', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        anyValue: const <String, String>{'a': '1', 'b': '2'},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=a%7C1%7Cb%7C2',
+      );
+    });
+
+    test('alias to array encodes identically to an inline array', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        aliasList: const ['a', 'b', 'c'],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'aliasList=a%7Cb%7Cc',
+      );
+    });
+
+    test('mixed composite object variant flattens', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        mixedComposite: const StringOrClassClass(Class(name: 'test', age: 1)),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'mixedComposite=name%7Ctest%7Cage%7C1',
+      );
+    });
+
+    test('mixed composite string variant has no object encoding', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testPipeDelimitedComplex(
+        mixedComposite: const StringOrClassString('hello'),
+      );
+
+      expect(response, isA<TonikError<void>>());
+      final error = response as TonikError<void>;
+      expect(error.type, TonikErrorType.encoding);
+    });
+  });
 }

--- a/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/pipe_delimited_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -48,7 +48,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -61,7 +61,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -74,7 +74,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -87,7 +87,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -102,7 +102,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -117,7 +117,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -132,7 +132,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -146,13 +146,12 @@ void main() {
         $class: const Class(name: 'test', age: 1),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'class=name%7Ctest%7Cage%7C1',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('classNested', () async {
@@ -168,7 +167,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'nested objects have no flat parameter representation',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -181,7 +180,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -193,13 +192,12 @@ void main() {
         classAlias: const ClassAlias(name: 'test', age: 1),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'classAlias=name%7Ctest%7Cage%7C1',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('anyOfPrimitive', () async {
@@ -211,7 +209,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -223,13 +221,12 @@ void main() {
         anyOfComplex: const AnyOfComplex($class: Class(name: 'test', age: 1)),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'anyOfComplex=name%7Ctest%7Cage%7C1',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('oneOfPrimitive', () async {
@@ -241,7 +238,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -255,13 +252,12 @@ void main() {
         ),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'oneOfComplex=value%7Ctest%7Camount%7C1',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('allOfPrimitive', () async {
@@ -273,7 +269,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -288,13 +284,12 @@ void main() {
         ),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'allOfComplex=name%7Ctest%7Cage%7C1%7Cvalue%7Ctest%7Camount%7C1',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
   });
 
@@ -308,7 +303,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -327,7 +322,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -342,7 +337,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -357,7 +352,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -372,7 +367,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -387,7 +382,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -402,7 +397,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -419,7 +414,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -434,7 +429,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -452,7 +447,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -668,7 +663,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -683,7 +678,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -698,7 +693,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -733,7 +728,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -764,7 +759,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in pipeDelimited encoding',
+        reason: 'parameter cannot be pipeDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -795,6 +795,34 @@ void main() {
       );
     });
 
+    test('any holding a list joins elements', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        anyValue: const ['blue', 'black', 'brown'],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=blue%20black%20brown',
+      );
+    });
+
+    test('any holding a dynamic map flattens numeric values', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        anyValue: const <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=R%20100%20G%20200%20B%20150',
+      );
+    });
+
     test('alias to array encodes identically to an inline array', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testSpaceDelimitedComplex(

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -765,4 +765,73 @@ void main() {
       expect(error.type, TonikErrorType.encoding);
     });
   });
+
+  group('complex - object shapes', () {
+    test('free-form map flattens key/value pairs', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        freeFormMap: const {'k1': 'v1', 'k2': 'v2'},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'freeFormMap=k1%20v1%20k2%20v2',
+      );
+    });
+
+    test('any holding a map flattens key/value pairs', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        anyValue: const <String, String>{'a': '1', 'b': '2'},
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'anyValue=a%201%20b%202',
+      );
+    });
+
+    test('alias to array encodes identically to an inline array', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        aliasList: const ['a', 'b', 'c'],
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'aliasList=a%20b%20c',
+      );
+    });
+
+    test('mixed composite object variant flattens', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        mixedComposite: const StringOrClassClass(Class(name: 'test', age: 1)),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'mixedComposite=name%20test%20age%201',
+      );
+    });
+
+    test('mixed composite string variant has no object encoding', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testSpaceDelimitedComplex(
+        mixedComposite: const StringOrClassString('hello'),
+      );
+
+      expect(response, isA<TonikError<void>>());
+      final error = response as TonikError<void>;
+      expect(error.type, TonikErrorType.encoding);
+    });
+  });
 }

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -35,7 +35,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -48,7 +48,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -61,7 +61,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -74,7 +74,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -87,7 +87,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -102,7 +102,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -117,7 +117,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -132,7 +132,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -146,13 +146,12 @@ void main() {
         $class: const Class(name: 'test', age: 1),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'class=name%20test%20age%201',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('classNested', () async {
@@ -168,7 +167,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'nested objects have no flat parameter representation',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -181,7 +180,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -193,13 +192,12 @@ void main() {
         classAlias: const ClassAlias(name: 'test', age: 1),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'classAlias=name%20test%20age%201',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('anyOfPrimitive', () async {
@@ -211,7 +209,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -223,13 +221,12 @@ void main() {
         anyOfComplex: const AnyOfComplex($class: Class(name: 'test', age: 1)),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'anyOfComplex=name%20test%20age%201',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('oneOfPrimitive', () async {
@@ -241,7 +238,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -255,13 +252,12 @@ void main() {
         ),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'oneOfComplex=value%20test%20amount%201',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
 
     test('allOfPrimitive', () async {
@@ -273,7 +269,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -288,13 +284,12 @@ void main() {
         ),
       );
 
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
       expect(
-        response,
-        isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        success.response.requestOptions.uri.query,
+        'allOfComplex=name%20test%20age%201%20value%20test%20amount%201',
       );
-      final error = response as TonikError<void>;
-      expect(error.type, TonikErrorType.encoding);
     });
   });
 
@@ -308,7 +303,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -327,7 +322,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -342,7 +337,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -357,7 +352,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -372,7 +367,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -387,7 +382,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -402,7 +397,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -419,7 +414,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -434,7 +429,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -452,7 +447,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -668,7 +663,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -683,7 +678,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -698,7 +693,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -733,7 +728,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);
@@ -764,7 +759,7 @@ void main() {
       expect(
         response,
         isA<TonikError<void>>(),
-        reason: 'only lists are supported in spaceDelimited encoding',
+        reason: 'parameter cannot be spaceDelimited-encoded',
       );
       final error = response as TonikError<void>;
       expect(error.type, TonikErrorType.encoding);

--- a/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/space_delimited_test.dart
@@ -781,48 +781,6 @@ void main() {
       );
     });
 
-    test('any holding a map flattens key/value pairs', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testSpaceDelimitedComplex(
-        anyValue: const <String, String>{'a': '1', 'b': '2'},
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=a%201%20b%202',
-      );
-    });
-
-    test('any holding a list joins elements', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testSpaceDelimitedComplex(
-        anyValue: const ['blue', 'black', 'brown'],
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=blue%20black%20brown',
-      );
-    });
-
-    test('any holding a dynamic map flattens numeric values', () async {
-      final api = buildQueryApi(responseStatus: '204');
-      final response = await api.testSpaceDelimitedComplex(
-        anyValue: const <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
-      );
-
-      expect(response, isA<TonikSuccess<void>>());
-      final success = response as TonikSuccess<void>;
-      expect(
-        success.response.requestOptions.uri.query,
-        'anyValue=R%20100%20G%20200%20B%20150',
-      );
-    });
-
     test('alias to array encodes identically to an inline array', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testSpaceDelimitedComplex(

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -263,6 +263,14 @@ class AllOfGenerator {
             else
               buildToDeepObjectMethod(),
             if (model.isReadOnly)
+              buildReadOnlyToPipeDelimitedMethod(encodingExceptionBody)
+            else
+              buildToPipeDelimitedMethod(),
+            if (model.isReadOnly)
+              buildReadOnlyToSpaceDelimitedMethod(encodingExceptionBody)
+            else
+              buildToSpaceDelimitedMethod(),
+            if (model.isReadOnly)
               buildReadOnlyUriEncodeMethod(encodingExceptionBody)
             else
               _buildUriEncodeMethod(

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -295,6 +295,8 @@ class AnyOfGenerator {
             _buildToLabelMethod(actualClassName, model, normalized),
             _buildToMatrixMethod(actualClassName, model, normalized),
             buildToDeepObjectMethod(),
+            buildToPipeDelimitedMethod(),
+            buildToSpaceDelimitedMethod(),
             if (model.isReadOnly)
               buildReadOnlyUriEncodeMethod(encodingExceptionBody)
             else

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -8,6 +8,7 @@ import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
 import 'package:tonik_generate/src/util/additional_properties_builders.dart';
 import 'package:tonik_generate/src/util/additional_properties_helpers.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
+import 'package:tonik_generate/src/util/composite_guard_builders.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 import 'package:tonik_generate/src/util/default_resolution.dart';
@@ -271,6 +272,8 @@ class ClassGenerator {
           _buildToLabelMethod(),
           _buildToMatrixMethod(),
           _buildToDeepObjectMethod(),
+          buildToPipeDelimitedMethod(),
+          buildToSpaceDelimitedMethod(),
           _buildUriEncodeMethod(className),
         ]);
 

--- a/packages/tonik_generate/lib/src/model/one_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/one_of_generator.dart
@@ -188,6 +188,14 @@ class OneOfGenerator {
             else
               buildToDeepObjectMethod(),
             if (useThrowBody)
+              buildReadOnlyToPipeDelimitedMethod(throwBody)
+            else
+              buildToPipeDelimitedMethod(),
+            if (useThrowBody)
+              buildReadOnlyToSpaceDelimitedMethod(throwBody)
+            else
+              buildToSpaceDelimitedMethod(),
+            if (useThrowBody)
               buildReadOnlyUriEncodeMethod(throwBody)
             else
               _generateUriEncodeMethod(className, model, variantNames),

--- a/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
+++ b/packages/tonik_generate/lib/src/util/composite_guard_builders.dart
@@ -153,6 +153,76 @@ Method buildReadOnlyToDeepObjectMethod(Code exceptionBody) {
   );
 }
 
+/// Builds a read-only delimited method ([methodName]) that throws.
+Method _buildReadOnlyToDelimitedMethod(String methodName, Code exceptionBody) {
+  return Method(
+    (b) => b
+      ..annotations.add(refer('override', 'dart:core'))
+      ..name = methodName
+      ..returns = buildParameterEntryListType()
+      ..requiredParameters.add(
+        Parameter(
+          (b) => b
+            ..name = 'paramName'
+            ..type = refer('String', 'dart:core'),
+        ),
+      )
+      ..optionalParameters.addAll(buildDelimitedEncodingParameters())
+      ..lambda = true
+      ..body = exceptionBody,
+  );
+}
+
+/// Builds a read-only `toPipeDelimited` method that throws.
+Method buildReadOnlyToPipeDelimitedMethod(Code exceptionBody) =>
+    _buildReadOnlyToDelimitedMethod('toPipeDelimited', exceptionBody);
+
+/// Builds a read-only `toSpaceDelimited` method that throws.
+Method buildReadOnlyToSpaceDelimitedMethod(Code exceptionBody) =>
+    _buildReadOnlyToDelimitedMethod('toSpaceDelimited', exceptionBody);
+
+/// Builds a delimited method ([methodName]) delegating to
+/// `parameterProperties`.
+Method _buildToDelimitedMethod(String methodName) {
+  return Method(
+    (b) => b
+      ..annotations.add(refer('override', 'dart:core'))
+      ..name = methodName
+      ..returns = buildParameterEntryListType()
+      ..requiredParameters.add(
+        Parameter(
+          (b) => b
+            ..name = 'paramName'
+            ..type = refer('String', 'dart:core'),
+        ),
+      )
+      ..optionalParameters.addAll(buildDelimitedEncodingParameters())
+      ..body = Block.of([
+        refer('parameterProperties')
+            .call([], {'allowEmpty': refer('allowEmpty')})
+            .property(methodName)
+            .call(
+              [refer('paramName')],
+              {
+                'allowEmpty': refer('allowEmpty'),
+                'allowReserved': refer('allowReserved'),
+              },
+            )
+            .returned
+            .statement,
+      ]),
+  );
+}
+
+/// Builds the `toPipeDelimited` method that delegates to `parameterProperties`.
+Method buildToPipeDelimitedMethod() =>
+    _buildToDelimitedMethod('toPipeDelimited');
+
+/// Builds the `toSpaceDelimited` method that delegates to
+/// `parameterProperties`.
+Method buildToSpaceDelimitedMethod() =>
+    _buildToDelimitedMethod('toSpaceDelimited');
+
 /// Builds a write-only `fromJson` factory constructor that throws.
 Constructor buildWriteOnlyFromJsonConstructor(String className) {
   return Constructor(

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -53,7 +53,6 @@ List<Code> _buildToDelimitedQueryParameterCode(
   }
 
   if (_isObjectModel(model)) {
-    // explode: true on an object is left undefined by the specification.
     if (explode) {
       return [
         generateEncodingExceptionExpression(

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -55,7 +55,8 @@ List<Code> _buildToDelimitedQueryParameterCode(
         ClassModel() ||
         AllOfModel() ||
         OneOfModel() ||
-        AnyOfModel()
+        AnyOfModel() ||
+        AnyModel()
         when explode => [
       generateEncodingExceptionExpression(
         'Parameter $parameterName: $encodingName encoding of objects with '
@@ -80,6 +81,14 @@ List<Code> _buildToDelimitedQueryParameterCode(
         allowEmpty: allowEmpty,
         allowReserved: allowReserved,
       ),
+    AnyModel() => _buildAnyDelimitedCode(
+      parameterName,
+      parameter.rawName,
+      encoding: encoding,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    ),
     _ => [
       generateEncodingExceptionExpression(
         'Parameter $parameterName: $encodingName encoding supports only '
@@ -157,6 +166,33 @@ List<Code> _buildObjectDelimitedCode(
 
   return [
     refer(r'_$entries').property('addAll').call([flattened]).statement,
+  ];
+}
+
+List<Code> _buildAnyDelimitedCode(
+  String parameterName,
+  String rawName, {
+  required QueryParameterEncoding encoding,
+  required bool explode,
+  required bool allowEmpty,
+  required bool allowReserved,
+}) {
+  final functionName = encoding == QueryParameterEncoding.spaceDelimited
+      ? 'encodeAnyToSpaceDelimited'
+      : 'encodeAnyToPipeDelimited';
+
+  final entries =
+      refer(functionName, 'package:tonik_util/tonik_util.dart').call(
+    [refer(parameterName), specLiteralString(rawName)],
+    {
+      'explode': literalBool(explode),
+      'allowEmpty': literalBool(allowEmpty),
+      if (allowReserved) 'allowReserved': literalBool(true),
+    },
+  );
+
+  return [
+    refer(r'_$entries').property('addAll').call([entries]).statement,
   ];
 }
 

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -85,7 +85,6 @@ List<Code> _buildToDelimitedQueryParameterCode(
       parameterName,
       parameter.rawName,
       encoding: encoding,
-      explode: explode,
       allowEmpty: allowEmpty,
       allowReserved: allowReserved,
     ),
@@ -133,8 +132,8 @@ List<Code> _buildMapDelimitedCode(
     ],
     UnsupportedMapPropertyValueConversion() => [
       generateEncodingExceptionExpression(
-        '$encodingName encoding is not supported for Map types with '
-        'complex values. Parameter "$rawName" cannot be encoded.',
+        'Parameter $parameterName: $encodingName encoding does not support '
+        'Map types with complex values',
         raw: true,
       ).statement,
     ],
@@ -173,7 +172,6 @@ List<Code> _buildAnyDelimitedCode(
   String parameterName,
   String rawName, {
   required QueryParameterEncoding encoding,
-  required bool explode,
   required bool allowEmpty,
   required bool allowReserved,
 }) {
@@ -185,7 +183,6 @@ List<Code> _buildAnyDelimitedCode(
       refer(functionName, 'package:tonik_util/tonik_util.dart').call(
     [refer(parameterName), specLiteralString(rawName)],
     {
-      'explode': literalBool(explode),
       'allowEmpty': literalBool(allowEmpty),
       if (allowReserved) 'allowReserved': literalBool(true),
     },

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -2,6 +2,7 @@ import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/map_property_value_expression_builder.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 
 BuiltStatements buildToDelimitedQueryParameterCode(
@@ -32,15 +33,15 @@ List<Code> _buildToDelimitedQueryParameterCode(
   bool allowEmpty = true,
   bool allowReserved = false,
 }) {
-  final model = parameter.model;
+  final resolved = parameter.model.resolved;
   final encodingName = encoding == QueryParameterEncoding.spaceDelimited
       ? 'spaceDelimited'
       : 'pipeDelimited';
 
-  if (model is ListModel) {
-    return _buildDelimitedCode(
+  return switch (resolved) {
+    ListModel() => _buildDelimitedCode(
       parameterName,
-      model.content,
+      resolved.content,
       parameter.rawName,
       encoding: encoding,
       explode: explode,
@@ -48,43 +49,88 @@ List<Code> _buildToDelimitedQueryParameterCode(
       allowReserved: allowReserved,
       encodingName: encodingName,
       isContentNullable:
-          model.isContentNullable || model.content.isEffectivelyNullable,
-    );
-  }
-
-  if (_isObjectModel(model)) {
-    if (explode) {
-      return [
-        generateEncodingExceptionExpression(
-          'Parameter $parameterName: $encodingName encoding of objects with '
-          'explode: true is not defined by the specification',
-          raw: true,
-        ).statement,
-      ];
-    }
-
-    return _buildObjectDelimitedCode(
+          resolved.isContentNullable || resolved.content.isEffectivelyNullable,
+    ),
+    MapModel() ||
+        ClassModel() ||
+        AllOfModel() ||
+        OneOfModel() ||
+        AnyOfModel()
+        when explode => [
+      generateEncodingExceptionExpression(
+        'Parameter $parameterName: $encodingName encoding of objects with '
+        'explode: true is not defined by the specification',
+        raw: true,
+      ).statement,
+    ],
+    MapModel() => _buildMapDelimitedCode(
       parameterName,
       parameter.rawName,
+      resolved,
       encoding: encoding,
+      encodingName: encodingName,
       allowEmpty: allowEmpty,
       allowReserved: allowReserved,
-    );
-  }
-
-  return [
-    generateEncodingExceptionExpression(
-      'Parameter $parameterName: $encodingName encoding supports only '
-      'list and object types',
-      raw: true,
-    ).statement,
-  ];
+    ),
+    ClassModel() || AllOfModel() || OneOfModel() || AnyOfModel() =>
+      _buildObjectDelimitedCode(
+        parameterName,
+        parameter.rawName,
+        encoding: encoding,
+        allowEmpty: allowEmpty,
+        allowReserved: allowReserved,
+      ),
+    _ => [
+      generateEncodingExceptionExpression(
+        'Parameter $parameterName: $encodingName encoding supports only '
+        'array and object types',
+        raw: true,
+      ).statement,
+    ],
+  };
 }
 
-bool _isObjectModel(Model model) => switch (model.resolved) {
-  ClassModel() || AllOfModel() || OneOfModel() || AnyOfModel() => true,
-  _ => false,
-};
+List<Code> _buildMapDelimitedCode(
+  String parameterName,
+  String rawName,
+  MapModel model, {
+  required QueryParameterEncoding encoding,
+  required String encodingName,
+  required bool allowEmpty,
+  required bool allowReserved,
+}) {
+  final methodName = encoding == QueryParameterEncoding.spaceDelimited
+      ? 'toSpaceDelimited'
+      : 'toPipeDelimited';
+
+  final conversion = buildMapPropertyValueConversion(
+    refer(parameterName),
+    model,
+    isNullable: false,
+    context: rawName,
+  );
+
+  return switch (conversion) {
+    SupportedMapPropertyValueConversion(:final expression) => [
+      refer(r'_$entries').property('addAll').call([
+        expression.property(methodName).call(
+          [specLiteralString(rawName)],
+          {
+            'allowEmpty': literalBool(allowEmpty),
+            if (allowReserved) 'allowReserved': literalBool(true),
+          },
+        ),
+      ]).statement,
+    ],
+    UnsupportedMapPropertyValueConversion() => [
+      generateEncodingExceptionExpression(
+        '$encodingName encoding is not supported for Map types with '
+        'complex values. Parameter "$rawName" cannot be encoded.',
+        raw: true,
+      ).statement,
+    ],
+  };
+}
 
 List<Code> _buildObjectDelimitedCode(
   String parameterName,

--- a/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_delimited_query_parameter_expression_generator.dart
@@ -37,28 +37,82 @@ List<Code> _buildToDelimitedQueryParameterCode(
       ? 'spaceDelimited'
       : 'pipeDelimited';
 
-  if (model is! ListModel) {
-    return [
-      generateEncodingExceptionExpression(
-        'Parameter $parameterName: $encodingName encoding only '
-        'supports list types',
-        raw: true,
-      ).statement,
-    ];
+  if (model is ListModel) {
+    return _buildDelimitedCode(
+      parameterName,
+      model.content,
+      parameter.rawName,
+      encoding: encoding,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+      encodingName: encodingName,
+      isContentNullable:
+          model.isContentNullable || model.content.isEffectivelyNullable,
+    );
   }
 
-  return _buildDelimitedCode(
-    parameterName,
-    model.content,
-    parameter.rawName,
-    encoding: encoding,
-    explode: explode,
-    allowEmpty: allowEmpty,
-    allowReserved: allowReserved,
-    encodingName: encodingName,
-    isContentNullable:
-        model.isContentNullable || model.content.isEffectivelyNullable,
-  );
+  if (_isObjectModel(model)) {
+    // explode: true on an object is left undefined by the specification.
+    if (explode) {
+      return [
+        generateEncodingExceptionExpression(
+          'Parameter $parameterName: $encodingName encoding of objects with '
+          'explode: true is not defined by the specification',
+          raw: true,
+        ).statement,
+      ];
+    }
+
+    return _buildObjectDelimitedCode(
+      parameterName,
+      parameter.rawName,
+      encoding: encoding,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+
+  return [
+    generateEncodingExceptionExpression(
+      'Parameter $parameterName: $encodingName encoding supports only '
+      'list and object types',
+      raw: true,
+    ).statement,
+  ];
+}
+
+bool _isObjectModel(Model model) => switch (model.resolved) {
+  ClassModel() || AllOfModel() || OneOfModel() || AnyOfModel() => true,
+  _ => false,
+};
+
+List<Code> _buildObjectDelimitedCode(
+  String parameterName,
+  String rawName, {
+  required QueryParameterEncoding encoding,
+  required bool allowEmpty,
+  required bool allowReserved,
+}) {
+  final methodName = encoding == QueryParameterEncoding.spaceDelimited
+      ? 'toSpaceDelimited'
+      : 'toPipeDelimited';
+
+  final flattened = refer(parameterName)
+      .property('parameterProperties')
+      .call([], {'allowEmpty': literalBool(allowEmpty)})
+      .property(methodName)
+      .call(
+        [specLiteralString(rawName)],
+        {
+          'allowEmpty': literalBool(allowEmpty),
+          if (allowReserved) 'allowReserved': literalBool(true),
+        },
+      );
+
+  return [
+    refer(r'_$entries').property('addAll').call([flattened]).statement,
+  ];
 }
 
 List<Code> _buildDelimitedCode(

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -268,9 +268,6 @@ List<Parameter> buildDeepObjectEncodingParameters() => [
   buildBoolParameter('allowReserved'),
 ];
 
-/// Encoding parameters for delimited object styles (`toPipeDelimited` /
-/// `toSpaceDelimited`), which carry no `explode`: delimited objects always
-/// collapse into a single entry.
 List<Parameter> buildDelimitedEncodingParameters() => [
   buildBoolParameter('allowEmpty', required: true),
   buildBoolParameter('allowReserved'),

--- a/packages/tonik_generate/lib/src/util/type_reference_generator.dart
+++ b/packages/tonik_generate/lib/src/util/type_reference_generator.dart
@@ -268,6 +268,14 @@ List<Parameter> buildDeepObjectEncodingParameters() => [
   buildBoolParameter('allowReserved'),
 ];
 
+/// Encoding parameters for delimited object styles (`toPipeDelimited` /
+/// `toSpaceDelimited`), which carry no `explode`: delimited objects always
+/// collapse into a single entry.
+List<Parameter> buildDelimitedEncodingParameters() => [
+  buildBoolParameter('allowEmpty', required: true),
+  buildBoolParameter('allowReserved'),
+];
+
 /// Parameters for an inline `uriEncode` signature.
 List<Parameter> buildUriEncodeParameters() => [
   buildBoolParameter('allowEmpty', required: true),

--- a/packages/tonik_generate/test/src/model/all_of_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_delimited_generator_test.dart
@@ -1,0 +1,93 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/all_of_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+void main() {
+  group('AllOfGenerator delimited generation', () {
+    late AllOfGenerator generator;
+    late NameManager nameManager;
+    late NameGenerator nameGenerator;
+    late Context context;
+    late DartEmitter emitter;
+
+    setUp(() {
+      nameGenerator = NameGenerator();
+      nameManager = NameManager(
+        generator: nameGenerator,
+        stableModelSorter: StableModelSorter(),
+      );
+      generator = AllOfGenerator(
+        nameManager: nameManager,
+        package: 'example',
+        stableModelSorter: StableModelSorter(),
+      );
+      context = Context.initial();
+      emitter = DartEmitter(useNullSafetySyntax: true);
+    });
+
+    AllOfModel simpleModel() => AllOfModel(
+      isDeprecated: false,
+      name: 'AllOfSimple',
+      models: {
+        StringModel(context: context),
+        IntegerModel(context: context),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    test('toPipeDelimited has the delimited signature', () {
+      final generatedClass = generator.generateClass(simpleModel());
+      final method = generatedClass.methods.firstWhere(
+        (m) => m.name == 'toPipeDelimited',
+      );
+
+      expect(
+        method.returns?.accept(emitter).toString(),
+        'List<ParameterEntry>',
+      );
+      expect(method.requiredParameters.length, 1);
+      expect(method.requiredParameters.first.name, 'paramName');
+      expect(method.optionalParameters.length, 2);
+      expect(
+        method.optionalParameters.map((p) => p.name),
+        containsAll(['allowEmpty', 'allowReserved']),
+      );
+    });
+
+    test('toPipeDelimited delegates to the parameterProperties encoder', () {
+      final generatedClass = generator.generateClass(simpleModel());
+
+      const expectedMethod = '''
+        List<ParameterEntry> toPipeDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      final generatedCode = generatedClass.accept(emitter).toString();
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('toSpaceDelimited delegates to the parameterProperties encoder', () {
+      final generatedClass = generator.generateClass(simpleModel());
+
+      const expectedMethod = '''
+        List<ParameterEntry> toSpaceDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      final generatedCode = generatedClass.accept(emitter).toString();
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/model/any_of_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_delimited_generator_test.dart
@@ -1,0 +1,93 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/any_of_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+void main() {
+  group('AnyOfGenerator delimited generation', () {
+    late AnyOfGenerator generator;
+    late NameManager nameManager;
+    late NameGenerator nameGenerator;
+    late Context context;
+    late DartEmitter emitter;
+
+    setUp(() {
+      nameGenerator = NameGenerator();
+      nameManager = NameManager(
+        generator: nameGenerator,
+        stableModelSorter: StableModelSorter(),
+      );
+      generator = AnyOfGenerator(
+        nameManager: nameManager,
+        package: 'example',
+        stableModelSorter: StableModelSorter(),
+      );
+      context = Context.initial();
+      emitter = DartEmitter(useNullSafetySyntax: true);
+    });
+
+    AnyOfModel simpleModel() => AnyOfModel(
+      isDeprecated: false,
+      name: 'AnyOfSimple',
+      models: {
+        (discriminatorValue: 'string', model: StringModel(context: context)),
+        (discriminatorValue: 'int', model: IntegerModel(context: context)),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    test('toPipeDelimited has the delimited signature', () {
+      final generatedClass = generator.generateClass(simpleModel());
+      final method = generatedClass.methods.firstWhere(
+        (m) => m.name == 'toPipeDelimited',
+      );
+
+      expect(
+        method.returns?.accept(emitter).toString(),
+        'List<ParameterEntry>',
+      );
+      expect(method.requiredParameters.length, 1);
+      expect(method.requiredParameters.first.name, 'paramName');
+      expect(method.optionalParameters.length, 2);
+      expect(
+        method.optionalParameters.map((p) => p.name),
+        containsAll(['allowEmpty', 'allowReserved']),
+      );
+    });
+
+    test('toPipeDelimited delegates to the parameterProperties encoder', () {
+      final generatedClass = generator.generateClass(simpleModel());
+      final generatedCode = generatedClass.accept(emitter).toString();
+
+      const expectedMethod = '''
+        List<ParameterEntry> toPipeDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('toSpaceDelimited delegates to the parameterProperties encoder', () {
+      final generatedClass = generator.generateClass(simpleModel());
+      final generatedCode = generatedClass.accept(emitter).toString();
+
+      const expectedMethod = '''
+        List<ParameterEntry> toSpaceDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
@@ -1,0 +1,136 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/class_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+void main() {
+  group('ClassGenerator delimited generation', () {
+    late ClassGenerator generator;
+    late NameManager nameManager;
+    late NameGenerator nameGenerator;
+    late Context context;
+    late DartEmitter emitter;
+
+    setUp(() {
+      nameGenerator = NameGenerator();
+      nameManager = NameManager(
+        generator: nameGenerator,
+        stableModelSorter: StableModelSorter(),
+      );
+      generator = ClassGenerator(
+        nameManager: nameManager,
+        package: 'example',
+      );
+      context = Context.initial();
+      emitter = DartEmitter(useNullSafetySyntax: true);
+    });
+
+    ClassModel singlePropertyModel() => ClassModel(
+      isDeprecated: false,
+      name: 'TestModel',
+      properties: [
+        Property(
+          name: 'name',
+          model: StringModel(context: context),
+          isRequired: true,
+          isNullable: false,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: null,
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+
+    test('toPipeDelimited has the delimited signature', () {
+      final result = generator.generateClass(singlePropertyModel());
+      final method = result.methods.firstWhere(
+        (m) => m.name == 'toPipeDelimited',
+      );
+
+      expect(
+        method.returns?.accept(emitter).toString(),
+        'List<ParameterEntry>',
+      );
+      expect(method.requiredParameters.length, 1);
+      expect(method.requiredParameters.first.name, 'paramName');
+      expect(
+        method.requiredParameters.first.type?.accept(emitter).toString(),
+        'String',
+      );
+      expect(method.optionalParameters.length, 2);
+      expect(method.optionalParameters.first.name, 'allowEmpty');
+      expect(method.optionalParameters.first.required, isTrue);
+      expect(method.optionalParameters.first.named, isTrue);
+      expect(method.optionalParameters.last.name, 'allowReserved');
+      expect(method.optionalParameters.last.required, isFalse);
+      expect(method.optionalParameters.last.named, isTrue);
+    });
+
+    test('toSpaceDelimited has the delimited signature', () {
+      final result = generator.generateClass(singlePropertyModel());
+      final method = result.methods.firstWhere(
+        (m) => m.name == 'toSpaceDelimited',
+      );
+
+      expect(
+        method.returns?.accept(emitter).toString(),
+        'List<ParameterEntry>',
+      );
+      expect(method.requiredParameters.length, 1);
+      expect(method.requiredParameters.first.name, 'paramName');
+      expect(method.optionalParameters.length, 2);
+      expect(method.optionalParameters.first.name, 'allowEmpty');
+      expect(method.optionalParameters.last.name, 'allowReserved');
+    });
+
+    test('toPipeDelimited delegates to the parameterProperties encoder', () {
+      final result = generator.generateClass(singlePropertyModel());
+
+      const expectedMethod = '''
+        List<ParameterEntry> toPipeDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      final generatedCode = result.accept(emitter).toString();
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('toSpaceDelimited delegates to the parameterProperties encoder', () {
+      final result = generator.generateClass(singlePropertyModel());
+
+      const expectedMethod = '''
+        List<ParameterEntry> toSpaceDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
+          return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
+        }
+      ''';
+
+      final generatedCode = result.accept(emitter).toString();
+      expect(
+        collapseWhitespace(generatedCode),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('delimited methods carry the @override annotation', () {
+      final result = generator.generateClass(singlePropertyModel());
+
+      for (final methodName in ['toPipeDelimited', 'toSpaceDelimited']) {
+        final method = result.methods.firstWhere((m) => m.name == methodName);
+        expect(
+          method.annotations.any(
+            (a) => a.accept(emitter).toString().contains('override'),
+          ),
+          isTrue,
+        );
+      }
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/model/one_of_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_delimited_generator_test.dart
@@ -1,0 +1,123 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/model/one_of_generator.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+
+void main() {
+  group('OneOfGenerator delimited generation', () {
+    late OneOfGenerator generator;
+    late NameManager nameManager;
+    late NameGenerator nameGenerator;
+    late Context context;
+    late DartEmitter emitter;
+
+    final format = DartFormatter(
+      languageVersion: DartFormatter.latestLanguageVersion,
+    ).format;
+
+    setUp(() {
+      nameGenerator = NameGenerator();
+      nameManager = NameManager(
+        generator: nameGenerator,
+        stableModelSorter: StableModelSorter(),
+      );
+      generator = OneOfGenerator(
+        nameManager: nameManager,
+        package: 'example',
+        stableModelSorter: StableModelSorter(),
+      );
+      context = Context.initial();
+      emitter = DartEmitter(useNullSafetySyntax: true);
+    });
+
+    OneOfModel simpleModel() => OneOfModel(
+      isDeprecated: false,
+      name: 'OneOfPrimitive',
+      models: {
+        (discriminatorValue: 'string', model: StringModel(context: context)),
+        (discriminatorValue: 'int', model: IntegerModel(context: context)),
+      },
+      context: context,
+      examples: const [],
+    );
+
+    test('toPipeDelimited delegates to the parameterProperties encoder', () {
+      final classes = generator.generateClasses(simpleModel());
+      final baseClass = classes.firstWhere((c) => c.name == 'OneOfPrimitive');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+List<ParameterEntry> toPipeDelimited( String paramName, { required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited( paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
+
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('toSpaceDelimited delegates to the parameterProperties encoder', () {
+      final classes = generator.generateClasses(simpleModel());
+      final baseClass = classes.firstWhere((c) => c.name == 'OneOfPrimitive');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+List<ParameterEntry> toSpaceDelimited( String paramName, { required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited( paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
+''';
+
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('empty oneOf emits a throwing toPipeDelimited variant', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'EmptyOneOf',
+        models: const {},
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'EmptyOneOf');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+List<ParameterEntry> toPipeDelimited( String paramName, { required bool allowEmpty, bool allowReserved = false, }) => throw EncodingException( r'EmptyOneOf has no variants and cannot be encoded.', );
+''';
+
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('empty oneOf emits a throwing toSpaceDelimited variant', () {
+      final model = OneOfModel(
+        isDeprecated: false,
+        name: 'EmptyOneOf',
+        models: const {},
+        context: context,
+        examples: const [],
+      );
+
+      final classes = generator.generateClasses(model);
+      final baseClass = classes.firstWhere((c) => c.name == 'EmptyOneOf');
+      final generated = format(baseClass.accept(emitter).toString());
+
+      const expectedMethod = '''
+List<ParameterEntry> toSpaceDelimited( String paramName, { required bool allowEmpty, bool allowReserved = false, }) => throw EncodingException( r'EmptyOneOf has no variants and cannot be encoded.', );
+''';
+
+      expect(
+        collapseWhitespace(generated),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+  });
+}

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -2991,5 +2991,95 @@ void main() {
         collapseWhitespace(format(expectedMethod)),
       );
     });
+
+    QueryParameterObject anyDelimitedParam({
+      required QueryParameterEncoding encoding,
+    }) => QueryParameterObject(
+      name: 'data',
+      rawName: 'data',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      encoding: encoding,
+      allowReserved: false,
+      model: AnyModel(context: context),
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    test('encodes pipeDelimited AnyModel via encodeAnyToPipeDelimited', () {
+      final queryParam = anyDelimitedParam(
+        encoding: QueryParameterEncoding.pipeDelimited,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({Object? data}) {
+          final _$entries = <ParameterEntry>[];
+          if (data != null) {
+            _$entries.addAll(
+              encodeAnyToPipeDelimited(
+                data,
+                r'data',
+                explode: false,
+                allowEmpty: false,
+              ),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'data', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('encodes spaceDelimited AnyModel via encodeAnyToSpaceDelimited', () {
+      final queryParam = anyDelimitedParam(
+        encoding: QueryParameterEncoding.spaceDelimited,
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({Object? data}) {
+          final _$entries = <ParameterEntry>[];
+          if (data != null) {
+            _$entries.addAll(
+              encodeAnyToSpaceDelimited(
+                data,
+                r'data',
+                explode: false,
+                allowEmpty: false,
+              ),
+            );
+          }
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final method = generator.generateQueryParametersMethod(
+        buildOperation(queryParam),
+        [(normalizedName: 'data', parameter: queryParam)],
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -1553,7 +1553,7 @@ void main() {
           String? _queryParameters({required String name}) {
             final _$entries = <ParameterEntry>[];
             throw EncodingException(
-              r'Parameter name: spaceDelimited encoding supports only list and object types',
+              r'Parameter name: spaceDelimited encoding supports only array and object types',
             );
             if (_$entries.isEmpty) {
               return null;
@@ -2068,7 +2068,7 @@ void main() {
         String? _queryParameters({required String $class}) {
           final _$entries = <ParameterEntry>[];
           throw EncodingException(
-            r'Parameter $class: spaceDelimited encoding supports only list and object types',
+            r'Parameter $class: spaceDelimited encoding supports only array and object types',
           );
           if (_$entries.isEmpty) {
             return null;

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -194,6 +194,144 @@ void main() {
       );
     });
 
+    test('encodes pipeDelimited object query parameter via '
+        'parameterProperties', () {
+      final queryParam = QueryParameterObject(
+        name: 'color',
+        rawName: 'color',
+        description: null,
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: true,
+        explode: false,
+        encoding: QueryParameterEncoding.pipeDelimited,
+        allowReserved: false,
+        model: ClassModel(
+          isDeprecated: false,
+          context: context,
+          properties: const [],
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final operation = Operation(
+        operationId: 'listColors',
+        context: context,
+        summary: 'List colors',
+        description: 'Lists colors',
+        tags: const {},
+        isDeprecated: false,
+        path: '/colors',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: {queryParam},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required AnonymousModel color}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            color.parameterProperties(allowEmpty: true).toPipeDelimited(r'color', allowEmpty: true),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final queryParameters =
+          <({String normalizedName, QueryParameterObject parameter})>[
+            (normalizedName: 'color', parameter: queryParam),
+          ];
+
+      final method = generator.generateQueryParametersMethod(
+        operation,
+        queryParameters,
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('encodes spaceDelimited object query parameter via '
+        'parameterProperties', () {
+      final queryParam = QueryParameterObject(
+        name: 'coord',
+        rawName: 'coord',
+        description: null,
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: true,
+        explode: false,
+        encoding: QueryParameterEncoding.spaceDelimited,
+        allowReserved: false,
+        model: ClassModel(
+          isDeprecated: false,
+          context: context,
+          properties: const [],
+          examples: const [],
+        ),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final operation = Operation(
+        operationId: 'listCoords',
+        context: context,
+        summary: 'List coords',
+        description: 'Lists coords',
+        tags: const {},
+        isDeprecated: false,
+        path: '/coords',
+        method: HttpMethod.get,
+        headers: const {},
+        queryParameters: {queryParam},
+        pathParameters: const {},
+        cookieParameters: const {},
+        responses: const {},
+        securitySchemes: const {},
+      );
+
+      const expectedMethod = r'''
+        String? _queryParameters({required AnonymousModel coord}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            coord.parameterProperties(allowEmpty: true).toSpaceDelimited(r'coord', allowEmpty: true),
+          );
+          if (_$entries.isEmpty) {
+            return null;
+          }
+          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        }
+      ''';
+
+      final queryParameters =
+          <({String normalizedName, QueryParameterObject parameter})>[
+            (normalizedName: 'coord', parameter: queryParam),
+          ];
+
+      final method = generator.generateQueryParametersMethod(
+        operation,
+        queryParameters,
+      );
+
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
     test('encodes query parameters with deepObject style', () {
       final queryParam = QueryParameterObject(
         name: 'filter',
@@ -1415,7 +1553,7 @@ void main() {
           String? _queryParameters({required String name}) {
             final _$entries = <ParameterEntry>[];
             throw EncodingException(
-              r'Parameter name: spaceDelimited encoding only supports list types',
+              r'Parameter name: spaceDelimited encoding supports only list and object types',
             );
             if (_$entries.isEmpty) {
               return null;
@@ -1930,7 +2068,7 @@ void main() {
         String? _queryParameters({required String $class}) {
           final _$entries = <ParameterEntry>[];
           throw EncodingException(
-            r'Parameter $class: spaceDelimited encoding only supports list types',
+            r'Parameter $class: spaceDelimited encoding supports only list and object types',
           );
           if (_$entries.isEmpty) {
             return null;

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -3023,7 +3023,6 @@ void main() {
               encodeAnyToPipeDelimited(
                 data,
                 r'data',
-                explode: false,
                 allowEmpty: false,
               ),
             );
@@ -3059,7 +3058,6 @@ void main() {
               encodeAnyToSpaceDelimited(
                 data,
                 r'data',
-                explode: false,
                 allowEmpty: false,
               ),
             );

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -1321,7 +1321,7 @@ void main() {
             format('''
               void test() {
                 throw EncodingException(
-                  r'pipeDelimited encoding is not supported for Map types with complex values. Parameter "nested" cannot be encoded.',
+                  r'Parameter nested: pipeDelimited encoding does not support Map types with complex values',
                 );
               }
             '''),
@@ -1552,7 +1552,6 @@ void main() {
                   encodeAnyToPipeDelimited(
                     data,
                     r'data',
-                    explode: false,
                     allowEmpty: true,
                   ),
                 );
@@ -1588,7 +1587,6 @@ void main() {
                   encodeAnyToSpaceDelimited(
                     data,
                     r'data',
-                    explode: false,
                     allowEmpty: true,
                   ),
                 );
@@ -1625,10 +1623,40 @@ void main() {
                   encodeAnyToPipeDelimited(
                     data,
                     r'data',
-                    explode: false,
                     allowEmpty: true,
                     allowReserved: true,
                   ),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('explode AnyModel throws the specification-undefined exception', () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: true,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'data',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          explode: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'Parameter data: pipeDelimited encoding of objects with explode: true is not defined by the specification',
                 );
               }
             '''),

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -1055,7 +1055,7 @@ void main() {
     });
 
     group('unsupported models', () {
-      test('primitive throws the list-and-object-only exception', () {
+      test('primitive throws the array-and-object-only exception', () {
         final parameter = createParameter(
           name: 'name',
           rawName: 'name',
@@ -1077,7 +1077,447 @@ void main() {
             format('''
               void test() {
                 throw EncodingException(
-                  r'Parameter name: spaceDelimited encoding supports only list and object types',
+                  r'Parameter name: spaceDelimited encoding supports only array and object types',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('enum throws the array-and-object-only exception', () {
+        final parameter = createParameter(
+          name: 'status',
+          rawName: 'status',
+          model: EnumModel<String>(
+            isDeprecated: false,
+            context: context,
+            values: {
+              const EnumEntry(value: 'active'),
+              const EnumEntry(value: 'inactive'),
+            },
+            isNullable: false,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'status',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'Parameter status: pipeDelimited encoding supports only array and object types',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    });
+
+    group('alias resolving to list', () {
+      test('spaceDelimited alias to string list emits the list path', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: AliasModel(
+            name: 'TagList',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toSpaceDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited alias to string list emits the list path', () {
+        final parameter = createParameter(
+          name: 'tags',
+          rawName: 'tags',
+          model: AliasModel(
+            name: 'TagList',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'tags',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                for (final value in tags.toPipeDelimited(
+                  explode: false,
+                  allowEmpty: true,
+                )) {
+                  _$entries.add((name: r'tags', value: value));
+                }
+              }
+            '''),
+          ),
+        );
+      });
+    });
+
+    group('map parameters', () {
+      test('spaceDelimited Map<String, String> flattens via '
+          'buildMapPropertyValueConversion', () {
+        final parameter = createParameter(
+          name: 'filter',
+          rawName: 'filter',
+          model: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'filter',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  filter
+                      .map((k, v) => MapEntry(k, PropertyValue.scalar(v)))
+                      .toSpaceDelimited(r'filter', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('pipeDelimited Map<String, int> flattens via '
+          'buildMapPropertyValueConversion', () {
+        final parameter = createParameter(
+          name: 'counts',
+          rawName: 'counts',
+          model: MapModel(
+            valueModel: IntegerModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'counts',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  counts
+                      .map((k, v) => MapEntry(k, PropertyValue.scalar(v.toString())))
+                      .toPipeDelimited(r'counts', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('map with complex value type throws the unsupported-complex-value '
+          'exception', () {
+        final parameter = createParameter(
+          name: 'nested',
+          rawName: 'nested',
+          model: MapModel(
+            valueModel: ClassModel(
+              name: 'Inner',
+              properties: const [],
+              isDeprecated: false,
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+          ),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'nested',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'pipeDelimited encoding is not supported for Map types with complex values. Parameter "nested" cannot be encoded.',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('explode map throws the specification-undefined exception', () {
+        final parameter = createParameter(
+          name: 'filter',
+          rawName: 'filter',
+          model: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          explode: true,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'filter',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          explode: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'Parameter filter: pipeDelimited encoding of objects with explode: true is not defined by the specification',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    });
+
+    group('composite parameters', () {
+      OneOfModel allSimpleOneOf() => OneOfModel(
+        name: 'SimpleVariant',
+        isDeprecated: false,
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (discriminatorValue: null, model: IntegerModel(context: context)),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      OneOfModel allComplexOneOf() => OneOfModel(
+        name: 'ComplexVariant',
+        isDeprecated: false,
+        models: {
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              name: 'ClassA',
+              properties: const [],
+              isDeprecated: false,
+              context: context,
+              examples: const [],
+            ),
+          ),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              name: 'ClassB',
+              properties: const [],
+              isDeprecated: false,
+              context: context,
+              examples: const [],
+            ),
+          ),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      OneOfModel mixedOneOf() => OneOfModel(
+        name: 'MixedVariant',
+        isDeprecated: false,
+        models: {
+          (discriminatorValue: null, model: StringModel(context: context)),
+          (
+            discriminatorValue: null,
+            model: ClassModel(
+              name: 'ClassA',
+              properties: const [],
+              isDeprecated: false,
+              context: context,
+              examples: const [],
+            ),
+          ),
+        },
+        context: context,
+        examples: const [],
+      );
+
+      test('all-simple oneOf flattens via parameterProperties '
+          '(pipeDelimited)', () {
+        final parameter = createParameter(
+          name: 'variant',
+          rawName: 'variant',
+          model: allSimpleOneOf(),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'variant',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  variant
+                      .parameterProperties(allowEmpty: true)
+                      .toPipeDelimited(r'variant', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('all-complex oneOf flattens via parameterProperties '
+          '(pipeDelimited)', () {
+        final parameter = createParameter(
+          name: 'variant',
+          rawName: 'variant',
+          model: allComplexOneOf(),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'variant',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  variant
+                      .parameterProperties(allowEmpty: true)
+                      .toPipeDelimited(r'variant', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('mixed oneOf flattens via parameterProperties '
+          '(spaceDelimited)', () {
+        final parameter = createParameter(
+          name: 'variant',
+          rawName: 'variant',
+          model: mixedOneOf(),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'variant',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  variant
+                      .parameterProperties(allowEmpty: true)
+                      .toSpaceDelimited(r'variant', allowEmpty: true),
                 );
               }
             '''),

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -1525,5 +1525,116 @@ void main() {
         );
       });
     });
+
+    group('any parameters', () {
+      test('pipeDelimited AnyModel dispatches to encodeAnyToPipeDelimited', () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'data',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  encodeAnyToPipeDelimited(
+                    data,
+                    r'data',
+                    explode: false,
+                    allowEmpty: true,
+                  ),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited AnyModel dispatches to encodeAnyToSpaceDelimited',
+          () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'data',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  encodeAnyToSpaceDelimited(
+                    data,
+                    r'data',
+                    explode: false,
+                    allowEmpty: true,
+                  ),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('AnyModel threads allowReserved into encodeAnyToPipeDelimited', () {
+        final parameter = createParameter(
+          name: 'data',
+          rawName: 'data',
+          model: AnyModel(context: context),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'data',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  encodeAnyToPipeDelimited(
+                    data,
+                    r'data',
+                    explode: false,
+                    allowEmpty: true,
+                    allowReserved: true,
+                  ),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -908,5 +908,182 @@ void main() {
         );
       });
     });
+
+    group('object parameters', () {
+      ClassModel colorClass() => ClassModel(
+        name: 'Color',
+        properties: const [],
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+      );
+
+      test('pipeDelimited object (non-explode) flattens via '
+          'parameterProperties', () {
+        final parameter = createParameter(
+          name: 'color',
+          rawName: 'color',
+          model: colorClass(),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'color',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  color
+                      .parameterProperties(allowEmpty: true)
+                      .toPipeDelimited(r'color', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('spaceDelimited object (non-explode) flattens via '
+          'parameterProperties', () {
+        final parameter = createParameter(
+          name: 'coord',
+          rawName: 'coord',
+          model: colorClass(),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'coord',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  coord
+                      .parameterProperties(allowEmpty: true)
+                      .toSpaceDelimited(r'coord', allowEmpty: true),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('object threads allowReserved into the flattening call', () {
+        final parameter = createParameter(
+          name: 'color',
+          rawName: 'color',
+          model: colorClass(),
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'color',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          allowReserved: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format(r'''
+              void test() {
+                _$entries.addAll(
+                  color
+                      .parameterProperties(allowEmpty: true)
+                      .toPipeDelimited(
+                        r'color',
+                        allowEmpty: true,
+                        allowReserved: true,
+                      ),
+                );
+              }
+            '''),
+          ),
+        );
+      });
+
+      test('explode object throws the specification-undefined exception', () {
+        final parameter = createParameter(
+          name: 'color',
+          rawName: 'color',
+          model: colorClass(),
+          explode: true,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'color',
+          parameter,
+          encoding: QueryParameterEncoding.pipeDelimited,
+          explode: true,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'Parameter color: pipeDelimited encoding of objects with explode: true is not defined by the specification',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    });
+
+    group('unsupported models', () {
+      test('primitive throws the list-and-object-only exception', () {
+        final parameter = createParameter(
+          name: 'name',
+          rawName: 'name',
+          model: StringModel(context: context),
+          explode: false,
+          allowEmpty: true,
+        );
+
+        final codes = buildToDelimitedQueryParameterCode(
+          'name',
+          parameter,
+          encoding: QueryParameterEncoding.spaceDelimited,
+        );
+
+        final code = emitStatements(codes);
+        expect(
+          collapseWhitespace(code),
+          collapseWhitespace(
+            format('''
+              void test() {
+                throw EncodingException(
+                  r'Parameter name: spaceDelimited encoding supports only list and object types',
+                );
+              }
+            '''),
+          ),
+        );
+      });
+    });
   });
 }

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -508,12 +508,10 @@ List<ParameterEntry> encodeAnyToPipeDelimited(
     );
   }
   if (value is Map<String, dynamic>) {
-    if (value.isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     final flattened = <String, String>{
       for (final entry in value.entries)
-        entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
+        if (entry.value != null)
+          entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
     };
     return flattened.toPipeDelimited(
       paramName,
@@ -522,10 +520,11 @@ List<ParameterEntry> encodeAnyToPipeDelimited(
     );
   }
   if (value is List<dynamic>) {
-    if (value.isEmpty && !allowEmpty) {
+    final filtered = value.where((item) => item != null).toList();
+    if (filtered.isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
-    final joined = value
+    final joined = filtered
         .map((item) => encodeAnyValueToString(item, allowEmpty: true))
         .toList()
         .toPipeDelimited(
@@ -568,12 +567,10 @@ List<ParameterEntry> encodeAnyToSpaceDelimited(
     );
   }
   if (value is Map<String, dynamic>) {
-    if (value.isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     final flattened = <String, String>{
       for (final entry in value.entries)
-        entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
+        if (entry.value != null)
+          entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
     };
     return flattened.toSpaceDelimited(
       paramName,
@@ -582,10 +579,11 @@ List<ParameterEntry> encodeAnyToSpaceDelimited(
     );
   }
   if (value is List<dynamic>) {
-    if (value.isEmpty && !allowEmpty) {
+    final filtered = value.where((item) => item != null).toList();
+    if (filtered.isEmpty && !allowEmpty) {
       throw const EmptyValueException();
     }
-    final joined = value
+    final joined = filtered
         .map((item) => encodeAnyValueToString(item, allowEmpty: true))
         .toList()
         .toSpaceDelimited(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -7,6 +7,7 @@ import 'package:tonik_util/src/encoding/label_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/matrix_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/simple_encoder_extensions.dart';
+import 'package:tonik_util/src/encoding/string_map_delimited_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/unknown_value_encoding.dart';
 import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 
@@ -473,6 +474,88 @@ List<ParameterEntry> encodeAnyToDeepObject(
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to deepObject style. '
     'DeepObject only supports objects and Map<String, String>.',
+  );
+}
+
+/// Encodes any value to pipeDelimited style. Used for AnyModel fields.
+///
+/// Handles runtime type detection for values of unknown type. Generated
+/// models implementing [ParameterEncodable] encode themselves;
+/// `Map<String, String>` values use extension methods.
+///
+/// [explode] is accepted for family consistency with the other `encodeAny…`
+/// helpers but is not forwarded: delimited object styles always collapse into
+/// a single entry.
+///
+/// When [allowReserved] is true, reserved characters in keys and values are
+/// kept literal; the flag is forwarded to both branches.
+List<ParameterEntry> encodeAnyToPipeDelimited(
+  Object? value,
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+  bool allowReserved = false,
+}) {
+  if (value == null) {
+    if (!allowEmpty) {
+      throw const EmptyValueException();
+    }
+    return [];
+  }
+  if (value is ParameterEncodable) {
+    return value.toPipeDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+  if (value is Map<String, String>) {
+    return value.toPipeDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+  throw EncodingException(
+    'Cannot encode ${value.runtimeType} to pipeDelimited style. '
+    'pipeDelimited only supports objects and Map<String, String>.',
+  );
+}
+
+/// Encodes any value to spaceDelimited style. Used for AnyModel fields.
+///
+/// Mirrors [encodeAnyToPipeDelimited]; see its documentation for the [explode]
+/// and [allowReserved] semantics.
+List<ParameterEntry> encodeAnyToSpaceDelimited(
+  Object? value,
+  String paramName, {
+  required bool explode,
+  required bool allowEmpty,
+  bool allowReserved = false,
+}) {
+  if (value == null) {
+    if (!allowEmpty) {
+      throw const EmptyValueException();
+    }
+    return [];
+  }
+  if (value is ParameterEncodable) {
+    return value.toSpaceDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+  if (value is Map<String, String>) {
+    return value.toSpaceDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+  throw EncodingException(
+    'Cannot encode ${value.runtimeType} to spaceDelimited style. '
+    'spaceDelimited only supports objects and Map<String, String>.',
   );
 }
 

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -6,7 +6,9 @@ import 'package:tonik_util/src/encoding/form_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/label_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/matrix_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/pipe_delimited_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/simple_encoder_extensions.dart';
+import 'package:tonik_util/src/encoding/space_delimited_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/string_map_delimited_encoder_extensions.dart';
 import 'package:tonik_util/src/encoding/unknown_value_encoding.dart';
 import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
@@ -479,12 +481,13 @@ List<ParameterEntry> encodeAnyToDeepObject(
 
 /// Encodes any value to pipeDelimited style. Used for AnyModel fields.
 ///
-/// Handles runtime type detection for values of unknown type. Generated
-/// models implementing [ParameterEncodable] encode themselves;
-/// `Map<String, String>` values use extension methods.
+/// pipeDelimited supports both arrays and flat objects. Generated models
+/// implementing [ParameterEncodable] encode themselves; flat maps and lists
+/// are flattened into a single `|`-joined entry via the extension methods,
+/// which URI-encode each token. Nested collections are rejected.
 ///
 /// When [allowReserved] is true, reserved characters in keys and values are
-/// kept literal; the flag is forwarded to both branches.
+/// kept literal; the flag is forwarded to every branch.
 List<ParameterEntry> encodeAnyToPipeDelimited(
   Object? value,
   String paramName, {
@@ -504,23 +507,47 @@ List<ParameterEntry> encodeAnyToPipeDelimited(
       allowReserved: allowReserved,
     );
   }
-  if (value is Map<String, String>) {
-    return value.toPipeDelimited(
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final flattened = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
+    };
+    return flattened.toPipeDelimited(
       paramName,
       allowEmpty: allowEmpty,
       allowReserved: allowReserved,
     );
   }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final joined = value
+        .map((item) => encodeAnyValueToString(item, allowEmpty: true))
+        .toList()
+        .toPipeDelimited(
+          explode: false,
+          allowEmpty: allowEmpty,
+          allowReserved: allowReserved,
+        );
+    if (joined.isEmpty) {
+      return const [];
+    }
+    return [(name: paramName, value: joined.single)];
+  }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to pipeDelimited style. '
-    'pipeDelimited only supports objects and Map<String, String>.',
+    'pipeDelimited only supports objects and arrays.',
   );
 }
 
 /// Encodes any value to spaceDelimited style. Used for AnyModel fields.
 ///
-/// Mirrors [encodeAnyToPipeDelimited]; see its documentation for the
-/// [allowReserved] semantics.
+/// Mirrors [encodeAnyToPipeDelimited]; the `%20` delimiter is the only
+/// difference. See its documentation for the [allowReserved] semantics.
 List<ParameterEntry> encodeAnyToSpaceDelimited(
   Object? value,
   String paramName, {
@@ -540,16 +567,40 @@ List<ParameterEntry> encodeAnyToSpaceDelimited(
       allowReserved: allowReserved,
     );
   }
-  if (value is Map<String, String>) {
-    return value.toSpaceDelimited(
+  if (value is Map<String, dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final flattened = <String, String>{
+      for (final entry in value.entries)
+        entry.key: encodeAnyValueToString(entry.value, allowEmpty: true),
+    };
+    return flattened.toSpaceDelimited(
       paramName,
       allowEmpty: allowEmpty,
       allowReserved: allowReserved,
     );
   }
+  if (value is List<dynamic>) {
+    if (value.isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    final joined = value
+        .map((item) => encodeAnyValueToString(item, allowEmpty: true))
+        .toList()
+        .toSpaceDelimited(
+          explode: false,
+          allowEmpty: allowEmpty,
+          allowReserved: allowReserved,
+        );
+    if (joined.isEmpty) {
+      return const [];
+    }
+    return [(name: paramName, value: joined.single)];
+  }
   throw EncodingException(
     'Cannot encode ${value.runtimeType} to spaceDelimited style. '
-    'spaceDelimited only supports objects and Map<String, String>.',
+    'spaceDelimited only supports objects and arrays.',
   );
 }
 

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -483,16 +483,11 @@ List<ParameterEntry> encodeAnyToDeepObject(
 /// models implementing [ParameterEncodable] encode themselves;
 /// `Map<String, String>` values use extension methods.
 ///
-/// [explode] is accepted for family consistency with the other `encodeAny…`
-/// helpers but is not forwarded: delimited object styles always collapse into
-/// a single entry.
-///
 /// When [allowReserved] is true, reserved characters in keys and values are
 /// kept literal; the flag is forwarded to both branches.
 List<ParameterEntry> encodeAnyToPipeDelimited(
   Object? value,
   String paramName, {
-  required bool explode,
   required bool allowEmpty,
   bool allowReserved = false,
 }) {
@@ -524,12 +519,11 @@ List<ParameterEntry> encodeAnyToPipeDelimited(
 
 /// Encodes any value to spaceDelimited style. Used for AnyModel fields.
 ///
-/// Mirrors [encodeAnyToPipeDelimited]; see its documentation for the [explode]
-/// and [allowReserved] semantics.
+/// Mirrors [encodeAnyToPipeDelimited]; see its documentation for the
+/// [allowReserved] semantics.
 List<ParameterEntry> encodeAnyToSpaceDelimited(
   Object? value,
   String paramName, {
-  required bool explode,
   required bool allowEmpty,
   bool allowReserved = false,
 }) {

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -481,13 +481,8 @@ List<ParameterEntry> encodeAnyToDeepObject(
 
 /// Encodes any value to pipeDelimited style. Used for AnyModel fields.
 ///
-/// pipeDelimited supports both arrays and flat objects. Generated models
-/// implementing [ParameterEncodable] encode themselves; flat maps and lists
-/// are flattened into a single `|`-joined entry via the extension methods,
-/// which URI-encode each token. Nested collections are rejected.
-///
 /// When [allowReserved] is true, reserved characters in keys and values are
-/// kept literal; the flag is forwarded to every branch.
+/// kept literal.
 List<ParameterEntry> encodeAnyToPipeDelimited(
   Object? value,
   String paramName, {

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -93,14 +93,9 @@ abstract interface class DeepObjectEncodable {
 }
 
 /// Marker interface for types that support pipe-delimited object encoding.
-///
-/// Unlike [DeepObjectEncodable], delimited object styles have no `explode`
-/// parameter: the object always collapses into a single entry whose
-/// alternating key/value tokens are joined by a literal `|`.
 abstract interface class PipeDelimitedEncodable {
   /// Encodes this value using pipeDelimited style parameter encoding.
   ///
-  /// The [paramName] is the parameter name of the single produced entry.
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [allowReserved] is true, reserved characters in keys and values are
   /// kept literal; the `|` delimiter is unaffected.
@@ -112,13 +107,9 @@ abstract interface class PipeDelimitedEncodable {
 }
 
 /// Marker interface for types that support space-delimited object encoding.
-///
-/// Like [PipeDelimitedEncodable] but the alternating key/value tokens are
-/// joined by a pre-escaped `%20`.
 abstract interface class SpaceDelimitedEncodable {
   /// Encodes this value using spaceDelimited style parameter encoding.
   ///
-  /// The [paramName] is the parameter name of the single produced entry.
   /// When [allowEmpty] is false, empty values throw an exception.
   /// When [allowReserved] is true, reserved characters in keys and values are
   /// kept literal; the `%20` delimiter is unaffected.

--- a/packages/tonik_util/lib/src/encoding/encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/encodable.dart
@@ -92,6 +92,43 @@ abstract interface class DeepObjectEncodable {
   });
 }
 
+/// Marker interface for types that support pipe-delimited object encoding.
+///
+/// Unlike [DeepObjectEncodable], delimited object styles have no `explode`
+/// parameter: the object always collapses into a single entry whose
+/// alternating key/value tokens are joined by a literal `|`.
+abstract interface class PipeDelimitedEncodable {
+  /// Encodes this value using pipeDelimited style parameter encoding.
+  ///
+  /// The [paramName] is the parameter name of the single produced entry.
+  /// When [allowEmpty] is false, empty values throw an exception.
+  /// When [allowReserved] is true, reserved characters in keys and values are
+  /// kept literal; the `|` delimiter is unaffected.
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  });
+}
+
+/// Marker interface for types that support space-delimited object encoding.
+///
+/// Like [PipeDelimitedEncodable] but the alternating key/value tokens are
+/// joined by a pre-escaped `%20`.
+abstract interface class SpaceDelimitedEncodable {
+  /// Encodes this value using spaceDelimited style parameter encoding.
+  ///
+  /// The [paramName] is the parameter name of the single produced entry.
+  /// When [allowEmpty] is false, empty values throw an exception.
+  /// When [allowReserved] is true, reserved characters in keys and values are
+  /// kept literal; the `%20` delimiter is unaffected.
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  });
+}
+
 /// Marker interface for types that support JSON encoding.
 abstract interface class JsonEncodable {
   /// Converts this value to a JSON-compatible representation.
@@ -131,4 +168,6 @@ abstract interface class ParameterEncodable
         SimpleEncodable,
         FormEncodable,
         DeepObjectEncodable,
+        PipeDelimitedEncodable,
+        SpaceDelimitedEncodable,
         JsonEncodable {}

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -46,6 +46,34 @@ void _guardEmpty(Map<String, PropertyValue> map, {required bool allowEmpty}) {
   }
 }
 
+List<ParameterEntry> _delimitedEntries(
+  Map<String, PropertyValue> map,
+  String paramName, {
+  required String delimiter,
+  required bool allowEmpty,
+  required bool allowReserved,
+}) {
+  _guardEmpty(map, allowEmpty: allowEmpty);
+  if (map.isEmpty) {
+    return const [];
+  }
+
+  String encode(String value) => encodeUriValue(
+    value,
+    allowReserved: allowReserved,
+    useQueryComponent: false,
+  );
+  String encodeProperty(PropertyValue value) => switch (value) {
+    ScalarPropertyValue(:final value) => encode(value),
+    ArrayPropertyValue(:final values) => values.map(encode).join(delimiter),
+  };
+
+  final flattened = map.entries
+      .expand((e) => [encode(e.key), encodeProperty(e.value)])
+      .join(delimiter);
+  return [(name: paramName, value: flattened)];
+}
+
 /// Enforces empty-value and URI-escaping rules for object-valued parameters.
 extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Produces alternating key/value tokens with configurable URI escaping.
@@ -165,6 +193,35 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
     ];
     return [(name: paramName, value: parts.join(','))];
   }
+
+  /// Flattens the object to a single entry whose alternating key/value tokens
+  /// are joined by a literal `|`, matching tonik's array pipeDelimited
+  /// convention of keeping the delimiter unescaped.
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) => _delimitedEntries(
+    this,
+    paramName,
+    delimiter: '|',
+    allowEmpty: allowEmpty,
+    allowReserved: allowReserved,
+  );
+
+  /// Flattens the object to a single entry whose alternating key/value tokens
+  /// are joined by `%20`.
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) => _delimitedEntries(
+    this,
+    paramName,
+    delimiter: '%20',
+    allowEmpty: allowEmpty,
+    allowReserved: allowReserved,
+  );
 
   /// Keeps keys component-encoded when [allowReserved] preserves value bytes.
   /// Throws [EncodingException] for a non-explode call or an array value, and

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -196,13 +196,10 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
     return [(name: paramName, value: parts.join(','))];
   }
 
-  /// Flattens the object to a single entry whose alternating key/value tokens
-  /// are joined by a literal `|`, matching tonik's array pipeDelimited
-  /// convention of keeping the delimiter unescaped.
+  /// Joins the alternating key/value tokens with a literal `|`.
   ///
-  /// Array-valued properties join their elements with the literal `|`, so they
-  /// collapse into the same delimiter stream and cannot be round-tripped; this
-  /// ambiguity is inherent to the style, as with the form path.
+  /// Array-valued properties join their elements with the same `|`, so they
+  /// collapse irreversibly into the delimiter stream, as on the form path.
   List<ParameterEntry> toPipeDelimited(
     String paramName, {
     required bool allowEmpty,
@@ -215,14 +212,10 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
     allowReserved: allowReserved,
   );
 
-  /// Flattens the object to a single entry whose alternating key/value tokens
-  /// are joined by a pre-escaped `%20`, matching tonik's array spaceDelimited
-  /// convention. The delimiter stays pre-escaped so a literal space never
-  /// reaches the query string.
+  /// Joins the alternating key/value tokens with a pre-escaped `%20`.
   ///
-  /// A space inside a value, and array-valued properties, collapse into the
-  /// same delimiter stream and cannot be round-tripped; this ambiguity is
-  /// inherent to the style, as with the form path.
+  /// A value's own space also encodes to `%20`, so (like array-valued
+  /// properties) it collapses irreversibly into the delimiter stream.
   List<ParameterEntry> toSpaceDelimited(
     String paramName, {
     required bool allowEmpty,

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -65,6 +65,8 @@ List<ParameterEntry> _delimitedEntries(
   );
   String encodeProperty(PropertyValue value) => switch (value) {
     ScalarPropertyValue(:final value) => encode(value),
+    // Array elements collapse into the delimiter stream, indistinguishable
+    // from the key/value tokens, consistent with the form/toUri path.
     ArrayPropertyValue(:final values) => values.map(encode).join(delimiter),
   };
 
@@ -210,7 +212,9 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   );
 
   /// Flattens the object to a single entry whose alternating key/value tokens
-  /// are joined by `%20`.
+  /// are joined by a pre-escaped `%20`, matching tonik's array spaceDelimited
+  /// convention. The delimiter stays pre-escaped so a literal space never
+  /// reaches the query string.
   List<ParameterEntry> toSpaceDelimited(
     String paramName, {
     required bool allowEmpty,

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -196,10 +196,11 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
     return [(name: paramName, value: parts.join(','))];
   }
 
-  /// Joins the alternating key/value tokens with a literal `|`.
+  /// Joins the alternating key/value tokens with a `|`.
   ///
-  /// Array-valued properties join their elements with the same `|`, so they
-  /// collapse irreversibly into the delimiter stream, as on the form path.
+  /// On the wire the `|` is percent-encoded to `%7C`, identical to a `|`
+  /// inside a value, so keys, values, and array elements all collapse
+  /// irreversibly into the delimiter stream.
   List<ParameterEntry> toPipeDelimited(
     String paramName, {
     required bool allowEmpty,
@@ -214,8 +215,8 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
 
   /// Joins the alternating key/value tokens with a pre-escaped `%20`.
   ///
-  /// A value's own space also encodes to `%20`, so (like array-valued
-  /// properties) it collapses irreversibly into the delimiter stream.
+  /// A value's own space also encodes to `%20`, so keys, values, and array
+  /// elements all collapse irreversibly into the delimiter stream.
   List<ParameterEntry> toSpaceDelimited(
     String paramName, {
     required bool allowEmpty,

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -200,9 +200,9 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// are joined by a literal `|`, matching tonik's array pipeDelimited
   /// convention of keeping the delimiter unescaped.
   ///
-  /// A pipe inside a value, and array-valued properties, collapse into the
-  /// same delimiter stream and cannot be round-tripped; this ambiguity is
-  /// inherent to the style, as with the form path.
+  /// Array-valued properties join their elements with the literal `|`, so they
+  /// collapse into the same delimiter stream and cannot be round-tripped; this
+  /// ambiguity is inherent to the style, as with the form path.
   List<ParameterEntry> toPipeDelimited(
     String paramName, {
     required bool allowEmpty,

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -199,6 +199,10 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// Flattens the object to a single entry whose alternating key/value tokens
   /// are joined by a literal `|`, matching tonik's array pipeDelimited
   /// convention of keeping the delimiter unescaped.
+  ///
+  /// A pipe inside a value, and array-valued properties, collapse into the
+  /// same delimiter stream and cannot be round-tripped; this ambiguity is
+  /// inherent to the style, as with the form path.
   List<ParameterEntry> toPipeDelimited(
     String paramName, {
     required bool allowEmpty,
@@ -215,6 +219,10 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   /// are joined by a pre-escaped `%20`, matching tonik's array spaceDelimited
   /// convention. The delimiter stays pre-escaped so a literal space never
   /// reaches the query string.
+  ///
+  /// A space inside a value, and array-valued properties, collapse into the
+  /// same delimiter stream and cannot be round-tripped; this ambiguity is
+  /// inherent to the style, as with the form path.
   List<ParameterEntry> toSpaceDelimited(
     String paramName, {
     required bool allowEmpty,

--- a/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
@@ -1,0 +1,62 @@
+import 'package:tonik_util/src/encoding/encoding_exception.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
+
+/// Extensions flattening a `Map<String, String>` into a single delimited entry.
+///
+/// Both styles collapse the map to one [ParameterEntry] whose value is the
+/// alternating key/value tokens joined by the style delimiter, named by the
+/// caller-supplied parameter name. Tonik keeps the delimiter unescaped and
+/// URI-encodes every key
+/// and value, so a delimiter appearing inside a value is percent-encoded and
+/// stays distinct from the separator.
+extension StringMapDelimitedEncoder on Map<String, String> {
+  /// Joins the alternating key/value tokens with a literal `|`.
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) => _delimitedEntries(
+    paramName,
+    delimiter: '|',
+    allowEmpty: allowEmpty,
+    allowReserved: allowReserved,
+  );
+
+  /// Joins the alternating key/value tokens with a pre-escaped `%20`.
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) => _delimitedEntries(
+    paramName,
+    delimiter: '%20',
+    allowEmpty: allowEmpty,
+    allowReserved: allowReserved,
+  );
+
+  List<ParameterEntry> _delimitedEntries(
+    String paramName, {
+    required String delimiter,
+    required bool allowEmpty,
+    required bool allowReserved,
+  }) {
+    if (isEmpty && !allowEmpty) {
+      throw const EmptyValueException();
+    }
+    if (isEmpty) {
+      return const [];
+    }
+
+    String encode(String value) => encodeUriValue(
+      value,
+      allowReserved: allowReserved,
+      useQueryComponent: false,
+    );
+
+    final flattened = entries
+        .expand((e) => [encode(e.key), encode(e.value)])
+        .join(delimiter);
+    return [(name: paramName, value: flattened)];
+  }
+}

--- a/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
@@ -2,18 +2,11 @@ import 'package:tonik_util/src/encoding/encoding_exception.dart';
 import 'package:tonik_util/src/encoding/parameter_entry.dart';
 import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 
-/// Extensions flattening a `Map<String, String>` into a single delimited entry.
+/// Flattens a `Map<String, String>` into a single delimited [ParameterEntry].
 ///
-/// Both styles collapse the map to one [ParameterEntry] whose value is the
-/// alternating key/value tokens joined by the style delimiter, named by the
-/// caller-supplied parameter name. Map values are always scalars here, so there
-/// are no array-valued-property concerns.
-///
-/// Round-trip safety differs by style. Pipe uses a literal `|` separator while
-/// a `|` inside a value encodes to `%7C`, so the two stay distinct and the
-/// map round-trips. Space uses a pre-escaped `%20` separator, but a space
-/// inside a value also encodes to `%20`, making it indistinguishable from the
-/// separator — space-delimited values cannot round-trip.
+/// A value's `|` encodes to `%7C`, distinct from pipe's literal `|` separator,
+/// so pipeDelimited round-trips; spaceDelimited cannot, as a value's space and
+/// the `%20` separator are identical.
 extension StringMapDelimitedEncoder on Map<String, String> {
   /// Joins the alternating key/value tokens with a literal `|`.
   List<ParameterEntry> toPipeDelimited(

--- a/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
@@ -4,9 +4,9 @@ import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 
 /// Flattens a `Map<String, String>` into a single delimited [ParameterEntry].
 ///
-/// A value's `|` encodes to `%7C`, distinct from pipe's literal `|` separator,
-/// so pipeDelimited round-trips; spaceDelimited cannot, as a value's space and
-/// the `%20` separator are identical.
+/// On the wire both delimiters are percent-encoded (`|` as `%7C`, space as
+/// `%20`), so a delimiter character inside a value is indistinguishable from
+/// the structural delimiter for both styles — neither round-trips.
 extension StringMapDelimitedEncoder on Map<String, String> {
   /// Joins the alternating key/value tokens with a literal `|`.
   List<ParameterEntry> toPipeDelimited(

--- a/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/string_map_delimited_encoder_extensions.dart
@@ -6,10 +6,14 @@ import 'package:tonik_util/src/encoding/uri_value_encoder.dart';
 ///
 /// Both styles collapse the map to one [ParameterEntry] whose value is the
 /// alternating key/value tokens joined by the style delimiter, named by the
-/// caller-supplied parameter name. Tonik keeps the delimiter unescaped and
-/// URI-encodes every key
-/// and value, so a delimiter appearing inside a value is percent-encoded and
-/// stays distinct from the separator.
+/// caller-supplied parameter name. Map values are always scalars here, so there
+/// are no array-valued-property concerns.
+///
+/// Round-trip safety differs by style. Pipe uses a literal `|` separator while
+/// a `|` inside a value encodes to `%7C`, so the two stay distinct and the
+/// map round-trips. Space uses a pre-escaped `%20` separator, but a space
+/// inside a value also encodes to `%20`, making it indistinguishable from the
+/// separator — space-delimited values cannot round-trip.
 extension StringMapDelimitedEncoder on Map<String, String> {
   /// Joins the alternating key/value tokens with a literal `|`.
   List<ParameterEntry> toPipeDelimited(

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -27,6 +27,7 @@ export 'src/encoding/property_value_form_encoder.dart';
 export 'src/encoding/property_value_style_encoders.dart';
 export 'src/encoding/simple_encoder_extensions.dart';
 export 'src/encoding/space_delimited_encoder_extensions.dart';
+export 'src/encoding/string_map_delimited_encoder_extensions.dart';
 export 'src/encoding/unknown_value_encoding.dart';
 export 'src/encoding/uri_encoder_extensions.dart';
 export 'src/encoding_shape.dart';

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -79,6 +79,24 @@ class TestEncodableModel implements ParameterEncodable {
   }
 
   @override
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    return [(name: paramName, value: 'name|$name|value|$value')];
+  }
+
+  @override
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    return [(name: paramName, value: 'name%20$name%20value%20$value')];
+  }
+
+  @override
   Object? toJson() => {'name': name, 'value': value};
 }
 
@@ -164,6 +182,30 @@ class QueryComponentAwareEncodable implements ParameterEncodable {
   }) {
     if (allowReserved) {
       return [(name: '$paramName[k]', value: '$rawValue!reserved')];
+    }
+    throw UnimplementedError();
+  }
+
+  @override
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    if (allowReserved) {
+      return [(name: paramName, value: '$rawValue!reserved')];
+    }
+    throw UnimplementedError();
+  }
+
+  @override
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    if (allowReserved) {
+      return [(name: paramName, value: '$rawValue!reserved')];
     }
     throw UnimplementedError();
   }
@@ -2188,6 +2230,220 @@ void main() {
           );
         },
       );
+    });
+  });
+
+  group('encodeAnyToPipeDelimited', () {
+    group('ParameterEncodable', () {
+      test('delegates to the value toPipeDelimited', () {
+        const model = TestEncodableModel(name: 'test', value: 42);
+        final result = encodeAnyToPipeDelimited(
+          model,
+          'obj',
+          explode: false,
+          allowEmpty: false,
+        );
+        expect(result, [(name: 'obj', value: 'name|test|value|42')]);
+      });
+
+      test('forwards allowReserved to the value toPipeDelimited', () {
+        const model = QueryComponentAwareEncodable('value');
+        final result = encodeAnyToPipeDelimited(
+          model,
+          'obj',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+        expect(result, [(name: 'obj', value: 'value!reserved')]);
+      });
+    });
+
+    group('Map<String, String>', () {
+      test('flattens a map into a single pipe-joined entry', () {
+        final result = encodeAnyToPipeDelimited(
+          {'color': 'red', 'size': 'large'},
+          'filter',
+          explode: false,
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'filter', value: 'color|red|size|large')]);
+      });
+
+      test('omits an empty map when allowEmpty=true', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, String>{},
+          'filter',
+          explode: false,
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+    });
+
+    group('null handling', () {
+      test('encodes null as empty when allowEmpty=true', () {
+        expect(
+          encodeAnyToPipeDelimited(
+            null,
+            'obj',
+            explode: false,
+            allowEmpty: true,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('throws for null when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            null,
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+    });
+
+    group('unsupported types', () {
+      test('throws for a String value', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            'hello',
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for an int value', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            42,
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for an unsupported object type', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            Object(),
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+  });
+
+  group('encodeAnyToSpaceDelimited', () {
+    group('ParameterEncodable', () {
+      test('delegates to the value toSpaceDelimited', () {
+        const model = TestEncodableModel(name: 'test', value: 42);
+        final result = encodeAnyToSpaceDelimited(
+          model,
+          'obj',
+          explode: false,
+          allowEmpty: false,
+        );
+        expect(result, [(name: 'obj', value: 'name%20test%20value%2042')]);
+      });
+
+      test('forwards allowReserved to the value toSpaceDelimited', () {
+        const model = QueryComponentAwareEncodable('value');
+        final result = encodeAnyToSpaceDelimited(
+          model,
+          'obj',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+        );
+        expect(result, [(name: 'obj', value: 'value!reserved')]);
+      });
+    });
+
+    group('Map<String, String>', () {
+      test('flattens a map into a single %20-joined entry', () {
+        final result = encodeAnyToSpaceDelimited(
+          {'color': 'red', 'size': 'large'},
+          'filter',
+          explode: false,
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'filter', value: 'color%20red%20size%20large')]);
+      });
+
+      test('omits an empty map when allowEmpty=true', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, String>{},
+          'filter',
+          explode: false,
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+    });
+
+    group('null handling', () {
+      test('encodes null as empty when allowEmpty=true', () {
+        expect(
+          encodeAnyToSpaceDelimited(
+            null,
+            'obj',
+            explode: false,
+            allowEmpty: true,
+          ),
+          isEmpty,
+        );
+      });
+
+      test('throws for null when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            null,
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+    });
+
+    group('unsupported types', () {
+      test('throws for a String value', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            'hello',
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('throws for an unsupported object type', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            Object(),
+            'obj',
+            explode: false,
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
     });
   });
 

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2277,6 +2277,121 @@ void main() {
       });
     });
 
+    group('List<dynamic>', () {
+      test('joins string elements with a literal pipe', () {
+        final result = encodeAnyToPipeDelimited(
+          ['blue', 'black', 'brown'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: 'blue|black|brown')]);
+      });
+
+      test('joins numeric elements with a literal pipe', () {
+        final result = encodeAnyToPipeDelimited(
+          [1, 2, 3],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: '1|2|3')]);
+      });
+
+      test('uri-encodes elements while keeping the pipe delimiter literal', () {
+        final result = encodeAnyToPipeDelimited(
+          ['a b', 'c'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: 'a%20b|c')]);
+      });
+
+      test('omits an empty list when allowEmpty=true', () {
+        final result = encodeAnyToPipeDelimited(
+          <dynamic>[],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an empty list when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            <dynamic>[],
+            'p',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for a nested list element', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            [
+              [1, 2],
+            ],
+            'p',
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('flattens numeric values into a pipe-joined entry', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'R|100|G|200|B|150')]);
+      });
+
+      test('uri-encodes values while keeping the pipe delimiter literal', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{'note': 'a b'},
+          'q',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'q', value: 'note|a%20b')]);
+      });
+
+      test('omits an empty map when allowEmpty=true', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an empty map when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            <String, dynamic>{},
+            'color',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for a nested list value', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            <String, dynamic>{
+              'x': [1, 2],
+            },
+            'color',
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+
     group('null handling', () {
       test('encodes null as empty when allowEmpty=true', () {
         expect(
@@ -2378,6 +2493,94 @@ void main() {
           allowEmpty: true,
         );
         expect(result, isEmpty);
+      });
+    });
+
+    group('List<dynamic>', () {
+      test('joins string elements with a pre-escaped %20', () {
+        final result = encodeAnyToSpaceDelimited(
+          ['blue', 'black', 'brown'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: 'blue%20black%20brown')]);
+      });
+
+      test('omits an empty list when allowEmpty=true', () {
+        final result = encodeAnyToSpaceDelimited(
+          <dynamic>[],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an empty list when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            <dynamic>[],
+            'p',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for a nested list element', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            [
+              [1, 2],
+            ],
+            'p',
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+    });
+
+    group('Map<String, dynamic>', () {
+      test('flattens numeric values into a %20-joined entry', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, dynamic>{'R': 100, 'G': 200, 'B': 150},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'R%20100%20G%20200%20B%20150')]);
+      });
+
+      test('omits an empty map when allowEmpty=true', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, dynamic>{},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an empty map when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            <String, dynamic>{},
+            'color',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
+
+      test('throws for a nested map value', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            <String, dynamic>{
+              'x': <String, dynamic>{'y': 1},
+            },
+            'color',
+            allowEmpty: true,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
       });
     });
 

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2417,6 +2417,17 @@ void main() {
         );
       });
 
+      test('throws for an int value', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            42,
+            'obj',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EncodingException>()),
+        );
+      });
+
       test('throws for an unsupported object type', () {
         expect(
           () => encodeAnyToSpaceDelimited(

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2337,6 +2337,44 @@ void main() {
           throwsA(isA<EncodingException>()),
         );
       });
+
+      test('omits a null item while keeping the rest', () {
+        final result = encodeAnyToPipeDelimited(
+          [null, 'blue'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: 'blue')]);
+      });
+
+      test('preserves an empty-string item', () {
+        final result = encodeAnyToPipeDelimited(
+          ['', 'blue'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: '|blue')]);
+      });
+
+      test('omits an all-null list when allowEmpty=true', () {
+        final result = encodeAnyToPipeDelimited(
+          [null],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an all-null list when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            [null],
+            'p',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
     });
 
     group('Map<String, dynamic>', () {
@@ -2388,6 +2426,44 @@ void main() {
             allowEmpty: true,
           ),
           throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('omits a null member while keeping the rest', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{'R': null, 'G': 200},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'G|200')]);
+      });
+
+      test('preserves an empty-string member', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{'x': ''},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'x|')]);
+      });
+
+      test('omits an all-null map when allowEmpty=true', () {
+        final result = encodeAnyToPipeDelimited(
+          <String, dynamic>{'R': null},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an all-null map when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToPipeDelimited(
+            <String, dynamic>{'R': null},
+            'color',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
         );
       });
     });
@@ -2538,6 +2614,44 @@ void main() {
           throwsA(isA<EncodingException>()),
         );
       });
+
+      test('omits a null item while keeping the rest', () {
+        final result = encodeAnyToSpaceDelimited(
+          [null, 'blue'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: 'blue')]);
+      });
+
+      test('preserves an empty-string item', () {
+        final result = encodeAnyToSpaceDelimited(
+          ['', 'blue'],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'p', value: '%20blue')]);
+      });
+
+      test('omits an all-null list when allowEmpty=true', () {
+        final result = encodeAnyToSpaceDelimited(
+          [null],
+          'p',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an all-null list when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            [null],
+            'p',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
+        );
+      });
     });
 
     group('Map<String, dynamic>', () {
@@ -2580,6 +2694,44 @@ void main() {
             allowEmpty: true,
           ),
           throwsA(isA<EncodingException>()),
+        );
+      });
+
+      test('omits a null member while keeping the rest', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, dynamic>{'R': null, 'G': 200},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'G%20200')]);
+      });
+
+      test('preserves an empty-string member', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, dynamic>{'x': ''},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, [(name: 'color', value: 'x%20')]);
+      });
+
+      test('omits an all-null map when allowEmpty=true', () {
+        final result = encodeAnyToSpaceDelimited(
+          <String, dynamic>{'R': null},
+          'color',
+          allowEmpty: true,
+        );
+        expect(result, isEmpty);
+      });
+
+      test('throws for an all-null map when allowEmpty=false', () {
+        expect(
+          () => encodeAnyToSpaceDelimited(
+            <String, dynamic>{'R': null},
+            'color',
+            allowEmpty: false,
+          ),
+          throwsA(isA<EmptyValueException>()),
         );
       });
     });

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2240,7 +2240,6 @@ void main() {
         final result = encodeAnyToPipeDelimited(
           model,
           'obj',
-          explode: false,
           allowEmpty: false,
         );
         expect(result, [(name: 'obj', value: 'name|test|value|42')]);
@@ -2251,7 +2250,6 @@ void main() {
         final result = encodeAnyToPipeDelimited(
           model,
           'obj',
-          explode: false,
           allowEmpty: true,
           allowReserved: true,
         );
@@ -2264,7 +2262,6 @@ void main() {
         final result = encodeAnyToPipeDelimited(
           {'color': 'red', 'size': 'large'},
           'filter',
-          explode: false,
           allowEmpty: true,
         );
         expect(result, [(name: 'filter', value: 'color|red|size|large')]);
@@ -2274,7 +2271,6 @@ void main() {
         final result = encodeAnyToPipeDelimited(
           <String, String>{},
           'filter',
-          explode: false,
           allowEmpty: true,
         );
         expect(result, isEmpty);
@@ -2287,7 +2283,6 @@ void main() {
           encodeAnyToPipeDelimited(
             null,
             'obj',
-            explode: false,
             allowEmpty: true,
           ),
           isEmpty,
@@ -2299,7 +2294,6 @@ void main() {
           () => encodeAnyToPipeDelimited(
             null,
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EmptyValueException>()),
@@ -2313,7 +2307,6 @@ void main() {
           () => encodeAnyToPipeDelimited(
             'hello',
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EncodingException>()),
@@ -2325,7 +2318,6 @@ void main() {
           () => encodeAnyToPipeDelimited(
             42,
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EncodingException>()),
@@ -2337,7 +2329,6 @@ void main() {
           () => encodeAnyToPipeDelimited(
             Object(),
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EncodingException>()),
@@ -2353,7 +2344,6 @@ void main() {
         final result = encodeAnyToSpaceDelimited(
           model,
           'obj',
-          explode: false,
           allowEmpty: false,
         );
         expect(result, [(name: 'obj', value: 'name%20test%20value%2042')]);
@@ -2364,7 +2354,6 @@ void main() {
         final result = encodeAnyToSpaceDelimited(
           model,
           'obj',
-          explode: false,
           allowEmpty: true,
           allowReserved: true,
         );
@@ -2377,7 +2366,6 @@ void main() {
         final result = encodeAnyToSpaceDelimited(
           {'color': 'red', 'size': 'large'},
           'filter',
-          explode: false,
           allowEmpty: true,
         );
         expect(result, [(name: 'filter', value: 'color%20red%20size%20large')]);
@@ -2387,7 +2375,6 @@ void main() {
         final result = encodeAnyToSpaceDelimited(
           <String, String>{},
           'filter',
-          explode: false,
           allowEmpty: true,
         );
         expect(result, isEmpty);
@@ -2400,7 +2387,6 @@ void main() {
           encodeAnyToSpaceDelimited(
             null,
             'obj',
-            explode: false,
             allowEmpty: true,
           ),
           isEmpty,
@@ -2412,7 +2398,6 @@ void main() {
           () => encodeAnyToSpaceDelimited(
             null,
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EmptyValueException>()),
@@ -2426,7 +2411,6 @@ void main() {
           () => encodeAnyToSpaceDelimited(
             'hello',
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EncodingException>()),
@@ -2438,7 +2422,6 @@ void main() {
           () => encodeAnyToSpaceDelimited(
             Object(),
             'obj',
-            explode: false,
             allowEmpty: false,
           ),
           throwsA(isA<EncodingException>()),

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -660,4 +660,93 @@ void main() {
       );
     });
   });
+
+  group('PropertyValueStyleEncoders.toPipeDelimited', () {
+    test('flattens alternating key/value tokens joined by literal pipe', () {
+      const value = {
+        'R': PropertyValue.scalar('100'),
+        'G': PropertyValue.scalar('200'),
+        'B': PropertyValue.scalar('150'),
+      };
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'R|100|G|200|B|150')],
+      );
+    });
+
+    test('uri-encodes values while keeping the pipe delimiter literal', () {
+      const value = {
+        'note': PropertyValue.scalar('a b'),
+        'op': PropertyValue.scalar('x=y'),
+      };
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'note|a%20b|op|x%3Dy')],
+      );
+    });
+
+    test('joins array elements with the pipe delimiter', () {
+      const value = {
+        'tags': PropertyValue.array(['a', 'b']),
+      };
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'tags|a|b')],
+      );
+    });
+
+    test('omits an empty object when allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('empty object throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toPipeDelimited('color', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
+
+  group('PropertyValueStyleEncoders.toSpaceDelimited', () {
+    test('flattens alternating key/value tokens joined by %20', () {
+      const value = {
+        'R': PropertyValue.scalar('100'),
+        'G': PropertyValue.scalar('200'),
+        'B': PropertyValue.scalar('150'),
+      };
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'R%20100%20G%20200%20B%20150')],
+      );
+    });
+
+    test('uri-encodes values while keeping the space delimiter as %20', () {
+      const value = {'op': PropertyValue.scalar('x=y')};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'op%20x%3Dy')],
+      );
+    });
+
+    test('omits an empty object when allowEmpty=true', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('empty object throws with allowEmpty=false', () {
+      const value = <String, PropertyValue>{};
+      expect(
+        () => value.toSpaceDelimited('coord', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
 }

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -695,6 +695,32 @@ void main() {
       );
     });
 
+    test('percent-encodes reserved key and value chars without allowReserved',
+        () {
+      const value = {'a/b': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'a%2Fb|a%2Fb%3Ac')],
+      );
+    });
+
+    test('keeps reserved key and value chars literal with allowReserved', () {
+      const value = {'a/b': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true, allowReserved: true),
+        [(name: 'color', value: 'a/b|a/b:c')],
+      );
+    });
+
+    test('percent-encodes a pipe inside a value, keeping the delimiter literal',
+        () {
+      const value = {'a': PropertyValue.scalar('x|y')};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'a|x%7Cy')],
+      );
+    });
+
     test('omits an empty object when allowEmpty=true', () {
       const value = <String, PropertyValue>{};
       expect(
@@ -730,6 +756,41 @@ void main() {
       expect(
         value.toSpaceDelimited('coord', allowEmpty: true),
         [(name: 'coord', value: 'op%20x%3Dy')],
+      );
+    });
+
+    test('joins array elements with the space delimiter', () {
+      const value = {
+        'tags': PropertyValue.array(['a', 'b']),
+      };
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'tags%20a%20b')],
+      );
+    });
+
+    test('percent-encodes reserved key and value chars without allowReserved',
+        () {
+      const value = {'a/b': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'a%2Fb%20a%2Fb%3Ac')],
+      );
+    });
+
+    test('keeps reserved key and value chars literal with allowReserved', () {
+      const value = {'a/b': PropertyValue.scalar('a/b:c')};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true, allowReserved: true),
+        [(name: 'coord', value: 'a/b%20a/b:c')],
+      );
+    });
+
+    test('a space inside a value becomes %20, matching the delimiter', () {
+      const value = {'a': PropertyValue.scalar('x y')};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'a%20x%20y')],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -695,6 +695,27 @@ void main() {
       );
     });
 
+    test('percent-encodes a pipe inside an array element, join stays literal',
+        () {
+      const value = {
+        'tags': PropertyValue.array(['a|b', 'c']),
+      };
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'tags|a%7Cb|c')],
+      );
+    });
+
+    test('empty array-valued property yields a trailing pipe token', () {
+      const value = {
+        'tags': PropertyValue.array(<String>[]),
+      };
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'tags|')],
+      );
+    });
+
     test('percent-encodes reserved key and value chars without allowReserved',
         () {
       const value = {'a/b': PropertyValue.scalar('a/b:c')};
@@ -766,6 +787,26 @@ void main() {
       expect(
         value.toSpaceDelimited('coord', allowEmpty: true),
         [(name: 'coord', value: 'tags%20a%20b')],
+      );
+    });
+
+    test('percent-encodes a space inside an array element, join stays %20', () {
+      const value = {
+        'tags': PropertyValue.array(['a b', 'c']),
+      };
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'tags%20a%20b%20c')],
+      );
+    });
+
+    test('empty array-valued property yields a trailing %20 token', () {
+      const value = {
+        'tags': PropertyValue.array(<String>[]),
+      };
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'tags%20')],
       );
     });
 

--- a/packages/tonik_util/test/src/encoding/string_map_delimited_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/string_map_delimited_encoder_extensions_test.dart
@@ -1,0 +1,115 @@
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  group('StringMapDelimitedEncoder.toPipeDelimited', () {
+    test('flattens alternating key/value tokens joined by literal pipe', () {
+      const value = {'R': '100', 'G': '200', 'B': '150'};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'R|100|G|200|B|150')],
+      );
+    });
+
+    test('uri-encodes keys and values while keeping the pipe literal', () {
+      const value = {'note': 'a b', 'op': 'x=y'};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'note|a%20b|op|x%3Dy')],
+      );
+    });
+
+    test('percent-encodes a pipe inside a value, keeping the delimiter literal',
+        () {
+      const value = {'a': 'x|y'};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'a|x%7Cy')],
+      );
+    });
+
+    test('percent-encodes reserved key and value chars without allowReserved',
+        () {
+      const value = {'a/b': 'a/b:c'};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        [(name: 'color', value: 'a%2Fb|a%2Fb%3Ac')],
+      );
+    });
+
+    test('keeps reserved key and value chars literal with allowReserved', () {
+      const value = {'a/b': 'a/b:c'};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true, allowReserved: true),
+        [(name: 'color', value: 'a/b|a/b:c')],
+      );
+    });
+
+    test('omits an empty map when allowEmpty=true', () {
+      const value = <String, String>{};
+      expect(
+        value.toPipeDelimited('color', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, String>{};
+      expect(
+        () => value.toPipeDelimited('color', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
+
+  group('StringMapDelimitedEncoder.toSpaceDelimited', () {
+    test('flattens alternating key/value tokens joined by %20', () {
+      const value = {'R': '100', 'G': '200', 'B': '150'};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'R%20100%20G%20200%20B%20150')],
+      );
+    });
+
+    test('a space inside a value becomes %20, matching the delimiter', () {
+      const value = {'a': 'x y'};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'a%20x%20y')],
+      );
+    });
+
+    test('percent-encodes reserved key and value chars without allowReserved',
+        () {
+      const value = {'a/b': 'a/b:c'};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        [(name: 'coord', value: 'a%2Fb%20a%2Fb%3Ac')],
+      );
+    });
+
+    test('keeps reserved key and value chars literal with allowReserved', () {
+      const value = {'a/b': 'a/b:c'};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true, allowReserved: true),
+        [(name: 'coord', value: 'a/b%20a/b:c')],
+      );
+    });
+
+    test('omits an empty map when allowEmpty=true', () {
+      const value = <String, String>{};
+      expect(
+        value.toSpaceDelimited('coord', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('empty map throws with allowEmpty=false', () {
+      const value = <String, String>{};
+      expect(
+        () => value.toSpaceDelimited('coord', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+  });
+}


### PR DESCRIPTION
## Problem

Object-typed `pipeDelimited` and `spaceDelimited` query parameters emitted an unconditional `throw EncodingException('… only supports list types')` in the generated `_queryParameters` body. The code compiled cleanly (`dart analyze` reported no issues), so the failure was invisible until the operation was invoked — at which point *every* call failed regardless of input, and no request could be built.

## Standard

The OpenAPI style table (OAS 3.0.4 / 3.1.1, Parameter Object → Style Values / Style Examples) defines both styles for `type: array, object` in query parameters. For an object with `explode: false`, the object flattens to a single query key using the same key/value flattening as `form`, swapping the `,` delimiter:

| style | object serialization |
|---|---|
| pipeDelimited | `color=R\|100\|G\|200\|B\|150` |
| spaceDelimited | `coord=R%20100%20G%20200%20B%20150` |

`explode: true` on an object is left undefined by the spec (and `explode` defaults to `false` for these styles).

## Fix

- Add `toPipeDelimited` / `toSpaceDelimited` object-flattening encoders on `Map<String, PropertyValue>`, alongside the existing `toUri` / `toSimple` / `toLabel` / `toMatrix` encoders. Each flattens the object to a single entry of alternating URI-encoded key/value tokens joined by the delimiter.
- Route object query parameters through `parameterProperties()`, mirroring the `form` path, instead of hitting the list-only guard.
- The pipe delimiter is kept **literal** to match tonik's existing array `pipeDelimited` behavior (the URI layer renders it as `%7C` on the wire); the space delimiter is `%20`.
- `explode: true` on an object now throws a contextual `EncodingException` accurately stating the case is undefined by the specification, replacing the misleading list-only message. Primitives and unsupported list content continue to throw with context.

## Tests

- Runtime encoder unit tests (tonik_util): flatten, value percent-encoding with literal delimiter, array-valued property, empty-object omission / throw.
- Generator unit tests (tonik_generate): full method-body comparisons for the flattening call (both styles), `allowReserved` threading, the explode:true throw, and the primitive throw.
- Integration tests: `pipeDelimited` and `spaceDelimited` object query parameters now succeed end-to-end with the flattened wire query; nested-object, primitive, and explode:true cases remain contextual errors.