### PR TITLE
Drop spurious '=' for empty members in label object params

### DIFF
--- a/integration_test/path_encoding/path_encoding_test/test/label_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/label_test.dart
@@ -236,7 +236,7 @@ void main() {
       );
     });
 
-    test('object with empty property (explode=true) keeps trailing equals',
+    test('object with empty property (explode=true) drops the trailing equals',
         () async {
       final api = buildLabelApi();
       final response = await api.testLabelObjectExplode(
@@ -249,7 +249,7 @@ void main() {
 
       expect(
         success.response.requestOptions.uri.path,
-        '/v1/label/object/explode/.name=.count=5',
+        '/v1/label/object/explode/.name.count=5',
       );
     });
 

--- a/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
@@ -119,10 +119,16 @@ extension LabelStringMapEncoder on Map<String, String> {
     if (explode) {
       return entries.map(
         (entry) {
+          final key = Uri.encodeComponent(entry.key);
+          // Label uses ifemp="": an empty member expands to the name alone,
+          // without '='. Only form-style '?'/'&' keep the '='.
+          if (entry.value.isEmpty) {
+            return '.$key';
+          }
           final value = alreadyEncoded
               ? entry.value
               : entry.value.uriEncode(allowEmpty: allowEmpty);
-          return '.${Uri.encodeComponent(entry.key)}=$value';
+          return '.$key=$value';
         },
       ).join();
     } else {

--- a/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
@@ -120,8 +120,6 @@ extension LabelStringMapEncoder on Map<String, String> {
       return entries.map(
         (entry) {
           final key = Uri.encodeComponent(entry.key);
-          // Label uses ifemp="": an empty member expands to the name alone,
-          // without '='. Only form-style '?'/'&' keep the '='.
           if (entry.value.isEmpty) {
             return '.$key';
           }

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -106,13 +106,18 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return '.';
     }
     if (explode) {
-      return entries
-          .map(
-            (e) =>
-                '.${Uri.encodeComponent(e.key)}='
-                '${_encodeValue(e.value, literal: false)}',
-          )
-          .join();
+      // Label uses ifemp="": an empty member expands to the name alone,
+      // without '='. Only form-style '?'/'&' keep the '='.
+      return entries.map((e) {
+        final key = Uri.encodeComponent(e.key);
+        final isValueEmpty = switch (e.value) {
+          ScalarPropertyValue(:final value) => value.isEmpty,
+          ArrayPropertyValue(:final values) => values.isEmpty,
+        };
+        return isValueEmpty
+            ? '.$key'
+            : '.$key=${_encodeValue(e.value, literal: false)}';
+      }).join();
     }
     return '.${_collapsedPairs(this, literal: false)}';
   }

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -106,8 +106,6 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return '.';
     }
     if (explode) {
-      // Label uses ifemp="": an empty member expands to the name alone,
-      // without '='. Only form-style '?'/'&' keep the '='.
       return entries.map((e) {
         final key = Uri.encodeComponent(e.key);
         final isValueEmpty = switch (e.value) {

--- a/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
@@ -252,6 +252,21 @@ void main() {
       );
     });
 
+    test('empty value renders name-only when exploded', () {
+      expect(
+        {'k': ''}.toLabel(explode: true, allowEmpty: true),
+        '.k',
+      );
+    });
+
+    test('empty value beside a filled value renders name-only when exploded',
+        () {
+      expect(
+        {'color': '', 'size': 'xl'}.toLabel(explode: true, allowEmpty: true),
+        '.color.size=xl',
+      );
+    });
+
     test('encodes empty object when allowEmpty is true', () {
       expect(
         <String, String>{}.toLabel(explode: false, allowEmpty: true),

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -283,22 +283,25 @@ void main() {
       );
     });
 
-    test('empty scalar renders with allowEmpty=true', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=true',
+        () {
       const value = {'k': PropertyValue.scalar('')};
       expect(value.toLabel(explode: false, allowEmpty: true), '.k,');
-      expect(value.toLabel(explode: true, allowEmpty: true), '.k=');
+      expect(value.toLabel(explode: true, allowEmpty: true), '.k');
     });
 
-    test('empty scalar renders with allowEmpty=false', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.scalar('')};
       expect(value.toLabel(explode: false, allowEmpty: false), '.k,');
-      expect(value.toLabel(explode: true, allowEmpty: false), '.k=');
+      expect(value.toLabel(explode: true, allowEmpty: false), '.k');
     });
 
-    test('empty array renders empty value with allowEmpty=false', () {
+    test('empty array renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.array(<String>[])};
       expect(value.toLabel(explode: false, allowEmpty: false), '.k,');
-      expect(value.toLabel(explode: true, allowEmpty: false), '.k=');
+      expect(value.toLabel(explode: true, allowEmpty: false), '.k');
     });
 
     test('empty scalar beside a filled scalar renders with allowEmpty=false',
@@ -313,7 +316,7 @@ void main() {
       );
       expect(
         value.toLabel(explode: true, allowEmpty: false),
-        '.color=.size=xl',
+        '.color.size=xl',
       );
     });
 


### PR DESCRIPTION
## Summary

For a `style: label`, `explode: true` object parameter, RFC 6570 requires an object member whose value is the empty string to expand to the key alone (`.name`, no `=`) — the label operator is unnamed with `ifemp = ""`, so the `=` is dropped. Only the form-style `?`/`&` operators keep the `=`. Both label object encoders emitted `.name=` unconditionally, while the sibling `matrix` encoder in the same file already handled the empty case correctly.

For `{ name: "", active: "true" }`:

- Before: `.name=.active=true`
- After:  `.name.active=true`

## Changes

- `toLabel` on `Map<String, PropertyValue>` now emits `.name` (no `=`) for an empty member, using the same empty-value check as `toMatrix`.
- `LabelStringMapEncoder.toLabel` (free-form / `additionalProperties` maps) applies the same check.
- Keys remain percent-encoded in both the empty and non-empty branches.
- Updated the unit and path-encoding integration expectations; added empty-value map coverage.

A one-element array holding an empty string (`['']`) is not an empty array and still renders `.k=`, matching the matrix behavior.

## Testing

- `tonik_util`: all tests pass; `dart analyze` clean.