### PR TITLE
Implement HTTP transport client adapter lifecycle

### DIFF
--- a/packages/tonik_generate/lib/src/server/server_generator.dart
+++ b/packages/tonik_generate/lib/src/server/server_generator.dart
@@ -192,8 +192,10 @@ class ServerGenerator {
                 refer(backendGenerator.clientAdapterFieldName)
                     .assign(
                       refer(backendGenerator.clientAdapterName).call([
-                        refer('baseUrl'),
-                        refer('serverConfig'),
+                        ...backendGenerator.clientAdapterConstructorArguments(
+                          baseUrl: refer('baseUrl'),
+                          serverConfig: refer('serverConfig'),
+                        ),
                       ]),
                     )
                     .code,

--- a/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
@@ -109,6 +109,12 @@ final class DioBackendGenerator implements TransportBackendGenerator {
   String get clientAdapterFieldName => r'_$dioAdapter';
 
   @override
+  List<Expression> clientAdapterConstructorArguments({
+    required Expression baseUrl,
+    required Expression serverConfig,
+  }) => [baseUrl, serverConfig];
+
+  @override
   Method generateBodyMethod({
     required Operation operation,
     required NameManager nameManager,

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -95,9 +95,116 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
   String get clientAdapterFieldName => r'_$httpClientAdapter';
 
   @override
-  Class generateClientAdapter() => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
-  );
+  List<Expression> clientAdapterConstructorArguments({
+    required Expression baseUrl,
+    required Expression serverConfig,
+  }) => [serverConfig];
+
+  @override
+  Class generateClientAdapter() {
+    final clientType = nativeClientType;
+
+    return Class(
+      (b) => b
+        ..name = clientAdapterName
+        ..fields.addAll([
+          Field(
+            (f) => f
+              ..name = 'serverConfig'
+              ..type = serverConfigType
+              ..modifier = FieldModifier.final$,
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$client'
+              ..type = TypeReference(
+                (b) => b
+                  ..symbol = 'Client'
+                  ..url = 'package:http/http.dart'
+                  ..isNullable = true,
+              ),
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$ownsClient'
+              ..type = refer('bool', 'dart:core')
+              ..assignment = literalFalse.code,
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$isClosed'
+              ..type = refer('bool', 'dart:core')
+              ..assignment = literalFalse.code,
+          ),
+          Field(
+            (f) => f
+              ..name = r'_$closedError'
+              ..type = refer('StateError', 'dart:core')
+              ..modifier = FieldModifier.final$
+              ..assignment = refer('StateError', 'dart:core').newInstance([
+                literalString(
+                  'Cannot access the HTTP client after the server has been '
+                  'closed.',
+                ),
+              ]).code,
+          ),
+        ])
+        ..constructors.add(
+          Constructor(
+            (c) => c.requiredParameters.add(
+              Parameter(
+                (p) => p
+                  ..name = 'serverConfig'
+                  ..toThis = true,
+              ),
+            ),
+          ),
+        )
+        ..methods.addAll([
+          Method(
+            (m) => m
+              ..name = clientGetterName
+              ..type = MethodType.getter
+              ..returns = clientType
+              ..body = Block.of([
+                const Code(r'if (_$isClosed) {'),
+                const Code(r'  throw _$closedError;'),
+                const Code('}'),
+                const Code(''),
+                const Code(r'final cachedClient = _$client;'),
+                const Code('if (cachedClient != null) {'),
+                const Code('  return cachedClient;'),
+                const Code('}'),
+                const Code(''),
+                const Code('final configuredClient = serverConfig.client;'),
+                const Code(
+                  'final resolvedClient = configuredClient ?? '
+                  'serverConfig.clientFactory?.call() ?? ',
+                ),
+                clientType.newInstance([]).code,
+                const Code(';'),
+                const Code(r'_$ownsClient = configuredClient == null;'),
+                const Code(r'return _$client = resolvedClient;'),
+              ]),
+          ),
+          Method(
+            (m) => m
+              ..name = 'close'
+              ..returns = refer('void')
+              ..body = Block.of([
+                const Code(r'if (_$isClosed) {'),
+                const Code('  return;'),
+                const Code('}'),
+                const Code(''),
+                const Code(r'_$isClosed = true;'),
+                const Code(r'if (_$ownsClient) {'),
+                const Code(r'  _$client?.close();'),
+                const Code('}'),
+              ]),
+          ),
+        ]),
+    );
+  }
 
   @override
   Method generateBodyMethod({
@@ -128,7 +235,55 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     required OperationRequestPlan plan,
     required String responseVariable,
     required Reference resultValueType,
-  }) => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
-  );
+  }) {
+    const resolvedClient = r'_$client';
+
+    return Block.of([
+      const Code('final '),
+      nativeClientType.code,
+      const Code(' $resolvedClient;'),
+      Block.of([
+        const Code('try {'),
+        refer(
+          resolvedClient,
+        ).assign(refer(clientAccessorFieldName).call([])).statement,
+        const Code('} on '),
+        refer('Object', 'dart:core').code,
+        const Code(' catch (exception, stackTrace) {'),
+        _resultClass('TonikError', resultValueType)
+            .call(
+              [refer('exception')],
+              {
+                'stackTrace': refer('stackTrace'),
+                'type': refer(
+                  'TonikErrorType.other',
+                  'package:tonik_util/tonik_util.dart',
+                ),
+                'response': literalNull,
+              },
+            )
+            .returned
+            .statement,
+        const Code('}\n'),
+      ]),
+      refer('UnsupportedError', 'dart:core')
+          .newInstance([
+            literalString(
+              'The http transport backend does not support request dispatch '
+              'yet.',
+            ),
+          ])
+          .thrown
+          .statement,
+    ]);
+  }
+
+  Reference _resultClass(String symbol, Reference resultValueType) {
+    return TypeReference(
+      (b) => b
+        ..symbol = symbol
+        ..url = 'package:tonik_util/tonik_util.dart'
+        ..types.addAll([resultValueType, nativeResponseType]),
+    );
+  }
 }

--- a/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
@@ -67,6 +67,11 @@ abstract interface class TransportBackendGenerator {
 
   String get clientAdapterFieldName;
 
+  List<Expression> clientAdapterConstructorArguments({
+    required Expression baseUrl,
+    required Expression serverConfig,
+  });
+
   Class generateClientAdapter();
 
   Method generateBodyMethod({

--- a/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
+++ b/packages/tonik_generate/test/src/api_client/api_client_generator_test.dart
@@ -6,6 +6,7 @@ import 'package:tonik_generate/src/api_client/api_client_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/transport/dio_backend_generator.dart';
+import 'package:tonik_generate/src/transport/http_backend_generator.dart';
 import 'package:tonik_generate/src/util/operation_parameter_defaults.dart';
 
 void main() {
@@ -156,6 +157,45 @@ void main() {
         expect(
           initializerCode,
           '_getUser = GetUser(server.baseUrl, () => server.dio, )',
+        );
+      });
+
+      test('captures the http client getter without resolving it', () {
+        final httpGenerator = ApiClientGenerator(
+          nameManager: nameManager,
+          package: 'test_package',
+          backendGenerator: const HttpBackendGenerator(),
+          defaultsCache: OperationDefaultsCache(
+            nameManager: nameManager,
+            package: 'test_package',
+          ),
+        );
+        final operation = Operation(
+          operationId: 'getUser',
+          context: testContext,
+          tags: {Tag(name: 'users')},
+          isDeprecated: false,
+          path: '/users/{id}',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: const {},
+          securitySchemes: const {},
+        );
+
+        final generatedClass = httpGenerator.generateClass(
+          {operation},
+          Tag(name: 'users'),
+          testServers,
+        );
+        final initializer =
+            generatedClass.constructors.single.initializers.single;
+
+        expect(
+          initializer.accept(emitter).toString(),
+          '_getUser = GetUser(server.baseUrl, () => server.client, )',
         );
       });
 

--- a/packages/tonik_generate/test/src/pubspec_generator_test.dart
+++ b/packages/tonik_generate/test/src/pubspec_generator_test.dart
@@ -250,8 +250,10 @@ void main() {
 
       expect(dio, contains('dio: ^5.8.0+1'));
       expect(dio, isNot(contains('http:')));
+      expect(dio, isNot(contains('dio_web_adapter:')));
       expect(http, contains('http: ^1.6.0'));
       expect(http, isNot(contains('dio:')));
+      expect(http, isNot(contains('dio_web_adapter:')));
     });
   });
 }

--- a/packages/tonik_generate/test/src/server/server_generator_test.dart
+++ b/packages/tonik_generate/test/src/server/server_generator_test.dart
@@ -6,6 +6,7 @@ import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/server/server_generator.dart';
 import 'package:tonik_generate/src/transport/dio_backend_generator.dart';
+import 'package:tonik_generate/src/transport/http_backend_generator.dart';
 
 void main() {
   late ServerGenerator generator;
@@ -469,6 +470,104 @@ void main() {
           CustomServer({
             required super.baseUrl,
             super.serverConfig = const _i2.ServerConfig<_i3.Dio>(),
+          });
+        }
+      ''';
+
+      expect(
+        collapseWhitespace(format(result.code)),
+        collapseWhitespace(format(expectedCode)),
+      );
+    });
+
+    test('generates the complete http lifecycle server library', () {
+      final httpNameManager = NameManager(
+        generator: NameGenerator(),
+        stableModelSorter: StableModelSorter(),
+      );
+      final httpGenerator = ServerGenerator(
+        nameManager: httpNameManager,
+        backendGenerator: const HttpBackendGenerator(),
+      );
+      final result = httpGenerator.generate(const []);
+
+      expect(result.filename, 'server.dart');
+
+      const expectedCode = r'''
+        // Generated code - do not modify by hand
+
+        // ignore_for_file: no_leading_underscores_for_library_prefixes
+        import 'dart:core' as _i3;
+
+        import 'package:http/http.dart' as _i2;
+        import 'package:tonik_util/tonik_util.dart' as _i1;
+
+        class _HttpClientAdapter {
+          _HttpClientAdapter(this.serverConfig);
+
+          final _i1.ServerConfig<_i2.Client> serverConfig;
+
+          _i2.Client? _$client;
+
+          _i3.bool _$ownsClient = false;
+
+          _i3.bool _$isClosed = false;
+
+          final _i3.StateError _$closedError = _i3.StateError(
+            'Cannot access the HTTP client after the server has been closed.',
+          );
+
+          _i2.Client get client {
+            if (_$isClosed) {
+              throw _$closedError;
+            }
+
+            final cachedClient = _$client;
+            if (cachedClient != null) {
+              return cachedClient;
+            }
+
+            final configuredClient = serverConfig.client;
+            final resolvedClient =
+                configuredClient ??
+                serverConfig.clientFactory?.call() ??
+                _i2.Client();
+            _$ownsClient = configuredClient == null;
+            return _$client = resolvedClient;
+          }
+
+          void close() {
+            if (_$isClosed) {
+              return;
+            }
+
+            _$isClosed = true;
+            if (_$ownsClient) {
+              _$client?.close();
+            }
+          }
+        }
+
+        sealed class Server {
+          Server({required this.baseUrl, required this.serverConfig})
+            : _$httpClientAdapter = _HttpClientAdapter(serverConfig);
+
+          final _i3.String baseUrl;
+
+          final _i1.ServerConfig<_i2.Client> serverConfig;
+
+          final _HttpClientAdapter _$httpClientAdapter;
+
+          _i2.Client get client => _$httpClientAdapter.client;
+
+          void close() => _$httpClientAdapter.close();
+        }
+
+        /// Custom server with user-defined base URL
+        class CustomServer extends Server {
+          CustomServer({
+            required super.baseUrl,
+            super.serverConfig = const _i1.ServerConfig<_i2.Client>(),
           });
         }
       ''';

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -1,0 +1,189 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/transport/http_backend_generator.dart';
+import 'package:tonik_generate/src/transport/operation_request_plan.dart';
+
+void main() {
+  const generator = HttpBackendGenerator();
+  final emitter = DartEmitter(useNullSafetySyntax: true);
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  group('http client adapter', () {
+    late Class adapter;
+
+    setUp(() {
+      adapter = generator.generateClientAdapter();
+    });
+
+    test('tracks cached ownership and one stable closed error', () {
+      expect(
+        adapter.fields.map((field) => field.name),
+        [
+          'serverConfig',
+          r'_$client',
+          r'_$ownsClient',
+          r'_$isClosed',
+          r'_$closedError',
+        ],
+      );
+
+      final serverConfig = adapter.fields.first;
+      expect(
+        serverConfig.type?.accept(emitter).toString(),
+        'ServerConfig<Client>',
+      );
+      expect(serverConfig.modifier, FieldModifier.final$);
+
+      final closedError = adapter.fields.last;
+      expect(
+        closedError.type?.accept(emitter).toString(),
+        'StateError',
+      );
+      expect(closedError.modifier, FieldModifier.final$);
+    });
+
+    test(
+      'resolves default injected and factory clients once with ownership',
+      () {
+        final getter = adapter.methods.singleWhere(
+          (method) => method.name == 'client',
+        );
+
+        const expectedMethod = r'''
+Client client() {
+  if (_$isClosed) {
+    throw _$closedError;
+  }
+
+  final cachedClient = _$client;
+  if (cachedClient != null) {
+    return cachedClient;
+  }
+
+  final configuredClient = serverConfig.client;
+  final resolvedClient =
+      configuredClient ?? serverConfig.clientFactory?.call() ?? Client();
+  _$ownsClient = configuredClient == null;
+  return _$client = resolvedClient;
+}
+''';
+
+        expect(
+          collapseWhitespace(format(_asMethod(getter, emitter))),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+
+    test(
+      'closes only an owned resolved client once without resolving on close',
+      () {
+        final close = adapter.methods.singleWhere(
+          (method) => method.name == 'close',
+        );
+
+        expect(
+          close.returns?.accept(emitter).toString(),
+          'void',
+        );
+
+        const expectedMethod = r'''
+void close() {
+  if (_$isClosed) {
+    return;
+  }
+
+  _$isClosed = true;
+  if (_$ownsClient) {
+    _$client?.close();
+  }
+}
+''';
+
+        expect(
+          collapseWhitespace(format(_asMethod(close, emitter))),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+  });
+
+  test(
+    'resolves through the accessor before dispatch and maps closed access',
+    () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.get,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          followRedirects: true,
+          maxRedirects: 5,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final method = Method(
+        (b) => b
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (b) => b
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(refer('void', 'dart:core')),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
+Future<void> dispatch() async {
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  throw UnsupportedError(
+    'The http transport backend does not support request dispatch yet.',
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    },
+  );
+}
+
+String _asMethod(Method method, DartEmitter emitter) {
+  final wrapped = method.rebuild(
+    (builder) => builder
+      ..type = null
+      ..name = method.name,
+  );
+  return '${wrapped.accept(emitter)}';
+}

--- a/packages/tonik_generate/test/src/transport/transport_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/transport_backend_generator_test.dart
@@ -37,16 +37,12 @@ void main() {
       expect(backend.dependencies, [
         const DependencyDescriptor(name: 'http', versionConstraint: '^1.6.0'),
       ]);
-      expect(
-        backend.generateClientAdapter,
-        throwsA(
-          isA<UnsupportedError>().having(
-            (error) => error.message,
-            'message',
-            contains('http'),
-          ),
-        ),
-      );
+      expect(backend.nativeClientType.symbol, 'Client');
+      expect(backend.nativeClientType.url, 'package:http/http.dart');
+      expect(backend.nativeResponseType.symbol, 'Response');
+      expect(backend.nativeResponseType.url, 'package:http/http.dart');
+      expect(backend.nativeResponseType.types, isEmpty);
+      expect(backend.generateClientAdapter().name, '_HttpClientAdapter');
     });
   });
 }


### PR DESCRIPTION
## Summary

- Generate the HTTP client adapter with lazy client resolution and ownership tracking
- Support injected clients, client factories, default clients, and safe closing
- Integrate backend-specific adapter constructor arguments and preserve Dio behavior
- Add HTTP backend generation and lifecycle coverage
- Keep HTTP request dispatch explicitly unsupported for now

## Testing

- Added unit tests for adapter resolution, ownership, closing, dispatch error mapping, server generation, API client generation, and dependencies