### PR TITLE
Plan generated HTTP backends with collision-safe naming and server variables

### DIFF
--- a/docs/features.md
+++ b/docs/features.md
@@ -146,16 +146,18 @@ Error types on `TonikError`: `encoding`, `decoding`, `network`, `cancelled`, `ot
 
 ### Request Cancellation
 
-Every generated operation accepts an optional `CancelToken` parameter, letting you cancel in-flight requests:
+Every generated API method accepts an optional backend-neutral
+`TonikCancellation`, letting you cancel in-flight requests without exposing
+the selected HTTP client:
 
 ```dart
-final cancelToken = CancelToken();
+final cancellation = TonikCancellation();
 
 // Start the request
-final future = api.getUsers(cancelToken: cancelToken);
+final future = api.getUsers(cancellation: cancellation);
 
 // Cancel it (e.g. when the user navigates away)
-cancelToken.cancel();
+cancellation.cancel();
 
 final result = await future;
 switch (result) {
@@ -168,7 +170,14 @@ switch (result) {
 }
 ```
 
-Cancelled requests return `TonikError` with `type: TonikErrorType.cancelled`, distinct from network errors.
+Cancelled requests return `TonikError` with
+`type: TonikErrorType.cancelled`, distinct from network errors.
+
+Generated servers own clients that they create themselves, either by default or
+through a configured factory. Call `server.close()` when the server is no
+longer needed; closing is safe to repeat and does not create a client that was
+never used. Explicitly injected clients remain caller-owned and are not closed
+by the generated server.
 
 ---
 

--- a/integration_test/naming/naming_test/pubspec.lock
+++ b/integration_test/naming/naming_test/pubspec.lock
@@ -352,13 +352,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.6.19"
-  test_helpers:
-    dependency: "direct dev"
-    description:
-      path: "../../test_helpers"
-      relative: true
-    source: path
-    version: "1.0.0"
   tonik_util:
     dependency: "direct main"
     description:

--- a/integration_test/naming/naming_test/pubspec.yaml
+++ b/integration_test/naming/naming_test/pubspec.yaml
@@ -14,8 +14,6 @@ dependencies:
 
 dev_dependencies:
   test: ^1.25.15
-  test_helpers:
-    path: ../../test_helpers
   very_good_analysis: ^10.2.0
 
 dependency_overrides:

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -133,14 +133,14 @@ void main() {
     });
   });
 
-  group('cancelToken parameter collision', () {
+  group('OpenAPI cancelToken parameters', () {
     test(
-      'API method accepts cancelTokenQuery and portable cancellation',
+      'API method accepts cancelToken and portable cancellation',
       () async {
         final dio = _successfulDio();
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.getWithCancelTokenQuery(
-          cancelTokenQuery: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 
@@ -155,12 +155,12 @@ void main() {
     );
 
     test(
-      'API method sends cancelTokenPath and threads portable cancellation',
+      'API method sends cancelToken path and threads portable cancellation',
       () async {
         final dio = _successfulDio();
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.getWithCancelTokenPath(
-          cancelTokenPath: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 
@@ -175,12 +175,12 @@ void main() {
     );
 
     test(
-      'API method sends cancelTokenHeader and threads portable cancellation',
+      'API method sends cancelToken header and threads portable cancellation',
       () async {
         final dio = _successfulDio();
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.getWithCancelTokenHeader(
-          cancelTokenHeader: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 
@@ -195,12 +195,12 @@ void main() {
     );
 
     test(
-      'API method sends cancelTokenCookie and threads portable cancellation',
+      'API method sends cancelToken cookie and threads portable cancellation',
       () async {
         final dio = _successfulDio();
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.getWithCancelTokenCookie(
-          cancelTokenCookie: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 
@@ -220,7 +220,7 @@ void main() {
         final dio = _successfulDio();
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.getWithCancelTokenSanitized(
-          cancelTokenQuery: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 
@@ -241,7 +241,7 @@ void main() {
         final api = _apiForDio(dio, 'http://localhost');
         final response = await api.postWithCancelTokenAndBody(
           body: const SimpleResult(id: 'test'),
-          cancelTokenQuery: 'myToken',
+          cancelToken: 'myToken',
           cancellation: TonikCancellation(),
         );
 

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -19,31 +19,11 @@ import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/user.dart';
 import 'package:naming_api/src/model/user_model.dart';
 import 'package:naming_api/src/model/weird_property_names.dart';
-import 'package:naming_api/src/operation/get_hostile_query_names.dart';
-import 'package:naming_api/src/operation/get_param_counter_collision.dart';
-import 'package:naming_api/src/operation/get_param_suffix_collision.dart';
-import 'package:naming_api/src/operation/get_with_call_query.dart';
-import 'package:naming_api/src/operation/get_with_cancel_token_cookie.dart';
-import 'package:naming_api/src/operation/get_with_cancel_token_header.dart';
-import 'package:naming_api/src/operation/get_with_cancel_token_path.dart';
-import 'package:naming_api/src/operation/get_with_cancel_token_query.dart';
-import 'package:naming_api/src/operation/get_with_cancel_token_sanitized.dart';
-import 'package:naming_api/src/operation/post_multipart_name_collisions.dart';
-import 'package:naming_api/src/operation/post_with_cancel_token_and_body.dart';
 import 'package:naming_api/src/server/server.dart';
 import 'package:test/test.dart';
-import 'package:test_helpers/test_helpers.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 void main() {
-  late ImposterServer imposterServer;
-  late String baseUrl;
-
-  setUpAll(() async {
-    imposterServer = await setupImposterServer();
-    baseUrl = 'http://localhost:${imposterServer.port}';
-  });
-
   group('keyword operationId method names', () {
     test('API client has escaped keyword method names', () {
       // The fact that DefaultApi2 compiles proves operationIds like
@@ -155,13 +135,13 @@ void main() {
 
   group('cancelToken parameter collision', () {
     test(
-      'GetWithCancelTokenQuery call() accepts cancelTokenQuery and '
-      'built-in cancelToken',
+      'API method accepts cancelTokenQuery and portable cancellation',
       () async {
-        final op = GetWithCancelTokenQuery(Dio(BaseOptions(baseUrl: baseUrl)));
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.getWithCancelTokenQuery(
           cancelTokenQuery: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -175,13 +155,13 @@ void main() {
     );
 
     test(
-      'GetWithCancelTokenPath call() sends cancelTokenPath as path segment '
-      'and threads built-in cancelToken through to Dio',
+      'API method sends cancelTokenPath and threads portable cancellation',
       () async {
-        final op = GetWithCancelTokenPath(Dio(BaseOptions(baseUrl: baseUrl)));
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.getWithCancelTokenPath(
           cancelTokenPath: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -195,13 +175,13 @@ void main() {
     );
 
     test(
-      'GetWithCancelTokenHeader call() sends cancelTokenHeader as request '
-      'header and threads built-in cancelToken through to Dio',
+      'API method sends cancelTokenHeader and threads portable cancellation',
       () async {
-        final op = GetWithCancelTokenHeader(Dio(BaseOptions(baseUrl: baseUrl)));
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.getWithCancelTokenHeader(
           cancelTokenHeader: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -215,13 +195,13 @@ void main() {
     );
 
     test(
-      'GetWithCancelTokenCookie call() sends cancelTokenCookie as Cookie '
-      'header and threads built-in cancelToken through to Dio',
+      'API method sends cancelTokenCookie and threads portable cancellation',
       () async {
-        final op = GetWithCancelTokenCookie(Dio(BaseOptions(baseUrl: baseUrl)));
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.getWithCancelTokenCookie(
           cancelTokenCookie: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -235,15 +215,13 @@ void main() {
     );
 
     test(
-      'GetWithCancelTokenSanitized call() sends cancelTokenQuery under '
-      'wire key Cancel-Token and threads built-in cancelToken through to Dio',
+      'API method preserves sanitized cancel token wire names',
       () async {
-        final op = GetWithCancelTokenSanitized(
-          Dio(BaseOptions(baseUrl: baseUrl)),
-        );
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.getWithCancelTokenSanitized(
           cancelTokenQuery: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -257,16 +235,14 @@ void main() {
     );
 
     test(
-      'PostWithCancelTokenAndBody call() sends cancelTokenQuery as query '
-      'param, body as JSON, and threads built-in cancelToken through to Dio',
+      'API method sends colliding query and body with portable cancellation',
       () async {
-        final op = PostWithCancelTokenAndBody(
-          Dio(BaseOptions(baseUrl: baseUrl)),
-        );
-        final response = await op.call(
+        final dio = _successfulDio();
+        final api = _apiForDio(dio, 'http://localhost');
+        final response = await api.postWithCancelTokenAndBody(
           body: const SimpleResult(id: 'test'),
           cancelTokenQuery: 'myToken',
-          cancelToken: CancelToken(),
+          cancellation: TonikCancellation(),
         );
 
         expect(response, isA<TonikSuccess<void, Response<Object?>>>());
@@ -361,7 +337,9 @@ void main() {
         ),
       );
 
-      await GetWithCallQuery(dio).call($call: 'invoke');
+      await _apiForDio(dio, 'http://localhost').getWithCallQuery(
+        $call: 'invoke',
+      );
 
       expect(capturedUri?.queryParameters, {'call': 'invoke'});
     });
@@ -454,11 +432,11 @@ void main() {
           ),
         );
 
-        final operation = GetParamCounterCollision(dio);
+        final api = _apiForDio(dio, 'http://localhost');
 
         // The named-arg call site IS the compile-time check on Dart names:
         // if any of the four were renamed, this wouldn't compile.
-        await operation.call(
+        await api.getParamCounterCollision(
           tokenPath: 'P',
           tokenQuery: 'A',
           tokenQuery2: 'B',
@@ -526,9 +504,9 @@ void main() {
             ),
           );
 
-          final operation = GetParamSuffixCollision(dio);
+          final api = _apiForDio(dio, 'http://localhost');
 
-          await operation.call(
+          await api.getParamSuffixCollision(
             idPath2: 'P',
             idQuery: 42,
             idPath: true,
@@ -583,7 +561,7 @@ void main() {
         ),
       );
 
-      await GetHostileQueryNames(dio).call(
+      await _apiForDio(dio, 'http://localhost').getHostileQueryNames(
         parameter: 'love',
         parameter2: 'cache-buster',
         expand: 'customer',
@@ -638,7 +616,7 @@ void main() {
         ),
       );
 
-      await PostMultipartNameCollisions(dio).call(
+      await _apiForDio(dio, 'http://localhost').postMultipartNameCollisions(
         body: MultipartNameCollisionForm(
           file: TonikFileBytes(Uint8List.fromList([1, 2, 3])),
         ),
@@ -661,4 +639,29 @@ void main() {
       });
     });
   });
+}
+
+DefaultApi2 _apiForDio(Dio dio, String baseUrl) {
+  return DefaultApi2(
+    CustomServer(
+      baseUrl: baseUrl,
+      serverConfig: ServerConfig<Dio>.client(dio),
+    ),
+  );
+}
+
+Dio _successfulDio() => Dio()..httpClientAdapter = _SuccessAdapter();
+
+class _SuccessAdapter implements HttpClientAdapter {
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    return ResponseBody.fromString('', 200);
+  }
+
+  @override
+  void close({bool force = false}) {}
 }

--- a/integration_test/naming/naming_test/test/response_body_collision_test.dart
+++ b/integration_test/naming/naming_test/test/response_body_collision_test.dart
@@ -1,8 +1,9 @@
 import 'dart:convert';
 
 import 'package:dio/dio.dart';
-import 'package:naming_api/src/operation/get_response_with_normalized_body_header.dart';
+import 'package:naming_api/src/api_client/default_api2.dart';
 import 'package:naming_api/src/response/response_body_collision_header_normalized_get200_response.dart';
+import 'package:naming_api/src/server/server.dart';
 import 'package:test/test.dart';
 import 'package:tonik_util/tonik_util.dart';
 
@@ -26,9 +27,14 @@ void main() {
         },
       ),
     );
-    final operation = GetResponseWithNormalizedBodyHeader(dio);
+    final api = DefaultApi2(
+      CustomServer(
+        baseUrl: 'http://localhost',
+        serverConfig: ServerConfig<Dio>.client(dio),
+      ),
+    );
 
-    final result = await operation.call();
+    final result = await api.getResponseWithNormalizedBodyHeader();
 
     expect(
       result,

--- a/integration_test/server_variables/server_variables_test/test/server_test.dart
+++ b/integration_test/server_variables/server_variables_test/test/server_test.dart
@@ -1,3 +1,6 @@
+import 'dart:async';
+import 'dart:typed_data';
+
 import 'package:dio/dio.dart';
 import 'package:server_variables_api/server_variables_api.dart';
 import 'package:test/test.dart';
@@ -225,6 +228,53 @@ void main() {
       },
     );
 
+    test('API client construction does not resolve a Dio factory', () {
+      var factoryCalls = 0;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.clientFactory(() {
+          factoryCalls++;
+          return Dio();
+        }),
+      );
+
+      final api = HealthApi(server);
+
+      expect(api, isA<HealthApi>());
+      expect(factoryCalls, 0);
+    });
+
+    test('factory preserves Dio configuration while server URL wins', () {
+      const serverBaseUrl = 'https://server.example.com';
+      final adapter = _TrackingAdapter();
+      final interceptor = InterceptorsWrapper();
+      final options = BaseOptions(
+        baseUrl: 'https://factory.example.com',
+        connectTimeout: const Duration(seconds: 17),
+        headers: {'x-client-header': 'preserved'},
+      );
+      late Dio created;
+      final server = CustomServer(
+        baseUrl: serverBaseUrl,
+        serverConfig: ServerConfig<Dio>.clientFactory(() {
+          created = Dio(options)
+            ..interceptors.add(interceptor)
+            ..httpClientAdapter = adapter;
+          return created;
+        }),
+      );
+
+      final resolved = server.dio;
+
+      expect(resolved, same(created));
+      expect(resolved.options.baseUrl, serverBaseUrl);
+      expect(resolved.options.connectTimeout, const Duration(seconds: 17));
+      expect(resolved.options.headers['x-client-header'], 'preserved');
+      expect(resolved.interceptors, contains(same(interceptor)));
+      expect(resolved.httpClientAdapter, same(adapter));
+      server.close();
+    });
+
     test('creates one default Dio lazily and applies the server URL', () {
       const serverBaseUrl = 'https://server.example.com';
       final server = CustomServer(baseUrl: serverBaseUrl);
@@ -235,4 +285,225 @@ void main() {
       expect(server.dio, same(resolved));
     });
   });
+
+  group('Dio client lifecycle', () {
+    test('close before use does not resolve a factory', () {
+      var factoryCalls = 0;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.clientFactory(() {
+          factoryCalls++;
+          return Dio();
+        }),
+      );
+
+      server
+        ..close()
+        ..close();
+
+      expect(factoryCalls, 0);
+    });
+
+    test('closes a factory-created Dio exactly once', () {
+      final adapter = _TrackingAdapter();
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.clientFactory(
+          () => Dio()..httpClientAdapter = adapter,
+        ),
+      );
+
+      expect(server.dio.httpClientAdapter, same(adapter));
+
+      server
+        ..close()
+        ..close();
+
+      expect(adapter.closeCalls, 1);
+    });
+
+    test('never closes an injected Dio', () {
+      final adapter = _TrackingAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.client(dio),
+      );
+
+      expect(server.dio, same(dio));
+
+      server
+        ..close()
+        ..close();
+
+      expect(adapter.closeCalls, 0);
+      dio.close();
+      expect(adapter.closeCalls, 1);
+    });
+
+    test('direct access and operations share one stable close error', () async {
+      final adapter = _TrackingAdapter();
+      final dio = Dio()..httpClientAdapter = adapter;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.client(dio),
+      );
+      final api = HealthApi(server);
+      server.close();
+
+      final firstError = _captureDioAccessError(server);
+      final secondError = _captureDioAccessError(server);
+      final result = await api.getHealth();
+
+      expect(firstError, isA<StateError>());
+      expect(secondError, same(firstError));
+      expect(
+        firstError.toString(),
+        'Bad state: Cannot access Dio after the server has been closed.',
+      );
+      expect(
+        result,
+        isA<TonikError<HealthStatus, Response<Object?>>>(),
+      );
+      final error = result as TonikError<HealthStatus, Response<Object?>>;
+      expect(error.type, TonikErrorType.other);
+      expect(error.error, same(firstError));
+      expect(error.response, isNull);
+      expect(error.stackTrace, isNot(StackTrace.empty));
+      expect(adapter.fetchCalls, 0);
+    });
+  });
+
+  group('portable cancellation', () {
+    test('pre-cancelled API calls do not resolve or dispatch Dio', () async {
+      final adapter = _TrackingAdapter();
+      final dio = Dio(BaseOptions(baseUrl: 'https://injected.example.com'))
+        ..httpClientAdapter = adapter;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.client(dio),
+      );
+      final api = HealthApi(server);
+      final cancellation = TonikCancellation()..cancel('no longer needed');
+
+      final result = await api.getHealth(cancellation: cancellation);
+
+      expect(
+        result,
+        isA<TonikError<HealthStatus, Response<Object?>>>(),
+      );
+      final error = result as TonikError<HealthStatus, Response<Object?>>;
+      expect(error.type, TonikErrorType.cancelled);
+      expect(error.response, isNull);
+      expect(adapter.fetchCalls, 0);
+      expect(dio.options.baseUrl, 'https://injected.example.com');
+    });
+
+    test('in-flight cancellation cancels Dio and maps the result', () async {
+      final adapter = _TrackingAdapter(waitForCancellation: true);
+      final dio = Dio()..httpClientAdapter = adapter;
+      final server = CustomServer(
+        baseUrl: 'https://server.example.com',
+        serverConfig: ServerConfig<Dio>.client(dio),
+      );
+      final api = HealthApi(server);
+      final cancellation = TonikCancellation();
+
+      final future = api.getHealth(cancellation: cancellation);
+      await adapter.dispatched.future;
+      cancellation.cancel('navigation');
+      final result = await future;
+
+      expect(adapter.fetchCalls, 1);
+      expect(
+        result,
+        isA<TonikError<HealthStatus, Response<Object?>>>(),
+      );
+      final error = result as TonikError<HealthStatus, Response<Object?>>;
+      expect(error.type, TonikErrorType.cancelled);
+    });
+
+    test(
+      'post-operation cancellation preserves the successful result',
+      () async {
+        final adapter = _TrackingAdapter();
+        final dio = Dio()..httpClientAdapter = adapter;
+        final server = CustomServer(
+          baseUrl: 'https://server.example.com',
+          serverConfig: ServerConfig<Dio>.client(dio),
+        );
+        final api = HealthApi(server);
+        final cancellation = TonikCancellation();
+
+        final result = await api.getHealth(cancellation: cancellation);
+        cancellation.cancel('too late');
+        await Future<void>.delayed(Duration.zero);
+
+        expect(adapter.fetchCalls, 1);
+        expect(
+          result,
+          isA<TonikSuccess<HealthStatus, Response<Object?>>>(),
+        );
+        final success = result as TonikSuccess<HealthStatus, Response<Object?>>;
+        expect(success.value.status, HealthStatusStatusModel.healthy);
+        expect(success.response.statusCode, 200);
+        expect(cancellation.isCancelled, isTrue);
+      },
+    );
+  });
+}
+
+Object _captureDioAccessError(Server server) {
+  try {
+    server.dio;
+  } on Object catch (error) {
+    return error;
+  }
+  throw StateError('Expected Dio access to fail.');
+}
+
+class _TrackingAdapter implements HttpClientAdapter {
+  _TrackingAdapter({this.waitForCancellation = false});
+
+  final bool waitForCancellation;
+  final Completer<void> dispatched = Completer<void>();
+  int fetchCalls = 0;
+  int closeCalls = 0;
+
+  @override
+  Future<ResponseBody> fetch(
+    RequestOptions options,
+    Stream<Uint8List>? requestStream,
+    Future<void>? cancelFuture,
+  ) async {
+    fetchCalls++;
+    if (!dispatched.isCompleted) {
+      dispatched.complete();
+    }
+
+    if (waitForCancellation) {
+      final cancellation = cancelFuture;
+      if (cancellation == null) {
+        throw StateError('Expected a Dio cancellation future.');
+      }
+      await cancellation;
+      throw DioException(
+        requestOptions: options,
+        type: DioExceptionType.cancel,
+      );
+    }
+
+    return ResponseBody.fromString(
+      '{"status":"healthy","timestamp":"2026-07-27T12:00:00Z"}',
+      200,
+      headers: {
+        Headers.contentTypeHeader: ['application/json'],
+      },
+    );
+  }
+
+  @override
+  void close({bool force = false}) {
+    closeCalls++;
+  }
 }

--- a/integration_test/server_variables/server_variables_test/test/server_test.dart
+++ b/integration_test/server_variables/server_variables_test/test/server_test.dart
@@ -257,10 +257,9 @@ void main() {
       final server = CustomServer(
         baseUrl: serverBaseUrl,
         serverConfig: ServerConfig<Dio>.clientFactory(() {
-          created = Dio(options)
+          return created = (Dio(options)
             ..interceptors.add(interceptor)
-            ..httpClientAdapter = adapter;
-          return created;
+            ..httpClientAdapter = adapter);
         }),
       );
 
@@ -289,15 +288,13 @@ void main() {
   group('Dio client lifecycle', () {
     test('close before use does not resolve a factory', () {
       var factoryCalls = 0;
-      final server = CustomServer(
-        baseUrl: 'https://server.example.com',
-        serverConfig: ServerConfig<Dio>.clientFactory(() {
-          factoryCalls++;
-          return Dio();
-        }),
-      );
-
-      server
+      CustomServer(
+          baseUrl: 'https://server.example.com',
+          serverConfig: ServerConfig<Dio>.clientFactory(() {
+            factoryCalls++;
+            return Dio();
+          }),
+        )
         ..close()
         ..close();
 

--- a/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
+++ b/packages/tonik_generate/lib/src/api_client/api_client_generator.dart
@@ -89,7 +89,14 @@ class ApiClientGenerator {
       return refer(fieldName)
           .assign(
             refer(operationName, operationUrl).call([
-              refer('server').property(backendGenerator.clientGetterName),
+              refer('server').property('baseUrl'),
+              Method(
+                (b) => b
+                  ..lambda = true
+                  ..body = refer(
+                    'server',
+                  ).property(backendGenerator.clientGetterName).code,
+              ).closure,
             ]),
           )
           .code;
@@ -180,11 +187,16 @@ class ApiClientGenerator {
     final operationFieldName =
         '_${nameManager.operationName(operation).toCamelCase()}';
 
+    final cancellationParameter = backendGenerator.cancellationParameter;
     final requiredParams = parameters.where((p) => p.required).toList();
-    final optionalParams = parameters.where((p) => !p.required).toList();
+    final optionalParams = [
+      ...parameters.where((p) => !p.required),
+      cancellationParameter,
+    ];
 
     final paramMap = {
       for (final param in parameters) param.name: refer(param.name),
+      cancellationParameter.name: refer(cancellationParameter.name),
     };
 
     final docs = formatDocComments([operation.summary, operation.description]);

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -9,13 +9,10 @@ const _defaultParameterPrefix = 'parameter';
 
 /// `cancellation` is reserved because the generated `call(...)` method
 /// declares a built-in `TonikCancellation? cancellation` parameter.
-/// The legacy `cancelToken` name remains reserved so regenerating an existing
-/// API does not unexpectedly rename an OpenAPI parameter at the same time.
 /// `body` is reserved only when a request body exists, since `call(...)`
 /// then also declares a `body` parameter.
 Set<String> operationReservedParameterNames({required bool hasRequestBody}) => {
   if (hasRequestBody) 'body',
-  'cancelToken',
   'cancellation',
 };
 

--- a/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/parameter_name_normalizer.dart
@@ -7,10 +7,10 @@ const _headerSuffix = 'Header';
 const _cookieSuffix = 'Cookie';
 const _defaultParameterPrefix = 'parameter';
 
-/// `cancelToken` is reserved because the generated `call(...)` method
-/// currently declares a built-in `CancelToken? cancelToken` parameter.
-/// `cancellation` is reserved for the portable cancellation parameter that
-/// replaces it in the coordinated transport migration.
+/// `cancellation` is reserved because the generated `call(...)` method
+/// declares a built-in `TonikCancellation? cancellation` parameter.
+/// The legacy `cancelToken` name remains reserved so regenerating an existing
+/// API does not unexpectedly rename an OpenAPI parameter at the same time.
 /// `body` is reserved only when a request body exists, since `call(...)`
 /// then also declares a `body` parameter.
 Set<String> operationReservedParameterNames({required bool hasRequestBody}) => {

--- a/packages/tonik_generate/lib/src/operation/operation_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/operation_generator.dart
@@ -118,14 +118,20 @@ class OperationGenerator {
       (b) {
         b
           ..name = className
-          ..fields.add(
+          ..fields.addAll([
             Field(
               (b) => b
-                ..name = backendGenerator.clientFieldName
+                ..name = '_baseUrl'
                 ..modifier = FieldModifier.final$
-                ..type = backendGenerator.nativeClientType,
+                ..type = refer('String', 'dart:core'),
             ),
-          )
+            Field(
+              (b) => b
+                ..name = backendGenerator.clientAccessorFieldName
+                ..modifier = FieldModifier.final$
+                ..type = backendGenerator.nativeClientAccessorType,
+            ),
+          ])
           ..fields.addAll(defaults.fields);
 
         if (operation.isDeprecated) {
@@ -140,13 +146,18 @@ class OperationGenerator {
           ..constructors.add(
             Constructor(
               (b) => b
-                ..requiredParameters.add(
+                ..requiredParameters.addAll([
                   Parameter(
                     (b) => b
-                      ..name = backendGenerator.clientFieldName
+                      ..name = '_baseUrl'
                       ..toThis = true,
                   ),
-                ),
+                  Parameter(
+                    (b) => b
+                      ..name = backendGenerator.clientAccessorFieldName
+                      ..toThis = true,
+                  ),
+                ]),
             ),
           )
           ..methods.addAll([
@@ -393,7 +404,7 @@ class OperationGenerator {
         declareFinal(r'_$baseUri')
             .assign(
               refer('Uri', 'dart:core').property('parse').call([
-                backendGenerator.baseUrlExpression,
+                refer('_baseUrl'),
               ]),
             )
             .statement,

--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -200,7 +200,7 @@ class ServerGenerator {
               ),
           ),
         )
-        ..methods.add(
+        ..methods.addAll([
           Method(
             (m) => m
               ..name = backendGenerator.clientGetterName
@@ -211,7 +211,16 @@ class ServerGenerator {
                 backendGenerator.clientAdapterFieldName,
               ).property(backendGenerator.clientGetterName).code,
           ),
-        ),
+          Method(
+            (m) => m
+              ..name = 'close'
+              ..returns = refer('void')
+              ..lambda = true
+              ..body = refer(
+                backendGenerator.clientAdapterFieldName,
+              ).property('close').call([]).code,
+          ),
+        ]),
     );
   }
 
@@ -298,6 +307,7 @@ class ServerGenerator {
                   'baseUrl',
                   'serverConfig',
                   backendGenerator.clientGetterName,
+                  'close',
                 }.contains(normalized)
                 ? '\$$normalized'
                 : normalized,

--- a/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
@@ -52,17 +52,13 @@ final class DioBackendGenerator implements TransportBackendGenerator {
   Reference get requestOptionsType => refer('Options', 'package:dio/dio.dart');
 
   @override
-  Expression get baseUrlExpression =>
-      refer(clientFieldName).property('options').property('baseUrl');
-
-  @override
   Parameter get cancellationParameter => Parameter(
     (b) => b
-      ..name = 'cancelToken'
+      ..name = 'cancellation'
       ..type = TypeReference(
         (b) => b
-          ..symbol = 'CancelToken'
-          ..url = 'package:dio/dio.dart'
+          ..symbol = 'TonikCancellation'
+          ..url = 'package:tonik_util/tonik_util.dart'
           ..isNullable = true,
       )
       ..named = true
@@ -99,7 +95,12 @@ final class DioBackendGenerator implements TransportBackendGenerator {
   String get clientGetterName => 'dio';
 
   @override
-  String get clientFieldName => '_dio';
+  String get clientAccessorFieldName => '_dio';
+
+  @override
+  Reference get nativeClientAccessorType => FunctionType(
+    (b) => b..returnType = nativeClientType,
+  );
 
   @override
   String get clientAdapterName => '_DioClientAdapter';
@@ -141,20 +142,114 @@ final class DioBackendGenerator implements TransportBackendGenerator {
     required String responseVariable,
     required Reference resultValueType,
   }) {
+    final cancelTokenType = TypeReference(
+      (b) => b
+        ..symbol = 'CancelToken'
+        ..url = 'package:dio/dio.dart'
+        ..isNullable = true,
+    );
+    final cancellation = plan.cancellation;
+    const internalCancelToken = r'_$cancelToken';
+    const resolvedDio = r'_$dio';
+
     return Block.of([
       const Code('final '),
       operationResponseType.code,
       Code(' $responseVariable;'),
+      cancelTokenType.code,
+      const Code(' $internalCancelToken;'),
+      Block.of([
+        const Code('if ('),
+        cancellation.code,
+        const Code(' != null) {'),
+        refer(internalCancelToken)
+            .assign(
+              refer('CancelToken', 'package:dio/dio.dart').newInstance([]),
+            )
+            .statement,
+        Block.of([
+          const Code('if ('),
+          cancellation.property('isCancelled').code,
+          const Code(') {'),
+          refer(internalCancelToken).property('cancel').call([
+            cancellation.property('reason'),
+          ]).statement,
+          _resultClass('TonikError', resultValueType)
+              .call(
+                [
+                  refer(
+                    internalCancelToken,
+                  ).property('cancelError').nullChecked,
+                ],
+                {
+                  'stackTrace': refer(
+                    internalCancelToken,
+                  ).property('cancelError').nullChecked.property('stackTrace'),
+                  'type': refer(
+                    'TonikErrorType.cancelled',
+                    'package:tonik_util/tonik_util.dart',
+                  ),
+                  'response': literalNull,
+                },
+              )
+              .returned
+              .statement,
+          const Code('}'),
+        ]),
+        refer('unawaited', 'dart:async').call([
+          cancellation.property('whenCancelled').property('then').call([
+            Method(
+              (m) => m
+                ..requiredParameters.add(
+                  Parameter((p) => p..name = '_'),
+                )
+                ..body = refer(internalCancelToken).nullChecked
+                    .property('cancel')
+                    .call([cancellation.property('reason')])
+                    .statement,
+            ).closure,
+          ]),
+        ]).statement,
+        const Code('}'),
+      ]),
+      const Code(''),
+      const Code('final '),
+      nativeClientType.code,
+      const Code(' $resolvedDio;'),
+      Block.of([
+        const Code('try {'),
+        refer(
+          resolvedDio,
+        ).assign(refer(clientAccessorFieldName).call([])).statement,
+        const Code('} on '),
+        refer('Object', 'dart:core').code,
+        const Code(' catch (exception, stackTrace) {'),
+        _resultClass('TonikError', resultValueType)
+            .call(
+              [refer('exception')],
+              {
+                'stackTrace': refer('stackTrace'),
+                'type': refer(
+                  'TonikErrorType.other',
+                  'package:tonik_util/tonik_util.dart',
+                ),
+                'response': literalNull,
+              },
+            )
+            .returned
+            .statement,
+        const Code('}\n'),
+      ]),
       Block.of([
         const Code('try {'),
         refer(responseVariable)
             .assign(
-              refer(clientFieldName).property('requestUri').call(
+              refer(resolvedDio).property('requestUri').call(
                 [plan.uri],
                 {
                   'data': refer(r'_$data'),
                   'options': refer(r'_$options'),
-                  'cancelToken': plan.cancellation,
+                  'cancelToken': refer(internalCancelToken),
                 },
                 [
                   TypeReference(
@@ -259,6 +354,29 @@ final class DioBackendGenerator implements TransportBackendGenerator {
                   ..isNullable = true,
               ),
           ),
+          Field(
+            (f) => f
+              ..name = r'_$ownsDio'
+              ..type = refer('bool', 'dart:core')
+              ..assignment = literalFalse.code,
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$isClosed'
+              ..type = refer('bool', 'dart:core')
+              ..assignment = literalFalse.code,
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$closedError'
+              ..type = refer('StateError', 'dart:core')
+              ..modifier = FieldModifier.final$
+              ..assignment = refer('StateError', 'dart:core').newInstance([
+                literalString(
+                  'Cannot access Dio after the server has been closed.',
+                ),
+              ]).code,
+          ),
         ])
         ..constructors.add(
           Constructor(
@@ -277,13 +395,17 @@ final class DioBackendGenerator implements TransportBackendGenerator {
               ]),
           ),
         )
-        ..methods.add(
+        ..methods.addAll([
           Method(
             (m) => m
               ..name = clientGetterName
               ..type = MethodType.getter
               ..returns = dioType
               ..body = Block.of([
+                const Code(r'if (_$isClosed) {'),
+                const Code(r'  throw _$closedError;'),
+                const Code('}'),
+                const Code(''),
                 const Code(r'final cachedDio = _$dio;'),
                 const Code('if (cachedDio != null) {'),
                 const Code('  return cachedDio;'),
@@ -299,11 +421,27 @@ final class DioBackendGenerator implements TransportBackendGenerator {
                 ),
                 dioType.newInstance([]).code,
                 const Code(';'),
+                const Code(r'_$ownsDio = client == null;'),
                 const Code('resolvedDio.options.baseUrl = baseUrl;'),
                 const Code(r'return _$dio = resolvedDio;'),
               ]),
           ),
-        ),
+          Method(
+            (m) => m
+              ..name = 'close'
+              ..returns = refer('void')
+              ..body = Block.of([
+                const Code(r'if (_$isClosed) {'),
+                const Code('  return;'),
+                const Code('}'),
+                const Code(''),
+                const Code(r'_$isClosed = true;'),
+                const Code(r'if (_$ownsDio) {'),
+                const Code(r'  _$dio?.close();'),
+                const Code('}'),
+              ]),
+          ),
+        ]),
     );
   }
 

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -35,13 +35,17 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
   );
 
   @override
-  Expression get baseUrlExpression => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
-  );
-
-  @override
-  Parameter get cancellationParameter => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
+  Parameter get cancellationParameter => Parameter(
+    (b) => b
+      ..name = 'cancellation'
+      ..type = TypeReference(
+        (b) => b
+          ..symbol = 'TonikCancellation'
+          ..url = 'package:tonik_util/tonik_util.dart'
+          ..isNullable = true,
+      )
+      ..named = true
+      ..required = false,
   );
 
   @override
@@ -77,7 +81,12 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
   String get clientGetterName => 'client';
 
   @override
-  String get clientFieldName => '_client';
+  String get clientAccessorFieldName => '_client';
+
+  @override
+  Reference get nativeClientAccessorType => FunctionType(
+    (b) => b..returnType = nativeClientType,
+  );
 
   @override
   String get clientAdapterName => '_HttpClientAdapter';

--- a/packages/tonik_generate/lib/src/transport/operation_request_planner.dart
+++ b/packages/tonik_generate/lib/src/transport/operation_request_planner.dart
@@ -37,7 +37,7 @@ class OperationRequestPlanner {
       contentType: _contentTypeExpression(requestBody, content),
       followRedirects: true,
       maxRedirects: 5,
-      cancellation: refer('cancelToken'),
+      cancellation: refer('cancellation'),
       response: _responseRequirements(operation),
       body: _bodyPlan(requestBody, content),
     );

--- a/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
@@ -40,8 +40,6 @@ abstract interface class TransportBackendGenerator {
 
   Reference get requestOptionsType;
 
-  Expression get baseUrlExpression;
-
   Parameter get cancellationParameter;
 
   Expression responseStatusCode(Expression response);
@@ -61,7 +59,9 @@ abstract interface class TransportBackendGenerator {
 
   String get clientGetterName;
 
-  String get clientFieldName;
+  String get clientAccessorFieldName;
+
+  Reference get nativeClientAccessorType;
 
   String get clientAdapterName;
 

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -92,7 +92,20 @@ void main() {
             .toString();
         expect(
           initializerCode,
-          '_getUser = GetUser(server.dio)',
+          '_getUser = GetUser(server.baseUrl, () => server.dio, )',
+        );
+
+        final method = generatedClass.methods.single;
+        expect(method.optionalParameters, hasLength(1));
+        final cancellation = method.optionalParameters.single;
+        expect(cancellation.name, 'cancellation');
+        expect(
+          cancellation.type?.accept(emitter).toString(),
+          'TonikCancellation?',
+        );
+        expect(
+          method.body?.accept(emitter).toString(),
+          '_getUser(cancellation: cancellation)',
         );
       });
 
@@ -142,7 +155,7 @@ void main() {
             .toString();
         expect(
           initializerCode,
-          '_getUser = GetUser(server.dio)',
+          '_getUser = GetUser(server.baseUrl, () => server.dio, )',
         );
       });
 
@@ -268,7 +281,9 @@ void main() {
           );
 
           const expectedMethod = '''
-            Future<TonikResult<void, Response<Object?>>> getUser() async => _getUser();
+            Future<TonikResult<void, Response<Object?>>> getUser({
+              TonikCancellation? cancellation,
+            }) async => _getUser(cancellation: cancellation);
           ''';
 
           expect(
@@ -335,8 +350,9 @@ void main() {
         test('generates method with path parameter', () {
           final method = generatedClass.methods.first;
           expect(method.name, 'getUser');
-          expect(method.optionalParameters.length, 1);
+          expect(method.optionalParameters.length, 2);
           expect(method.optionalParameters.first.name, 'id');
+          expect(method.optionalParameters.last.name, 'cancellation');
           expect(
             method.optionalParameters.first.type?.accept(emitter).toString(),
             'String',
@@ -349,7 +365,10 @@ void main() {
           );
 
           const expectedMethod = '''
-            Future<TonikResult<void, Response<Object?>>> getUser({required String id}) async => _getUser(id: id);
+            Future<TonikResult<void, Response<Object?>>> getUser({
+              required String id,
+              TonikCancellation? cancellation,
+            }) async => _getUser(id: id, cancellation: cancellation);
           ''';
 
           expect(
@@ -422,9 +441,10 @@ void main() {
         test('generates method with query parameters', () {
           final method = generatedClass.methods.first;
           expect(method.name, 'getUsers');
-          expect(method.optionalParameters.length, 2);
+          expect(method.optionalParameters.length, 3);
           expect(method.optionalParameters[0].name, 'limit');
           expect(method.optionalParameters[1].name, 'offset');
+          expect(method.optionalParameters[2].name, 'cancellation');
           expect(
             method.optionalParameters[0].type?.accept(emitter).toString(),
             'int?',
@@ -441,7 +461,15 @@ void main() {
           );
 
           const expectedMethod = '''
-            Future<TonikResult<void, Response<Object?>>> getUsers({int? limit, int? offset}) async => _getUsers(limit: limit, offset: offset);
+            Future<TonikResult<void, Response<Object?>>> getUsers({
+              int? limit,
+              int? offset,
+              TonikCancellation? cancellation,
+            }) async => _getUsers(
+              limit: limit,
+              offset: offset,
+              cancellation: cancellation,
+            );
           ''';
 
           expect(
@@ -515,8 +543,9 @@ void main() {
         test('generates method with request body', () {
           final method = generatedClass.methods.first;
           expect(method.name, 'createUser');
-          expect(method.optionalParameters.length, 1);
+          expect(method.optionalParameters.length, 2);
           expect(method.optionalParameters.first.name, 'body');
+          expect(method.optionalParameters.last.name, 'cancellation');
           expect(
             method.optionalParameters.first.type?.accept(emitter).toString(),
             'CreateUserRequestBody',
@@ -531,7 +560,11 @@ void main() {
           const expectedMethod = '''
             Future<TonikResult<void, Response<Object?>>> createUser({
               required CreateUserRequestBody body,
-            }) async => _createUser(body: body);
+              TonikCancellation? cancellation,
+            }) async => _createUser(
+              body: body,
+              cancellation: cancellation,
+            );
           ''';
 
           expect(
@@ -592,8 +625,9 @@ void main() {
         test('generates method with aliased parameter', () {
           final method = generatedClass.methods.first;
           expect(method.name, 'getUser');
-          expect(method.optionalParameters.length, 1);
+          expect(method.optionalParameters.length, 2);
           expect(method.optionalParameters.first.name, 'userId');
+          expect(method.optionalParameters.last.name, 'cancellation');
           expect(
             method.optionalParameters.first.type?.accept(emitter).toString(),
             'String',
@@ -606,7 +640,13 @@ void main() {
           );
 
           const expectedMethod = '''
-            Future<TonikResult<void, Response<Object?>>> getUser({required String userId}) async => _getUser(userId: userId);
+            Future<TonikResult<void, Response<Object?>>> getUser({
+              required String userId,
+              TonikCancellation? cancellation,
+            }) async => _getUser(
+              userId: userId,
+              cancellation: cancellation,
+            );
           ''';
 
           expect(
@@ -1871,7 +1911,10 @@ void main() {
       expect(result.code, contains('class UsersApi'));
       const expectedMethod = '''
 _i3.Future<_i4.TonikResult<void, _i5.Response<_i3.Object?>>>
-getUser() async => _getUser();
+getUser({
+  _i4.TonikCancellation? cancellation,
+}) async =>
+    _getUser(cancellation: cancellation);
 ''';
       expect(
         collapseWhitespace(result.code),
@@ -2091,7 +2134,8 @@ getUser() async => _getUser();
           const expectedMethod = '''
 Future<TonikResult<void, Response<Object?>>> listThings({
   String region = ListThings.regionDefault,
-}) async => _listThings(region: region);
+  TonikCancellation? cancellation,
+}) async => _listThings(region: region, cancellation: cancellation);
 ''';
 
           expect(
@@ -2162,8 +2206,9 @@ Future<TonikResult<void, Response<Object?>>> listThings({
           );
           const expectedMethod =
               'Future<TonikResult<void,Response<Object?>>> '
-              'listThings({DateTime? since}) '
-              'async => _listThings(since: since);';
+              'listThings({DateTime? since, TonikCancellation? cancellation}) '
+              'async => _listThings( '
+              'since: since, cancellation: cancellation);';
           expect(
             collapseWhitespace(generatedCode),
             contains(collapseWhitespace(format(expectedMethod))),

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -1100,8 +1100,7 @@ void main() {
       });
 
       test(
-        'parameter doc reference uses renamed identifier on cancelToken '
-        'collision',
+        'parameter doc reference preserves an OpenAPI cancelToken identifier',
         () {
           final operation = Operation(
             operationId: 'getA',
@@ -1145,11 +1144,7 @@ void main() {
 
           expect(
             method.docs,
-            contains('/// [cancelTokenQuery] Caller-supplied cancel token id'),
-          );
-          expect(
-            method.docs.any((d) => d.startsWith('/// [cancelToken] ')),
-            isFalse,
+            contains('/// [cancelToken] Caller-supplied cancel token id'),
           );
         },
       );

--- a/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
+++ b/packages/tonik_generate/test/src/naming/parameter_name_normalizer_test.dart
@@ -475,19 +475,6 @@ void main() {
       ]);
     });
 
-    test('reserves cancelToken for query parameters', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {},
-        queryParameters: {createQueryParameter('cancelToken')},
-        headers: {},
-        reservedNames: {'cancelToken'},
-      );
-
-      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
-        'cancelTokenQuery',
-      ]);
-    });
-
     test('reserves cancellation for query parameters', () {
       final result = normalizeRequestParameters(
         pathParameters: {},
@@ -500,91 +487,6 @@ void main() {
 
       expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
         'cancellationQuery',
-      ]);
-    });
-
-    test('reserves cancelToken for path parameters', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {createPathParameter('cancelToken')},
-        queryParameters: {},
-        headers: {},
-        reservedNames: {'cancelToken'},
-      );
-
-      expect(result.pathParameters.map((r) => r.normalizedName).toList(), [
-        'cancelTokenPath',
-      ]);
-    });
-
-    test('reserves cancelToken for header parameters', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {},
-        queryParameters: {},
-        headers: {createHeader('cancelToken')},
-        reservedNames: {'cancelToken'},
-      );
-
-      expect(result.headers.map((r) => r.normalizedName).toList(), [
-        'cancelTokenHeader',
-      ]);
-    });
-
-    test('reserves cancelToken for cookie parameters', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {},
-        queryParameters: {},
-        headers: {},
-        cookieParameters: {createCookieParameter('cancelToken')},
-        reservedNames: {'cancelToken'},
-      );
-
-      expect(result.cookieParameters.map((r) => r.normalizedName).toList(), [
-        'cancelTokenCookie',
-      ]);
-    });
-
-    test(
-      'reserves cancelToken for snake_case raw name that sanitizes to it',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {createQueryParameter('cancel_token')},
-          headers: {},
-          reservedNames: {'cancelToken'},
-        );
-
-        expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
-          'cancelTokenQuery',
-        ]);
-      },
-    );
-
-    test(
-      'reserves cancelToken for kebab-case raw name that sanitizes to it',
-      () {
-        final result = normalizeRequestParameters(
-          pathParameters: {},
-          queryParameters: {createQueryParameter('Cancel-Token')},
-          headers: {},
-          reservedNames: {'cancelToken'},
-        );
-
-        expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
-          'cancelTokenQuery',
-        ]);
-      },
-    );
-
-    test('does not rename non-colliding token-like names', () {
-      final result = normalizeRequestParameters(
-        pathParameters: {},
-        queryParameters: {createQueryParameter('token')},
-        headers: {},
-        reservedNames: {'cancelToken'},
-      );
-
-      expect(result.queryParameters.map((r) => r.normalizedName).toList(), [
-        'token',
       ]);
     });
   });
@@ -626,17 +528,17 @@ void main() {
   });
 
   group('operationReservedParameterNames', () {
-    test('always reserves cancellation names without a request body', () {
+    test('reserves cancellation without a request body', () {
       expect(
         operationReservedParameterNames(hasRequestBody: false),
-        {'cancelToken', 'cancellation'},
+        {'cancellation'},
       );
     });
 
     test('also reserves body when there is a request body', () {
       expect(
         operationReservedParameterNames(hasRequestBody: true),
-        {'body', 'cancelToken', 'cancellation'},
+        {'body', 'cancellation'},
       );
     });
   });

--- a/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_response_test.dart
@@ -236,12 +236,12 @@ void main() {
         );
 
         const expectedMethod = r'''
-Future<TonikResult<Never, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<Never, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/')
         ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}'
@@ -258,12 +258,43 @@ Future<TonikResult<Never, Response<Object?>>> call({CancelToken? cancelToken}) a
     );
   }
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<Never, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<Never, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -365,12 +396,12 @@ Future<TonikResult<Never, Response<Object?>>> call({CancelToken? cancelToken}) a
         );
 
         const expectedMethod = r'''
-Future<TonikResult<Never?, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<Never?, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/')
         ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}'
@@ -387,12 +418,43 @@ Future<TonikResult<Never?, Response<Object?>>> call({CancelToken? cancelToken}) 
     );
   }
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<Never?, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<Never?, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -2430,7 +2430,7 @@ Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellati
       );
 
       test(
-        'renames query parameter colliding with built-in cancelToken',
+        'preserves an OpenAPI query parameter named cancelToken',
         () {
           final queryParam = QueryParameterObject(
             name: 'cancelToken',
@@ -2465,7 +2465,7 @@ Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellati
 
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
-  required String cancelTokenQuery,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -2478,7 +2478,7 @@ Future<TonikResult<void, Response<Object?>>> call({
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
       path: _$newPath,
-      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+      query: _queryParameters(cancelToken: cancelToken),
     );
     _$data = _data();
     _$options = _options();
@@ -2564,7 +2564,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenQuery', 'cancellation']);
+          expect(paramNames, ['cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2575,7 +2575,7 @@ Future<TonikResult<void, Response<Object?>>> call({
       );
 
       test(
-        'renames query parameter colliding with built-in cancelToken when '
+        'preserves an OpenAPI query parameter named cancelToken when '
         'request body is also present',
         () {
           final requestBody = RequestBodyObject(
@@ -2628,7 +2628,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String body,
-  required String cancelTokenQuery,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -2641,7 +2641,7 @@ Future<TonikResult<void, Response<Object?>>> call({
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
       path: _$newPath,
-      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+      query: _queryParameters(cancelToken: cancelToken),
     );
     _$data = _data(body: body);
     _$options = _options();
@@ -2727,7 +2727,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['body', 'cancelTokenQuery', 'cancellation']);
+          expect(paramNames, ['body', 'cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2738,7 +2738,7 @@ Future<TonikResult<void, Response<Object?>>> call({
       );
 
       test(
-        'renames path parameter colliding with built-in cancelToken',
+        'preserves an OpenAPI path parameter named cancelToken',
         () {
           final pathParam = PathParameterObject(
             name: 'cancelToken',
@@ -2772,7 +2772,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
-  required String cancelTokenPath,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -2781,7 +2781,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
   try {
     final _$baseUri = Uri.parse(_baseUrl);
-    final _$pathResult = _path(cancelTokenPath: cancelTokenPath);
+    final _$pathResult = _path(cancelToken: cancelToken);
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
     _$data = _data();
@@ -2868,7 +2868,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenPath', 'cancellation']);
+          expect(paramNames, ['cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2879,7 +2879,7 @@ Future<TonikResult<void, Response<Object?>>> call({
       );
 
       test(
-        'renames header parameter colliding with built-in cancelToken',
+        'preserves an OpenAPI header parameter named cancelToken',
         () {
           final header = RequestHeaderObject(
             name: 'cancelToken',
@@ -2913,7 +2913,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
-  required String cancelTokenHeader,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -2926,7 +2926,7 @@ Future<TonikResult<void, Response<Object?>>> call({
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
     _$data = _data();
-    _$options = _options(cancelTokenHeader: cancelTokenHeader);
+    _$options = _options(cancelToken: cancelToken);
   } on Object catch (exception, stackTrace) {
     return TonikError<void, Response<Object?>>(
       exception,
@@ -3009,7 +3009,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenHeader', 'cancellation']);
+          expect(paramNames, ['cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -3020,7 +3020,7 @@ Future<TonikResult<void, Response<Object?>>> call({
       );
 
       test(
-        'renames cookie parameter colliding with built-in cancelToken',
+        'preserves an OpenAPI cookie parameter named cancelToken',
         () {
           final cookie = CookieParameterObject(
             name: 'cancelToken',
@@ -3053,7 +3053,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
-  required String cancelTokenCookie,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -3066,7 +3066,7 @@ Future<TonikResult<void, Response<Object?>>> call({
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
     _$data = _data();
-    _$options = _options(cancelTokenCookie: cancelTokenCookie);
+    _$options = _options(cancelToken: cancelToken);
   } on Object catch (exception, stackTrace) {
     return TonikError<void, Response<Object?>>(
       exception,
@@ -3149,7 +3149,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenCookie', 'cancellation']);
+          expect(paramNames, ['cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -3160,7 +3160,7 @@ Future<TonikResult<void, Response<Object?>>> call({
       );
 
       test(
-        'renames query parameter that sanitizes to cancelToken',
+        'preserves a query parameter that sanitizes to cancelToken',
         () {
           final queryParam = QueryParameterObject(
             name: 'Cancel-Token',
@@ -3195,7 +3195,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
-  required String cancelTokenQuery,
+  required String cancelToken,
   TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
@@ -3208,7 +3208,7 @@ Future<TonikResult<void, Response<Object?>>> call({
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
       path: _$newPath,
-      query: _queryParameters(cancelTokenQuery: cancelTokenQuery),
+      query: _queryParameters(cancelToken: cancelToken),
     );
     _$data = _data();
     _$options = _options();
@@ -3294,7 +3294,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenQuery', 'cancellation']);
+          expect(paramNames, ['cancelToken', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(

--- a/packages/tonik_generate/test/src/operation/operation_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/operation_generator_test.dart
@@ -61,13 +61,13 @@ void main() {
         );
 
         const expectedMethod = r'''
-Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -83,12 +83,43 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -139,14 +170,14 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
         expect(method.name, 'call');
         expect(method.requiredParameters, isEmpty);
         expect(method.optionalParameters, hasLength(1));
-        final cancelParam = method.optionalParameters.first;
-        expect(cancelParam.name, 'cancelToken');
+        final cancellationParam = method.optionalParameters.first;
+        expect(cancellationParam.name, 'cancellation');
         expect(
-          cancelParam.type?.accept(emitter).toString(),
-          'CancelToken?',
+          cancellationParam.type?.accept(emitter).toString(),
+          'TonikCancellation?',
         );
-        expect(cancelParam.named, isTrue);
-        expect(cancelParam.required, isFalse);
+        expect(cancellationParam.named, isTrue);
+        expect(cancellationParam.required, isFalse);
 
         final methodString = format(method.accept(emitter).toString());
         expect(
@@ -191,14 +222,14 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
         const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String myHeader,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -214,12 +245,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -319,13 +381,13 @@ Future<TonikResult<void, Response<Object?>>> call({
         const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required int petId,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path(petId: petId);
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -340,12 +402,43 @@ Future<TonikResult<void, Response<Object?>>> call({
     );
   }
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -444,13 +537,13 @@ Future<TonikResult<void, Response<Object?>>> call({
         );
 
         const expectedMethod = r'''
-Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -466,12 +559,43 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -584,14 +708,14 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
 Future<TonikResult<void, Response<Object?>>> call({
   required String filter,
   String? sort,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -609,12 +733,43 @@ Future<TonikResult<void, Response<Object?>>> call({
     );
   }
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -717,7 +872,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           );
 
           expect(method.optionalParameters, hasLength(1));
-          expect(method.optionalParameters.first.name, 'cancelToken');
+          expect(method.optionalParameters.first.name, 'cancellation');
           expect(method.requiredParameters, isEmpty);
         },
       );
@@ -829,14 +984,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   String? body,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -852,12 +1007,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1036,14 +1222,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required UploadForm body,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1059,12 +1245,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1181,14 +1398,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   UploadForm? body,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1204,12 +1421,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1412,13 +1660,13 @@ Future<TonikResult<void, Response<Object?>>> call({
         );
 
         const expectedMethod = r'''
-Future<TonikResult<String, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<String, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1434,12 +1682,43 @@ Future<TonikResult<String, Response<Object?>>> call({CancelToken? cancelToken}) 
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<String, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<String, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1524,13 +1803,13 @@ Future<TonikResult<String, Response<Object?>>> call({CancelToken? cancelToken}) 
           normalizedParams,
         );
         const expectedMethod = r'''
-Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1546,12 +1825,43 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1656,13 +1966,13 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
           );
 
           const expectedMethod = r'''
-Future<TonikResult<List<ActivePet>, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<List<ActivePet>, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1678,12 +1988,43 @@ Future<TonikResult<List<ActivePet>, Response<Object?>>> call({CancelToken? cance
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<List<ActivePet>, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<List<ActivePet>, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1766,13 +2107,13 @@ Future<TonikResult<List<ActivePet>, Response<Object?>>> call({CancelToken? cance
         );
 
         const expectedMethod = r'''
-Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1788,12 +2129,43 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -1831,7 +2203,7 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
       });
 
       test(
-        'generates cancelToken parameter with correct type and optionality',
+        'generates cancellation parameter with correct type and optionality',
         () {
           final operation = Operation(
             operationId: 'cancelTest',
@@ -1862,20 +2234,19 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
             normalizedParams,
           );
 
-          // cancelToken should be the last optional parameter
-          final cancelParam = method.optionalParameters.last;
-          expect(cancelParam.name, 'cancelToken');
+          final cancellationParam = method.optionalParameters.last;
+          expect(cancellationParam.name, 'cancellation');
           expect(
-            cancelParam.type?.accept(emitter).toString(),
-            'CancelToken?',
+            cancellationParam.type?.accept(emitter).toString(),
+            'TonikCancellation?',
           );
-          expect(cancelParam.named, isTrue);
-          expect(cancelParam.required, isFalse);
+          expect(cancellationParam.named, isTrue);
+          expect(cancellationParam.required, isFalse);
         },
       );
 
       test(
-        'generates cancelToken as last parameter when other params exist',
+        'generates cancellation as last parameter when other params exist',
         () {
           final pathParam = PathParameterObject(
             name: 'id',
@@ -1925,7 +2296,7 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
 
           expect(method.optionalParameters, hasLength(2));
           expect(method.optionalParameters.first.name, 'id');
-          expect(method.optionalParameters.last.name, 'cancelToken');
+          expect(method.optionalParameters.last.name, 'cancellation');
         },
       );
 
@@ -1962,13 +2333,13 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
           );
 
           const expectedMethod = r'''
-Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) async {
+Future<TonikResult<void, Response<Object?>>> call({TonikCancellation? cancellation}) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -1984,12 +2355,43 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2064,14 +2466,14 @@ Future<TonikResult<void, Response<Object?>>> call({CancelToken? cancelToken}) as
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String cancelTokenQuery,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -2090,12 +2492,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2131,7 +2564,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenQuery', 'cancelToken']);
+          expect(paramNames, ['cancelTokenQuery', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2196,14 +2629,14 @@ Future<TonikResult<void, Response<Object?>>> call({
 Future<TonikResult<void, Response<Object?>>> call({
   required String body,
   required String cancelTokenQuery,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -2222,12 +2655,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2263,7 +2727,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['body', 'cancelTokenQuery', 'cancelToken']);
+          expect(paramNames, ['body', 'cancelTokenQuery', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2309,14 +2773,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String cancelTokenPath,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path(cancelTokenPath: cancelTokenPath);
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -2332,12 +2796,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2373,7 +2868,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenPath', 'cancelToken']);
+          expect(paramNames, ['cancelTokenPath', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2419,14 +2914,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String cancelTokenHeader,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -2442,12 +2937,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2483,7 +3009,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenHeader', 'cancelToken']);
+          expect(paramNames, ['cancelTokenHeader', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2528,14 +3054,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String cancelTokenCookie,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(path: _$newPath);
@@ -2551,12 +3077,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2592,7 +3149,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenCookie', 'cancelToken']);
+          expect(paramNames, ['cancelTokenCookie', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2639,14 +3196,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   required String cancelTokenQuery,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -2665,12 +3222,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -2706,7 +3294,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['cancelTokenQuery', 'cancelToken']);
+          expect(paramNames, ['cancelTokenQuery', 'cancellation']);
 
           final methodString = format(method.accept(emitter).toString());
           expect(
@@ -2756,7 +3344,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final paramNames = method.optionalParameters
               .map((p) => p.name)
               .toList();
-          expect(paramNames, ['token', 'cancelToken']);
+          expect(paramNames, ['token', 'cancellation']);
         },
       );
     });
@@ -2852,15 +3440,17 @@ Future<TonikResult<void, Response<Object?>>> call({
         final result = generator.generateCallableOperation(operation);
         final code = result.code;
         expect(
-          code,
+          collapseWhitespace(code),
           contains(
-            ' _i2.Future<_i3.TonikResult<void, '
-            '_i1.Response<_i2.Object?>>> call({\n'
-            '    required _i2.String body,\n'
-            '    required _i2.String id,\n'
-            '    _i2.int? limit,\n'
-            '    _i1.CancelToken? cancelToken,\n'
-            '  }) async',
+            collapseWhitespace(
+              ' _i1.Future<_i3.TonikResult<void, '
+              '_i2.Response<_i1.Object?>>> call({\n'
+              '    required _i1.String body,\n'
+              '    required _i1.String id,\n'
+              '    _i1.int? limit,\n'
+              '    _i3.TonikCancellation? cancellation,\n'
+              '  }) async',
+            ),
           ),
         );
       });
@@ -2944,15 +3534,17 @@ Future<TonikResult<void, Response<Object?>>> call({
         final result = generator.generateCallableOperation(operation);
         final code = result.code;
         expect(
-          code,
+          collapseWhitespace(code),
           contains(
-            ' _i2.Future<_i3.TonikResult<void, '
-            '_i1.Response<_i2.Object?>>> call({\n'
-            '    required _i2.String userId,\n'
-            '    _i2.int? pageSize,\n'
-            '    required _i2.String authToken,\n'
-            '    _i1.CancelToken? cancelToken,\n'
-            '  }) async',
+            collapseWhitespace(
+              ' _i1.Future<_i3.TonikResult<void, '
+              '_i2.Response<_i1.Object?>>> call({\n'
+              '    required _i1.String userId,\n'
+              '    _i1.int? pageSize,\n'
+              '    required _i1.String authToken,\n'
+              '    _i3.TonikCancellation? cancellation,\n'
+              '  }) async',
+            ),
           ),
         );
       });
@@ -3186,6 +3778,7 @@ Future<TonikResult<void, Response<Object?>>> call({
 
           final fieldNames = result.fields.map((f) => f.name).toList();
           expect(fieldNames, [
+            '_baseUrl',
             '_dio',
             'idDefault',
             'regionDefault',
@@ -3450,7 +4043,7 @@ Future<TonikResult<void, Response<Object?>>> call({
           final result = generator.generateClass(operation, 'Upload');
 
           final fieldNames = result.fields.map((f) => f.name).toList();
-          expect(fieldNames, ['_dio']);
+          expect(fieldNames, ['_baseUrl', '_dio']);
         },
       );
 
@@ -3492,13 +4085,13 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedMethod = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   String region = regionDefault,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -3517,12 +4110,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {
@@ -3687,14 +4311,14 @@ Future<TonikResult<void, Response<Object?>>> call({
           const expectedCall = r'''
 Future<TonikResult<void, Response<Object?>>> call({
   Status status = statusDefault,
-  CancelToken? cancelToken,
+  TonikCancellation? cancellation,
 }) async {
   late final Uri _$uri;
   late final Object? _$data;
   late final Options _$options;
 
   try {
-    final _$baseUri = Uri.parse(_dio.options.baseUrl);
+    final _$baseUri = Uri.parse(_baseUrl);
     final _$pathResult = _path();
     final _$newPath = _$baseUri.path.endsWith('/') ? '${_$baseUri.path.substring(0, _$baseUri.path.length - 1)}/${_$pathResult.join('/')}' : '${_$baseUri.path}/${_$pathResult.join('/')}';
     _$uri = _$baseUri.replace(
@@ -3713,12 +4337,43 @@ Future<TonikResult<void, Response<Object?>>> call({
   }
 
   final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
   try {
-    _$response = await _dio.requestUri<List<int>>(
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
       _$uri,
       data: _$data,
       options: _$options,
-      cancelToken: cancelToken,
+      cancelToken: _$cancelToken,
     );
   } on DioException catch (exception, stackTrace) {
     if (exception.type == DioExceptionType.cancel) {

--- a/packages/tonik_generate/test/src/server/server_generator_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_test.dart
@@ -76,6 +76,10 @@ void main() {
       final dioGetter = dioAdapter.methods.firstWhere((m) => m.name == 'dio');
 
       const expectedBody = r'''
+        if (_$isClosed) {
+          throw _$closedError;
+        }
+
         final cachedDio = _$dio;
         if (cachedDio != null) {
           return cachedDio;
@@ -85,6 +89,7 @@ void main() {
         final clientFactory = serverConfig.clientFactory;
 
         final resolvedDio = client ?? clientFactory?.call() ?? Dio() ;
+        _$ownsDio = client == null;
         resolvedDio.options.baseUrl = baseUrl;
         return _$dio = resolvedDio;
       ''';
@@ -157,6 +162,17 @@ void main() {
       expect(
         collapseWhitespace(bodyCode),
         collapseWhitespace(r'_$dioAdapter.dio'),
+      );
+    });
+
+    test('generates idempotent adapter-backed close', () {
+      final close = baseClass.methods.firstWhere((m) => m.name == 'close');
+
+      expect(close.returns?.accept(emitter).toString(), 'void');
+      expect(close.lambda, isTrue);
+      expect(
+        collapseWhitespace(close.body!.accept(emitter).toString()),
+        collapseWhitespace(r'_$dioAdapter.close()'),
       );
     });
   });
@@ -380,7 +396,19 @@ void main() {
 
           _i3.Dio? _$dio;
 
+          _i1.bool _$ownsDio = false;
+
+          _i1.bool _$isClosed = false;
+
+          final _i1.StateError _$closedError = _i1.StateError(
+            'Cannot access Dio after the server has been closed.',
+          );
+
           _i3.Dio get dio {
+            if (_$isClosed) {
+              throw _$closedError;
+            }
+
             final cachedDio = _$dio;
             if (cachedDio != null) {
               return cachedDio;
@@ -390,8 +418,20 @@ void main() {
             final clientFactory = serverConfig.clientFactory;
             final resolvedDio =
                 client ?? clientFactory?.call() ?? _i3.Dio();
+            _$ownsDio = client == null;
             resolvedDio.options.baseUrl = baseUrl;
             return _$dio = resolvedDio;
+          }
+
+          void close() {
+            if (_$isClosed) {
+              return;
+            }
+
+            _$isClosed = true;
+            if (_$ownsDio) {
+              _$dio?.close();
+            }
           }
         }
 
@@ -406,6 +446,8 @@ void main() {
           final _DioClientAdapter _$dioAdapter;
 
           _i3.Dio get dio => _$dioAdapter.dio;
+
+          void close() => _$dioAdapter.close();
         }
 
         /// Production server - https://production.example.com

--- a/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_variables_test.dart
@@ -626,12 +626,13 @@ void main() {
     test('does not shadow members of the generated base server', () {
       final servers = [
         const Server(
-          url: 'https://{baseUrl}.{serverConfig}.example.com/{dio}',
+          url: 'https://{baseUrl}.{serverConfig}.example.com/{dio}/{close}',
           description: 'Inherited member collision server',
           variables: [
             ServerVariable(name: 'baseUrl', defaultValue: 'base'),
             ServerVariable(name: 'serverConfig', defaultValue: 'config'),
             ServerVariable(name: 'dio', defaultValue: 'client'),
+            ServerVariable(name: 'close', defaultValue: 'shutdown'),
           ],
         ),
       ];
@@ -642,11 +643,12 @@ void main() {
           .map((parameter) => parameter.name)
           .toList();
 
-      expect(fieldNames, [r'$baseUrl', r'$serverConfig', r'$dio']);
+      expect(fieldNames, [r'$baseUrl', r'$serverConfig', r'$dio', r'$close']);
       expect(parameterNames, [
         r'$baseUrl',
         r'$serverConfig',
         r'$dio',
+        r'$close',
         'serverConfig',
       ]);
     });

--- a/packages/tonik_generate/test/src/transport/dio_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/dio_backend_generator_test.dart
@@ -1,0 +1,243 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/transport/dio_backend_generator.dart';
+import 'package:tonik_generate/src/transport/operation_request_plan.dart';
+
+void main() {
+  const generator = DioBackendGenerator();
+  final emitter = DartEmitter(useNullSafetySyntax: true);
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  test('exposes portable cancellation while keeping Dio bridging private', () {
+    final parameter = generator.cancellationParameter;
+
+    expect(parameter.name, 'cancellation');
+    expect(
+      parameter.type?.accept(emitter).toString(),
+      'TonikCancellation?',
+    );
+    expect(parameter.named, isTrue);
+    expect(parameter.required, isFalse);
+  });
+
+  group('Dio client adapter', () {
+    late Class adapter;
+
+    setUp(() {
+      adapter = generator.generateClientAdapter();
+    });
+
+    test('tracks cached ownership and one stable closed error', () {
+      expect(
+        adapter.fields.map((field) => field.name),
+        [
+          'baseUrl',
+          'serverConfig',
+          r'_$dio',
+          r'_$ownsDio',
+          r'_$isClosed',
+          r'_$closedError',
+        ],
+      );
+
+      final closedError = adapter.fields.singleWhere(
+        (field) => field.name == r'_$closedError',
+      );
+      expect(
+        closedError.type?.accept(emitter).toString(),
+        'StateError',
+      );
+      expect(closedError.modifier, FieldModifier.final$);
+    });
+
+    test(
+      'resolves once, records ownership, and rejects access after close',
+      () {
+        final getter = adapter.methods.singleWhere(
+          (method) => method.name == 'dio',
+        );
+
+        const expectedMethod = r'''
+Dio dio() {
+  if (_$isClosed) {
+    throw _$closedError;
+  }
+
+  final cachedDio = _$dio;
+  if (cachedDio != null) {
+    return cachedDio;
+  }
+
+  final client = serverConfig.client;
+  final clientFactory = serverConfig.clientFactory;
+  final resolvedDio = client ?? clientFactory?.call() ?? Dio();
+  _$ownsDio = client == null;
+  resolvedDio.options.baseUrl = baseUrl;
+  return _$dio = resolvedDio;
+}
+''';
+
+        expect(
+          collapseWhitespace(format(_asMethod(getter, emitter))),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test('closes an owned resolved Dio once without resolving on close', () {
+      final close = adapter.methods.singleWhere(
+        (method) => method.name == 'close',
+      );
+
+      expect(
+        close.returns?.accept(emitter).toString(),
+        'void',
+      );
+
+      const expectedMethod = r'''
+void close() {
+  if (_$isClosed) {
+    return;
+  }
+
+  _$isClosed = true;
+  if (_$ownsDio) {
+    _$dio?.close();
+  }
+}
+''';
+
+      expect(
+        collapseWhitespace(format(_asMethod(close, emitter))),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+  });
+
+  test(
+    'guards pre-cancellation, resolves lazily, and bridges in-flight cancel '
+    'without a shadow-prone local',
+    () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.get,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          followRedirects: true,
+          maxRedirects: 5,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (b) => b
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(refer('void')),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
+Future<void> dispatch() async {
+  final Response<List<int>> _$response;
+  CancelToken? _$cancelToken;
+  if (cancellation != null) {
+    _$cancelToken = CancelToken();
+    if (cancellation.isCancelled) {
+      _$cancelToken.cancel(cancellation.reason);
+      return TonikError<void, Response<Object?>>(
+        _$cancelToken.cancelError!,
+        stackTrace: _$cancelToken.cancelError!.stackTrace,
+        type: TonikErrorType.cancelled,
+        response: null,
+      );
+    }
+    unawaited(
+      cancellation.whenCancelled.then((_) {
+        _$cancelToken!.cancel(cancellation.reason);
+      }),
+    );
+  }
+
+  final Dio _$dio;
+  try {
+    _$dio = _dio();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  try {
+    _$response = await _$dio.requestUri<List<int>>(
+      _$uri,
+      data: _$data,
+      options: _$options,
+      cancelToken: _$cancelToken,
+    );
+  } on DioException catch (exception, stackTrace) {
+    if (exception.type == DioExceptionType.cancel) {
+      return TonikError<void, Response<Object?>>(
+        exception,
+        stackTrace: stackTrace,
+        type: TonikErrorType.cancelled,
+        response: exception.response,
+      );
+    }
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: exception.response,
+    );
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response<Object?>>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.network,
+      response: null,
+    );
+  }
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    },
+  );
+}
+
+String _asMethod(Method method, DartEmitter emitter) {
+  final wrapped = method.rebuild(
+    (builder) => builder
+      ..type = null
+      ..name = method.name,
+  );
+  return '${wrapped.accept(emitter)}';
+}

--- a/packages/tonik_generate/test/src/transport/operation_request_plan_test.dart
+++ b/packages/tonik_generate/test/src/transport/operation_request_plan_test.dart
@@ -234,6 +234,10 @@ void main() {
         expect(plan.methodName, _methodNames[method]);
         expect(plan.body, isA<AbsentBodyPlan>());
         expect(plan.response.expectsBytes, isTrue);
+        expect(
+          plan.cancellation.accept(DartEmitter()).toString(),
+          'cancellation',
+        );
       }
     });
 

--- a/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_defaults_test.dart
@@ -1182,13 +1182,7 @@ void main() {
 
       expect(
         names,
-        containsAll(<String>[
-          'call',
-          'body',
-          'cancelToken',
-          'cancellation',
-          'region',
-        ]),
+        containsAll(<String>['call', 'body', 'cancellation', 'region']),
       );
     });
 
@@ -1208,7 +1202,7 @@ void main() {
       expect(names.contains('body'), isFalse);
       expect(
         names,
-        containsAll(<String>['cancelToken', 'cancellation', 'call']),
+        containsAll(<String>['cancellation', 'call']),
       );
     });
   });

--- a/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/operation_parameter_generator_test.dart
@@ -1711,8 +1711,8 @@ void main() {
     );
   });
 
-  group('cancelToken parameter name collision', () {
-    test('adds Query suffix to query parameter named cancelToken', () {
+  group('OpenAPI cancelToken parameters', () {
+    test('preserves a query parameter named cancelToken', () {
       final queryParam = QueryParameterObject(
         name: null,
         rawName: 'cancelToken',
@@ -1751,8 +1751,7 @@ void main() {
       );
 
       final paramNames = parameters.map((p) => p.name).toList();
-      expect(paramNames, contains('cancelTokenQuery'));
-      expect(paramNames, isNot(contains('cancelToken')));
+      expect(paramNames, contains('cancelToken'));
       expect(
         paramNames.toSet().length,
         paramNames.length,
@@ -1760,7 +1759,7 @@ void main() {
       );
     });
 
-    test('adds Path suffix to path parameter named cancelToken', () {
+    test('preserves a path parameter named cancelToken', () {
       final pathParam = PathParameterObject(
         name: null,
         rawName: 'cancelToken',
@@ -1798,8 +1797,7 @@ void main() {
       );
 
       final paramNames = parameters.map((p) => p.name).toList();
-      expect(paramNames, contains('cancelTokenPath'));
-      expect(paramNames, isNot(contains('cancelToken')));
+      expect(paramNames, contains('cancelToken'));
       expect(
         paramNames.toSet().length,
         paramNames.length,
@@ -1807,7 +1805,7 @@ void main() {
       );
     });
 
-    test('adds Header suffix to header parameter named cancelToken', () {
+    test('preserves a header parameter named cancelToken', () {
       final headerParam = RequestHeaderObject(
         name: null,
         rawName: 'cancelToken',
@@ -1845,8 +1843,7 @@ void main() {
       );
 
       final paramNames = parameters.map((p) => p.name).toList();
-      expect(paramNames, contains('cancelTokenHeader'));
-      expect(paramNames, isNot(contains('cancelToken')));
+      expect(paramNames, contains('cancelToken'));
       expect(
         paramNames.toSet().length,
         paramNames.length,
@@ -1854,7 +1851,7 @@ void main() {
       );
     });
 
-    test('adds Cookie suffix to cookie parameter named cancelToken', () {
+    test('preserves a cookie parameter named cancelToken', () {
       final cookieParam = CookieParameterObject(
         name: null,
         rawName: 'cancelToken',
@@ -1891,8 +1888,7 @@ void main() {
       );
 
       final paramNames = parameters.map((p) => p.name).toList();
-      expect(paramNames, contains('cancelTokenCookie'));
-      expect(paramNames, isNot(contains('cancelToken')));
+      expect(paramNames, contains('cancelToken'));
       expect(
         paramNames.toSet().length,
         paramNames.length,
@@ -1901,7 +1897,7 @@ void main() {
     });
 
     test(
-      'renames query parameter named cancelToken even when '
+      'preserves a query parameter named cancelToken when '
       'request body is present',
       () {
         final queryParam = QueryParameterObject(
@@ -1965,8 +1961,7 @@ void main() {
 
         final paramNames = parameters.map((p) => p.name).toList();
         expect(paramNames, contains('body'));
-        expect(paramNames, contains('cancelTokenQuery'));
-        expect(paramNames, isNot(contains('cancelToken')));
+        expect(paramNames, contains('cancelToken'));
         expect(
           paramNames.toSet().length,
           paramNames.length,
@@ -1976,8 +1971,7 @@ void main() {
     );
 
     test(
-      'does not rename query parameter named token (no collision with '
-      'cancelToken)',
+      'preserves an unrelated query parameter named token',
       () {
         final queryParam = QueryParameterObject(
           name: null,


### PR DESCRIPTION
## Summary

- Introduce operation request planning for generated HTTP and Dio backends.
- Improve parameter and response-body naming collision handling.
- Add server-variable support to generated clients and servers.
- Update feature documentation and integration coverage.

## Testing

- Added and updated unit tests for API clients, operations, servers, naming, and transport request plans.
- Updated integration tests for naming collisions and server variables.