### PR TITLE
Lower HTTP requests into transport-specific options and headers

### DIFF
--- a/packages/tonik_generate/lib/src/transport/dio/dio_options_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/dio/dio_options_generator.dart
@@ -1,16 +1,9 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
-import 'package:tonik_generate/src/util/exception_code_generator.dart';
-import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
-import 'package:tonik_generate/src/util/map_property_value_expression_builder.dart';
-import 'package:tonik_generate/src/util/source_file_url.dart';
-import 'package:tonik_generate/src/util/spec_literal_string.dart';
-import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
-import 'package:tonik_generate/src/util/type_reference_generator.dart';
-import 'package:tonik_util/tonik_util.dart';
+import 'package:tonik_generate/src/transport/request_headers_generator.dart';
 
-/// Generator for creating options method for operations.
+/// Generator for creating Dio options methods for operations.
 class DioOptionsGenerator {
   const DioOptionsGenerator({
     required this.nameManager,
@@ -22,58 +15,44 @@ class DioOptionsGenerator {
   final String package;
   final bool useImmutableCollections;
 
-  /// Generates the options method for the operation.
   Method generateOptionsMethod(
     Operation operation,
     List<({String normalizedName, RequestHeaderObject parameter})> headers,
     List<({String normalizedName, CookieParameterObject parameter})>
     cookieParameters,
   ) {
-    final bodyStatements = <Code>[];
-    final parameters = <Parameter>[];
+    final generated = RequestHeadersGenerator(
+      nameManager: nameManager,
+      package: package,
+      headerValueType: refer('dynamic', 'dart:core'),
+      useImmutableCollections: useImmutableCollections,
+    ).generate(operation, headers, cookieParameters);
 
-    final methodString = _generateMethodString(operation.method);
-    final contentType = _generateContentType(
-      operation.requestBody,
-      bodyStatements,
-      parameters,
-    );
-    _generateHeaders(
-      headers,
-      bodyStatements,
-      parameters,
-      operation,
-    );
-    _generateCookieHeader(
-      cookieParameters,
-      bodyStatements,
-      parameters,
-    );
-
-    final optionsExpr = refer('Options', 'package:dio/dio.dart').call([], {
-      'method': literalString(methodString),
+    final options = refer('Options', 'package:dio/dio.dart').call([], {
+      'method': literalString(_methodName(operation.method)),
       'headers': refer(r'_$headers'),
-      'contentType': ?contentType,
+      'contentType': ?generated.contentType,
       'responseType': refer(
         'ResponseType',
         'package:dio/dio.dart',
       ).property('bytes'),
-      'validateStatus': _generateValidateStatus(),
+      'validateStatus': _validateStatus(),
     });
-
-    bodyStatements.add(optionsExpr.returned.statement);
 
     return Method(
       (b) => b
         ..name = '_options'
         ..returns = refer('Options', 'package:dio/dio.dart')
-        ..optionalParameters.addAll(parameters)
+        ..optionalParameters.addAll(generated.parameters)
         ..lambda = false
-        ..body = Block((b) => b..statements.addAll(bodyStatements)),
+        ..body = Block.of([
+          ...generated.statements,
+          options.returned.statement,
+        ]),
     );
   }
 
-  String _generateMethodString(HttpMethod method) => switch (method) {
+  String _methodName(HttpMethod method) => switch (method) {
     HttpMethod.get => 'GET',
     HttpMethod.post => 'POST',
     HttpMethod.put => 'PUT',
@@ -84,498 +63,7 @@ class DioOptionsGenerator {
     HttpMethod.trace => 'TRACE',
   };
 
-  Expression? _generateContentType(
-    RequestBody? requestBody,
-    List<Code> bodyStatements,
-    List<Parameter> parameters,
-  ) {
-    if (requestBody?.resolvedContent.isEmpty ?? true) {
-      return null;
-    }
-
-    if (requestBody!.contentCount == 1) {
-      final singleContent = requestBody.resolvedContent.first;
-      if (singleContent.contentType == ContentType.multipart) {
-        return literalNull;
-      }
-      if (requestBody.isRequired) {
-        return specLiteralString(singleContent.rawContentType);
-      }
-
-      // Optional bodies omit the Content-Type header when no body is sent.
-      parameters.add(
-        Parameter(
-          (b) => b
-            ..name = 'body'
-            ..type = typeReference(
-              singleContent.model,
-              nameManager,
-              package,
-              isNullableOverride: true,
-              useImmutableCollections: useImmutableCollections,
-            )
-            ..named = true
-            ..required = false,
-        ),
-      );
-      bodyStatements.add(
-        declareFinal(r'_$contentType')
-            .assign(
-              refer('body')
-                  .equalTo(literalNull)
-                  .conditional(
-                    literalNull,
-                    specLiteralString(singleContent.rawContentType),
-                  ),
-            )
-            .statement,
-      );
-      return refer(r'_$contentType');
-    }
-
-    final (baseName, subclassNames) = nameManager.requestBodyNames(requestBody);
-    final requestBodyUrl = sourceFileUrl(package, 'request_body', baseName);
-    parameters.add(
-      Parameter(
-        (b) => b
-          ..name = 'body'
-          ..type = TypeReference(
-            (b) => b
-              ..symbol = baseName
-              ..url = requestBodyUrl
-              ..isNullable = !requestBody.isRequired,
-          )
-          ..named = true
-          ..required = requestBody.isRequired,
-      ),
-    );
-
-    final cases = <Code>[];
-    for (final content in requestBody.resolvedContent) {
-      final className = subclassNames[content.rawContentType]!;
-      final caseCode = [
-        refer(className, requestBodyUrl).code,
-        const Code(' _ => '),
-        if (content.contentType == ContentType.multipart)
-          literalNull.code
-        else
-          specLiteralString(content.rawContentType).code,
-        const Code(',\n'),
-      ];
-      cases.addAll(caseCode);
-    }
-
-    // Optional bodies omit the Content-Type header.
-    if (!requestBody.isRequired) {
-      cases.add(const Code('null => null,\n'));
-    }
-
-    bodyStatements.add(
-      declareFinal(r'_$contentType')
-          .assign(
-            CodeExpression(
-              Block.of([
-                const Code('switch (body) {'),
-                ...cases,
-                const Code('}'),
-              ]),
-            ),
-          )
-          .statement,
-    );
-    return refer(r'_$contentType');
-  }
-
-  void _generateHeaders(
-    List<({String normalizedName, RequestHeaderObject parameter})> headers,
-    List<Code> bodyStatements,
-    List<Parameter> parameters,
-    Operation operation,
-  ) {
-    // Accept header logic
-    final hasAcceptHeader = headers.any(
-      (h) => h.parameter.rawName.toLowerCase() == 'accept',
-    );
-    final acceptHeader = headers
-        .cast<({String normalizedName, RequestHeaderObject parameter})?>()
-        .firstWhere(
-          (h) => h?.parameter.rawName.toLowerCase() == 'accept',
-          orElse: () => null,
-        );
-    String? acceptParamName;
-    var acceptIsRequired = false;
-    if (acceptHeader != null) {
-      acceptParamName = acceptHeader.normalizedName;
-      acceptIsRequired = acceptHeader.parameter.isRequired;
-    }
-
-    // Collect all unique response content types
-    final contentTypes = <String>{};
-
-    for (final response in operation.responses.values) {
-      if (response is ResponseObject) {
-        for (final body in response.bodies) {
-          contentTypes.add(body.rawContentType);
-        }
-      }
-    }
-
-    final acceptValue = contentTypes.isNotEmpty
-        ? contentTypes.join(',')
-        : '*/*';
-
-    bodyStatements.add(
-      declareFinal(r'_$headers')
-          .assign(
-            literalMap(
-              {},
-              refer('String', 'dart:core'),
-              refer('dynamic', 'dart:core'),
-            ),
-          )
-          .statement,
-    );
-
-    // For required Accept header, always assign using encoder
-    if (hasAcceptHeader && acceptIsRequired) {
-      bodyStatements.add(
-        refer(r'_$headers')
-            .index(specLiteralString('Accept'))
-            .assign(
-              buildToSimpleHeaderParameterExpression(
-                acceptParamName!,
-                acceptHeader!.parameter,
-                explode: acceptHeader.parameter.explode,
-                allowEmpty: acceptHeader.parameter.allowEmptyValue,
-              ).expression,
-            )
-            .statement,
-      );
-    } else if (hasAcceptHeader && !acceptIsRequired) {
-      bodyStatements
-        ..add(Code('if ($acceptParamName != null) {'))
-        ..add(
-          refer(r'_$headers')
-              .index(specLiteralString('Accept'))
-              .assign(
-                buildToSimpleHeaderParameterExpression(
-                  acceptParamName!,
-                  acceptHeader!.parameter,
-                  explode: acceptHeader.parameter.explode,
-                  allowEmpty: acceptHeader.parameter.allowEmptyValue,
-                  isNullChecked: true,
-                ).expression,
-              )
-              .statement,
-        )
-        ..add(const Code('} else {'))
-        ..add(
-          refer(r'_$headers')
-              .index(literalString('Accept'))
-              .assign(specLiteralString(acceptValue))
-              .statement,
-        )
-        ..add(const Code('}'));
-    } else {
-      // No Accept header param, just assign default
-      bodyStatements.add(
-        refer(r'_$headers')
-            .index(literalString('Accept'))
-            .assign(specLiteralString(acceptValue))
-            .statement,
-      );
-    }
-
-    // Only add headerEncoder if there are user-defined headers
-    // (excluding Accept) or Accept needs encoding
-
-    for (final headerParam in headers) {
-      // Skip Accept header, already handled
-      if (headerParam.parameter.rawName.toLowerCase() == 'accept') {
-        parameters.add(
-          _generateHeaderParameter(
-            headerParam.normalizedName,
-            headerParam.parameter,
-          ),
-        );
-        continue;
-      }
-      final paramName = headerParam.normalizedName;
-      final resolvedParam = headerParam.parameter;
-
-      // For simple encoding, reject headers that are lists with
-      // complex elements
-      if (resolvedParam.encoding == HeaderParameterEncoding.simple &&
-          resolvedParam.model is ListModel &&
-          (resolvedParam.model as ListModel).content.encodingShape !=
-              EncodingShape.simple) {
-        if (resolvedParam.isRequired) {
-          // Required: immediately throw at runtime
-          bodyStatements.add(
-            generateEncodingExceptionExpression(
-              'Simple encoding does not support list with complex elements for'
-              ' header ${resolvedParam.rawName}',
-            ).statement,
-          );
-        } else {
-          // Optional: only throw if provided
-          bodyStatements.add(
-            Block.of([
-              Code('if ($paramName != null) {'),
-              generateEncodingExceptionExpression(
-                'Simple encoding does not support list with complex elements'
-                ' for header ${resolvedParam.rawName}',
-              ).statement,
-              const Code('}'),
-            ]),
-          );
-        }
-        parameters.add(_generateHeaderParameter(paramName, resolvedParam));
-        continue;
-      }
-
-      parameters.add(_generateHeaderParameter(paramName, resolvedParam));
-
-      if (!resolvedParam.isRequired) {
-        final headerAssignment = _generateHeaderAssignment(
-          paramName,
-          resolvedParam,
-          isNullChecked: true,
-        );
-        bodyStatements.add(
-          Block.of([
-            Code('if ($paramName != null) {'),
-            headerAssignment,
-            const Code('}'),
-          ]),
-        );
-      } else {
-        final headerAssignment = _generateHeaderAssignment(
-          paramName,
-          resolvedParam,
-        );
-        bodyStatements.add(headerAssignment);
-      }
-    }
-  }
-
-  /// Generates the Cookie header for cookie parameters.
-  ///
-  /// Cookies are encoded using form style (the only style valid for cookies
-  /// per OpenAPI 3.x) and concatenated as `name1=value1; name2=value2`.
-  void _generateCookieHeader(
-    List<({String normalizedName, CookieParameterObject parameter})>
-    cookieParameters,
-    List<Code> bodyStatements,
-    List<Parameter> parameters,
-  ) {
-    if (cookieParameters.isEmpty) {
-      return;
-    }
-
-    for (final cookie in cookieParameters) {
-      final paramType = typeReference(
-        cookie.parameter.model,
-        nameManager,
-        package,
-        isNullableOverride: !cookie.parameter.isRequired,
-        useImmutableCollections: useImmutableCollections,
-      );
-
-      parameters.add(
-        Parameter(
-          (b) => b
-            ..name = cookie.normalizedName
-            ..type = paramType
-            ..named = true
-            ..required = cookie.parameter.isRequired,
-        ),
-      );
-    }
-
-    final requiredCookies = cookieParameters
-        .where((c) => c.parameter.isRequired)
-        .toList();
-    final optionalCookies = cookieParameters
-        .where((c) => !c.parameter.isRequired)
-        .toList();
-
-    bodyStatements.add(
-      declareFinal(r'_$cookieParts')
-          .assign(
-            literalList(
-              [],
-              refer('String', 'dart:core'),
-            ),
-          )
-          .statement,
-    );
-
-    for (final cookie in requiredCookies) {
-      _addCookieEncodingStatement(cookie, bodyStatements);
-    }
-
-    for (final cookie in optionalCookies) {
-      bodyStatements.add(Code('if (${cookie.normalizedName} != null) {'));
-      _addCookieEncodingStatement(cookie, bodyStatements);
-      bodyStatements.add(const Code('}'));
-    }
-
-    bodyStatements
-      ..add(const Code(r'if (_$cookieParts.isNotEmpty) {'))
-      ..add(
-        refer(r'_$headers')
-            .index(specLiteralString('Cookie'))
-            .assign(
-              refer(r'_$cookieParts').property('join').call([
-                literalString('; '),
-              ]),
-            )
-            .statement,
-      )
-      ..add(const Code('}'));
-  }
-
-  void _addCookieEncodingStatement(
-    ({String normalizedName, CookieParameterObject parameter}) cookie,
-    List<Code> bodyStatements,
-  ) {
-    final model = cookie.parameter.model;
-    final rawName = cookie.parameter.rawName;
-    final paramName = cookie.normalizedName;
-    final explode = cookie.parameter.explode;
-
-    final resolved = model.resolved;
-    final isBinary =
-        resolved is BinaryModel ||
-        (resolved is ListModel && resolved.content.resolved is BinaryModel);
-    if (isBinary) {
-      bodyStatements.add(
-        generateEncodingExceptionExpression(
-          'Binary data cannot be form-encoded for cookie $rawName',
-        ).statement,
-      );
-      return;
-    }
-    if (resolved is NeverModel ||
-        (resolved is ListModel && resolved.content.resolved is NeverModel)) {
-      bodyStatements.add(
-        generateEncodingExceptionExpression(
-          'Cannot encode NeverModel - this type does not permit any value '
-          'for cookie $rawName',
-        ).statement,
-      );
-      return;
-    }
-
-    if (resolved is MapModel) {
-      final conversion = buildMapPropertyValueConversion(
-        refer(paramName),
-        resolved,
-        isNullable: false,
-        context: rawName,
-      );
-      if (conversion is UnsupportedMapPropertyValueConversion) {
-        bodyStatements.add(
-          generateEncodingExceptionExpression(
-            'Map with complex value types cannot be form-encoded '
-            'for cookie $rawName',
-            raw: true,
-          ).statement,
-        );
-        return;
-      }
-    }
-
-    if (isAnyModelFormValue(model)) {
-      final encodedValue =
-          refer(
-            'encodeAnyToForm',
-            'package:tonik_util/tonik_util.dart',
-          ).call(
-            [refer(paramName)],
-            {
-              'explode': literalBool(explode),
-              'allowEmpty': literalBool(true),
-            },
-          );
-      bodyStatements.add(
-        refer(r'_$cookieParts').property('add').call([
-          literalList([
-            specLiteralString('$rawName='),
-            encodedValue,
-          ]).property('join').call([]),
-        ]).statement,
-      );
-      return;
-    }
-
-    final entries = buildFormEntriesValueExpression(
-      refer(paramName),
-      model,
-      paramName: specLiteralString(rawName),
-      explode: literalBool(explode),
-      allowEmpty: literalBool(true),
-      mapContext: rawName,
-    );
-
-    if (entries == null) {
-      bodyStatements.add(
-        generateEncodingExceptionExpression(
-          'Unsupported model type for form-encoded cookie $rawName',
-        ).statement,
-      );
-      return;
-    }
-
-    bodyStatements.add(
-      refer(r'_$cookieParts').property('addAll').call([
-        entries.property('map').call([formEntryToWireString()]),
-      ]).statement,
-    );
-  }
-
-  Parameter _generateHeaderParameter(
-    String paramName,
-    RequestHeaderObject resolvedParam,
-  ) {
-    final parameterType = typeReference(
-      resolvedParam.model,
-      nameManager,
-      package,
-      isNullableOverride: !resolvedParam.isRequired,
-      useImmutableCollections: useImmutableCollections,
-    );
-
-    return Parameter(
-      (b) => b
-        ..name = paramName
-        ..type = parameterType
-        ..named = true
-        ..required = resolvedParam.isRequired,
-    );
-  }
-
-  Code _generateHeaderAssignment(
-    String paramName,
-    RequestHeaderObject resolvedParam, {
-    bool isNullChecked = false,
-  }) {
-    final valueExpression = buildToSimpleHeaderParameterExpression(
-      paramName,
-      resolvedParam,
-      explode: resolvedParam.explode,
-      allowEmpty: resolvedParam.allowEmptyValue,
-      isNullChecked: isNullChecked,
-    );
-
-    return refer(r'_$headers')
-        .index(specLiteralString(resolvedParam.rawName))
-        .assign(valueExpression.expression)
-        .statement;
-  }
-
-  Expression _generateValidateStatus() => Method(
+  Expression _validateStatus() => Method(
     (b) => b
       ..lambda = true
       ..requiredParameters.add(Parameter((b) => b..name = '_'))

--- a/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
@@ -1,0 +1,239 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/built_expression.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/inline_helper_context.dart';
+import 'package:tonik_generate/src/util/source_file_url.dart';
+import 'package:tonik_generate/src/util/to_form_value_expression_generator.dart';
+import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
+import 'package:tonik_generate/src/util/type_reference_generator.dart';
+
+/// Generates exact request body bytes for ordinary `package:http` requests.
+class HttpBodyGenerator {
+  const HttpBodyGenerator({
+    required this.nameManager,
+    required this.package,
+    this.useImmutableCollections = false,
+  });
+
+  final NameManager nameManager;
+  final String package;
+  final bool useImmutableCollections;
+
+  Method generateBodyMethod(Operation operation) {
+    final requestBody = operation.requestBody;
+    if (requestBody == null || requestBody.resolvedContent.isEmpty) {
+      return Method(
+        (b) => b
+          ..name = '_data'
+          ..returns = refer('Object?', 'dart:core')
+          ..lambda = false
+          ..body = const Code('return null;'),
+      );
+    }
+
+    final content = requestBody.resolvedContent.toList();
+    if (content.any((item) => item.contentType == ContentType.multipart)) {
+      throw UnsupportedError(
+        'The http transport backend does not support multipart bodies yet.',
+      );
+    }
+
+    final helperContext = InlineHelperContext(nameManager: nameManager);
+    final inlineHelpers = <InlineHelper>[];
+    final isRequired = requestBody.isRequired;
+
+    if (content.length > 1) {
+      final (baseName, subclassNames) = nameManager.requestBodyNames(
+        requestBody,
+      );
+      final requestBodyUrl = sourceFileUrl(package, 'request_body', baseName);
+      final cases = <Code>[];
+
+      for (final item in content) {
+        final variantName = subclassNames[item.rawContentType]!;
+        final built = _bodyBytesExpression(
+          operation: operation,
+          content: item,
+          valueName: 'value.value',
+          helperContext: helperContext,
+        );
+        inlineHelpers.addAll(built.inlineFunctions);
+        cases.add(
+          Block.of([
+            const Code('final '),
+            refer(variantName, requestBodyUrl).code,
+            const Code(' value => '),
+            built.unsafeRawBody.code,
+            const Code(','),
+          ]),
+        );
+      }
+
+      if (!isRequired) {
+        cases.add(const Code('null => null,'));
+      }
+
+      return Method(
+        (b) => b
+          ..name = '_data'
+          ..returns = refer('Object?', 'dart:core')
+          ..optionalParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'body'
+                ..type = TypeReference(
+                  (t) => t
+                    ..symbol = baseName
+                    ..url = requestBodyUrl
+                    ..isNullable = !isRequired,
+                )
+                ..named = true
+                ..required = isRequired,
+            ),
+          )
+          ..lambda = false
+          ..body = Block.of([
+            ...spliceInlineHelpers(inlineHelpers),
+            const Code('return switch (body) {'),
+            ...cases,
+            const Code('};'),
+          ]),
+      );
+    }
+
+    final item = content.single;
+    final built = _bodyBytesExpression(
+      operation: operation,
+      content: item,
+      valueName: 'body',
+      helperContext: helperContext,
+    );
+    inlineHelpers.addAll(built.inlineFunctions);
+
+    return Method(
+      (b) => b
+        ..name = '_data'
+        ..returns = refer('Object?', 'dart:core')
+        ..optionalParameters.add(
+          Parameter(
+            (p) => p
+              ..name = 'body'
+              ..type = typeReference(
+                item.model,
+                nameManager,
+                package,
+                isNullableOverride: !isRequired,
+                useImmutableCollections: useImmutableCollections,
+              )
+              ..named = true
+              ..required = isRequired,
+          ),
+        )
+        ..lambda = false
+        ..body = Block.of([
+          if (!isRequired) const Code('if (body == null) return null;'),
+          ...spliceInlineHelpers(inlineHelpers),
+          const Code('return '),
+          built.unsafeRawBody.code,
+          const Code(';'),
+        ]),
+    );
+  }
+
+  BuiltExpression _bodyBytesExpression({
+    required Operation operation,
+    required RequestContent content,
+    required String valueName,
+    required InlineHelperContext helperContext,
+  }) {
+    final value = refer(valueName);
+    switch (content.contentType) {
+      case ContentType.json:
+        final json = buildToJsonPropertyExpression(
+          valueName,
+          Property(
+            name: 'body',
+            model: content.model,
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            defaultValue: null,
+            examples: const [],
+          ),
+          nameManager: nameManager,
+          package: package,
+          helperContext: helperContext,
+          contextClass: operation.operationId,
+          contextProperty: 'body',
+        );
+        return BuiltExpression(
+          body: refer('utf8', 'dart:convert').property('encode').call([
+            refer('jsonEncode', 'dart:convert').call([json.unsafeRawBody]),
+          ]),
+          inlineFunctions: json.inlineFunctions,
+        );
+      case ContentType.text:
+        final encoding = _textEncoding(content.rawContentType);
+        if (encoding == null) {
+          final charset = _charset(content.rawContentType);
+          return BuiltExpression.simple(
+            generateEncodingExceptionExpression(
+              'Unsupported text encoding: $charset.',
+            ),
+          );
+        }
+        return BuiltExpression.simple(
+          encoding.property('encode').call([value]),
+        );
+      case ContentType.bytes:
+        final resolved = content.model.resolved;
+        if (resolved is BinaryModel) {
+          return BuiltExpression.simple(value.property('toBytes').call([]));
+        }
+        if (resolved is PrimitiveModel) {
+          return BuiltExpression.simple(value);
+        }
+        return BuiltExpression.simple(
+          generateEncodingExceptionExpression(
+            'Unsupported model for bytes content type.',
+          ),
+        );
+      case ContentType.form:
+        final form = buildToFormValueExpression(
+          valueName,
+          content.model,
+          useQueryComponent: true,
+          encoding: content.formEncoding,
+        );
+        return BuiltExpression(
+          body: refer(
+            'utf8',
+            'dart:convert',
+          ).property('encode').call([form.unsafeRawBody]),
+          inlineFunctions: form.inlineFunctions,
+        );
+      case ContentType.multipart:
+        throw StateError('Multipart bodies are handled by HTTP-09.');
+    }
+  }
+
+  Expression? _textEncoding(String rawContentType) {
+    final charset = _charset(rawContentType);
+
+    return switch (charset) {
+      'utf-8' || 'utf8' => refer('utf8', 'dart:convert'),
+      'iso-8859-1' || 'latin1' => refer('latin1', 'dart:convert'),
+      'us-ascii' || 'ascii' => refer('ascii', 'dart:convert'),
+      _ => null,
+    };
+  }
+
+  String _charset(String rawContentType) =>
+      RegExp(
+        r'(?:^|;)\s*charset\s*=\s*"?([^";\s]+)',
+        caseSensitive: false,
+      ).firstMatch(rawContentType)?.group(1)?.toLowerCase() ??
+      'utf-8';
+}

--- a/packages/tonik_generate/lib/src/transport/http/http_headers_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_headers_generator.dart
@@ -1,0 +1,75 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/transport/request_headers_generator.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
+
+/// Generates the exact string header map applied to a `package:http` request.
+class HttpHeadersGenerator {
+  const HttpHeadersGenerator({
+    required this.nameManager,
+    required this.package,
+    this.useImmutableCollections = false,
+  });
+
+  final NameManager nameManager;
+  final String package;
+  final bool useImmutableCollections;
+
+  Method generateHeadersMethod(
+    Operation operation,
+    List<({String normalizedName, RequestHeaderObject parameter})> headers,
+    List<({String normalizedName, CookieParameterObject parameter})>
+    cookieParameters,
+  ) {
+    final stringType = refer('String', 'dart:core');
+    final generated = RequestHeadersGenerator(
+      nameManager: nameManager,
+      package: package,
+      headerValueType: stringType,
+      useImmutableCollections: useImmutableCollections,
+    ).generate(operation, headers, cookieParameters);
+    final statements = <Code>[...generated.statements];
+    final requestBody = operation.requestBody;
+    final content = requestBody?.resolvedContent.toList() ?? const [];
+
+    if (generated.contentType != null &&
+        content.isNotEmpty &&
+        content.singleOrNull?.contentType != ContentType.multipart) {
+      final assignContentType = refer(r'_$headers')
+          .index(specLiteralString('Content-Type'))
+          .assign(generated.contentType!)
+          .statement;
+      if (requestBody!.isRequired && content.length == 1) {
+        statements.add(assignContentType);
+      } else {
+        statements.add(
+          Block.of([
+            const Code(r'if (_$contentType != null) {'),
+            refer(r'_$headers')
+                .index(specLiteralString('Content-Type'))
+                .assign(refer(r'_$contentType'))
+                .statement,
+            const Code('}'),
+          ]),
+        );
+      }
+    }
+
+    statements.add(refer(r'_$headers').returned.statement);
+
+    return Method(
+      (b) => b
+        ..name = '_options'
+        ..returns = TypeReference(
+          (t) => t
+            ..symbol = 'Map'
+            ..url = 'dart:core'
+            ..types.addAll([stringType, stringType]),
+        )
+        ..optionalParameters.addAll(generated.parameters)
+        ..lambda = false
+        ..body = Block.of(statements),
+    );
+  }
+}

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -1,6 +1,8 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/transport/http/http_body_generator.dart';
+import 'package:tonik_generate/src/transport/http/http_headers_generator.dart';
 import 'package:tonik_generate/src/transport/operation_request_plan.dart';
 import 'package:tonik_generate/src/transport/transport_backend_generator.dart';
 
@@ -30,8 +32,14 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
   );
 
   @override
-  Reference get requestOptionsType => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
+  Reference get requestOptionsType => TypeReference(
+    (b) => b
+      ..symbol = 'Map'
+      ..url = 'dart:core'
+      ..types.addAll([
+        refer('String', 'dart:core'),
+        refer('String', 'dart:core'),
+      ]),
   );
 
   @override
@@ -212,9 +220,11 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     required NameManager nameManager,
     required String package,
     required bool useImmutableCollections,
-  }) => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
-  );
+  }) => HttpBodyGenerator(
+    nameManager: nameManager,
+    package: package,
+    useImmutableCollections: useImmutableCollections,
+  ).generateBodyMethod(operation);
 
   @override
   Method generateOptionsMethod({
@@ -226,9 +236,11 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     headers,
     required List<({String normalizedName, CookieParameterObject parameter})>
     cookies,
-  }) => throw UnsupportedError(
-    'The http transport backend is not supported yet.',
-  );
+  }) => HttpHeadersGenerator(
+    nameManager: nameManager,
+    package: package,
+    useImmutableCollections: useImmutableCollections,
+  ).generateHeadersMethod(operation, headers, cookies);
 
   @override
   Code generateDispatchStatements({
@@ -236,9 +248,54 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     required String responseVariable,
     required Reference resultValueType,
   }) {
+    final cancellation = plan.cancellation;
     const resolvedClient = r'_$client';
+    const request = r'_$request';
+    final bodyBytesType = TypeReference(
+      (b) => b
+        ..symbol = 'List'
+        ..url = 'dart:core'
+        ..types.add(refer('int', 'dart:core')),
+    );
 
     return Block.of([
+      const Code('late final '),
+      nativeResponseType.code,
+      Code(' $responseVariable;'),
+      Block.of([
+        const Code('if ('),
+        cancellation.code,
+        const Code(' != null && '),
+        cancellation.property('isCancelled').code,
+        const Code(') {'),
+        declareFinal('exception')
+            .assign(
+              refer(
+                'RequestAbortedException',
+                'package:http/http.dart',
+              ).newInstance([plan.uri]),
+            )
+            .statement,
+        _resultClass('TonikError', resultValueType)
+            .call(
+              [refer('exception')],
+              {
+                'stackTrace': refer(
+                  'StackTrace',
+                  'dart:core',
+                ).property('current'),
+                'type': refer(
+                  'TonikErrorType.cancelled',
+                  'package:tonik_util/tonik_util.dart',
+                ),
+                'response': literalNull,
+              },
+            )
+            .returned
+            .statement,
+        const Code('}'),
+      ]),
+      const Code(''),
       const Code('final '),
       nativeClientType.code,
       const Code(' $resolvedClient;'),
@@ -266,11 +323,72 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
             .statement,
         const Code('}\n'),
       ]),
+      const Code('late final '),
+      refer('AbortableRequest', 'package:http/http.dart').code,
+      const Code(' $request;'),
+      Block.of([
+        const Code('try {'),
+        refer(request)
+            .assign(
+              refer(
+                'AbortableRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                {
+                  'abortTrigger': cancellation.nullSafeProperty(
+                    'whenCancelled',
+                  ),
+                },
+              ),
+            )
+            .statement,
+        refer(request).property('headers').property('addAll').call([
+          refer(r'_$options'),
+        ]).statement,
+        refer(request)
+            .property('followRedirects')
+            .assign(literalBool(plan.followRedirects))
+            .statement,
+        refer(request)
+            .property('maxRedirects')
+            .assign(literalNum(plan.maxRedirects))
+            .statement,
+        Block.of([
+          const Code(r'if (_$data != null) {'),
+          refer(request)
+              .property('bodyBytes')
+              .assign(refer(r'_$data').asA(bodyBytesType))
+              .statement,
+          const Code('}'),
+        ]),
+        const Code('} on '),
+        refer('Object', 'dart:core').code,
+        const Code(' catch (exception, stackTrace) {'),
+        _resultClass('TonikError', resultValueType)
+            .call(
+              [refer('exception')],
+              {
+                'stackTrace': refer('stackTrace'),
+                'type': refer(
+                  'TonikErrorType.encoding',
+                  'package:tonik_util/tonik_util.dart',
+                ),
+                'response': literalNull,
+              },
+            )
+            .returned
+            .statement,
+        const Code('}\n'),
+      ]),
+      refer(
+        resolvedClient,
+      ).property('send').call([refer(request)]).awaited.statement,
       refer('UnsupportedError', 'dart:core')
           .newInstance([
             literalString(
-              'The http transport backend does not support request dispatch '
-              'yet.',
+              'The http transport backend does not support response '
+              'normalization yet.',
             ),
           ])
           .thrown

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -346,14 +346,6 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
         refer(request).property('headers').property('addAll').call([
           refer(r'_$options'),
         ]).statement,
-        refer(request)
-            .property('followRedirects')
-            .assign(literalBool(plan.followRedirects))
-            .statement,
-        refer(request)
-            .property('maxRedirects')
-            .assign(literalNum(plan.maxRedirects))
-            .statement,
         Block.of([
           const Code(r'if (_$data != null) {'),
           refer(request)

--- a/packages/tonik_generate/lib/src/transport/operation_request_plan.dart
+++ b/packages/tonik_generate/lib/src/transport/operation_request_plan.dart
@@ -16,8 +16,6 @@ class OperationRequestPlan {
     required List<RequestValuePlan> headers,
     required List<RequestValuePlan> cookies,
     required this.contentType,
-    required this.followRedirects,
-    required this.maxRedirects,
     required this.cancellation,
     required this.response,
     required this.body,
@@ -33,8 +31,6 @@ class OperationRequestPlan {
   final List<RequestValuePlan> headers;
   final List<RequestValuePlan> cookies;
   final Expression? contentType;
-  final bool followRedirects;
-  final int maxRedirects;
   final Expression cancellation;
   final ResponseRequirements response;
   final RequestBodyPlan body;

--- a/packages/tonik_generate/lib/src/transport/operation_request_planner.dart
+++ b/packages/tonik_generate/lib/src/transport/operation_request_planner.dart
@@ -35,8 +35,6 @@ class OperationRequestPlanner {
           _cookieValue(normalizedName, parameter),
       ],
       contentType: _contentTypeExpression(requestBody, content),
-      followRedirects: true,
-      maxRedirects: 5,
       cancellation: refer('cancellation'),
       response: _responseRequirements(operation),
       body: _bodyPlan(requestBody, content),

--- a/packages/tonik_generate/lib/src/transport/request_headers_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/request_headers_generator.dart
@@ -1,0 +1,562 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
+import 'package:tonik_generate/src/util/map_property_value_expression_builder.dart';
+import 'package:tonik_generate/src/util/source_file_url.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
+import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
+import 'package:tonik_generate/src/util/type_reference_generator.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+class GeneratedRequestHeaders {
+  const GeneratedRequestHeaders({
+    required this.statements,
+    required this.parameters,
+    required this.contentType,
+  });
+
+  final List<Code> statements;
+  final List<Parameter> parameters;
+  final Expression? contentType;
+}
+
+/// Builds backend-neutral generated header and cookie statements.
+class RequestHeadersGenerator {
+  const RequestHeadersGenerator({
+    required this.nameManager,
+    required this.package,
+    required this.headerValueType,
+    this.useImmutableCollections = false,
+  });
+
+  final NameManager nameManager;
+  final String package;
+  final Reference headerValueType;
+  final bool useImmutableCollections;
+
+  GeneratedRequestHeaders generate(
+    Operation operation,
+    List<({String normalizedName, RequestHeaderObject parameter})> headers,
+    List<({String normalizedName, CookieParameterObject parameter})>
+    cookieParameters,
+  ) {
+    final bodyStatements = <Code>[];
+    final parameters = <Parameter>[];
+
+    final contentType = _generateContentType(
+      operation.requestBody,
+      bodyStatements,
+      parameters,
+    );
+    _generateHeaders(
+      headers,
+      bodyStatements,
+      parameters,
+      operation,
+    );
+    _generateCookieHeader(
+      cookieParameters,
+      bodyStatements,
+      parameters,
+    );
+
+    return GeneratedRequestHeaders(
+      statements: bodyStatements,
+      parameters: parameters,
+      contentType: contentType,
+    );
+  }
+
+  Expression? _generateContentType(
+    RequestBody? requestBody,
+    List<Code> bodyStatements,
+    List<Parameter> parameters,
+  ) {
+    if (requestBody?.resolvedContent.isEmpty ?? true) {
+      return null;
+    }
+
+    if (requestBody!.contentCount == 1) {
+      final singleContent = requestBody.resolvedContent.first;
+      if (singleContent.contentType == ContentType.multipart) {
+        return literalNull;
+      }
+      if (requestBody.isRequired) {
+        return specLiteralString(singleContent.rawContentType);
+      }
+
+      // Optional bodies omit the Content-Type header when no body is sent.
+      parameters.add(
+        Parameter(
+          (b) => b
+            ..name = 'body'
+            ..type = typeReference(
+              singleContent.model,
+              nameManager,
+              package,
+              isNullableOverride: true,
+              useImmutableCollections: useImmutableCollections,
+            )
+            ..named = true
+            ..required = false,
+        ),
+      );
+      bodyStatements.add(
+        declareFinal(r'_$contentType')
+            .assign(
+              refer('body')
+                  .equalTo(literalNull)
+                  .conditional(
+                    literalNull,
+                    specLiteralString(singleContent.rawContentType),
+                  ),
+            )
+            .statement,
+      );
+      return refer(r'_$contentType');
+    }
+
+    final (baseName, subclassNames) = nameManager.requestBodyNames(requestBody);
+    final requestBodyUrl = sourceFileUrl(package, 'request_body', baseName);
+    parameters.add(
+      Parameter(
+        (b) => b
+          ..name = 'body'
+          ..type = TypeReference(
+            (b) => b
+              ..symbol = baseName
+              ..url = requestBodyUrl
+              ..isNullable = !requestBody.isRequired,
+          )
+          ..named = true
+          ..required = requestBody.isRequired,
+      ),
+    );
+
+    final cases = <Code>[];
+    for (final content in requestBody.resolvedContent) {
+      final className = subclassNames[content.rawContentType]!;
+      final caseCode = [
+        refer(className, requestBodyUrl).code,
+        const Code(' _ => '),
+        if (content.contentType == ContentType.multipart)
+          literalNull.code
+        else
+          specLiteralString(content.rawContentType).code,
+        const Code(',\n'),
+      ];
+      cases.addAll(caseCode);
+    }
+
+    // Optional bodies omit the Content-Type header.
+    if (!requestBody.isRequired) {
+      cases.add(const Code('null => null,\n'));
+    }
+
+    bodyStatements.add(
+      declareFinal(r'_$contentType')
+          .assign(
+            CodeExpression(
+              Block.of([
+                const Code('switch (body) {'),
+                ...cases,
+                const Code('}'),
+              ]),
+            ),
+          )
+          .statement,
+    );
+    return refer(r'_$contentType');
+  }
+
+  void _generateHeaders(
+    List<({String normalizedName, RequestHeaderObject parameter})> headers,
+    List<Code> bodyStatements,
+    List<Parameter> parameters,
+    Operation operation,
+  ) {
+    // Accept header logic
+    final hasAcceptHeader = headers.any(
+      (h) => h.parameter.rawName.toLowerCase() == 'accept',
+    );
+    final acceptHeader = headers
+        .cast<({String normalizedName, RequestHeaderObject parameter})?>()
+        .firstWhere(
+          (h) => h?.parameter.rawName.toLowerCase() == 'accept',
+          orElse: () => null,
+        );
+    String? acceptParamName;
+    var acceptIsRequired = false;
+    if (acceptHeader != null) {
+      acceptParamName = acceptHeader.normalizedName;
+      acceptIsRequired = acceptHeader.parameter.isRequired;
+    }
+
+    // Collect all unique response content types
+    final contentTypes = <String>{};
+
+    for (final response in operation.responses.values) {
+      if (response is ResponseObject) {
+        for (final body in response.bodies) {
+          contentTypes.add(body.rawContentType);
+        }
+      }
+    }
+
+    final acceptValue = contentTypes.isNotEmpty
+        ? contentTypes.join(',')
+        : '*/*';
+
+    bodyStatements.add(
+      declareFinal(r'_$headers')
+          .assign(
+            literalMap(
+              {},
+              refer('String', 'dart:core'),
+              headerValueType,
+            ),
+          )
+          .statement,
+    );
+
+    // For required Accept header, always assign using encoder
+    if (hasAcceptHeader && acceptIsRequired) {
+      bodyStatements.add(
+        refer(r'_$headers')
+            .index(specLiteralString('Accept'))
+            .assign(
+              buildToSimpleHeaderParameterExpression(
+                acceptParamName!,
+                acceptHeader!.parameter,
+                explode: acceptHeader.parameter.explode,
+                allowEmpty: acceptHeader.parameter.allowEmptyValue,
+              ).expression,
+            )
+            .statement,
+      );
+    } else if (hasAcceptHeader && !acceptIsRequired) {
+      bodyStatements
+        ..add(Code('if ($acceptParamName != null) {'))
+        ..add(
+          refer(r'_$headers')
+              .index(specLiteralString('Accept'))
+              .assign(
+                buildToSimpleHeaderParameterExpression(
+                  acceptParamName!,
+                  acceptHeader!.parameter,
+                  explode: acceptHeader.parameter.explode,
+                  allowEmpty: acceptHeader.parameter.allowEmptyValue,
+                  isNullChecked: true,
+                ).expression,
+              )
+              .statement,
+        )
+        ..add(const Code('} else {'))
+        ..add(
+          refer(r'_$headers')
+              .index(literalString('Accept'))
+              .assign(specLiteralString(acceptValue))
+              .statement,
+        )
+        ..add(const Code('}'));
+    } else {
+      // No Accept header param, just assign default
+      bodyStatements.add(
+        refer(r'_$headers')
+            .index(literalString('Accept'))
+            .assign(specLiteralString(acceptValue))
+            .statement,
+      );
+    }
+
+    // Only add headerEncoder if there are user-defined headers
+    // (excluding Accept) or Accept needs encoding
+
+    for (final headerParam in headers) {
+      // Skip Accept header, already handled
+      if (headerParam.parameter.rawName.toLowerCase() == 'accept') {
+        parameters.add(
+          _generateHeaderParameter(
+            headerParam.normalizedName,
+            headerParam.parameter,
+          ),
+        );
+        continue;
+      }
+      final paramName = headerParam.normalizedName;
+      final resolvedParam = headerParam.parameter;
+
+      // For simple encoding, reject headers that are lists with
+      // complex elements
+      if (resolvedParam.encoding == HeaderParameterEncoding.simple &&
+          resolvedParam.model is ListModel &&
+          (resolvedParam.model as ListModel).content.encodingShape !=
+              EncodingShape.simple) {
+        if (resolvedParam.isRequired) {
+          // Required: immediately throw at runtime
+          bodyStatements.add(
+            generateEncodingExceptionExpression(
+              'Simple encoding does not support list with complex elements for'
+              ' header ${resolvedParam.rawName}',
+            ).statement,
+          );
+        } else {
+          // Optional: only throw if provided
+          bodyStatements.add(
+            Block.of([
+              Code('if ($paramName != null) {'),
+              generateEncodingExceptionExpression(
+                'Simple encoding does not support list with complex elements'
+                ' for header ${resolvedParam.rawName}',
+              ).statement,
+              const Code('}'),
+            ]),
+          );
+        }
+        parameters.add(_generateHeaderParameter(paramName, resolvedParam));
+        continue;
+      }
+
+      parameters.add(_generateHeaderParameter(paramName, resolvedParam));
+
+      if (!resolvedParam.isRequired) {
+        final headerAssignment = _generateHeaderAssignment(
+          paramName,
+          resolvedParam,
+          isNullChecked: true,
+        );
+        bodyStatements.add(
+          Block.of([
+            Code('if ($paramName != null) {'),
+            headerAssignment,
+            const Code('}'),
+          ]),
+        );
+      } else {
+        final headerAssignment = _generateHeaderAssignment(
+          paramName,
+          resolvedParam,
+        );
+        bodyStatements.add(headerAssignment);
+      }
+    }
+  }
+
+  /// Generates the Cookie header for cookie parameters.
+  ///
+  /// Cookies are encoded using form style (the only style valid for cookies
+  /// per OpenAPI 3.x) and concatenated as `name1=value1; name2=value2`.
+  void _generateCookieHeader(
+    List<({String normalizedName, CookieParameterObject parameter})>
+    cookieParameters,
+    List<Code> bodyStatements,
+    List<Parameter> parameters,
+  ) {
+    if (cookieParameters.isEmpty) {
+      return;
+    }
+
+    for (final cookie in cookieParameters) {
+      final paramType = typeReference(
+        cookie.parameter.model,
+        nameManager,
+        package,
+        isNullableOverride: !cookie.parameter.isRequired,
+        useImmutableCollections: useImmutableCollections,
+      );
+
+      parameters.add(
+        Parameter(
+          (b) => b
+            ..name = cookie.normalizedName
+            ..type = paramType
+            ..named = true
+            ..required = cookie.parameter.isRequired,
+        ),
+      );
+    }
+
+    final requiredCookies = cookieParameters
+        .where((c) => c.parameter.isRequired)
+        .toList();
+    final optionalCookies = cookieParameters
+        .where((c) => !c.parameter.isRequired)
+        .toList();
+
+    bodyStatements.add(
+      declareFinal(r'_$cookieParts')
+          .assign(
+            literalList(
+              [],
+              refer('String', 'dart:core'),
+            ),
+          )
+          .statement,
+    );
+
+    for (final cookie in requiredCookies) {
+      _addCookieEncodingStatement(cookie, bodyStatements);
+    }
+
+    for (final cookie in optionalCookies) {
+      bodyStatements.add(Code('if (${cookie.normalizedName} != null) {'));
+      _addCookieEncodingStatement(cookie, bodyStatements);
+      bodyStatements.add(const Code('}'));
+    }
+
+    bodyStatements
+      ..add(const Code(r'if (_$cookieParts.isNotEmpty) {'))
+      ..add(
+        refer(r'_$headers')
+            .index(specLiteralString('Cookie'))
+            .assign(
+              refer(r'_$cookieParts').property('join').call([
+                literalString('; '),
+              ]),
+            )
+            .statement,
+      )
+      ..add(const Code('}'));
+  }
+
+  void _addCookieEncodingStatement(
+    ({String normalizedName, CookieParameterObject parameter}) cookie,
+    List<Code> bodyStatements,
+  ) {
+    final model = cookie.parameter.model;
+    final rawName = cookie.parameter.rawName;
+    final paramName = cookie.normalizedName;
+    final explode = cookie.parameter.explode;
+
+    final resolved = model.resolved;
+    final isBinary =
+        resolved is BinaryModel ||
+        (resolved is ListModel && resolved.content.resolved is BinaryModel);
+    if (isBinary) {
+      bodyStatements.add(
+        generateEncodingExceptionExpression(
+          'Binary data cannot be form-encoded for cookie $rawName',
+        ).statement,
+      );
+      return;
+    }
+    if (resolved is NeverModel ||
+        (resolved is ListModel && resolved.content.resolved is NeverModel)) {
+      bodyStatements.add(
+        generateEncodingExceptionExpression(
+          'Cannot encode NeverModel - this type does not permit any value '
+          'for cookie $rawName',
+        ).statement,
+      );
+      return;
+    }
+
+    if (resolved is MapModel) {
+      final conversion = buildMapPropertyValueConversion(
+        refer(paramName),
+        resolved,
+        isNullable: false,
+        context: rawName,
+      );
+      if (conversion is UnsupportedMapPropertyValueConversion) {
+        bodyStatements.add(
+          generateEncodingExceptionExpression(
+            'Map with complex value types cannot be form-encoded '
+            'for cookie $rawName',
+            raw: true,
+          ).statement,
+        );
+        return;
+      }
+    }
+
+    if (isAnyModelFormValue(model)) {
+      final encodedValue =
+          refer(
+            'encodeAnyToForm',
+            'package:tonik_util/tonik_util.dart',
+          ).call(
+            [refer(paramName)],
+            {
+              'explode': literalBool(explode),
+              'allowEmpty': literalBool(true),
+            },
+          );
+      bodyStatements.add(
+        refer(r'_$cookieParts').property('add').call([
+          literalList([
+            specLiteralString('$rawName='),
+            encodedValue,
+          ]).property('join').call([]),
+        ]).statement,
+      );
+      return;
+    }
+
+    final entries = buildFormEntriesValueExpression(
+      refer(paramName),
+      model,
+      paramName: specLiteralString(rawName),
+      explode: literalBool(explode),
+      allowEmpty: literalBool(true),
+      mapContext: rawName,
+    );
+
+    if (entries == null) {
+      bodyStatements.add(
+        generateEncodingExceptionExpression(
+          'Unsupported model type for form-encoded cookie $rawName',
+        ).statement,
+      );
+      return;
+    }
+
+    bodyStatements.add(
+      refer(r'_$cookieParts').property('addAll').call([
+        entries.property('map').call([formEntryToWireString()]),
+      ]).statement,
+    );
+  }
+
+  Parameter _generateHeaderParameter(
+    String paramName,
+    RequestHeaderObject resolvedParam,
+  ) {
+    final parameterType = typeReference(
+      resolvedParam.model,
+      nameManager,
+      package,
+      isNullableOverride: !resolvedParam.isRequired,
+      useImmutableCollections: useImmutableCollections,
+    );
+
+    return Parameter(
+      (b) => b
+        ..name = paramName
+        ..type = parameterType
+        ..named = true
+        ..required = resolvedParam.isRequired,
+    );
+  }
+
+  Code _generateHeaderAssignment(
+    String paramName,
+    RequestHeaderObject resolvedParam, {
+    bool isNullChecked = false,
+  }) {
+    final valueExpression = buildToSimpleHeaderParameterExpression(
+      paramName,
+      resolvedParam,
+      explode: resolvedParam.explode,
+      allowEmpty: resolvedParam.allowEmptyValue,
+      isNullChecked: isNullChecked,
+    );
+
+    return refer(r'_$headers')
+        .index(specLiteralString(resolvedParam.rawName))
+        .assign(valueExpression.expression)
+        .statement;
+  }
+}

--- a/packages/tonik_generate/test/src/transport/dio_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/dio_backend_generator_test.dart
@@ -131,8 +131,6 @@ void close() {
           headers: const [],
           cookies: const [],
           contentType: null,
-          followRedirects: true,
-          maxRedirects: 5,
           cancellation: refer('cancellation'),
           response: ResponseRequirements(
             expectsBytes: true,

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:code_builder/code_builder.dart';
 import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
@@ -5,6 +7,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 import 'package:tonik_generate/src/transport/http/http_body_generator.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 void main() {
   late HttpBodyGenerator generator;
@@ -146,7 +149,7 @@ Object? _data({required CreateOrderRequest body}) {
       ),
     );
 
-    const expected = r'''
+    const expected = '''
 Object? _data({required Map<String, List<LineItem>> body}) {
   return utf8.encode(
     jsonEncode(
@@ -241,20 +244,21 @@ Object? _data({String? body}) {
     );
   });
 
-  test('UTF-8 encodes ordered form entries without a map conversion', () {
-    final method = generator.generateBodyMethod(
-      _operation(
-        context,
-        requestBody: _body(
+  group('form-urlencoded bodies', () {
+    test('UTF-8 encodes a scalar without inventing a field name', () {
+      final method = generator.generateBodyMethod(
+        _operation(
           context,
-          model: StringModel(context: context),
-          contentType: ContentType.form,
-          rawContentType: 'application/x-www-form-urlencoded',
+          requestBody: _body(
+            context,
+            model: StringModel(context: context),
+            contentType: ContentType.form,
+            rawContentType: 'application/x-www-form-urlencoded',
+          ),
         ),
-      ),
-    );
+      );
 
-    const expected = r'''
+      const expected = r'''
 Object? _data({required String body}) {
   return utf8.encode(
     body
@@ -270,9 +274,195 @@ Object? _data({required String body}) {
 }
 ''';
 
-    expect(
-      collapseWhitespace(format('${method.accept(emitter)}')),
-      collapseWhitespace(format(expected)),
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('UTF-8 encodes a top-level array without collapsing entries', () {
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            contentType: ContentType.form,
+            rawContentType: 'application/x-www-form-urlencoded',
+          ),
+        ),
+      );
+
+      const expected = r'''
+Object? _data({required List<String> body}) {
+  return utf8.encode(
+    body
+        .toForm(
+          '',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+        )
+        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+        .join('&'),
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test(
+      'UTF-8 encodes an object with reserved and repeated field metadata',
+      () {
+        final form = _profileFormModel(context);
+        final method = generator.generateBodyMethod(
+          _operation(
+            context,
+            requestBody: _body(
+              context,
+              model: form.model,
+              contentType: ContentType.form,
+              rawContentType: 'application/x-www-form-urlencoded',
+              formEncoding: {
+                form.callback: const FieldEncoding(
+                  allowReserved: true,
+                  style: EncodingStyle.form,
+                  explode: true,
+                ),
+                form.tags: const FieldEncoding(
+                  allowReserved: false,
+                  style: EncodingStyle.form,
+                  explode: true,
+                ),
+              },
+            ),
+          ),
+        );
+
+        const expected = r'''
+Object? _data({required ProfileSubmission body}) {
+  return utf8.encode(
+    body
+        .toForm(
+          '',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+          fieldEncodings: <String, FormFieldEncoding>{
+            r'callback': const FormFieldEncoding(allowReserved: true),
+            r'tags': const FormFieldEncoding(explode: true),
+          },
+        )
+        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+        .join('&'),
+  );
+}
+''';
+
+        expect(
+          collapseWhitespace(format('${method.accept(emitter)}')),
+          collapseWhitespace(format(expected)),
+        );
+      },
+    );
+
+    test('omits an optional object before applying field encodings', () {
+      final form = _profileFormModel(context);
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: form.model,
+            contentType: ContentType.form,
+            rawContentType: 'application/x-www-form-urlencoded',
+            isRequired: false,
+            formEncoding: {
+              form.callback: const FieldEncoding(
+                allowReserved: true,
+                style: EncodingStyle.form,
+                explode: true,
+              ),
+            },
+          ),
+        ),
+      );
+
+      const expected = r'''
+Object? _data({ProfileSubmission? body}) {
+  if (body == null) return null;
+  return utf8.encode(
+    body
+        .toForm(
+          '',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+          fieldEncodings: <String, FormFieldEncoding>{
+            r'callback': const FormFieldEncoding(allowReserved: true),
+            r'tags': const FormFieldEncoding(explode: true),
+          },
+        )
+        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+        .join('&'),
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test(
+      'produces exact bytes for Unicode reserved empty and repeated values',
+      () {
+        final entries =
+            <String, PropertyValue>{
+              'display name': const PropertyValue.scalar('Zoë & Co'),
+              'callback': const PropertyValue.scalar(
+                'https://example.test/a/b?x=1&next=%2F',
+              ),
+              'tags': const PropertyValue.array(['red & blue', '', '雪']),
+              'note': const PropertyValue.scalar(''),
+            }.toForm(
+              '',
+              explode: true,
+              allowEmpty: true,
+              useQueryComponent: true,
+              fieldEncodings: const {
+                'callback': FormFieldEncoding(allowReserved: true),
+                'tags': FormFieldEncoding(explode: true),
+              },
+            );
+
+        final wireBody = entries
+            .map(
+              (entry) => entry.name.isEmpty
+                  ? entry.value
+                  : '${entry.name}=${entry.value}',
+            )
+            .join('&');
+        const expected =
+            'display+name=Zo%C3%AB+%26+Co'
+            '&callback=https://example.test/a/b?x%3D1%26next%3D%252F'
+            '&tags=red+%26+blue'
+            '&tags='
+            '&tags=%E9%9B%AA'
+            '&note=';
+
+        expect(wireBody, expected);
+        expect(utf8.encode(wireBody), utf8.encode(expected));
+      },
     );
   });
 
@@ -364,6 +554,7 @@ RequestBodyObject _body(
   required ContentType contentType,
   required String rawContentType,
   bool isRequired = true,
+  Map<Property, FieldEncoding>? formEncoding,
 }) => RequestBodyObject(
   name: 'payload',
   context: context,
@@ -375,8 +566,72 @@ RequestBodyObject _body(
       contentType: contentType,
       rawContentType: rawContentType,
       examples: const [],
+      formEncoding: formEncoding,
     ),
   },
+);
+
+typedef _ProfileForm = ({
+  ClassModel model,
+  Property callback,
+  Property tags,
+});
+
+_ProfileForm _profileFormModel(Context context) {
+  final displayName = _formProperty(
+    context,
+    name: 'display name',
+    model: StringModel(context: context),
+  );
+  final callback = _formProperty(
+    context,
+    name: 'callback',
+    model: StringModel(context: context),
+  );
+  final tags = _formProperty(
+    context,
+    name: 'tags',
+    model: ListModel(
+      content: StringModel(context: context),
+      context: context,
+      examples: const [],
+    ),
+  );
+  final note = _formProperty(
+    context,
+    name: 'note',
+    model: StringModel(context: context),
+    isRequired: false,
+    isNullable: true,
+  );
+
+  return (
+    model: ClassModel(
+      name: 'ProfileSubmission',
+      properties: [displayName, callback, tags, note],
+      context: context,
+      isDeprecated: false,
+      examples: const [],
+    ),
+    callback: callback,
+    tags: tags,
+  );
+}
+
+Property _formProperty(
+  Context context, {
+  required String name,
+  required Model model,
+  bool isRequired = true,
+  bool isNullable = false,
+}) => Property(
+  name: name,
+  model: model,
+  isRequired: isRequired,
+  isNullable: isNullable,
+  isDeprecated: false,
+  examples: const [],
+  defaultValue: null,
 );
 
 ClassModel _customerModel(Context context) => ClassModel(

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -1,0 +1,358 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/transport/http/http_body_generator.dart';
+
+void main() {
+  late HttpBodyGenerator generator;
+  late Context context;
+  late DartEmitter emitter;
+  late String Function(String, {Object? uri}) format;
+
+  setUp(() {
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+    format = DartFormatter(
+      languageVersion: DartFormatter.latestLanguageVersion,
+    ).format;
+    generator = HttpBodyGenerator(
+      nameManager: NameManager(
+        generator: NameGenerator(),
+        stableModelSorter: StableModelSorter(),
+      ),
+      package: 'test_package',
+    );
+  });
+
+  test('emits no synthetic payload when the request body is absent', () {
+    final method = generator.generateBodyMethod(_operation(context));
+
+    const expected = '''
+Object? _data() {
+  return null;
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('JSON encodes a scalar exactly once before UTF-8 encoding', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: StringModel(context: context),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({required String body}) {
+  return utf8.encode(jsonEncode(body));
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('JSON encodes an object exactly once before UTF-8 encoding', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: ClassModel(
+            name: 'Payload',
+            properties: const [],
+            context: context,
+            isDeprecated: false,
+            examples: const [],
+          ),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({required Payload body}) {
+  return utf8.encode(jsonEncode(body.toJson()));
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('JSON encodes a nested recursive map exactly once', () {
+    final tree = MapModel(
+      name: 'Tree',
+      valueModel: AnyModel(context: context),
+      context: context,
+      examples: const [],
+    );
+    tree.valueModel = tree;
+
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: tree,
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      ),
+    );
+
+    const expected = r'''
+Object? _data({required Tree body}) {
+  late final Object? Function(Object?) _$encodeTree;
+  _$encodeTree = (Object? raw) {
+    if (raw is! Tree) {
+      throw EncodingException(
+        'Cannot encode value as Tree (at \'sendPayload.body\'); got: '
+        '${raw.runtimeType}',
+      );
+    }
+    final v = raw;
+    return v.map((k, v) => MapEntry(k, _$encodeTree(v)));
+  };
+  return utf8.encode(jsonEncode(_$encodeTree(body)));
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('uses the declared supported charset for text', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: StringModel(context: context),
+          contentType: ContentType.text,
+          rawContentType: 'text/plain; charset=iso-8859-1',
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({required String body}) {
+  return latin1.encode(body);
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('preserves binary body bytes unchanged', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: BinaryModel(context: context),
+          contentType: ContentType.bytes,
+          rawContentType: 'application/octet-stream',
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({required TonikFile body}) {
+  return body.toBytes();
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('omits an optional body without encoding JSON null', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: StringModel(context: context),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+          isRequired: false,
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({String? body}) {
+  if (body == null) return null;
+  return utf8.encode(jsonEncode(body));
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('UTF-8 encodes ordered form entries without a map conversion', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: StringModel(context: context),
+          contentType: ContentType.form,
+          rawContentType: 'application/x-www-form-urlencoded',
+        ),
+      ),
+    );
+
+    const expected = r'''
+Object? _data({required String body}) {
+  return utf8.encode(
+    body
+        .toForm(
+          '',
+          explode: true,
+          allowEmpty: true,
+          useQueryComponent: true,
+        )
+        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+        .join('&'),
+  );
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('emits an encoding failure for an unsupported text charset', () {
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: StringModel(context: context),
+          contentType: ContentType.text,
+          rawContentType: 'text/plain; charset=utf-16',
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({required String body}) {
+  return throw EncodingException('Unsupported text encoding: utf-16.');
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('lowers each selected non-multipart content type to bytes', () {
+    final requestBody = RequestBodyObject(
+      name: 'payload',
+      context: context,
+      description: null,
+      isRequired: true,
+      content: {
+        RequestContent(
+          model: StringModel(context: context),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+          examples: const [],
+        ),
+        RequestContent(
+          model: StringModel(context: context),
+          contentType: ContentType.text,
+          rawContentType: 'text/plain',
+          examples: const [],
+        ),
+      },
+    );
+    final method = generator.generateBodyMethod(
+      _operation(context, requestBody: requestBody),
+    );
+
+    const expected = '''
+Object? _data({required Payload body}) {
+  return switch (body) {
+    final PayloadJson value => utf8.encode(jsonEncode(value.value)),
+    final PayloadPlain value => utf8.encode(value.value),
+  };
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+}
+
+Operation _operation(Context context, {RequestBody? requestBody}) => Operation(
+  operationId: 'sendPayload',
+  path: '/payload',
+  method: HttpMethod.post,
+  requestBody: requestBody,
+  responses: const {},
+  pathParameters: const {},
+  queryParameters: const {},
+  headers: const {},
+  cookieParameters: const {},
+  securitySchemes: const {},
+  context: context,
+  tags: const {},
+  isDeprecated: false,
+);
+
+RequestBodyObject _body(
+  Context context, {
+  required Model model,
+  required ContentType contentType,
+  required String rawContentType,
+  bool isRequired = true,
+}) => RequestBodyObject(
+  name: 'payload',
+  context: context,
+  description: null,
+  isRequired: isRequired,
+  content: {
+    RequestContent(
+      model: model,
+      contentType: contentType,
+      rawContentType: rawContentType,
+      examples: const [],
+    ),
+  },
+);

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -67,15 +67,40 @@ Object? _data({required String body}) {
     );
   });
 
-  test('JSON encodes an object exactly once before UTF-8 encoding', () {
+  test('JSON encodes a nested order object exactly once', () {
+    final customer = _customerModel(context);
+    final lineItem = _lineItemModel(context);
     final method = generator.generateBodyMethod(
       _operation(
         context,
         requestBody: _body(
           context,
           model: ClassModel(
-            name: 'Payload',
-            properties: const [],
+            name: 'CreateOrderRequest',
+            properties: [
+              Property(
+                name: 'customer',
+                model: customer,
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+              Property(
+                name: 'lineItems',
+                model: ListModel(
+                  content: lineItem,
+                  context: context,
+                  examples: const [],
+                ),
+                isRequired: true,
+                isNullable: false,
+                isDeprecated: false,
+                examples: const [],
+                defaultValue: null,
+              ),
+            ],
             context: context,
             isDeprecated: false,
             examples: const [],
@@ -87,7 +112,7 @@ Object? _data({required String body}) {
     );
 
     const expected = '''
-Object? _data({required Payload body}) {
+Object? _data({required CreateOrderRequest body}) {
   return utf8.encode(jsonEncode(body.toJson()));
 }
 ''';
@@ -98,21 +123,23 @@ Object? _data({required Payload body}) {
     );
   });
 
-  test('JSON encodes a nested recursive map exactly once', () {
-    final tree = MapModel(
-      name: 'Tree',
-      valueModel: AnyModel(context: context),
-      context: context,
-      examples: const [],
-    );
-    tree.valueModel = tree;
+  test('JSON encodes grouped line items through a map and lists once', () {
+    final lineItem = _lineItemModel(context);
 
     final method = generator.generateBodyMethod(
       _operation(
         context,
         requestBody: _body(
           context,
-          model: tree,
+          model: MapModel(
+            valueModel: ListModel(
+              content: lineItem,
+              context: context,
+              examples: const [],
+            ),
+            context: context,
+            examples: const [],
+          ),
           contentType: ContentType.json,
           rawContentType: 'application/json',
         ),
@@ -120,19 +147,14 @@ Object? _data({required Payload body}) {
     );
 
     const expected = r'''
-Object? _data({required Tree body}) {
-  late final Object? Function(Object?) _$encodeTree;
-  _$encodeTree = (Object? raw) {
-    if (raw is! Tree) {
-      throw EncodingException(
-        'Cannot encode value as Tree (at \'sendPayload.body\'); got: '
-        '${raw.runtimeType}',
-      );
-    }
-    final v = raw;
-    return v.map((k, v) => MapEntry(k, _$encodeTree(v)));
-  };
-  return utf8.encode(jsonEncode(_$encodeTree(body)));
+Object? _data({required Map<String, List<LineItem>> body}) {
+  return utf8.encode(
+    jsonEncode(
+      body.map(
+        (k, v) => MapEntry(k, v.map((e) => e.toJson()).toList()),
+      ),
+    ),
+  );
 }
 ''';
 
@@ -355,4 +377,49 @@ RequestBodyObject _body(
       examples: const [],
     ),
   },
+);
+
+ClassModel _customerModel(Context context) => ClassModel(
+  name: 'Customer',
+  properties: [
+    Property(
+      name: 'id',
+      model: StringModel(context: context),
+      isRequired: true,
+      isNullable: false,
+      isDeprecated: false,
+      examples: const [],
+      defaultValue: null,
+    ),
+  ],
+  context: context,
+  isDeprecated: false,
+  examples: const [],
+);
+
+ClassModel _lineItemModel(Context context) => ClassModel(
+  name: 'LineItem',
+  properties: [
+    Property(
+      name: 'sku',
+      model: StringModel(context: context),
+      isRequired: true,
+      isNullable: false,
+      isDeprecated: false,
+      examples: const [],
+      defaultValue: null,
+    ),
+    Property(
+      name: 'quantity',
+      model: IntegerModel(context: context),
+      isRequired: true,
+      isNullable: false,
+      isDeprecated: false,
+      examples: const [],
+      defaultValue: null,
+    ),
+  ],
+  context: context,
+  isDeprecated: false,
+  examples: const [],
 );

--- a/packages/tonik_generate/test/src/transport/http/http_headers_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_headers_generator_test.dart
@@ -1,0 +1,207 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/transport/http/http_headers_generator.dart';
+
+void main() {
+  late Context context;
+  late HttpHeadersGenerator generator;
+  late DartEmitter emitter;
+  late String Function(String, {Object? uri}) format;
+
+  setUp(() {
+    context = Context.initial();
+    emitter = DartEmitter(useNullSafetySyntax: true);
+    format = DartFormatter(
+      languageVersion: DartFormatter.latestLanguageVersion,
+    ).format;
+    generator = HttpHeadersGenerator(
+      nameManager: NameManager(
+        generator: NameGenerator(),
+        stableModelSorter: StableModelSorter(),
+      ),
+      package: 'test_package',
+    );
+  });
+
+  test('emits the default Accept header', () {
+    final method = generator.generateHeadersMethod(
+      _operation(context),
+      const [],
+      const [],
+    );
+
+    const expected = r'''
+Map<String, String> _options() {
+  final _$headers = <String, String>{};
+  _$headers['Accept'] = r'*/*';
+  return _$headers;
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('sets content type only when an optional body is present', () {
+    final method = generator.generateHeadersMethod(
+      _operation(
+        context,
+        requestBody: RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: false,
+          content: {
+            RequestContent(
+              model: StringModel(context: context),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+          },
+        ),
+      ),
+      const [],
+      const [],
+    );
+
+    const expected = r'''
+Map<String, String> _options({String? body}) {
+  final _$contentType = body == null ? null : r'application/json';
+  final _$headers = <String, String>{};
+  _$headers['Accept'] = r'*/*';
+  if (_$contentType != null) {
+    _$headers[r'Content-Type'] = _$contentType;
+  }
+  return _$headers;
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('preserves encoded headers and multiple cookies', () {
+    final header = RequestHeaderObject(
+      name: 'X-Trace',
+      rawName: 'X-Trace',
+      description: null,
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      explode: false,
+      model: StringModel(context: context),
+      encoding: HeaderParameterEncoding.simple,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+    final firstCookie = _cookie(context, 'session', isRequired: true);
+    final secondCookie = _cookie(context, 'theme', isRequired: false);
+    final method = generator.generateHeadersMethod(
+      _operation(
+        context,
+        headers: {header},
+        cookies: {firstCookie, secondCookie},
+      ),
+      [(normalizedName: 'xTrace', parameter: header)],
+      [
+        (normalizedName: 'session', parameter: firstCookie),
+        (normalizedName: 'theme', parameter: secondCookie),
+      ],
+    );
+
+    const expected = r'''
+Map<String, String> _options({
+  required String xTrace,
+  required String session,
+  String? theme,
+}) {
+  final _$headers = <String, String>{};
+  _$headers['Accept'] = r'*/*';
+  _$headers[r'X-Trace'] = xTrace.toSimple(
+    explode: false,
+    allowEmpty: false,
+    literal: true,
+  );
+  final _$cookieParts = <String>[];
+  _$cookieParts.addAll(
+    session
+        .toForm(
+          r'session',
+          explode: false,
+          allowEmpty: true,
+        )
+        .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}'),
+  );
+  if (theme != null) {
+    _$cookieParts.addAll(
+      theme
+          .toForm(
+            r'theme',
+            explode: false,
+            allowEmpty: true,
+          )
+          .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}'),
+    );
+  }
+  if (_$cookieParts.isNotEmpty) {
+    _$headers[r'Cookie'] = _$cookieParts.join('; ');
+  }
+  return _$headers;
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+}
+
+Operation _operation(
+  Context context, {
+  RequestBody? requestBody,
+  Set<RequestHeader> headers = const {},
+  Set<CookieParameter> cookies = const {},
+}) => Operation(
+  operationId: 'sendPayload',
+  path: '/payload',
+  method: HttpMethod.post,
+  requestBody: requestBody,
+  responses: const {},
+  pathParameters: const {},
+  queryParameters: const {},
+  headers: headers,
+  cookieParameters: cookies,
+  securitySchemes: const {},
+  context: context,
+  tags: const {},
+  isDeprecated: false,
+);
+
+CookieParameterObject _cookie(
+  Context context,
+  String name, {
+  required bool isRequired,
+}) => CookieParameterObject(
+  name: name,
+  rawName: name,
+  description: null,
+  isRequired: isRequired,
+  isDeprecated: false,
+  explode: false,
+  model: StringModel(context: context),
+  encoding: CookieParameterEncoding.form,
+  context: context,
+  examples: const [],
+  defaultValue: null,
+);

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -113,61 +113,105 @@ void close() {
   });
 
   group('ordinary request dispatch', () {
-    for (final httpMethod in HttpMethod.values) {
-      test(
-        'emits and sends one abortable '
-        '${httpMethod.name.toUpperCase()} request',
-        () {
-          final followsRedirects = httpMethod != HttpMethod.trace;
-          final maxRedirects = httpMethod == HttpMethod.trace ? 2 : 5;
-          final statements = generator.generateDispatchStatements(
-            plan: OperationRequestPlan(
-              method: httpMethod,
-              uri: refer(r'_$uri'),
-              pathParameters: const [],
-              queryParameters: const [],
-              headers: const [],
-              cookies: const [],
-              contentType: null,
-              followRedirects: followsRedirects,
-              maxRedirects: maxRedirects,
-              cancellation: refer('cancellation'),
-              response: ResponseRequirements(
-                expectsBytes: true,
-                statuses: const [],
-                contentTypes: const [],
-              ),
-              body: const AbsentBodyPlan(),
-            ),
-            responseVariable: r'_$response',
-            resultValueType: refer('void', 'dart:core'),
-          );
+    test('emits and sends one abortable GET request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.get,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedGetDispatch,
+      );
+    });
 
-          final generatedMethod = Method(
-            (b) => b
-              ..name = 'dispatch'
-              ..returns = TypeReference(
-                (b) => b
-                  ..symbol = 'Future'
-                  ..url = 'dart:core'
-                  ..types.add(
-                    TypeReference(
-                      (b) => b
-                        ..symbol = 'TonikResult'
-                        ..url = 'package:tonik_util/tonik_util.dart'
-                        ..types.addAll([
-                          refer('void', 'dart:core'),
-                          refer('Response', 'package:http/http.dart'),
-                        ]),
-                    ),
-                  ),
-              )
-              ..modifier = MethodModifier.async
-              ..body = Block.of([statements]),
-          );
+    test('emits and sends one abortable HEAD request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.head,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedHeadDispatch,
+      );
+    });
 
-          final expectedMethod =
-              r'''
+    test('emits and sends one abortable POST request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.post,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedPostDispatch,
+      );
+    });
+
+    test('emits and sends one abortable PUT request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.put,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedPutDispatch,
+      );
+    });
+
+    test('emits and sends one abortable PATCH request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.patch,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedPatchDispatch,
+      );
+    });
+
+    test('emits and sends one abortable DELETE request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.delete,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedDeleteDispatch,
+      );
+    });
+
+    test('emits and sends one abortable OPTIONS request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.options,
+        followRedirects: true,
+        maxRedirects: 5,
+        expectedMethod: _expectedOptionsDispatch,
+      );
+    });
+
+    test('emits and sends one abortable TRACE request', () {
+      _expectDispatch(
+        generator: generator,
+        emitter: emitter,
+        format: format,
+        method: HttpMethod.trace,
+        followRedirects: false,
+        maxRedirects: 2,
+        expectedMethod: _expectedTraceDispatch,
+      );
+    });
+  });
+}
+
+const _expectedGetDispatch = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -195,13 +239,13 @@ Future<TonikResult<void, Response>> dispatch() async {
   late final AbortableRequest _$request;
   try {
     _$request = AbortableRequest(
-      'METHOD',
+      'GET',
       _$uri,
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = FOLLOWS_REDIRECTS;
-    _$request.maxRedirects = MAX_REDIRECTS;
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -219,19 +263,445 @@ Future<TonikResult<void, Response>> dispatch() async {
     'The http transport backend does not support response normalization yet.',
   );
 }
-'''
-                  .replaceFirst('METHOD', httpMethod.name.toUpperCase())
-                  .replaceFirst('FOLLOWS_REDIRECTS', '$followsRedirects')
-                  .replaceFirst('MAX_REDIRECTS', '$maxRedirects');
+''';
 
-          expect(
-            collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
-            collapseWhitespace(format(expectedMethod)),
-          );
-        },
-      );
+const _expectedHeadDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'HEAD',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
     }
-  });
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedPostDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'POST',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedPutDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'PUT',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedPatchDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'PATCH',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedDeleteDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'DELETE',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedOptionsDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'OPTIONS',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = true;
+    _$request.maxRedirects = 5;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+const _expectedTraceDispatch = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'TRACE',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = false;
+    _$request.maxRedirects = 2;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+void _expectDispatch({
+  required HttpBackendGenerator generator,
+  required DartEmitter emitter,
+  required String Function(String, {Object? uri}) format,
+  required HttpMethod method,
+  required bool followRedirects,
+  required int maxRedirects,
+  required String expectedMethod,
+}) {
+  final statements = generator.generateDispatchStatements(
+    plan: OperationRequestPlan(
+      method: method,
+      uri: refer(r'_$uri'),
+      pathParameters: const [],
+      queryParameters: const [],
+      headers: const [],
+      cookies: const [],
+      contentType: null,
+      followRedirects: followRedirects,
+      maxRedirects: maxRedirects,
+      cancellation: refer('cancellation'),
+      response: ResponseRequirements(
+        expectsBytes: true,
+        statuses: const [],
+        contentTypes: const [],
+      ),
+      body: const AbsentBodyPlan(),
+    ),
+    responseVariable: r'_$response',
+    resultValueType: refer('void', 'dart:core'),
+  );
+
+  final generatedMethod = Method(
+    (b) => b
+      ..name = 'dispatch'
+      ..returns = TypeReference(
+        (b) => b
+          ..symbol = 'Future'
+          ..url = 'dart:core'
+          ..types.add(
+            TypeReference(
+              (b) => b
+                ..symbol = 'TonikResult'
+                ..url = 'package:tonik_util/tonik_util.dart'
+                ..types.addAll([
+                  refer('void', 'dart:core'),
+                  refer('Response', 'package:http/http.dart'),
+                ]),
+            ),
+          ),
+      )
+      ..modifier = MethodModifier.async
+      ..body = Block.of([statements]),
+  );
+
+  expect(
+    collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+    collapseWhitespace(format(expectedMethod)),
+  );
 }
 
 String _asMethod(Method method, DartEmitter emitter) {

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -112,47 +112,74 @@ void close() {
     );
   });
 
-  test(
-    'resolves through the accessor before dispatch and maps closed access',
-    () {
-      final statements = generator.generateDispatchStatements(
-        plan: OperationRequestPlan(
-          method: HttpMethod.get,
-          uri: refer(r'_$uri'),
-          pathParameters: const [],
-          queryParameters: const [],
-          headers: const [],
-          cookies: const [],
-          contentType: null,
-          followRedirects: true,
-          maxRedirects: 5,
-          cancellation: refer('cancellation'),
-          response: ResponseRequirements(
-            expectsBytes: true,
-            statuses: const [],
-            contentTypes: const [],
-          ),
-          body: const AbsentBodyPlan(),
-        ),
-        responseVariable: r'_$response',
-        resultValueType: refer('void', 'dart:core'),
-      );
+  group('ordinary request dispatch', () {
+    for (final httpMethod in HttpMethod.values) {
+      test(
+        'emits and sends one abortable '
+        '${httpMethod.name.toUpperCase()} request',
+        () {
+          final followsRedirects = httpMethod != HttpMethod.trace;
+          final maxRedirects = httpMethod == HttpMethod.trace ? 2 : 5;
+          final statements = generator.generateDispatchStatements(
+            plan: OperationRequestPlan(
+              method: httpMethod,
+              uri: refer(r'_$uri'),
+              pathParameters: const [],
+              queryParameters: const [],
+              headers: const [],
+              cookies: const [],
+              contentType: null,
+              followRedirects: followsRedirects,
+              maxRedirects: maxRedirects,
+              cancellation: refer('cancellation'),
+              response: ResponseRequirements(
+                expectsBytes: true,
+                statuses: const [],
+                contentTypes: const [],
+              ),
+              body: const AbsentBodyPlan(),
+            ),
+            responseVariable: r'_$response',
+            resultValueType: refer('void', 'dart:core'),
+          );
 
-      final method = Method(
-        (b) => b
-          ..name = 'dispatch'
-          ..returns = TypeReference(
+          final generatedMethod = Method(
             (b) => b
-              ..symbol = 'Future'
-              ..url = 'dart:core'
-              ..types.add(refer('void', 'dart:core')),
-          )
-          ..modifier = MethodModifier.async
-          ..body = Block.of([statements]),
-      );
+              ..name = 'dispatch'
+              ..returns = TypeReference(
+                (b) => b
+                  ..symbol = 'Future'
+                  ..url = 'dart:core'
+                  ..types.add(
+                    TypeReference(
+                      (b) => b
+                        ..symbol = 'TonikResult'
+                        ..url = 'package:tonik_util/tonik_util.dart'
+                        ..types.addAll([
+                          refer('void', 'dart:core'),
+                          refer('Response', 'package:http/http.dart'),
+                        ]),
+                    ),
+                  ),
+              )
+              ..modifier = MethodModifier.async
+              ..body = Block.of([statements]),
+          );
 
-      const expectedMethod = r'''
-Future<void> dispatch() async {
+          final expectedMethod =
+              r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
   final Client _$client;
   try {
     _$client = _client();
@@ -165,18 +192,46 @@ Future<void> dispatch() async {
     );
   }
 
+  late final AbortableRequest _$request;
+  try {
+    _$request = AbortableRequest(
+      'METHOD',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.followRedirects = FOLLOWS_REDIRECTS;
+    _$request.maxRedirects = MAX_REDIRECTS;
+    if (_$data != null) {
+      _$request.bodyBytes = (_$data as List<int>);
+    }
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
   throw UnsupportedError(
-    'The http transport backend does not support request dispatch yet.',
+    'The http transport backend does not support response normalization yet.',
   );
 }
-''';
+'''
+                  .replaceFirst('METHOD', httpMethod.name.toUpperCase())
+                  .replaceFirst('FOLLOWS_REDIRECTS', '$followsRedirects')
+                  .replaceFirst('MAX_REDIRECTS', '$maxRedirects');
 
-      expect(
-        collapseWhitespace(format('${method.accept(emitter)}')),
-        collapseWhitespace(format(expectedMethod)),
+          expect(
+            collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+            collapseWhitespace(format(expectedMethod)),
+          );
+        },
       );
-    },
-  );
+    }
+  });
 }
 
 String _asMethod(Method method, DartEmitter emitter) {

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -52,6 +52,11 @@ void main() {
         final getter = adapter.methods.singleWhere(
           (method) => method.name == 'client',
         );
+        final generatedMethod = getter.rebuild(
+          (builder) => builder
+            ..type = null
+            ..name = getter.name,
+        );
 
         const expectedMethod = r'''
 Client client() {
@@ -73,7 +78,7 @@ Client client() {
 ''';
 
         expect(
-          collapseWhitespace(format(_asMethod(getter, emitter))),
+          collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
           collapseWhitespace(format(expectedMethod)),
         );
       },
@@ -91,6 +96,12 @@ Client client() {
           'void',
         );
 
+        final generatedMethod = close.rebuild(
+          (builder) => builder
+            ..type = null
+            ..name = close.name,
+        );
+
         const expectedMethod = r'''
 void close() {
   if (_$isClosed) {
@@ -105,7 +116,7 @@ void close() {
 ''';
 
         expect(
-          collapseWhitespace(format(_asMethod(close, emitter))),
+          collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
           collapseWhitespace(format(expectedMethod)),
         );
       },
@@ -114,88 +125,51 @@ void close() {
 
   group('ordinary request dispatch', () {
     test('emits and sends one abortable GET request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.get,
-        expectedMethod: _expectedGetDispatch,
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.get,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
       );
-    });
 
-    test('emits and sends one abortable HEAD request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.head,
-        expectedMethod: _expectedHeadDispatch,
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
       );
-    });
 
-    test('emits and sends one abortable POST request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.post,
-        expectedMethod: _expectedPostDispatch,
-      );
-    });
-
-    test('emits and sends one abortable PUT request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.put,
-        expectedMethod: _expectedPutDispatch,
-      );
-    });
-
-    test('emits and sends one abortable PATCH request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.patch,
-        expectedMethod: _expectedPatchDispatch,
-      );
-    });
-
-    test('emits and sends one abortable DELETE request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.delete,
-        expectedMethod: _expectedDeleteDispatch,
-      );
-    });
-
-    test('emits and sends one abortable OPTIONS request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.options,
-        expectedMethod: _expectedOptionsDispatch,
-      );
-    });
-
-    test('emits and sends one abortable TRACE request', () {
-      _expectDispatch(
-        generator: generator,
-        emitter: emitter,
-        format: format,
-        method: HttpMethod.trace,
-        expectedMethod: _expectedTraceDispatch,
-      );
-    });
-  });
-}
-
-const _expectedGetDispatch = r'''
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -247,7 +221,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedHeadDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable HEAD request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.head,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -299,7 +324,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedPostDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable POST request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.post,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -351,7 +427,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedPutDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable PUT request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.put,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -403,7 +530,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedPatchDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable PATCH request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.patch,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -455,7 +633,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedDeleteDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable DELETE request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.delete,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -507,7 +736,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedOptionsDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable OPTIONS request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.options,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -559,7 +839,58 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-const _expectedTraceDispatch = r'''
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test('emits and sends one abortable TRACE request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.trace,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: const AbsentBodyPlan(),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
 Future<TonikResult<void, Response>> dispatch() async {
   late final Response _$response;
   if (cancellation != null && cancellation.isCancelled) {
@@ -611,68 +942,10 @@ Future<TonikResult<void, Response>> dispatch() async {
 }
 ''';
 
-void _expectDispatch({
-  required HttpBackendGenerator generator,
-  required DartEmitter emitter,
-  required String Function(String, {Object? uri}) format,
-  required HttpMethod method,
-  required String expectedMethod,
-}) {
-  final statements = generator.generateDispatchStatements(
-    plan: OperationRequestPlan(
-      method: method,
-      uri: refer(r'_$uri'),
-      pathParameters: const [],
-      queryParameters: const [],
-      headers: const [],
-      cookies: const [],
-      contentType: null,
-      cancellation: refer('cancellation'),
-      response: ResponseRequirements(
-        expectsBytes: true,
-        statuses: const [],
-        contentTypes: const [],
-      ),
-      body: const AbsentBodyPlan(),
-    ),
-    responseVariable: r'_$response',
-    resultValueType: refer('void', 'dart:core'),
-  );
-
-  final generatedMethod = Method(
-    (b) => b
-      ..name = 'dispatch'
-      ..returns = TypeReference(
-        (b) => b
-          ..symbol = 'Future'
-          ..url = 'dart:core'
-          ..types.add(
-            TypeReference(
-              (b) => b
-                ..symbol = 'TonikResult'
-                ..url = 'package:tonik_util/tonik_util.dart'
-                ..types.addAll([
-                  refer('void', 'dart:core'),
-                  refer('Response', 'package:http/http.dart'),
-                ]),
-            ),
-          ),
-      )
-      ..modifier = MethodModifier.async
-      ..body = Block.of([statements]),
-  );
-
-  expect(
-    collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
-    collapseWhitespace(format(expectedMethod)),
-  );
-}
-
-String _asMethod(Method method, DartEmitter emitter) {
-  final wrapped = method.rebuild(
-    (builder) => builder
-      ..type = null
-      ..name = method.name,
-  );
-  return '${wrapped.accept(emitter)}';
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+  });
 }

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -119,8 +119,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.get,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedGetDispatch,
       );
     });
@@ -131,8 +129,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.head,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedHeadDispatch,
       );
     });
@@ -143,8 +139,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.post,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedPostDispatch,
       );
     });
@@ -155,8 +149,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.put,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedPutDispatch,
       );
     });
@@ -167,8 +159,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.patch,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedPatchDispatch,
       );
     });
@@ -179,8 +169,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.delete,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedDeleteDispatch,
       );
     });
@@ -191,8 +179,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.options,
-        followRedirects: true,
-        maxRedirects: 5,
         expectedMethod: _expectedOptionsDispatch,
       );
     });
@@ -203,8 +189,6 @@ void close() {
         emitter: emitter,
         format: format,
         method: HttpMethod.trace,
-        followRedirects: false,
-        maxRedirects: 2,
         expectedMethod: _expectedTraceDispatch,
       );
     });
@@ -244,8 +228,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -298,8 +280,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -352,8 +332,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -406,8 +384,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -460,8 +436,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -514,8 +488,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -568,8 +540,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = true;
-    _$request.maxRedirects = 5;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -622,8 +592,6 @@ Future<TonikResult<void, Response>> dispatch() async {
       abortTrigger: cancellation?.whenCancelled,
     );
     _$request.headers.addAll(_$options);
-    _$request.followRedirects = false;
-    _$request.maxRedirects = 2;
     if (_$data != null) {
       _$request.bodyBytes = (_$data as List<int>);
     }
@@ -648,8 +616,6 @@ void _expectDispatch({
   required DartEmitter emitter,
   required String Function(String, {Object? uri}) format,
   required HttpMethod method,
-  required bool followRedirects,
-  required int maxRedirects,
   required String expectedMethod,
 }) {
   final statements = generator.generateDispatchStatements(
@@ -661,8 +627,6 @@ void _expectDispatch({
       headers: const [],
       cookies: const [],
       contentType: null,
-      followRedirects: followRedirects,
-      maxRedirects: maxRedirects,
       cancellation: refer('cancellation'),
       response: ResponseRequirements(
         expectsBytes: true,

--- a/packages/tonik_generate/test/src/transport/operation_request_plan_test.dart
+++ b/packages/tonik_generate/test/src/transport/operation_request_plan_test.dart
@@ -17,8 +17,6 @@ void main() {
           headers: const [],
           cookies: const [],
           contentType: null,
-          followRedirects: true,
-          maxRedirects: 5,
           cancellation: refer('cancelToken'),
           response: ResponseRequirements(
             expectsBytes: true,
@@ -67,8 +65,6 @@ void main() {
         headers: [header],
         cookies: [cookie],
         contentType: literalString('application/json'),
-        followRedirects: false,
-        maxRedirects: 2,
         cancellation: refer('cancelToken'),
         response: ResponseRequirements(
           expectsBytes: true,
@@ -85,8 +81,6 @@ void main() {
       expect(plan.queryParameters, [same(query), same(query)]);
       expect(plan.headers.single, same(header));
       expect(plan.cookies.single, same(cookie));
-      expect(plan.followRedirects, isFalse);
-      expect(plan.maxRedirects, 2);
       expect(plan.body, isA<JsonBodyPlan>());
     });
 
@@ -109,8 +103,6 @@ void main() {
         headers: const [],
         cookies: const [],
         contentType: null,
-        followRedirects: true,
-        maxRedirects: 5,
         cancellation: refer('cancelToken'),
         response: response,
         body: const AbsentBodyPlan(),


### PR DESCRIPTION
## Summary

- Refactor HTTP request generation across Dio and HTTP backends.
- Generate request bodies, headers, and Dio options through dedicated generators.
- Expand generator tests for backend, body, and header output.

## Testing

- Added and updated unit tests for HTTP backend, body, and header generation.
- Not run (not requested).