### PR TITLE
Add multipart request support to the HTTP transport

### DIFF
--- a/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
@@ -1,6 +1,8 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/transport/http/http_multipart_generator.dart';
+import 'package:tonik_generate/src/transport/multipart_header_plan.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/inline_helper_context.dart';
@@ -34,12 +36,6 @@ class HttpBodyGenerator {
     }
 
     final content = requestBody.resolvedContent.toList();
-    if (content.any((item) => item.contentType == ContentType.multipart)) {
-      throw UnsupportedError(
-        'The http transport backend does not support multipart bodies yet.',
-      );
-    }
-
     final helperContext = InlineHelperContext(nameManager: nameManager);
     final inlineHelpers = <InlineHelper>[];
     final isRequired = requestBody.isRequired;
@@ -53,19 +49,35 @@ class HttpBodyGenerator {
 
       for (final item in content) {
         final variantName = subclassNames[item.rawContentType]!;
-        final built = _bodyBytesExpression(
-          operation: operation,
-          content: item,
-          valueName: 'value.value',
-          helperContext: helperContext,
-        );
-        inlineHelpers.addAll(built.inlineFunctions);
+        final isMultipart = item.contentType == ContentType.multipart;
+        final built = isMultipart
+            ? null
+            : _bodyBytesExpression(
+                operation: operation,
+                content: item,
+                valueName: 'value.value',
+                helperContext: helperContext,
+              );
+        if (built != null) inlineHelpers.addAll(built.inlineFunctions);
         cases.add(
           Block.of([
             const Code('final '),
             refer(variantName, requestBodyUrl).code,
             const Code(' value => '),
-            built.unsafeRawBody.code,
+            if (isMultipart)
+              Method(
+                (builder) => builder
+                  ..modifier = MethodModifier.async
+                  ..lambda = false
+                  ..body = Block.of(
+                    buildHttpMultipartBodyStatements(
+                      item,
+                      'value.value',
+                    ),
+                  ),
+              ).closure.call([]).awaited.code
+            else
+              built!.unsafeRawBody.code,
             const Code(','),
           ]),
         );
@@ -75,10 +87,21 @@ class HttpBodyGenerator {
         cases.add(const Code('null => null,'));
       }
 
+      final multipartHeaderParameters = _multipartHeaderParameters(operation);
+      final hasMultipart = content.any(
+        (item) => item.contentType == ContentType.multipart,
+      );
       return Method(
         (b) => b
           ..name = '_data'
-          ..returns = refer('Object?', 'dart:core')
+          ..returns = hasMultipart
+              ? TypeReference(
+                  (t) => t
+                    ..symbol = 'Future'
+                    ..url = 'dart:async'
+                    ..types.add(refer('Object?', 'dart:core')),
+                )
+              : refer('Object?', 'dart:core')
           ..optionalParameters.add(
             Parameter(
               (p) => p
@@ -93,6 +116,8 @@ class HttpBodyGenerator {
                 ..required = isRequired,
             ),
           )
+          ..optionalParameters.addAll(multipartHeaderParameters)
+          ..modifier = hasMultipart ? MethodModifier.async : null
           ..lambda = false
           ..body = Block.of([
             ...spliceInlineHelpers(inlineHelpers),
@@ -104,6 +129,41 @@ class HttpBodyGenerator {
     }
 
     final item = content.single;
+    if (item.contentType == ContentType.multipart) {
+      final multipartHeaderParameters = _multipartHeaderParameters(operation);
+      return Method(
+        (b) => b
+          ..name = '_data'
+          ..returns = TypeReference(
+            (t) => t
+              ..symbol = 'Future'
+              ..url = 'dart:async'
+              ..types.add(refer('Object?', 'dart:core')),
+          )
+          ..optionalParameters.add(
+            Parameter(
+              (p) => p
+                ..name = 'body'
+                ..type = typeReference(
+                  item.model,
+                  nameManager,
+                  package,
+                  isNullableOverride: !isRequired,
+                  useImmutableCollections: useImmutableCollections,
+                )
+                ..named = true
+                ..required = isRequired,
+            ),
+          )
+          ..optionalParameters.addAll(multipartHeaderParameters)
+          ..modifier = MethodModifier.async
+          ..lambda = false
+          ..body = Block.of([
+            if (!isRequired) const Code('if (body == null) return null;'),
+            ...buildHttpMultipartBodyStatements(item, 'body'),
+          ]),
+      );
+    }
     final built = _bodyBytesExpression(
       operation: operation,
       content: item,
@@ -236,4 +296,21 @@ class HttpBodyGenerator {
         caseSensitive: false,
       ).firstMatch(rawContentType)?.group(1)?.toLowerCase() ??
       'utf-8';
+
+  List<Parameter> _multipartHeaderParameters(Operation operation) => [
+    for (final info in extractOperationMultipartHeaderParamInfo(operation))
+      Parameter(
+        (parameter) => parameter
+          ..name = info.name
+          ..type = typeReference(
+            info.model,
+            nameManager,
+            package,
+            isNullableOverride: !info.isRequired,
+            useImmutableCollections: useImmutableCollections,
+          )
+          ..named = true
+          ..required = info.isRequired,
+      ),
+  ];
 }

--- a/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
@@ -84,7 +84,10 @@ Code _buildPart(
     BinaryModel() || Base64Model() => _addFilePart(
       rawName,
       value,
-      rawContentType: encoding?.rawContentType ?? 'application/octet-stream',
+      rawContentType: _rawContentType(
+        encoding,
+        'application/octet-stream',
+      ),
     ),
     ListModel() => _buildListParts(
       rawName,
@@ -100,7 +103,7 @@ Code _buildPart(
     StringModel() => _addTextPart(
       rawName,
       value,
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     ),
     AnyModel() => _addTextPart(
       rawName,
@@ -110,28 +113,25 @@ Code _buildPart(
           'package:tonik_util/tonik_util.dart',
         ).call([value]),
       ]),
-      rawContentType: encoding?.rawContentType ?? 'application/json',
+      rawContentType: _rawContentType(encoding, 'application/json'),
     ),
     MapModel() => _addTextPart(
       rawName,
       refer('jsonEncode', 'dart:convert').call([value]),
-      rawContentType: encoding?.rawContentType ?? 'application/json',
+      rawContentType: _rawContentType(encoding, 'application/json'),
     ),
-    ClassModel() ||
-    AllOfModel() ||
-    OneOfModel() ||
-    AnyOfModel() => _addTextPart(
+    ClassModel() || CompositeModel() => _addTextPart(
       rawName,
       refer(
         'jsonEncode',
         'dart:convert',
       ).call([value.property('toJson').call([])]),
-      rawContentType: encoding?.rawContentType ?? 'application/json',
+      rawContentType: _rawContentType(encoding, 'application/json'),
     ),
     EnumModel() => _addTextPart(
       rawName,
       _enumText(value, resolved, encoding?.contentType),
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     ),
     DateTimeModel() => _addTextPart(
       rawName,
@@ -140,27 +140,16 @@ Code _buildPart(
         encoding?.contentType,
         method: 'toTimeZonedIso8601String',
       ),
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     ),
-    IntegerModel() ||
-    DoubleModel() ||
-    NumberModel() ||
-    BooleanModel() ||
-    DateModel() ||
-    DecimalModel() ||
-    UriModel() => _addTextPart(
+    PrimitiveModel() => _addTextPart(
       rawName,
       _primitiveText(value, encoding?.contentType, method: 'toString'),
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     ),
-    AliasModel() => _buildPart(
-      resolved,
-      rawName,
-      value,
-      encoding: encoding,
-    ),
-    _ => generateEncodingExceptionExpression(
-      'Unsupported model type for multipart encoding.',
+    NamedModel() => generateEncodingExceptionExpression(
+      "Cannot encode cyclic AliasModel property '$rawName'.",
+      raw: true,
     ).statement,
   };
 }
@@ -180,6 +169,14 @@ Code _buildListParts(
     ).statement;
   }
 
+  if (content is AliasModel) {
+    return generateEncodingExceptionExpression(
+      'Cannot encode cyclic AliasModel list items for multipart property '
+      "'$rawName'.",
+      raw: true,
+    ).statement;
+  }
+
   if (content is BinaryModel || content is Base64Model) {
     return Block.of([
       const Code('for (final item in '),
@@ -188,7 +185,10 @@ Code _buildListParts(
       _addFilePart(
         rawName,
         refer('item'),
-        rawContentType: encoding?.rawContentType ?? 'application/octet-stream',
+        rawContentType: _rawContentType(
+          encoding,
+          'application/octet-stream',
+        ),
       ),
       const Code('}'),
     ]);
@@ -212,7 +212,7 @@ Code _buildListParts(
       refer('jsonEncode', 'dart:convert').call([
         _jsonListValue(value, content),
       ]),
-      rawContentType: encoding?.rawContentType ?? 'application/json',
+      rawContentType: _rawContentType(encoding, 'application/json'),
     );
   }
 
@@ -237,7 +237,7 @@ Code _buildListParts(
       _addTextPart(
         rawName,
         refer('jsonEncode', 'dart:convert').call([itemJson]),
-        rawContentType: encoding?.rawContentType ?? 'application/json',
+        rawContentType: _rawContentType(encoding, 'application/json'),
       ),
       const Code('}'),
     ]);
@@ -254,7 +254,7 @@ Code _buildListParts(
     return _addTextPart(
       rawName,
       serialized,
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     );
   }
 
@@ -265,7 +265,7 @@ Code _buildListParts(
     _addTextPart(
       rawName,
       _listItemText(refer('item'), content, encoding?.contentType),
-      rawContentType: encoding?.rawContentType ?? 'text/plain',
+      rawContentType: _rawContentType(encoding, 'text/plain'),
     ),
     const Code('}'),
   ]);
@@ -351,16 +351,12 @@ Expression _listItemText(
     contentType,
     method: 'toTimeZonedIso8601String',
   ),
-  IntegerModel() ||
-  DoubleModel() ||
-  NumberModel() ||
-  BooleanModel() ||
-  DateModel() ||
-  DecimalModel() ||
-  UriModel() => _primitiveText(value, contentType, method: 'toString'),
-  AliasModel() => _listItemText(value, model.resolved, contentType),
+  PrimitiveModel() => _primitiveText(value, contentType, method: 'toString'),
   _ => value.property('toString').call([]),
 };
+
+String _rawContentType(PartEncoding? encoding, String fallback) =>
+    encoding?.rawContentType ?? fallback;
 
 Expression _primitiveText(
   Expression value,

--- a/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
@@ -1,0 +1,454 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
+import 'package:tonik_generate/src/util/exception_code_generator.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
+import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
+
+/// Lowers one multipart body to an ordered list of `package:http` parts.
+///
+/// Every OpenAPI part is represented as a `MultipartFile` in generated code.
+/// This deliberately avoids `MultipartRequest.fields`, whose map shape cannot
+/// preserve duplicate names or ordering relative to file parts.
+List<Code> buildHttpMultipartBodyStatements(
+  RequestContent content,
+  String bodyAccessor,
+) {
+  final model = content.model.resolved;
+  if (model is! ClassModel) {
+    return [
+      refer('UnsupportedError', 'dart:core')
+          .newInstance([
+            literalString(
+              'Multipart request bodies require an object schema '
+              '(ClassModel). Got: ${model.runtimeType}.',
+            ),
+          ])
+          .thrown
+          .statement,
+    ];
+  }
+
+  final statements = <Code>[
+    declareFinal(r'_$multipartFiles')
+        .assign(
+          literalList(
+            [],
+            refer('MultipartFile', 'package:http/http.dart'),
+          ),
+        )
+        .statement,
+  ];
+  final properties = normalizeProperties(
+    model.properties.where((property) => !property.isReadOnly).toList(),
+  );
+
+  for (final (:normalizedName, :property) in properties) {
+    final isNullable = property.isNullable || !property.isRequired;
+    final accessor = refer(bodyAccessor).property(normalizedName);
+    final value = isNullable ? accessor.nullChecked : accessor;
+    final part = _buildPart(
+      property.model,
+      property.name,
+      value,
+      encoding: content.multipartEncoding?[property],
+    );
+
+    if (isNullable) {
+      statements.add(
+        Block.of([
+          const Code('if ('),
+          accessor.code,
+          const Code(' != null) {'),
+          part,
+          const Code('}'),
+        ]),
+      );
+    } else {
+      statements.add(part);
+    }
+  }
+
+  statements.add(refer(r'_$multipartFiles').returned.statement);
+  return statements;
+}
+
+Code _buildPart(
+  Model model,
+  String rawName,
+  Expression value, {
+  required PartEncoding? encoding,
+}) {
+  final resolved = model.resolved;
+  return switch (resolved) {
+    BinaryModel() || Base64Model() => _addFilePart(
+      rawName,
+      value,
+      rawContentType: encoding?.rawContentType ?? 'application/octet-stream',
+    ),
+    ListModel() => _buildListParts(
+      rawName,
+      value,
+      resolved,
+      encoding: encoding,
+    ),
+    NeverModel() => generateEncodingExceptionExpression(
+      "Cannot encode NeverModel property '$rawName' - this type does not "
+      'permit any value.',
+      raw: true,
+    ).statement,
+    StringModel() => _addTextPart(
+      rawName,
+      value,
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    ),
+    AnyModel() => _addTextPart(
+      rawName,
+      refer('jsonEncode', 'dart:convert').call([
+        refer(
+          'encodeAnyToJson',
+          'package:tonik_util/tonik_util.dart',
+        ).call([value]),
+      ]),
+      rawContentType: encoding?.rawContentType ?? 'application/json',
+    ),
+    MapModel() => _addTextPart(
+      rawName,
+      refer('jsonEncode', 'dart:convert').call([value]),
+      rawContentType: encoding?.rawContentType ?? 'application/json',
+    ),
+    ClassModel() ||
+    AllOfModel() ||
+    OneOfModel() ||
+    AnyOfModel() => _addTextPart(
+      rawName,
+      refer(
+        'jsonEncode',
+        'dart:convert',
+      ).call([value.property('toJson').call([])]),
+      rawContentType: encoding?.rawContentType ?? 'application/json',
+    ),
+    EnumModel() => _addTextPart(
+      rawName,
+      _enumText(value, resolved, encoding?.contentType),
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    ),
+    DateTimeModel() => _addTextPart(
+      rawName,
+      _primitiveText(
+        value,
+        encoding?.contentType,
+        method: 'toTimeZonedIso8601String',
+      ),
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    ),
+    IntegerModel() ||
+    DoubleModel() ||
+    NumberModel() ||
+    BooleanModel() ||
+    DateModel() ||
+    DecimalModel() ||
+    UriModel() => _addTextPart(
+      rawName,
+      _primitiveText(value, encoding?.contentType, method: 'toString'),
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    ),
+    AliasModel() => _buildPart(
+      resolved,
+      rawName,
+      value,
+      encoding: encoding,
+    ),
+    _ => generateEncodingExceptionExpression(
+      'Unsupported model type for multipart encoding.',
+    ).statement,
+  };
+}
+
+Code _buildListParts(
+  String rawName,
+  Expression value,
+  ListModel model, {
+  required PartEncoding? encoding,
+}) {
+  final content = model.content.resolved;
+  if (content is ListModel) {
+    return generateEncodingExceptionExpression(
+      'Arrays of arrays are not supported for multipart encoding '
+      '(property: $rawName).',
+      raw: true,
+    ).statement;
+  }
+
+  if (content is BinaryModel || content is Base64Model) {
+    return Block.of([
+      const Code('for (final item in '),
+      value.code,
+      const Code(') {'),
+      _addFilePart(
+        rawName,
+        refer('item'),
+        rawContentType: encoding?.rawContentType ?? 'application/octet-stream',
+      ),
+      const Code('}'),
+    ]);
+  }
+
+  final isStyleBased = encoding?.isStyleBased ?? false;
+  if (!isStyleBased &&
+      encoding?.contentType != null &&
+      encoding?.contentType != ContentType.text) {
+    if (encoding?.contentType != ContentType.json &&
+        encoding?.contentType != ContentType.bytes) {
+      return generateEncodingExceptionExpression(
+        'Unsupported contentType "${encoding?.rawContentType ?? ''}" for '
+        'array multipart property "$rawName". Only application/json is '
+        'supported for content-based array serialization.',
+        raw: true,
+      ).statement;
+    }
+    return _addTextPart(
+      rawName,
+      refer('jsonEncode', 'dart:convert').call([
+        _jsonListValue(value, content),
+      ]),
+      rawContentType: encoding?.rawContentType ?? 'application/json',
+    );
+  }
+
+  if (content is ClassModel ||
+      content is AllOfModel ||
+      content is OneOfModel ||
+      content is AnyOfModel ||
+      content is MapModel ||
+      content is AnyModel) {
+    final itemJson = switch (content) {
+      MapModel() => refer('item'),
+      AnyModel() => refer(
+        'encodeAnyToJson',
+        'package:tonik_util/tonik_util.dart',
+      ).call([refer('item')]),
+      _ => refer('item').property('toJson').call([]),
+    };
+    return Block.of([
+      const Code('for (final item in '),
+      value.code,
+      const Code(') {'),
+      _addTextPart(
+        rawName,
+        refer('jsonEncode', 'dart:convert').call([itemJson]),
+        rawContentType: encoding?.rawContentType ?? 'application/json',
+      ),
+      const Code('}'),
+    ]);
+  }
+
+  final explode = encoding?.explode ?? true;
+  if (!explode) {
+    final serialized = buildSimpleValueExpression(
+      value,
+      model,
+      explode: false,
+      allowEmpty: true,
+    ).unsafeRawBody;
+    return _addTextPart(
+      rawName,
+      serialized,
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    );
+  }
+
+  return Block.of([
+    const Code('for (final item in '),
+    value.code,
+    const Code(') {'),
+    _addTextPart(
+      rawName,
+      _listItemText(refer('item'), content, encoding?.contentType),
+      rawContentType: encoding?.rawContentType ?? 'text/plain',
+    ),
+    const Code('}'),
+  ]);
+}
+
+Expression _jsonListValue(Expression value, Model content) {
+  if (content is ClassModel ||
+      content is AllOfModel ||
+      content is OneOfModel ||
+      content is AnyOfModel) {
+    return value
+        .property('map')
+        .call([
+          Method(
+            (builder) => builder
+              ..lambda = true
+              ..requiredParameters.add(Parameter((p) => p..name = 'item'))
+              ..body = refer('item').property('toJson').call([]).code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([]);
+  }
+  if (content is EnumModel) {
+    return value
+        .property('map')
+        .call([
+          Method(
+            (builder) => builder
+              ..lambda = true
+              ..requiredParameters.add(Parameter((p) => p..name = 'item'))
+              ..body = refer('item').property('toJson').call([]).code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([]);
+  }
+  if (content is DateTimeModel) {
+    return value
+        .property('map')
+        .call([
+          Method(
+            (builder) => builder
+              ..lambda = true
+              ..requiredParameters.add(Parameter((p) => p..name = 'item'))
+              ..body = refer(
+                'item',
+              ).property('toTimeZonedIso8601String').call([]).code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([]);
+  }
+  if (content is AnyModel) {
+    return value
+        .property('map')
+        .call([
+          Method(
+            (builder) => builder
+              ..lambda = true
+              ..requiredParameters.add(Parameter((p) => p..name = 'item'))
+              ..body = refer(
+                'encodeAnyToJson',
+                'package:tonik_util/tonik_util.dart',
+              ).call([refer('item')]).code,
+          ).closure,
+        ])
+        .property('toList')
+        .call([]);
+  }
+  return value;
+}
+
+Expression _listItemText(
+  Expression value,
+  Model model,
+  ContentType? contentType,
+) => switch (model) {
+  StringModel() => value,
+  EnumModel() => _enumText(value, model, contentType),
+  DateTimeModel() => _primitiveText(
+    value,
+    contentType,
+    method: 'toTimeZonedIso8601String',
+  ),
+  IntegerModel() ||
+  DoubleModel() ||
+  NumberModel() ||
+  BooleanModel() ||
+  DateModel() ||
+  DecimalModel() ||
+  UriModel() => _primitiveText(value, contentType, method: 'toString'),
+  AliasModel() => _listItemText(value, model.resolved, contentType),
+  _ => value.property('toString').call([]),
+};
+
+Expression _primitiveText(
+  Expression value,
+  ContentType? contentType, {
+  required String method,
+}) {
+  if (contentType == ContentType.json) {
+    return refer('jsonEncode', 'dart:convert').call([value]);
+  }
+  return value.property(method).call([]);
+}
+
+Expression _enumText(
+  Expression value,
+  EnumModel<dynamic> model,
+  ContentType? contentType,
+) {
+  final json = value.property('toJson').call([]);
+  if (contentType == ContentType.json) {
+    return refer('jsonEncode', 'dart:convert').call([json]);
+  }
+  return model is EnumModel<String> ? json : json.property('toString').call([]);
+}
+
+Code _addFilePart(
+  String rawName,
+  Expression file, {
+  required String rawContentType,
+}) => _addPart(
+  rawName,
+  file.property('toBytes').call([]),
+  rawContentType: rawContentType,
+  filename: file.property('fileName').ifNullThen(specLiteralString(rawName)),
+);
+
+Code _addTextPart(
+  String rawName,
+  Expression text, {
+  required String rawContentType,
+}) {
+  final encoding = _encoding(rawContentType);
+  if (encoding == null) {
+    return generateEncodingExceptionExpression(
+      'Unsupported multipart text encoding: ${_charset(rawContentType)}.',
+    ).statement;
+  }
+  return _addPart(
+    rawName,
+    encoding.property('encode').call([text]),
+    rawContentType: rawContentType,
+  );
+}
+
+Code _addPart(
+  String rawName,
+  Expression bytes, {
+  required String rawContentType,
+  Expression? filename,
+}) {
+  final namedArguments = <String, Expression>{
+    'filename': ?filename,
+    'contentType': refer(
+      'MediaType',
+      'package:http/http.dart',
+    ).property('parse').call([specLiteralString(rawContentType)]),
+  };
+  return refer(r'_$multipartFiles').property('add').call([
+    refer(
+      'MultipartFile',
+      'package:http/http.dart',
+    ).property('fromBytes').call(
+      [specLiteralString(rawName), bytes],
+      namedArguments,
+    ),
+  ]).statement;
+}
+
+Expression? _encoding(String rawContentType) =>
+    switch (_charset(rawContentType)) {
+      'utf-8' || 'utf8' => refer('utf8', 'dart:convert'),
+      'iso-8859-1' || 'latin1' => refer('latin1', 'dart:convert'),
+      'us-ascii' || 'ascii' => refer('ascii', 'dart:convert'),
+      _ => null,
+    };
+
+String _charset(String rawContentType) =>
+    RegExp(
+      r'(?:^|;)\s*charset\s*=\s*"?([^";\s]+)',
+      caseSensitive: false,
+    ).firstMatch(rawContentType)?.group(1)?.toLowerCase() ??
+    'utf-8';

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -257,6 +257,28 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
         ..url = 'dart:core'
         ..types.add(refer('int', 'dart:core')),
     );
+    final multipartFilesType = TypeReference(
+      (b) => b
+        ..symbol = 'List'
+        ..url = 'dart:core'
+        ..types.add(refer('MultipartFile', 'package:http/http.dart')),
+    );
+    final isRequiredMultipart = switch (plan.body) {
+      MultipartBodyPlan(:final isRequired) => isRequired,
+      _ => false,
+    };
+    final canBeMultipart = switch (plan.body) {
+      MultipartBodyPlan() => true,
+      BodySelectionPlan(:final variants) => variants.any(
+        (variant) => variant is MultipartBodyPlan,
+      ),
+      _ => false,
+    };
+    final requestType = isRequiredMultipart
+        ? refer('AbortableMultipartRequest', 'package:http/http.dart')
+        : canBeMultipart
+        ? refer('BaseRequest', 'package:http/http.dart')
+        : refer('AbortableRequest', 'package:http/http.dart');
 
     return Block.of([
       const Code('late final '),
@@ -324,36 +346,46 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
         const Code('}\n'),
       ]),
       const Code('late final '),
-      refer('AbortableRequest', 'package:http/http.dart').code,
+      requestType.code,
       const Code(' $request;'),
       Block.of([
         const Code('try {'),
-        refer(request)
-            .assign(
-              refer(
-                'AbortableRequest',
-                'package:http/http.dart',
-              ).newInstance(
-                [literalString(plan.methodName), plan.uri],
-                {
-                  'abortTrigger': cancellation.nullSafeProperty(
-                    'whenCancelled',
-                  ),
-                },
-              ),
-            )
-            .statement,
+        if (isRequiredMultipart)
+          ..._requiredMultipartRequestStatements(
+            plan: plan,
+            request: request,
+            cancellation: cancellation,
+          )
+        else if (canBeMultipart)
+          ..._selectedRequestStatements(
+            plan: plan,
+            request: request,
+            cancellation: cancellation,
+            bodyBytesType: bodyBytesType,
+            multipartFilesType: multipartFilesType,
+          )
+        else
+          ..._ordinaryRequestStatements(
+            plan: plan,
+            request: request,
+            cancellation: cancellation,
+          ),
         refer(request).property('headers').property('addAll').call([
           refer(r'_$options'),
         ]).statement,
-        Block.of([
-          const Code(r'if (_$data != null) {'),
-          refer(request)
-              .property('bodyBytes')
-              .assign(refer(r'_$data').asA(bodyBytesType))
-              .statement,
-          const Code('}'),
-        ]),
+        if (isRequiredMultipart)
+          refer(request).property('files').property('addAll').call([
+            refer(r'_$data').asA(multipartFilesType),
+          ]).statement
+        else if (!canBeMultipart)
+          Block.of([
+            const Code(r'if (_$data != null) {'),
+            refer(request)
+                .property('bodyBytes')
+                .assign(refer(r'_$data').asA(bodyBytesType))
+                .statement,
+            const Code('}'),
+          ]),
         const Code('} on '),
         refer('Object', 'dart:core').code,
         const Code(' catch (exception, stackTrace) {'),
@@ -386,6 +418,109 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
           .thrown
           .statement,
     ]);
+  }
+
+  List<Code> _requiredMultipartRequestStatements({
+    required OperationRequestPlan plan,
+    required String request,
+    required Expression cancellation,
+  }) => [
+    refer(request)
+        .assign(
+          refer(
+            'AbortableMultipartRequest',
+            'package:http/http.dart',
+          ).newInstance(
+            [literalString(plan.methodName), plan.uri],
+            {
+              'abortTrigger': cancellation.nullSafeProperty('whenCancelled'),
+            },
+          ),
+        )
+        .statement,
+  ];
+
+  List<Code> _ordinaryRequestStatements({
+    required OperationRequestPlan plan,
+    required String request,
+    required Expression cancellation,
+  }) => [
+    refer(request)
+        .assign(
+          refer(
+            'AbortableRequest',
+            'package:http/http.dart',
+          ).newInstance(
+            [literalString(plan.methodName), plan.uri],
+            {
+              'abortTrigger': cancellation.nullSafeProperty('whenCancelled'),
+            },
+          ),
+        )
+        .statement,
+  ];
+
+  List<Code> _selectedRequestStatements({
+    required OperationRequestPlan plan,
+    required String request,
+    required Expression cancellation,
+    required TypeReference bodyBytesType,
+    required TypeReference multipartFilesType,
+  }) {
+    const multipartRequest = r'_$multipartRequest';
+    const ordinaryRequest = r'_$ordinaryRequest';
+    return [
+      Block.of([
+        const Code(r'if (_$data is '),
+        multipartFilesType.code,
+        const Code(') {'),
+        declareFinal(multipartRequest)
+            .assign(
+              refer(
+                'AbortableMultipartRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                {
+                  'abortTrigger': cancellation.nullSafeProperty(
+                    'whenCancelled',
+                  ),
+                },
+              ),
+            )
+            .statement,
+        refer(multipartRequest).property('files').property('addAll').call([
+          refer(r'_$data'),
+        ]).statement,
+        refer(request).assign(refer(multipartRequest)).statement,
+        const Code('} else {'),
+        declareFinal(ordinaryRequest)
+            .assign(
+              refer(
+                'AbortableRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                {
+                  'abortTrigger': cancellation.nullSafeProperty(
+                    'whenCancelled',
+                  ),
+                },
+              ),
+            )
+            .statement,
+        Block.of([
+          const Code(r'if (_$data != null) {'),
+          refer(ordinaryRequest)
+              .property('bodyBytes')
+              .assign(refer(r'_$data').asA(bodyBytesType))
+              .statement,
+          const Code('}'),
+        ]),
+        refer(request).assign(refer(ordinaryRequest)).statement,
+        const Code('}'),
+      ]),
+    ];
   }
 
   Reference _resultClass(String symbol, Reference resultValueType) {

--- a/packages/tonik_generate/pubspec.yaml
+++ b/packages/tonik_generate/pubspec.yaml
@@ -27,5 +27,7 @@ dependencies:
   tonik_util: ^0.9.0
 
 dev_dependencies:
+  http: ^1.6.0
+  mime: ^2.0.0
   test: ^1.26.3
   very_good_analysis: ^10.2.0

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -530,6 +530,305 @@ Object? _data({required Payload body}) {
       collapseWhitespace(format(expected)),
     );
   });
+
+  group('multipart bodies', () {
+    test(
+      'emits ordered duplicate-preserving scalar JSON and file parts',
+      () {
+        final metadata = ClassModel(
+          name: 'Metadata',
+          properties: [
+            _formProperty(
+              context,
+              name: 'id',
+              model: StringModel(context: context),
+            ),
+          ],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        );
+        final text = _formProperty(
+          context,
+          name: 'item',
+          model: StringModel(context: context),
+        );
+        final json = _formProperty(
+          context,
+          name: 'metadata',
+          model: metadata,
+        );
+        final file = _formProperty(
+          context,
+          name: 'item',
+          model: BinaryModel(context: context),
+        );
+        final optionalText = _formProperty(
+          context,
+          name: 'note',
+          model: StringModel(context: context),
+          isRequired: false,
+          isNullable: true,
+        );
+        final upload = ClassModel(
+          name: 'Upload',
+          properties: [text, json, file, optionalText],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        );
+
+        final method = generator.generateBodyMethod(
+          _operation(
+            context,
+            requestBody: _body(
+              context,
+              model: upload,
+              contentType: ContentType.multipart,
+              rawContentType: 'multipart/form-data',
+              multipartEncoding: {
+                text: const PartEncoding(
+                  contentType: ContentType.text,
+                  rawContentType: 'text/plain; charset=iso-8859-1',
+                  headers: null,
+                  style: null,
+                  explode: null,
+                  allowReserved: null,
+                ),
+                json: const PartEncoding(
+                  contentType: ContentType.json,
+                  rawContentType: 'application/json',
+                  headers: null,
+                  style: null,
+                  explode: null,
+                  allowReserved: null,
+                ),
+                file: const PartEncoding(
+                  contentType: ContentType.bytes,
+                  rawContentType: 'image/png',
+                  headers: null,
+                  style: null,
+                  explode: null,
+                  allowReserved: null,
+                ),
+              },
+            ),
+          ),
+        );
+
+        const expected = r'''
+Future<Object?> _data({required Upload body}) async {
+  final _$multipartFiles = <MultipartFile>[];
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'item',
+      latin1.encode(body.item),
+      contentType: MediaType.parse(r'text/plain; charset=iso-8859-1'),
+    ),
+  );
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'metadata',
+      utf8.encode(jsonEncode(body.metadata.toJson())),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'item',
+      body.item2.toBytes(),
+      filename: body.item2.fileName ?? r'item',
+      contentType: MediaType.parse(r'image/png'),
+    ),
+  );
+  if (body.note != null) {
+    _$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'note',
+        utf8.encode(body.note!),
+        contentType: MediaType.parse(r'text/plain'),
+      ),
+    );
+  }
+  return _$multipartFiles;
+}
+''';
+
+        expect(
+          collapseWhitespace(format('${method.accept(emitter)}')),
+          collapseWhitespace(format(expected)),
+        );
+      },
+    );
+
+    test('emits repeated scalar and file parts in collection order', () {
+      final tags = _formProperty(
+        context,
+        name: 'tag',
+        model: ListModel(
+          content: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+      );
+      final files = _formProperty(
+        context,
+        name: 'file',
+        model: ListModel(
+          content: BinaryModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+      );
+      final upload = ClassModel(
+        name: 'BatchUpload',
+        properties: [tags, files],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: upload,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+          ),
+        ),
+      );
+
+      const expected = r'''
+Future<Object?> _data({required BatchUpload body}) async {
+  final _$multipartFiles = <MultipartFile>[];
+  for (final item in body.tag) {
+    _$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'tag',
+        utf8.encode(item),
+        contentType: MediaType.parse(r'text/plain'),
+      ),
+    );
+  }
+  for (final item in body.file) {
+    _$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'file',
+        item.toBytes(),
+        filename: item.fileName ?? r'file',
+        contentType: MediaType.parse(r'application/octet-stream'),
+      ),
+    );
+  }
+  return _$multipartFiles;
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('omits an optional multipart body without emitting an empty part', () {
+      final upload = ClassModel(
+        name: 'OptionalUpload',
+        properties: [
+          _formProperty(
+            context,
+            name: 'value',
+            model: StringModel(context: context),
+          ),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: upload,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            isRequired: false,
+          ),
+        ),
+      );
+
+      const expected = r'''
+Future<Object?> _data({OptionalUpload? body}) async {
+  if (body == null) return null;
+  final _$multipartFiles = <MultipartFile>[];
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );
+  return _$multipartFiles;
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('emits an encoding failure for an unsupported part charset', () {
+      final value = _formProperty(
+        context,
+        name: 'value',
+        model: StringModel(context: context),
+      );
+      final upload = ClassModel(
+        name: 'UnsupportedTextUpload',
+        properties: [value],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: upload,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            multipartEncoding: {
+              value: const PartEncoding(
+                contentType: ContentType.text,
+                rawContentType: 'text/plain; charset=utf-16',
+                headers: null,
+                style: null,
+                explode: null,
+                allowReserved: null,
+              ),
+            },
+          ),
+        ),
+      );
+
+      const expected = r'''
+Future<Object?> _data({required UnsupportedTextUpload body}) async {
+  final _$multipartFiles = <MultipartFile>[];
+  throw EncodingException('Unsupported multipart text encoding: utf-16.');
+  return _$multipartFiles;
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+  });
 }
 
 Operation _operation(Context context, {RequestBody? requestBody}) => Operation(
@@ -555,6 +854,7 @@ RequestBodyObject _body(
   required String rawContentType,
   bool isRequired = true,
   Map<Property, FieldEncoding>? formEncoding,
+  Map<Property, PartEncoding>? multipartEncoding,
 }) => RequestBodyObject(
   name: 'payload',
   context: context,
@@ -567,6 +867,7 @@ RequestBodyObject _body(
       rawContentType: rawContentType,
       examples: const [],
       formEncoding: formEncoding,
+      multipartEncoding: multipartEncoding,
     ),
   },
 );

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -531,6 +531,68 @@ Object? _data({required Payload body}) {
     );
   });
 
+  test('lowers a runtime-selected JSON or multipart body', () {
+    final value = _formProperty(
+      context,
+      name: 'value',
+      model: StringModel(context: context),
+    );
+    final upload = ClassModel(
+      name: 'Upload',
+      properties: [value],
+      context: context,
+      isDeprecated: false,
+      examples: const [],
+    );
+    final requestBody = RequestBodyObject(
+      name: 'payload',
+      context: context,
+      description: null,
+      isRequired: true,
+      content: {
+        RequestContent(
+          model: StringModel(context: context),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+          examples: const [],
+        ),
+        RequestContent(
+          model: upload,
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          examples: const [],
+        ),
+      },
+    );
+    final method = generator.generateBodyMethod(
+      _operation(context, requestBody: requestBody),
+    );
+
+    const expected = r'''
+Future<Object?> _data({required Payload body}) async {
+  return switch (body) {
+    final PayloadJson value => utf8.encode(jsonEncode(value.value)),
+    final PayloadFormData value => await () async {
+      final _$multipartFiles = <MultipartFile>[];
+      _$multipartFiles.add(
+        MultipartFile.fromBytes(
+          r'value',
+          utf8.encode(value.value.value),
+          contentType: MediaType.parse(r'text/plain'),
+        ),
+      );
+      return _$multipartFiles;
+    }(),
+  };
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
   group('multipart bodies', () {
     test(
       'emits ordered duplicate-preserving scalar JSON and file parts',
@@ -819,6 +881,76 @@ Future<Object?> _data({OptionalUpload? body}) async {
 Future<Object?> _data({required UnsupportedTextUpload body}) async {
   final _$multipartFiles = <MultipartFile>[];
   throw EncodingException('Unsupported multipart text encoding: utf-16.');
+  return _$multipartFiles;
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${method.accept(emitter)}')),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('adds required per-part header parameters to the body method', () {
+      final value = _formProperty(
+        context,
+        name: 'value',
+        model: StringModel(context: context),
+      );
+      final upload = ClassModel(
+        name: 'HeaderUpload',
+        properties: [value],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final method = generator.generateBodyMethod(
+        _operation(
+          context,
+          requestBody: _body(
+            context,
+            model: upload,
+            contentType: ContentType.multipart,
+            rawContentType: 'multipart/form-data',
+            multipartEncoding: {
+              value: PartEncoding(
+                contentType: null,
+                rawContentType: null,
+                headers: {
+                  'X-Trace': ResponseHeaderObject(
+                    name: 'X-Trace',
+                    description: null,
+                    isRequired: true,
+                    isDeprecated: false,
+                    explode: false,
+                    model: IntegerModel(context: context),
+                    context: context,
+                    encoding: ResponseHeaderEncoding.simple,
+                    examples: const [],
+                  ),
+                },
+                style: null,
+                explode: null,
+                allowReserved: null,
+              ),
+            },
+          ),
+        ),
+      );
+
+      const expected = r'''
+Future<Object?> _data({
+  required HeaderUpload body,
+  required int valueTrace,
+}) async {
+  final _$multipartFiles = <MultipartFile>[];
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );
   return _$multipartFiles;
 }
 ''';

--- a/packages/tonik_generate/test/src/transport/http/http_multipart_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_multipart_generator_test.dart
@@ -1,0 +1,683 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/transport/http/http_multipart_generator.dart';
+
+void main() {
+  final context = Context.initial();
+  final emitter = DartEmitter(useNullSafetySyntax: true);
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  String emit(RequestContent content) {
+    final method = Method(
+      (builder) => builder
+        ..name = 'test'
+        ..returns = refer('Object?', 'dart:core')
+        ..body = Block.of(buildHttpMultipartBodyStatements(content, 'body')),
+    );
+    return format('${method.accept(emitter)}');
+  }
+
+  void expectPropertyCode(
+    Model model,
+    String expectedPartCode, {
+    PartEncoding? encoding,
+  }) {
+    final property = _property(context, model);
+    final content = _content(
+      context,
+      [property],
+      encodings: encoding == null ? null : {property: encoding},
+    );
+    final expected = [
+      'Object? test() {',
+      r'  final _$multipartFiles = <MultipartFile>[];',
+      expectedPartCode,
+      r'  return _$multipartFiles;',
+      '}',
+    ].join('\n');
+
+    expect(
+      collapseWhitespace(emit(content)),
+      collapseWhitespace(format(expected)),
+    );
+  }
+
+  group('root schema', () {
+    test('emits an explicit failure for a non-class body', () {
+      final content = RequestContent(
+        model: BinaryModel(context: context),
+        contentType: ContentType.multipart,
+        rawContentType: 'multipart/form-data',
+        examples: const [],
+      );
+
+      const expected = '''
+Object? test() {
+  throw UnsupportedError(
+    'Multipart request bodies require an object schema (ClassModel). Got: BinaryModel.',
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(emit(content)),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('resolves an alias wrapping a class body', () {
+      final body = ClassModel(
+        name: 'Body',
+        properties: [
+          _property(context, StringModel(context: context)),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final content = RequestContent(
+        model: AliasModel(
+          name: 'BodyAlias',
+          model: body,
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        ),
+        contentType: ContentType.multipart,
+        rawContentType: 'multipart/form-data',
+        examples: const [],
+      );
+
+      const expected = r'''
+Object? test() {
+  final _$multipartFiles = <MultipartFile>[];
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );
+  return _$multipartFiles;
+}
+''';
+
+      expect(
+        collapseWhitespace(emit(content)),
+        collapseWhitespace(format(expected)),
+      );
+    });
+  });
+
+  group('single-value parts', () {
+    test('rejects a cyclic alias', () {
+      final model = AliasModel(
+        name: 'CyclicValue',
+        model: StringModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      model.model = model;
+
+      expectPropertyCode(
+        model,
+        '  throw EncodingException(r"Cannot encode cyclic AliasModel '
+        'property \'value\'.");',
+      );
+    });
+
+    test('emits an encoding failure for Never', () {
+      expectPropertyCode(
+        NeverModel(context: context, isNullable: false),
+        '  throw EncodingException(r"Cannot encode NeverModel property '
+        '\'value\' - this type does not permit any value.");',
+      );
+    });
+
+    test('JSON encodes unconstrained values', () {
+      expectPropertyCode(
+        AnyModel(context: context),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(encodeAnyToJson(body.value))),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+      );
+    });
+
+    test('JSON encodes maps', () {
+      expectPropertyCode(
+        MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value)),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+      );
+    });
+
+    for (final entry in <({String name, Model model})>[
+      (
+        name: 'class',
+        model: _classModel(context, 'Nested'),
+      ),
+      (
+        name: 'allOf',
+        model: AllOfModel(
+          name: 'Combined',
+          models: {_classModel(context, 'AllOfMember')},
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        ),
+      ),
+      (
+        name: 'oneOf',
+        model: OneOfModel(
+          name: 'Either',
+          models: {
+            (
+              discriminatorValue: null,
+              model: _classModel(context, 'OneOfMember'),
+            ),
+          },
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        ),
+      ),
+      (
+        name: 'anyOf',
+        model: AnyOfModel(
+          name: 'Any',
+          models: {
+            (
+              discriminatorValue: null,
+              model: _classModel(context, 'AnyOfMember'),
+            ),
+          },
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+        ),
+      ),
+    ]) {
+      test('JSON encodes ${entry.name} objects', () {
+        expectPropertyCode(
+          entry.model,
+          r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value.toJson())),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+        );
+      });
+    }
+
+    test('uses plain and JSON encodings for string enums', () {
+      final model = _stringEnum(context);
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value.toJson()),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );''',
+      );
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value.toJson())),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      );
+    });
+
+    test('uses a plain string for integer enums', () {
+      expectPropertyCode(
+        _integerEnum(context),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value.toJson().toString()),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );''',
+      );
+    });
+
+    test('uses plain and JSON encodings for DateTime', () {
+      final model = DateTimeModel(context: context);
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value.toTimeZonedIso8601String()),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );''',
+      );
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value)),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      );
+    });
+
+    test('uses plain and JSON encodings for numeric primitives', () {
+      final model = IntegerModel(context: context);
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value.toString()),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );''',
+      );
+      expectPropertyCode(
+        model,
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value)),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+        ),
+      );
+    });
+
+    test('honors an ASCII part charset', () {
+      expectPropertyCode(
+        StringModel(context: context),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      ascii.encode(body.value),
+      contentType: MediaType.parse(r'text/plain; charset=us-ascii'),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.text,
+          rawContentType: 'text/plain; charset=us-ascii',
+        ),
+      );
+    });
+  });
+
+  group('content-based arrays', () {
+    test('rejects arrays of arrays', () {
+      expectPropertyCode(
+        ListModel(
+          content: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+        ),
+        "  throw EncodingException(r'Arrays of arrays are not supported for "
+        "multipart encoding (property: value).');",
+      );
+    });
+
+    test('rejects unsupported content types', () {
+      expectPropertyCode(
+        _list(context, StringModel(context: context)),
+        '''  throw EncodingException(r'Unsupported contentType '''
+        '''"application/x-www-form-urlencoded" for array multipart property '''
+        '''"value". Only application/json is supported for content-based array '''
+        '''serialization.');''',
+        encoding: _encoding(
+          contentType: ContentType.form,
+          rawContentType: 'application/x-www-form-urlencoded',
+        ),
+      );
+    });
+
+    test('accepts application/octet-stream content encoding', () {
+      expectPropertyCode(
+        _list(context, IntegerModel(context: context)),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(body.value)),
+      contentType: MediaType.parse(r'application/octet-stream'),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.bytes,
+          rawContentType: 'application/octet-stream',
+        ),
+      );
+    });
+
+    for (final entry
+        in <
+          ({
+            String name,
+            Model model,
+            String encodedValue,
+          })
+        >[
+          (
+            name: 'objects',
+            model: _classModel(context, 'ListItem'),
+            encodedValue: 'body.value.map((item) => item.toJson()).toList()',
+          ),
+          (
+            name: 'enums',
+            model: _stringEnum(context),
+            encodedValue: 'body.value.map((item) => item.toJson()).toList()',
+          ),
+          (
+            name: 'dates',
+            model: DateTimeModel(context: context),
+            encodedValue:
+                'body.value.map((item) => '
+                'item.toTimeZonedIso8601String()).toList()',
+          ),
+          (
+            name: 'unconstrained values',
+            model: AnyModel(context: context),
+            encodedValue:
+                'body.value.map((item) => encodeAnyToJson(item)).toList()',
+          ),
+          (
+            name: 'integers',
+            model: IntegerModel(context: context),
+            encodedValue: 'body.value',
+          ),
+        ]) {
+      test('JSON encodes ${entry.name}', () {
+        expectPropertyCode(
+          _list(context, entry.model),
+          '''
+  _\$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(jsonEncode(${entry.encodedValue})),
+      contentType: MediaType.parse(r'application/json'),
+    ),
+  );''',
+          encoding: _encoding(
+            contentType: ContentType.json,
+            rawContentType: 'application/json',
+          ),
+        );
+      });
+    }
+  });
+
+  group('repeated and style-based arrays', () {
+    test('rejects a cyclic item alias', () {
+      final item = AliasModel(
+        name: 'CyclicItem',
+        model: StringModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      item.model = item;
+
+      expectPropertyCode(
+        _list(context, item),
+        '  throw EncodingException(r"Cannot encode cyclic AliasModel list '
+        'items for multipart property \'value\'.");',
+      );
+    });
+
+    test('uses the fallback text representation for Never list items', () {
+      expectPropertyCode(
+        _list(context, NeverModel(context: context, isNullable: false)),
+        r'''
+  for (final item in body.value) {
+    _$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'value',
+        utf8.encode(item.toString()),
+        contentType: MediaType.parse(r'text/plain'),
+      ),
+    );
+  }''',
+      );
+    });
+
+    for (final entry
+        in <
+          ({
+            String name,
+            Model model,
+            String encodedItem,
+          })
+        >[
+          (
+            name: 'objects',
+            model: _classModel(context, 'RepeatedItem'),
+            encodedItem: 'jsonEncode(item.toJson())',
+          ),
+          (
+            name: 'maps',
+            model: MapModel(
+              valueModel: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            encodedItem: 'jsonEncode(item)',
+          ),
+          (
+            name: 'unconstrained values',
+            model: AnyModel(context: context),
+            encodedItem: 'jsonEncode(encodeAnyToJson(item))',
+          ),
+        ]) {
+      test('emits one JSON part for each ${entry.name} item', () {
+        expectPropertyCode(
+          _list(context, entry.model),
+          '''
+  for (final item in body.value) {
+    _\$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'value',
+        utf8.encode(${entry.encodedItem}),
+        contentType: MediaType.parse(r'application/json'),
+      ),
+    );
+  }''',
+        );
+      });
+    }
+
+    test('joins a non-exploded string array into one part', () {
+      expectPropertyCode(
+        _list(context, StringModel(context: context)),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(body.value.toSimple(explode: false, allowEmpty: true)),
+      contentType: MediaType.parse(r'text/plain'),
+    ),
+  );''',
+        encoding: _encoding(
+          style: EncodingStyle.form,
+          explode: false,
+          allowReserved: false,
+        ),
+      );
+    });
+
+    for (final entry
+        in <
+          ({
+            String name,
+            Model model,
+            String encodedItem,
+          })
+        >[
+          (
+            name: 'string enums',
+            model: _stringEnum(context),
+            encodedItem: 'item.toJson()',
+          ),
+          (
+            name: 'integer enums',
+            model: _integerEnum(context),
+            encodedItem: 'item.toJson().toString()',
+          ),
+          (
+            name: 'dates',
+            model: DateTimeModel(context: context),
+            encodedItem: 'item.toTimeZonedIso8601String()',
+          ),
+          (
+            name: 'integers',
+            model: IntegerModel(context: context),
+            encodedItem: 'item.toString()',
+          ),
+        ]) {
+      test('emits one text part for each ${entry.name} item', () {
+        expectPropertyCode(
+          _list(context, entry.model),
+          '''
+  for (final item in body.value) {
+    _\$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'value',
+        utf8.encode(${entry.encodedItem}),
+        contentType: MediaType.parse(r'text/plain'),
+      ),
+    );
+  }''',
+        );
+      });
+    }
+  });
+}
+
+RequestContent _content(
+  Context context,
+  List<Property> properties, {
+  Map<Property, PartEncoding>? encodings,
+}) => RequestContent(
+  model: ClassModel(
+    name: 'MultipartBody',
+    properties: properties,
+    context: context,
+    isDeprecated: false,
+    examples: const [],
+  ),
+  contentType: ContentType.multipart,
+  rawContentType: 'multipart/form-data',
+  multipartEncoding: encodings,
+  examples: const [],
+);
+
+Property _property(Context context, Model model) => Property(
+  name: 'value',
+  model: model,
+  isRequired: true,
+  isNullable: false,
+  isDeprecated: false,
+  examples: const [],
+  defaultValue: null,
+);
+
+ClassModel _classModel(Context context, String name) => ClassModel(
+  name: name,
+  properties: const [],
+  context: context,
+  isDeprecated: false,
+  examples: const [],
+);
+
+ListModel _list(Context context, Model content) => ListModel(
+  content: content,
+  context: context,
+  examples: const [],
+);
+
+EnumModel<String> _stringEnum(Context context) => EnumModel(
+  name: 'StringValue',
+  values: {const EnumEntry(value: 'value')},
+  isNullable: false,
+  context: context,
+  isDeprecated: false,
+  examples: const [],
+);
+
+EnumModel<int> _integerEnum(Context context) => EnumModel(
+  name: 'IntegerValue',
+  values: {const EnumEntry(value: 1)},
+  isNullable: false,
+  context: context,
+  isDeprecated: false,
+  examples: const [],
+);
+
+PartEncoding _encoding({
+  ContentType? contentType,
+  String? rawContentType,
+  EncodingStyle? style,
+  bool? explode,
+  bool? allowReserved,
+}) => PartEncoding(
+  contentType: contentType,
+  rawContentType: rawContentType,
+  headers: null,
+  style: style,
+  explode: explode,
+  allowReserved: allowReserved,
+);

--- a/packages/tonik_generate/test/src/transport/http/http_multipart_wire_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_multipart_wire_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+
+import 'package:http/http.dart';
+import 'package:mime/mime.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test(
+    'decoded multipart body preserves exact ordered duplicate parts',
+    () async {
+      final request = AbortableMultipartRequest(
+        'POST',
+        Uri.parse('https://example.com/upload'),
+      );
+      request.files.addAll([
+        MultipartFile.fromBytes(
+          'item',
+          latin1.encode('Grüße'),
+          contentType: MediaType.parse('text/plain; charset=iso-8859-1'),
+        ),
+        MultipartFile.fromBytes(
+          'metadata',
+          utf8.encode('{"empty":true}'),
+          contentType: MediaType.parse('application/json'),
+        ),
+        MultipartFile.fromBytes(
+          'item',
+          const [0, 1, 2, 255],
+          filename: 'first.bin',
+          contentType: MediaType.parse('application/octet-stream'),
+        ),
+        MultipartFile.fromBytes(
+          'empty',
+          const [],
+          contentType: MediaType.parse('text/plain'),
+        ),
+        MultipartFile.fromBytes(
+          'item',
+          const [3, 4],
+          filename: 'second.bin',
+          contentType: MediaType.parse('application/octet-stream'),
+        ),
+      ]);
+
+      final wireBytes = await request.finalize().toBytes();
+      final requestContentType = MediaType.parse(
+        request.headers['content-type']!,
+      );
+      final boundary = requestContentType.parameters['boundary']!;
+      final decoded = await Stream<List<int>>.value(
+        wireBytes,
+      ).transform(MimeMultipartTransformer(boundary)).toList();
+      final parts = <({Map<String, String> headers, List<int> bytes})>[];
+      for (final part in decoded) {
+        parts.add((
+          headers: part.headers,
+          bytes: await part.fold<List<int>>(
+            [],
+            (bytes, chunk) => bytes..addAll(chunk),
+          ),
+        ));
+      }
+
+      expect(parts, hasLength(5));
+      expect(
+        parts.map((part) => part.headers['content-disposition']).toList(),
+        [
+          'form-data; name="item"',
+          'form-data; name="metadata"',
+          'form-data; name="item"; filename="first.bin"',
+          'form-data; name="empty"',
+          'form-data; name="item"; filename="second.bin"',
+        ],
+      );
+      expect(parts.map((part) => part.headers['content-type']).toList(), [
+        'text/plain; charset=iso-8859-1',
+        'application/json',
+        'application/octet-stream',
+        'text/plain',
+        'application/octet-stream',
+      ]);
+      expect(parts.map((part) => part.bytes).toList(), [
+        latin1.encode('Grüße'),
+        utf8.encode('{"empty":true}'),
+        [0, 1, 2, 255],
+        <int>[],
+        [3, 4],
+      ]);
+    },
+  );
+}

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -1177,5 +1177,135 @@ Future<TonikResult<void, Response>> dispatch() async {
         );
       },
     );
+
+    test('supports runtime selection between JSON and multipart bodies', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.post,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: BodySelectionPlan(
+            value: refer('body'),
+            variants: [
+              JsonBodyPlan(
+                value: refer('body'),
+                rawContentType: 'application/json',
+                isRequired: true,
+              ),
+              MultipartBodyPlan(
+                value: refer('body'),
+                rawContentType: 'multipart/form-data',
+                parts: const [],
+                isRequired: true,
+              ),
+            ],
+            isRequired: true,
+          ),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final BaseRequest _$request;
+  try {
+    if (_$data is List<MultipartFile>) {
+      final _$multipartRequest = AbortableMultipartRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$multipartRequest.files.addAll(_$data);
+      _$request = _$multipartRequest;
+    } else {
+      final _$ordinaryRequest = AbortableRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      if (_$data != null) {
+        _$ordinaryRequest.bodyBytes = (_$data as List<int>);
+      }
+      _$request = _$ordinaryRequest;
+    }
+    _$request.headers.addAll(_$options);
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
   });
 }

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -948,4 +948,234 @@ Future<TonikResult<void, Response>> dispatch() async {
       );
     });
   });
+
+  group('multipart request dispatch', () {
+    test('emits and sends one abortable multipart request', () {
+      final statements = generator.generateDispatchStatements(
+        plan: OperationRequestPlan(
+          method: HttpMethod.post,
+          uri: refer(r'_$uri'),
+          pathParameters: const [],
+          queryParameters: const [],
+          headers: const [],
+          cookies: const [],
+          contentType: null,
+          cancellation: refer('cancellation'),
+          response: ResponseRequirements(
+            expectsBytes: true,
+            statuses: const [],
+            contentTypes: const [],
+          ),
+          body: MultipartBodyPlan(
+            value: refer('body'),
+            rawContentType: 'multipart/form-data',
+            parts: const [],
+            isRequired: true,
+          ),
+        ),
+        responseVariable: r'_$response',
+        resultValueType: refer('void', 'dart:core'),
+      );
+
+      final generatedMethod = Method(
+        (builder) => builder
+          ..name = 'dispatch'
+          ..returns = TypeReference(
+            (builder) => builder
+              ..symbol = 'Future'
+              ..url = 'dart:core'
+              ..types.add(
+                TypeReference(
+                  (builder) => builder
+                    ..symbol = 'TonikResult'
+                    ..url = 'package:tonik_util/tonik_util.dart'
+                    ..types.addAll([
+                      refer('void', 'dart:core'),
+                      refer('Response', 'package:http/http.dart'),
+                    ]),
+                ),
+              ),
+          )
+          ..modifier = MethodModifier.async
+          ..body = Block.of([statements]),
+      );
+
+      const expectedMethod = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final AbortableMultipartRequest _$request;
+  try {
+    _$request = AbortableMultipartRequest(
+      'POST',
+      _$uri,
+      abortTrigger: cancellation?.whenCancelled,
+    );
+    _$request.headers.addAll(_$options);
+    _$request.files.addAll((_$data as List<MultipartFile>));
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+      expect(
+        collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+        collapseWhitespace(format(expectedMethod)),
+      );
+    });
+
+    test(
+      'uses an ordinary bodyless request when optional multipart is null',
+      () {
+        final statements = generator.generateDispatchStatements(
+          plan: OperationRequestPlan(
+            method: HttpMethod.post,
+            uri: refer(r'_$uri'),
+            pathParameters: const [],
+            queryParameters: const [],
+            headers: const [],
+            cookies: const [],
+            contentType: null,
+            cancellation: refer('cancellation'),
+            response: ResponseRequirements(
+              expectsBytes: true,
+              statuses: const [],
+              contentTypes: const [],
+            ),
+            body: MultipartBodyPlan(
+              value: refer('body'),
+              rawContentType: 'multipart/form-data',
+              parts: const [],
+              isRequired: false,
+            ),
+          ),
+          responseVariable: r'_$response',
+          resultValueType: refer('void', 'dart:core'),
+        );
+
+        final generatedMethod = Method(
+          (builder) => builder
+            ..name = 'dispatch'
+            ..returns = TypeReference(
+              (builder) => builder
+                ..symbol = 'Future'
+                ..url = 'dart:core'
+                ..types.add(
+                  TypeReference(
+                    (builder) => builder
+                      ..symbol = 'TonikResult'
+                      ..url = 'package:tonik_util/tonik_util.dart'
+                      ..types.addAll([
+                        refer('void', 'dart:core'),
+                        refer('Response', 'package:http/http.dart'),
+                      ]),
+                  ),
+                ),
+            )
+            ..modifier = MethodModifier.async
+            ..body = Block.of([statements]),
+        );
+
+        const expectedMethod = r'''
+Future<TonikResult<void, Response>> dispatch() async {
+  late final Response _$response;
+  if (cancellation != null && cancellation.isCancelled) {
+    final exception = RequestAbortedException(_$uri);
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: StackTrace.current,
+      type: TonikErrorType.cancelled,
+      response: null,
+    );
+  }
+
+  final Client _$client;
+  try {
+    _$client = _client();
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.other,
+      response: null,
+    );
+  }
+
+  late final BaseRequest _$request;
+  try {
+    if (_$data is List<MultipartFile>) {
+      final _$multipartRequest = AbortableMultipartRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$multipartRequest.files.addAll(_$data);
+      _$request = _$multipartRequest;
+    } else {
+      final _$ordinaryRequest = AbortableRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      if (_$data != null) {
+        _$ordinaryRequest.bodyBytes = (_$data as List<int>);
+      }
+      _$request = _$ordinaryRequest;
+    }
+    _$request.headers.addAll(_$options);
+  } on Object catch (exception, stackTrace) {
+    return TonikError<void, Response>(
+      exception,
+      stackTrace: stackTrace,
+      type: TonikErrorType.encoding,
+      response: null,
+    );
+  }
+
+  await _$client.send(_$request);
+  throw UnsupportedError(
+    'The http transport backend does not support response normalization yet.',
+  );
+}
+''';
+
+        expect(
+          collapseWhitespace(format('${generatedMethod.accept(emitter)}')),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      },
+    );
+  });
 }


### PR DESCRIPTION
## Summary

- Add multipart request generation to the HTTP transport
- Update body and backend generators for multipart payloads
- Add multipart wire-format coverage

## Testing

- Added and updated unit tests for HTTP body, backend, and multipart generation