### PR TITLE
Encode empty path parameter arrays regardless of allowEmpty

### DIFF
--- a/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/label_encoder_extensions.dart
@@ -67,6 +67,9 @@ extension LabelBigDecimalEncoder on BigDecimal {
 extension LabelStringListEncoder on List<String> {
   /// Encodes this List value using label style encoding.
   ///
+  /// Empty lists are encoded as `.` regardless of [allowEmpty]. OpenAPI's
+  /// `allowEmptyValue` field does not apply to path parameters.
+  ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URI-encoded and should not be encoded again.
   String toLabel({
@@ -74,9 +77,6 @@ extension LabelStringListEncoder on List<String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     if (isEmpty) {
       return '.';
     }

--- a/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
@@ -105,9 +105,8 @@ extension MatrixStringListEncoder on List<String> {
   /// When [explode] is true, array items are separately encoded.
   /// When false, they are encoded as a single string with comma delimiters.
   ///
-  /// The [allowEmpty] parameter controls whether empty lists are allowed:
-  /// - When `true`, empty lists are encoded as `;paramName`
-  /// - When `false`, empty lists throw an exception
+  /// Empty lists are encoded as `;paramName` regardless of [allowEmpty].
+  /// OpenAPI's `allowEmptyValue` field does not apply to path parameters.
   ///
   /// The [alreadyEncoded] parameter indicates whether the list items are
   /// already URL-encoded. When `true`, items are not re-encoded to prevent
@@ -118,9 +117,6 @@ extension MatrixStringListEncoder on List<String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     if (isEmpty) {
       return ';$paramName';
     }

--- a/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/label_encoder_extensions_test.dart
@@ -178,20 +178,19 @@ void main() {
       );
     });
 
-    test('throws exception for empty List when allowEmpty is false', () {
+    test('encodes empty List when allowEmpty is false', () {
       expect(
-        () => <String>[].toLabel(explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        <String>[].toLabel(explode: false, allowEmpty: false),
+        '.',
       );
     });
 
     test(
-      'throws exception for empty List with explode=true '
-      'when allowEmpty is false',
+      'encodes empty List with explode=true when allowEmpty is false',
       () {
         expect(
-          () => <String>[].toLabel(explode: true, allowEmpty: false),
-          throwsA(isA<EmptyValueException>()),
+          <String>[].toLabel(explode: true, allowEmpty: false),
+          '.',
         );
       },
     );

--- a/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
@@ -231,8 +231,8 @@ void main() {
     test('encodes empty list with explode=false and allowEmpty=false', () {
       final list = <String>[];
       expect(
-        () => list.toMatrix('colors', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        list.toMatrix('colors', explode: false, allowEmpty: false),
+        ';colors',
       );
     });
 
@@ -247,8 +247,8 @@ void main() {
     test('encodes empty list with explode=true and allowEmpty=false', () {
       final list = <String>[];
       expect(
-        () => list.toMatrix('colors', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
+        list.toMatrix('colors', explode: true, allowEmpty: false),
+        ';colors',
       );
     });
 


### PR DESCRIPTION
## Summary

- Encode empty label-style arrays as `.` regardless of `allowEmpty`.
- Encode empty matrix-style arrays as `;paramName` regardless of `allowEmpty`.
- Clarify that `allowEmptyValue` does not apply to path parameters.
- Update label and matrix encoder tests.

## Testing

- Updated unit tests cover empty arrays with both explode settings.