### PR TITLE
Drop spurious '=' for empty members in simple object params

### DIFF
--- a/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/simple_test.dart
@@ -140,7 +140,7 @@ void main() {
     );
 
     test(
-      'object with empty property (explode=true) keeps trailing equals',
+      'object with empty property (explode=true) drops the trailing equals',
       () async {
         final api = buildSimpleApi();
         final response = await api.testSimpleSpecialKeysExplode(
@@ -153,7 +153,7 @@ void main() {
 
         expect(
           success.response.requestOptions.uri.path,
-          '/v1/simple/special-keys/explode/my.field=,a%3Db=42',
+          '/v1/simple/special-keys/explode/my.field,a%3Db=42',
         );
       },
     );

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -88,13 +88,18 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return '';
     }
     if (explode) {
-      return entries
-          .map(
-            (e) =>
-                '${_encodeKey(e.key, literal: literal)}='
-                '${_encodeValue(e.value, literal: literal)}',
-          )
-          .join(',');
+      // Simple uses ifemp="": an empty member expands to the name alone,
+      // without '='. Only form-style '?'/'&' keep the '='.
+      return entries.map((e) {
+        final key = _encodeKey(e.key, literal: literal);
+        final isValueEmpty = switch (e.value) {
+          ScalarPropertyValue(:final value) => value.isEmpty,
+          ArrayPropertyValue(:final values) => values.isEmpty,
+        };
+        return isValueEmpty
+            ? key
+            : '$key=${_encodeValue(e.value, literal: literal)}';
+      }).join(',');
     }
     return _collapsedPairs(this, literal: literal);
   }

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -88,8 +88,6 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
       return '';
     }
     if (explode) {
-      // Simple uses ifemp="": an empty member expands to the name alone,
-      // without '='. Only form-style '?'/'&' keep the '='.
       return entries.map((e) {
         final key = _encodeKey(e.key, literal: literal);
         final isValueEmpty = switch (e.value) {

--- a/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
@@ -146,16 +146,18 @@ extension SimpleStringMapEncoder on Map<String, String> {
       if (isEmpty) {
         return '';
       }
-      if (literal) {
-        return entries.map((e) => '${e.key}=${e.value}').join(',');
-      }
-      return entries
-          .map(
-            (e) =>
-                '${Uri.encodeComponent(e.key)}='
-                '${alreadyEncoded ? e.value : Uri.encodeComponent(e.value)}',
-          )
-          .join(',');
+      // Simple uses ifemp="": an empty member expands to the name alone,
+      // without '='. Only form-style '?'/'&' keep the '='.
+      return entries.map((e) {
+        final key = literal ? e.key : Uri.encodeComponent(e.key);
+        if (e.value.isEmpty) {
+          return key;
+        }
+        final value = literal
+            ? e.value
+            : (alreadyEncoded ? e.value : Uri.encodeComponent(e.value));
+        return '$key=$value';
+      }).join(',');
     } else {
       // explode=false: use uriEncode for key,value pairs
       return uriEncode(

--- a/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/simple_encoder_extensions.dart
@@ -146,8 +146,6 @@ extension SimpleStringMapEncoder on Map<String, String> {
       if (isEmpty) {
         return '';
       }
-      // Simple uses ifemp="": an empty member expands to the name alone,
-      // without '='. Only form-style '?'/'&' keep the '='.
       return entries.map((e) {
         final key = literal ? e.key : Uri.encodeComponent(e.key);
         if (e.value.isEmpty) {

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -126,22 +126,25 @@ void main() {
       );
     });
 
-    test('empty scalar renders with allowEmpty=true', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=true',
+        () {
       const value = {'k': PropertyValue.scalar('')};
       expect(value.toSimple(explode: false, allowEmpty: true), 'k,');
-      expect(value.toSimple(explode: true, allowEmpty: true), 'k=');
+      expect(value.toSimple(explode: true, allowEmpty: true), 'k');
     });
 
-    test('empty scalar renders with allowEmpty=false', () {
+    test('empty scalar renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.scalar('')};
       expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
-      expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'k');
     });
 
-    test('empty array renders empty value with allowEmpty=false', () {
+    test('empty array renders name-only when exploded with allowEmpty=false',
+        () {
       const value = {'k': PropertyValue.array(<String>[])};
       expect(value.toSimple(explode: false, allowEmpty: false), 'k,');
-      expect(value.toSimple(explode: true, allowEmpty: false), 'k=');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'k');
     });
 
     test('empty scalar beside a filled scalar renders with allowEmpty=false',
@@ -156,14 +159,15 @@ void main() {
       );
       expect(
         value.toSimple(explode: true, allowEmpty: false),
-        'color=,size=xl',
+        'color,size=xl',
       );
     });
 
-    test('empty array renders empty value with allowEmpty=true', () {
+    test('empty array renders name-only when exploded with allowEmpty=true',
+        () {
       const value = {'k': PropertyValue.array(<String>[])};
       expect(value.toSimple(explode: false, allowEmpty: true), 'k,');
-      expect(value.toSimple(explode: true, allowEmpty: true), 'k=');
+      expect(value.toSimple(explode: true, allowEmpty: true), 'k');
     });
 
     test('single empty-string element is not an empty array and never throws',

--- a/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/simple_encoder_extensions_test.dart
@@ -910,7 +910,7 @@ void main() {
         const value = {'': 'empty_key', 'empty_value': ''};
         expect(
           value.toSimple(explode: true, allowEmpty: true),
-          '=empty_key,empty_value=',
+          '=empty_key,empty_value',
         );
       });
 
@@ -1232,7 +1232,7 @@ void main() {
             allowEmpty: true,
             alreadyEncoded: true,
           ),
-          'key1=,key2=value',
+          'key1,key2=value',
         );
       });
 


### PR DESCRIPTION
## Summary

For a `style: simple`, `explode: true` object parameter, RFC 6570 requires an object member whose value is the empty string to expand to the key alone (`name`, no `=`) — simple is the default (unnamed) operator with `ifemp = ""`, so the `=` is dropped. Only the form-style `?`/`&` operators keep it. Both simple object encoders emitted `name=` unconditionally, while the sibling `matrix` encoder already handled the empty case correctly. `simple` is the default style for `in: header` and `in: path`, so this is the most-reached of the styles with this defect.

For `{ role: "admin", name: "" }` (`style: simple, explode: true`):

- Before: `role=admin,name=`
- After:  `role=admin,name`

## Changes

- `toSimple` on `Map<String, PropertyValue>` now emits `name` (no `=`) for an empty member, using the same empty-value check as `toMatrix`, preserving the `literal` header-field-value path.
- `SimpleStringMapEncoder.toSimple` (free-form / `additionalProperties` maps) applies the same check across both its literal and URI-encoded paths.
- Keys remain encoded in both the empty and non-empty branches.
- Updated unit and path-encoding integration expectations.

A one-element array holding an empty string (`['']`) is not an empty array and still renders `k=`, matching the matrix behavior.

## Testing

- `tonik_util`: all tests pass; `dart analyze` clean.