### PR TITLE
Preserve empty scalar values in deep object query parameters

### DIFF
--- a/integration_test/query_parameters/query_parameters_test/test/deep_object_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/deep_object_test.dart
@@ -326,6 +326,20 @@ void main() {
       );
     });
 
+    test('class with an empty scalar member', () async {
+      final api = buildQueryApi(responseStatus: '204');
+      final response = await api.testDeepObjectComplexExplode(
+        $class: const Class(name: '', age: 1),
+      );
+
+      expect(response, isA<TonikSuccess<void>>());
+      final success = response as TonikSuccess<void>;
+      expect(
+        success.response.requestOptions.uri.query,
+        'class%5Bname%5D=&class%5Bage%5D=1',
+      );
+    });
+
     test('classNested', () async {
       final api = buildQueryApi(responseStatus: '204');
       final response = await api.testDeepObjectComplexExplode(

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -174,7 +174,7 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
 
   /// Keeps keys component-encoded when [allowReserved] preserves value bytes.
   /// Throws [EncodingException] for a non-explode call or an array value, and
-  /// [EmptyValueException] on an empty map or value under `allowEmpty: false`.
+  /// [EmptyValueException] on an empty map under `allowEmpty: false`.
   List<ParameterEntry> toDeepObject(
     String paramName, {
     required bool explode,
@@ -195,9 +195,6 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
             'Lists are not supported in this encoding style',
           );
         case ScalarPropertyValue(:final value):
-          if (value.isEmpty && !allowEmpty) {
-            throw const EmptyValueException();
-          }
           result.add((
             name: '$paramName[${Uri.encodeComponent(entry.key)}]',
             value: encodeUriValue(

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -659,11 +659,26 @@ void main() {
       );
     });
 
-    test('empty scalar throws with allowEmpty=false', () {
+    test('empty scalar renders empty value with allowEmpty=false', () {
       const value = {'k': PropertyValue.scalar('')};
       expect(
-        () => value.toDeepObject('p', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        value.toDeepObject('p', explode: true, allowEmpty: false),
+        [(name: 'p[k]', value: '')],
+      );
+    });
+
+    test('empty scalar beside a filled scalar renders with allowEmpty=false',
+        () {
+      const value = {
+        'empty': PropertyValue.scalar(''),
+        'filled': PropertyValue.scalar('x'),
+      };
+      expect(
+        value.toDeepObject('p', explode: true, allowEmpty: false),
+        [
+          (name: 'p[empty]', value: ''),
+          (name: 'p[filled]', value: 'x'),
+        ],
       );
     });
   });


### PR DESCRIPTION
## Summary
- Allow empty scalar members in deep object query parameters.
- Continue rejecting empty maps when empty values are disallowed.
- Add utility and integration coverage for empty scalar encoding.

## Testing
- Added and updated unit and integration tests for empty scalar deep object values.