### PR TITLE
feat: support response charsets

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -11,6 +11,7 @@ Tonik is a Dart code generator for OpenAPI 3 specifications. This document provi
 | **No name conflicts** | Schema names like `Error`, `Response`, `List` work without collisions |
 | **Integer enums** | Full support, with optional unknown-value handling |
 | **All encoding styles** | `simple`, `label`, `matrix`, `form`, `deepObject`, `spaceDelimited`, `pipeDelimited` |
+| **Text response charsets** | Decodes legacy response encodings declared by `Content-Type`, including ISO-8859, Windows code pages, and common East Asian encodings |
 | **readOnly / writeOnly** | Properties excluded from the correct serialization direction automatically |
 | **Server variables** | URL templating with enum constraints and runtime substitution |
 | **Immutable collections** | Optional `IList`/`IMap` from [fast_immutable_collections](https://pub.dev/packages/fast_immutable_collections) with automatic serialization |
@@ -128,6 +129,16 @@ precedence over `*/*`. For example, if a response declares both
 `application/json` and `application/*`, an `application/json; charset=utf-8`
 response uses the exact JSON variant, while `application/problem+json` can
 match the `application/*` variant.
+
+For responses classified as text, Tonik also honors the runtime `charset`
+parameter. UTF-8 remains the default when the parameter is absent. Supported
+encodings include ASCII, ISO-8859-1 through ISO-8859-11 and ISO-8859-13 through
+ISO-8859-16, Windows-874 and Windows-1250 through Windows-1258, Shift_JIS,
+EUC-JP, EUC-KR, GBK, and UTF-16/UTF-32. Charset names and aliases are resolved
+by [`package:charset`](https://pub.dev/packages/charset). Unknown charsets fail
+with a `ResponseDecodingException` instead of silently falling back to UTF-8.
+GB18030 is not accepted because the dependency only provides a GBK codec for
+that label. JSON responses remain UTF-8, as required by the JSON specification.
 
 Error types on `TonikError`: `encoding`, `decoding`, `network`, `cancelled`, `other`.
 
@@ -299,6 +310,7 @@ Each operation generates a sealed response class. Every status code and content 
 | Distinct type per status code | ✅ |
 | Distinct type per content type | ✅ |
 | Response media-type ranges | ✅ (`type/*`, `*/*`) |
+| Text response charsets | ✅ (from runtime `Content-Type`) |
 | Exhaustive pattern matching | ✅ |
 | Range codes (`2XX`, `4XX`) | ✅ |
 | `default` response | ✅ |

--- a/docs/features.md
+++ b/docs/features.md
@@ -134,11 +134,13 @@ For responses classified as text, Tonik also honors the runtime `charset`
 parameter. UTF-8 remains the default when the parameter is absent. Supported
 encodings include ASCII, ISO-8859-1 through ISO-8859-11 and ISO-8859-13 through
 ISO-8859-16, Windows-874 and Windows-1250 through Windows-1258, Shift_JIS,
-EUC-JP, EUC-KR, GBK, and UTF-16/UTF-32. Charset names and aliases are resolved
+EUC-JP, GBK, and UTF-16/UTF-32. Charset names and aliases are resolved
 by [`package:charset`](https://pub.dev/packages/charset). Unknown charsets fail
 with a `ResponseDecodingException` instead of silently falling back to UTF-8.
 GB18030 is not accepted because the dependency only provides a GBK codec for
-that label. JSON responses remain UTF-8, as required by the JSON specification.
+that label. EUC-KR is also rejected because the dependency's decoder produces
+incorrect Unicode. JSON responses remain UTF-8, as required by the JSON
+specification.
 
 Error types on `TonikError`: `encoding`, `decoding`, `network`, `cancelled`, `other`.
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -18,7 +18,6 @@
   - `patternProperties` for regex-matched property schemas
   - `propertyNames` for property name validation
 - Supporting the `not` keyword
-- Support for non utf8 encodings, for example Content-Type: `text/plain; charset=iso-8859-1`
 
 ## Non-goals
 

--- a/integration_test/medama/medama_test/imposter/response.groovy
+++ b/integration_test/medama/medama_test/imposter/response.groovy
@@ -1,6 +1,7 @@
 // Get the response status from the request header
 def headers = context.request.headers
 def responseStatus = headers['X-Response-Status'] ?: headers['x-response-status'] ?: '200'
+def responseCharsetCase = headers['X-Response-Charset-Case'] ?: headers['x-response-charset-case']
 def statusCode = Integer.parseInt(responseStatus)
 
 // Add required headers based on endpoint and status code
@@ -24,14 +25,52 @@ if (path == '/auth/login' && method == 'POST' && statusCode == 200) {
 
 // Event ping endpoint (path may include query parameters)
 else if (path.startsWith('/event/ping') && method == 'GET' && statusCode == 200) {
-    respond()
+    def response = respond()
         .withStatusCode(statusCode)
-        .withHeader('Content-Type', 'text/plain')
         .withHeader('Last-Modified', 'Thu, 09 Jan 2026 00:00:00 GMT')
         .withHeader('Cache-Control', 'max-age=86400')
         .withHeader('X-Api-Commit', 'abc123def456')
-        .withContent('OK')
-        .usingDefaultBehaviour()
+
+    def charsetResponses = [
+        'utf8-default': [contentType: 'text/plain', file: 'charset-fixtures/utf8.bin'],
+        'utf8-alias': [contentType: 'text/plain; charset=utf8', file: 'charset-fixtures/utf8.bin'],
+        'quoted-uppercase-utf8': [contentType: 'Text/Plain; Charset="UTF-8"', file: 'charset-fixtures/utf8.bin'],
+        'us-ascii': [contentType: 'text/plain; charset=us-ascii', file: 'charset-fixtures/ascii.bin'],
+        'iso-8859-1': [contentType: 'text/plain; charset=iso-8859-1', file: 'charset-fixtures/iso-8859-1.bin'],
+        'iso-8859-15': [contentType: 'text/plain; charset=iso-8859-15', file: 'charset-fixtures/iso-8859-15.bin'],
+        'windows-1252': [contentType: 'text/plain; charset=windows-1252', file: 'charset-fixtures/windows-1252.bin'],
+        'windows-1251': [contentType: 'text/plain; charset=windows-1251', file: 'charset-fixtures/windows-1251.bin'],
+        'shift-jis': [contentType: 'text/plain; charset=shift_jis', file: 'charset-fixtures/shift-jis.bin'],
+        'windows-31j': [contentType: 'text/plain; charset=windows-31j', file: 'charset-fixtures/shift-jis.bin'],
+        'euc-jp': [contentType: 'text/plain; charset=euc-jp', file: 'charset-fixtures/euc-jp.bin'],
+        'euc-kr': [contentType: 'text/plain; charset=euc-kr', file: 'charset-fixtures/euc-kr.bin'],
+        'cp949': [contentType: 'text/plain; charset=cp949', file: 'charset-fixtures/euc-kr.bin'],
+        'gbk': [contentType: 'text/plain; charset=gbk', file: 'charset-fixtures/gbk.bin'],
+        'x-gbk': [contentType: 'text/plain; charset=x-gbk', file: 'charset-fixtures/gbk.bin'],
+        'utf-16': [contentType: 'text/plain; charset=utf-16', file: 'charset-fixtures/utf-16.bin'],
+        'utf-16le': [contentType: 'text/plain; charset=utf-16le', file: 'charset-fixtures/utf-16le.bin'],
+        'utf-16be': [contentType: 'text/plain; charset=utf-16be', file: 'charset-fixtures/utf-16be.bin'],
+        'utf-32': [contentType: 'text/plain; charset=utf-32', file: 'charset-fixtures/utf-32.bin'],
+        'utf-32le': [contentType: 'text/plain; charset=utf-32le', file: 'charset-fixtures/utf-32le.bin'],
+        'utf-32be': [contentType: 'text/plain; charset=utf-32be', file: 'charset-fixtures/utf-32be.bin'],
+        'unsupported': [contentType: 'text/plain; charset=made-up', file: 'charset-fixtures/ascii.bin'],
+        'gb18030': [contentType: 'text/plain; charset=gb18030', file: 'charset-fixtures/ascii.bin'],
+        'empty': [contentType: 'text/plain; charset=""', file: 'charset-fixtures/ascii.bin'],
+        'malformed': [contentType: 'text/plain; charset', file: 'charset-fixtures/ascii.bin'],
+        'malformed-bytes': [contentType: 'text/plain; charset=windows-1252', file: 'charset-fixtures/malformed-windows-1252.bin'],
+    ]
+
+    def charsetResponse = charsetResponses[responseCharsetCase]
+    if (charsetResponse != null) {
+        response
+            .withHeader('Content-Type', charsetResponse.contentType)
+            .withFile(charsetResponse.file)
+    } else {
+        response
+            .withHeader('Content-Type', 'text/plain')
+            .withContent('OK')
+            .usingDefaultBehaviour()
+    }
 }
 
 // For all other responses, use default behavior

--- a/integration_test/medama/medama_test/test/non_utf8_response_test.dart
+++ b/integration_test/medama/medama_test/test/non_utf8_response_test.dart
@@ -1,51 +1,403 @@
+import 'dart:convert';
 import 'dart:io';
 
+import 'package:dio/dio.dart';
 import 'package:medama_api/medama_api.dart';
 import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 void main() {
-  test('generated client honors ISO-8859-1 response charset', () async {
-    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
-    addTearDown(() => server.close(force: true));
+  late ImposterServer imposterServer;
+  late Directory fixtureDirectory;
+  late String baseUrl;
 
-    final requestHandled = server.first.then((request) async {
-      request.response
-        ..statusCode = HttpStatus.ok
-        ..headers.set(
-          HttpHeaders.contentTypeHeader,
-          'text/plain; charset=iso-8859-1',
-        )
-        ..headers.set(
-          HttpHeaders.lastModifiedHeader,
-          'Thu, 09 Jan 2026 00:00:00 GMT',
-        )
-        ..headers.set(HttpHeaders.cacheControlHeader, 'max-age=86400')
-        ..add(const [
-          0x63,
-          0x61,
-          0x66,
-          0xe9,
-          0x20,
-          0x64,
-          0xe9,
-          0x6a,
-          0xe0,
-          0x20,
-          0x76,
-          0x75,
-        ]);
-      await request.response.close();
-    });
-    final api = EventApi(
-      CustomServer(baseUrl: 'http://127.0.0.1:${server.port}'),
+  setUpAll(() async {
+    fixtureDirectory = _writeFixtures();
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}';
+  });
+
+  tearDownAll(() async {
+    await imposterServer.stop();
+    if (fixtureDirectory.existsSync()) {
+      fixtureDirectory.deleteSync(recursive: true);
+    }
+  });
+
+  EventApi buildEventApi(String responseCharsetCase) {
+    return EventApi(
+      CustomServer(
+        baseUrl: baseUrl,
+        serverConfig: ServerConfig(
+          baseOptions: BaseOptions(
+            headers: {'X-Response-Charset-Case': responseCharsetCase},
+          ),
+        ),
+      ),
     );
+  }
 
-    final response = await api.getEventPing();
-    await requestHandled;
+  group('successful response charsets', () {
+    for (final testCase in _successfulCases) {
+      test('decodes ${testCase.name}', () async {
+        final response = await buildEventApi(testCase.id).getEventPing();
 
-    final success = response as TonikSuccess<GetEventPingResponse>;
-    final response200 = success.value as GetEventPingResponse200;
-    expect(response200.body.body, 'café déjà vu');
+        final success = response as TonikSuccess<GetEventPingResponse>;
+        final response200 = success.value as GetEventPingResponse200;
+        expect(success.response.data, _fixtureBytes[testCase.fixture]);
+        expect(response200.body.body, testCase.expected);
+      });
+    }
+  });
+
+  group('invalid response charsets', () {
+    for (final testCase in _failureCases) {
+      test('reports ${testCase.name} as a decoding error', () async {
+        final response = await buildEventApi(testCase.id).getEventPing();
+
+        final error = response as TonikError<GetEventPingResponse>;
+        expect(error.type, TonikErrorType.decoding);
+        expect(error.response?.data, _fixtureBytes[testCase.fixture]);
+        expect(
+          error.error,
+          isA<ResponseDecodingException>().having(
+            (exception) => exception.message,
+            'message',
+            contains(testCase.message),
+          ),
+        );
+      });
+    }
   });
 }
+
+Directory _writeFixtures() {
+  final directory = Directory('imposter/charset-fixtures');
+  if (directory.existsSync()) {
+    directory.deleteSync(recursive: true);
+  }
+  directory.createSync();
+
+  for (final entry in _fixtureBytes.entries) {
+    File(
+      '${directory.path}/${entry.key}',
+    ).writeAsBytesSync(entry.value, flush: true);
+  }
+  return directory;
+}
+
+final _fixtureBytes = <String, List<int>>{
+  'utf8.bin': utf8.encode('Grüße 👋'),
+  'ascii.bin': const [
+    0x70,
+    0x6c,
+    0x61,
+    0x69,
+    0x6e,
+    0x20,
+    0x41,
+    0x53,
+    0x43,
+    0x49,
+    0x49,
+  ],
+  'iso-8859-1.bin': const [
+    0x63,
+    0x61,
+    0x66,
+    0xe9,
+    0x20,
+    0x64,
+    0xe9,
+    0x6a,
+    0xe0,
+    0x20,
+    0x76,
+    0x75,
+  ],
+  'iso-8859-15.bin': const [
+    0x50,
+    0x72,
+    0x69,
+    0x63,
+    0x65,
+    0x3a,
+    0x20,
+    0x31,
+    0x30,
+    0x20,
+    0xa4,
+  ],
+  'windows-1252.bin': const [
+    0x93,
+    0x54,
+    0x6f,
+    0x6e,
+    0x69,
+    0x6b,
+    0x94,
+    0x20,
+    0x80,
+  ],
+  'windows-1251.bin': const [0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2],
+  'malformed-windows-1252.bin': const [0x81],
+  'shift-jis.bin': const [0x93, 0xfa, 0x96, 0x7b],
+  'euc-jp.bin': const [0xc6, 0xfc, 0xcb, 0xdc],
+  'euc-kr.bin': const [0xc7, 0xd1, 0xb1, 0xb9],
+  'gbk.bin': const [0xd6, 0xd0, 0xce, 0xc4],
+  'utf-16.bin': const [
+    0xfe,
+    0xff,
+    0x00,
+    0x48,
+    0x00,
+    0x69,
+    0x00,
+    0x20,
+    0x20,
+    0xac,
+  ],
+  'utf-16le.bin': const [
+    0x48,
+    0x00,
+    0x69,
+    0x00,
+    0x20,
+    0x00,
+    0xac,
+    0x20,
+  ],
+  'utf-16be.bin': const [
+    0x00,
+    0x48,
+    0x00,
+    0x69,
+    0x00,
+    0x20,
+    0x20,
+    0xac,
+  ],
+  'utf-32.bin': const [
+    0x00,
+    0x00,
+    0xfe,
+    0xff,
+    0x00,
+    0x00,
+    0x00,
+    0x48,
+    0x00,
+    0x00,
+    0x00,
+    0x69,
+    0x00,
+    0x00,
+    0x00,
+    0x20,
+    0x00,
+    0x00,
+    0x20,
+    0xac,
+  ],
+  'utf-32le.bin': const [
+    0x48,
+    0x00,
+    0x00,
+    0x00,
+    0x69,
+    0x00,
+    0x00,
+    0x00,
+    0x20,
+    0x00,
+    0x00,
+    0x00,
+    0xac,
+    0x20,
+    0x00,
+    0x00,
+  ],
+  'utf-32be.bin': const [
+    0x00,
+    0x00,
+    0x00,
+    0x48,
+    0x00,
+    0x00,
+    0x00,
+    0x69,
+    0x00,
+    0x00,
+    0x00,
+    0x20,
+    0x00,
+    0x00,
+    0x20,
+    0xac,
+  ],
+};
+
+const _successfulCases =
+    <({String id, String name, String fixture, String expected})>[
+      (
+        id: 'utf8-default',
+        name: 'UTF-8 by default',
+        fixture: 'utf8.bin',
+        expected: 'Grüße 👋',
+      ),
+      (
+        id: 'utf8-alias',
+        name: 'the utf8 alias',
+        fixture: 'utf8.bin',
+        expected: 'Grüße 👋',
+      ),
+      (
+        id: 'quoted-uppercase-utf8',
+        name: 'a quoted case-insensitive UTF-8 declaration',
+        fixture: 'utf8.bin',
+        expected: 'Grüße 👋',
+      ),
+      (
+        id: 'us-ascii',
+        name: 'US-ASCII',
+        fixture: 'ascii.bin',
+        expected: 'plain ASCII',
+      ),
+      (
+        id: 'iso-8859-1',
+        name: 'ISO-8859-1',
+        fixture: 'iso-8859-1.bin',
+        expected: 'café déjà vu',
+      ),
+      (
+        id: 'iso-8859-15',
+        name: 'ISO-8859-15',
+        fixture: 'iso-8859-15.bin',
+        expected: 'Price: 10 €',
+      ),
+      (
+        id: 'windows-1252',
+        name: 'Windows-1252',
+        fixture: 'windows-1252.bin',
+        expected: '“Tonik” €',
+      ),
+      (
+        id: 'windows-1251',
+        name: 'Windows-1251',
+        fixture: 'windows-1251.bin',
+        expected: 'Привет',
+      ),
+      (
+        id: 'shift-jis',
+        name: 'Shift_JIS',
+        fixture: 'shift-jis.bin',
+        expected: '日本',
+      ),
+      (
+        id: 'windows-31j',
+        name: 'the Windows-31J alias',
+        fixture: 'shift-jis.bin',
+        expected: '日本',
+      ),
+      (
+        id: 'euc-jp',
+        name: 'EUC-JP',
+        fixture: 'euc-jp.bin',
+        expected: '日本',
+      ),
+      (
+        id: 'gbk',
+        name: 'GBK',
+        fixture: 'gbk.bin',
+        expected: '中文',
+      ),
+      (
+        id: 'x-gbk',
+        name: 'the X-GBK alias',
+        fixture: 'gbk.bin',
+        expected: '中文',
+      ),
+      (
+        id: 'utf-16',
+        name: 'UTF-16 with a byte-order mark',
+        fixture: 'utf-16.bin',
+        expected: 'Hi €',
+      ),
+      (
+        id: 'utf-16le',
+        name: 'explicit UTF-16LE without a byte-order mark',
+        fixture: 'utf-16le.bin',
+        expected: 'Hi €',
+      ),
+      (
+        id: 'utf-16be',
+        name: 'explicit UTF-16BE without a byte-order mark',
+        fixture: 'utf-16be.bin',
+        expected: 'Hi €',
+      ),
+      (
+        id: 'utf-32',
+        name: 'UTF-32 with a byte-order mark',
+        fixture: 'utf-32.bin',
+        expected: 'Hi €',
+      ),
+      (
+        id: 'utf-32le',
+        name: 'explicit UTF-32LE without a byte-order mark',
+        fixture: 'utf-32le.bin',
+        expected: 'Hi €',
+      ),
+      (
+        id: 'utf-32be',
+        name: 'explicit UTF-32BE without a byte-order mark',
+        fixture: 'utf-32be.bin',
+        expected: 'Hi €',
+      ),
+    ];
+
+const _failureCases =
+    <({String id, String name, String fixture, String message})>[
+      (
+        id: 'unsupported',
+        name: 'an unknown charset',
+        fixture: 'ascii.bin',
+        message: 'Unsupported response charset: "made-up"',
+      ),
+      (
+        id: 'gb18030',
+        name: 'GB18030 rather than treating it as GBK',
+        fixture: 'ascii.bin',
+        message: 'Unsupported response charset: "gb18030"',
+      ),
+      (
+        id: 'euc-kr',
+        name: 'EUC-KR rather than returning corrupt Unicode',
+        fixture: 'euc-kr.bin',
+        message: 'Unsupported response charset: "euc-kr"',
+      ),
+      (
+        id: 'cp949',
+        name: 'the CP949 alias rather than returning corrupt Unicode',
+        fixture: 'euc-kr.bin',
+        message: 'Unsupported response charset: "cp949"',
+      ),
+      (
+        id: 'empty',
+        name: 'an empty charset',
+        fixture: 'ascii.bin',
+        message: 'Response charset must not be empty',
+      ),
+      (
+        id: 'malformed',
+        name: 'a malformed Content-Type',
+        fixture: 'ascii.bin',
+        message: 'Invalid response Content-Type header',
+      ),
+      (
+        id: 'malformed-bytes',
+        name: 'malformed bytes for the declared charset',
+        fixture: 'malformed-windows-1252.bin',
+        message: 'Failed to decode response body using charset "windows-1252"',
+      ),
+    ];

--- a/integration_test/medama/medama_test/test/non_utf8_response_test.dart
+++ b/integration_test/medama/medama_test/test/non_utf8_response_test.dart
@@ -1,0 +1,51 @@
+import 'dart:io';
+
+import 'package:medama_api/medama_api.dart';
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('generated client honors ISO-8859-1 response charset', () async {
+    final server = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => server.close(force: true));
+
+    final requestHandled = server.first.then((request) async {
+      request.response
+        ..statusCode = HttpStatus.ok
+        ..headers.set(
+          HttpHeaders.contentTypeHeader,
+          'text/plain; charset=iso-8859-1',
+        )
+        ..headers.set(
+          HttpHeaders.lastModifiedHeader,
+          'Thu, 09 Jan 2026 00:00:00 GMT',
+        )
+        ..headers.set(HttpHeaders.cacheControlHeader, 'max-age=86400')
+        ..add(const [
+          0x63,
+          0x61,
+          0x66,
+          0xe9,
+          0x20,
+          0x64,
+          0xe9,
+          0x6a,
+          0xe0,
+          0x20,
+          0x76,
+          0x75,
+        ]);
+      await request.response.close();
+    });
+    final api = EventApi(
+      CustomServer(baseUrl: 'http://127.0.0.1:${server.port}'),
+    );
+
+    final response = await api.getEventPing();
+    await requestHandled;
+
+    final success = response as TonikSuccess<GetEventPingResponse>;
+    final response200 = success.value as GetEventPingResponse200;
+    expect(response200.body.body, 'café déjà vu');
+  });
+}

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -331,7 +331,15 @@ class ParseGenerator {
               refer(
                 'decodeResponseText',
                 'package:tonik_util/tonik_util.dart',
-              ).call([refer('response.data')]),
+              ).call(
+                [refer('response.data')],
+                {
+                  'contentType': refer('response')
+                      .property('headers')
+                      .property('value')
+                      .call([literalString('content-type')]),
+                },
+              ),
             )
             .statement,
       ],

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -1928,7 +1928,10 @@ String _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
           switch ((response.statusCode, _$mediaType)) {
     case (200, r'text/plain'):
-      final _$body = decodeResponseText(response.data);
+      final _$body = decodeResponseText(
+        response.data,
+        contentType: response.headers.value('content-type'),
+      );
       return _$body;
     default:
       final _$content = response.headers.value('content-type') ?? 'not specified';
@@ -2295,7 +2298,10 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
       final _$body = _$json.decodeJsonString();
       return AnonymousResponseJson(body: _$body);
     case (200, r'text/plain'):
-      final _$body = decodeResponseText(response.data);
+      final _$body = decodeResponseText(
+        response.data,
+        contentType: response.headers.value('content-type'),
+      );
       return AnonymousResponsePlain(body: _$body);
     case (200, r'application/octet-stream'):
       final _$body = TonikFileBytes(decodeResponseBytes(response.data));

--- a/packages/tonik_util/lib/src/decoding/response_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/response_decoder.dart
@@ -83,6 +83,11 @@ String _decodeUsingNamedCharset(
       'Unsupported response charset: "$charsetName".',
     );
   }
+  if (identical(encoding, charset.eucKr)) {
+    throw ResponseDecodingException(
+      'Unsupported response charset: "$charsetName".',
+    );
+  }
 
   if (identical(encoding, utf8)) {
     return utf8.decode(bytes, allowMalformed: true);

--- a/packages/tonik_util/lib/src/decoding/response_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/response_decoder.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:charset/charset.dart' as charset;
+import 'package:dio/dio.dart';
 import 'package:tonik_util/src/decoding/decoding_exception.dart';
 
 /// Decodes raw response bytes as JSON.
@@ -24,17 +26,104 @@ T decodeResponseJson<T>(List<int>? bytes) {
   return decoded;
 }
 
-/// Decodes raw response bytes as text (UTF-8).
+/// Decodes raw response bytes as text.
 ///
 /// Input is always `List<int>` (from ResponseType.bytes).
+/// The `charset` parameter in [contentType] selects the decoder. When the
+/// parameter is absent, UTF-8 is used for backwards compatibility.
 /// Returns the decoded String.
-String decodeResponseText(List<int>? bytes) {
+String decodeResponseText(List<int>? bytes, {String? contentType}) {
   if (bytes == null) {
     throw const ResponseDecodingException(
       'Response bytes are null, cannot decode text.',
     );
   }
-  return utf8.decode(bytes, allowMalformed: true);
+
+  final charsetName = _extractCharset(contentType);
+  if (charsetName == null) {
+    return utf8.decode(bytes, allowMalformed: true);
+  }
+
+  final normalized = _normalizeCharsetName(charsetName);
+  if (normalized == 'gb18030' || normalized == 'csgb18030') {
+    throw ResponseDecodingException(
+      'Unsupported response charset: "$charsetName".',
+    );
+  }
+
+  try {
+    return switch (normalized) {
+      'utf-16le' ||
+      'csutf16le' => const charset.Utf16Decoder().decodeUtf16Le(bytes),
+      'utf-16be' ||
+      'csutf16be' => const charset.Utf16Decoder().decodeUtf16Be(bytes),
+      'utf-32le' ||
+      'csutf32le' => const charset.Utf32Decoder().decodeUtf32Le(bytes),
+      'utf-32be' ||
+      'csutf32be' => const charset.Utf32Decoder().decodeUtf32Be(bytes),
+      _ => _decodeUsingNamedCharset(bytes, charsetName, normalized),
+    };
+  } on ResponseDecodingException {
+    rethrow;
+  } on Object catch (error) {
+    throw ResponseDecodingException(
+      'Failed to decode response body using charset "$charsetName": $error',
+    );
+  }
+}
+
+String _decodeUsingNamedCharset(
+  List<int> bytes,
+  String charsetName,
+  String normalized,
+) {
+  final encoding = charset.Charset.getByName(normalized);
+  if (encoding == null) {
+    throw ResponseDecodingException(
+      'Unsupported response charset: "$charsetName".',
+    );
+  }
+
+  if (identical(encoding, utf8)) {
+    return utf8.decode(bytes, allowMalformed: true);
+  }
+  return encoding.decode(bytes);
+}
+
+String _normalizeCharsetName(String charsetName) {
+  final normalized = charsetName.toLowerCase();
+  return switch (normalized) {
+    'utf8' ||
+    'utf_8' ||
+    'unicode-1-1-utf-8' ||
+    'unicode11utf8' ||
+    'unicode20utf8' ||
+    'x-unicode20utf8' => 'utf-8',
+    'sjis' || 'windows-31j' || 'x-sjis' => 'shift-jis',
+    'x-gbk' => 'gbk',
+    _ => normalized,
+  };
+}
+
+String? _extractCharset(String? contentType) {
+  if (contentType == null || contentType.trim().isEmpty) return null;
+
+  final DioMediaType mediaType;
+  try {
+    mediaType = DioMediaType.parse(contentType);
+  } on FormatException catch (error) {
+    throw ResponseDecodingException(
+      'Invalid response Content-Type header "$contentType": $error',
+    );
+  }
+  final charsetName = mediaType.parameters['charset']?.trim();
+  if (charsetName == null) return null;
+  if (charsetName.isEmpty) {
+    throw const ResponseDecodingException(
+      'Response charset must not be empty.',
+    );
+  }
+  return charsetName;
 }
 
 /// Returns raw response bytes as-is.

--- a/packages/tonik_util/pubspec.yaml
+++ b/packages/tonik_util/pubspec.yaml
@@ -17,6 +17,7 @@ environment:
 
 dependencies:
   big_decimal: ^0.7.0
+  charset: ^2.0.1
   collection: ^1.19.1
   dio: ^5.9.0
   meta: ^1.17.0

--- a/packages/tonik_util/test/src/decoding/response_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/response_decoder_test.dart
@@ -350,6 +350,24 @@ void main() {
           throwsA(isA<ResponseDecodingException>()),
         );
       });
+
+      test('does not use the broken EUC-KR decoder', () {
+        for (final charsetName in ['euc-kr', 'cp949']) {
+          expect(
+            () => decodeResponseText(
+              const [0xc7, 0xd1, 0xb1, 0xb9],
+              contentType: 'text/plain; charset=$charsetName',
+            ),
+            throwsA(
+              isA<ResponseDecodingException>().having(
+                (error) => error.message,
+                'message',
+                contains('Unsupported response charset: "$charsetName"'),
+              ),
+            ),
+          );
+        }
+      });
     });
 
     group('type validation', () {

--- a/packages/tonik_util/test/src/decoding/response_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/response_decoder_test.dart
@@ -115,6 +115,241 @@ void main() {
         expect(result, isA<String>());
         expect(result.length, 10000);
       });
+
+      test('uses UTF-8 when Content-Type has no charset', () {
+        final bytes = utf8.encode('Grüße 👋');
+
+        expect(
+          decodeResponseText(bytes, contentType: 'text/plain'),
+          'Grüße 👋',
+        );
+      });
+
+      test('parses quoted charset case-insensitively', () {
+        final bytes = utf8.encode('Grüße 👋');
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'Text/Plain; Charset="UTF-8"',
+          ),
+          'Grüße 👋',
+        );
+      });
+
+      test('accepts the common utf8 alias', () {
+        final bytes = utf8.encode('Grüße 👋');
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=utf8',
+          ),
+          'Grüße 👋',
+        );
+      });
+
+      test('decodes ISO-8859-1', () {
+        const bytes = [0x63, 0x61, 0x66, 0xe9];
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=iso-8859-1',
+          ),
+          'café',
+        );
+      });
+
+      test('decodes Windows-1252 distinctly from ISO-8859-1', () {
+        const bytes = [
+          0x93,
+          0x54,
+          0x6f,
+          0x6e,
+          0x69,
+          0x6b,
+          0x94,
+          0x20,
+          0x80,
+        ];
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=windows-1252',
+          ),
+          '“Tonik” €',
+        );
+      });
+
+      test('decodes Windows-1251', () {
+        const bytes = [0xcf, 0xf0, 0xe8, 0xe2, 0xe5, 0xf2];
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=windows-1251',
+          ),
+          'Привет',
+        );
+      });
+
+      test('decodes Shift_JIS', () {
+        const bytes = [0x93, 0xfa, 0x96, 0x7b];
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=shift_jis',
+          ),
+          '日本',
+        );
+      });
+
+      test('decodes GBK', () {
+        const bytes = [0xd6, 0xd0, 0xce, 0xc4];
+
+        expect(
+          decodeResponseText(
+            bytes,
+            contentType: 'text/plain; charset=gbk',
+          ),
+          '中文',
+        );
+      });
+
+      test('honors explicit UTF-16 endianness without a BOM', () {
+        const littleEndian = [0x48, 0x00, 0x69, 0x00, 0x20, 0x00, 0xac, 0x20];
+        const bigEndian = [0x00, 0x48, 0x00, 0x69, 0x00, 0x20, 0x20, 0xac];
+
+        expect(
+          decodeResponseText(
+            littleEndian,
+            contentType: 'text/plain; charset=utf-16le',
+          ),
+          'Hi €',
+        );
+        expect(
+          decodeResponseText(
+            bigEndian,
+            contentType: 'text/plain; charset=utf-16be',
+          ),
+          'Hi €',
+        );
+      });
+
+      test('honors explicit UTF-32 endianness without a BOM', () {
+        const littleEndian = [
+          0x48,
+          0x00,
+          0x00,
+          0x00,
+          0x69,
+          0x00,
+          0x00,
+          0x00,
+          0x20,
+          0x00,
+          0x00,
+          0x00,
+          0xac,
+          0x20,
+          0x00,
+          0x00,
+        ];
+        const bigEndian = [
+          0x00,
+          0x00,
+          0x00,
+          0x48,
+          0x00,
+          0x00,
+          0x00,
+          0x69,
+          0x00,
+          0x00,
+          0x00,
+          0x20,
+          0x00,
+          0x00,
+          0x20,
+          0xac,
+        ];
+
+        expect(
+          decodeResponseText(
+            littleEndian,
+            contentType: 'text/plain; charset=utf-32le',
+          ),
+          'Hi €',
+        );
+        expect(
+          decodeResponseText(
+            bigEndian,
+            contentType: 'text/plain; charset=utf-32be',
+          ),
+          'Hi €',
+        );
+      });
+
+      test('throws for unsupported charset', () {
+        expect(
+          () => decodeResponseText(
+            const [0x66, 0x6f, 0x6f],
+            contentType: 'text/plain; charset=made-up',
+          ),
+          throwsA(
+            isA<ResponseDecodingException>().having(
+              (error) => error.message,
+              'message',
+              contains('Unsupported response charset: "made-up"'),
+            ),
+          ),
+        );
+      });
+
+      test('wraps malformed encoded bytes', () {
+        expect(
+          () => decodeResponseText(
+            const [0x81],
+            contentType: 'text/plain; charset=windows-1252',
+          ),
+          throwsA(
+            isA<ResponseDecodingException>().having(
+              (error) => error.message,
+              'message',
+              contains('Failed to decode response body'),
+            ),
+          ),
+        );
+      });
+
+      test('throws for malformed Content-Type', () {
+        expect(
+          () => decodeResponseText(
+            const [0x66, 0x6f, 0x6f],
+            contentType: 'text/plain; charset',
+          ),
+          throwsA(
+            isA<ResponseDecodingException>().having(
+              (error) => error.message,
+              'message',
+              contains('Invalid response Content-Type header'),
+            ),
+          ),
+        );
+      });
+
+      test('does not treat GB18030 as GBK', () {
+        expect(
+          () => decodeResponseText(
+            const [0x66, 0x6f, 0x6f],
+            contentType: 'text/plain; charset=gb18030',
+          ),
+          throwsA(isA<ResponseDecodingException>()),
+        );
+      });
     });
 
     group('type validation', () {


### PR DESCRIPTION
## Summary

- Decode text response bodies using the `charset` declared by the runtime `Content-Type` header.
- Keep UTF-8 as the default and support common ISO-8859, Windows, East Asian, UTF-16, and UTF-32 encodings via `package:charset`.
- Pass response content types through generated parsers and add unit, generator, and documentation coverage.
- Exercise generated clients against raw response files served by Imposter across 19 successful charset/alias cases and 7 decoding-error cases.

## Why

Text responses are currently always decoded as UTF-8, which corrupts bodies served with legacy encodings such as `text/plain; charset=iso-8859-1`.

## Impact

Generated clients now honor declared charsets for text responses. Missing charset parameters continue to use UTF-8. Unsupported or malformed charset declarations produce a `ResponseDecodingException`; JSON response decoding is unchanged. GB18030 and EUC-KR aliases are rejected because the dependency cannot decode them correctly.

## Validation

- `melos exec --scope=tonik_util -- fvm dart test`
- `melos exec --scope=tonik_generate -- fvm dart test`
- `melos run test-integration-medama`
- `melos exec -- fvm dart analyze --fatal-infos`
- `fvm dart analyze --fatal-infos` in `integration_test/medama/medama_test`
