### PR TITLE
ci: run dual-backend integration tests

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -11,18 +11,18 @@ permissions:
 
 jobs:
   generate-integration:
+    name: Generate (${{ matrix.backend }}, ${{ matrix.os }}, Dart ${{ matrix.sdk }})
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
-        include:
-          - os: ubuntu-latest
-            sdk: stable
+        backend: [dio, http]
+        os: [ubuntu-latest, macos-latest, windows-latest]
+        sdk: [stable, beta]
+        exclude:
           - os: macos-latest
-            sdk: stable
+            sdk: beta
           - os: windows-latest
-            sdk: stable
-          - os: ubuntu-latest
             sdk: beta
 
     steps:
@@ -39,8 +39,9 @@ jobs:
           path: |
             ~/.pub-cache
             ${{ github.workspace }}/.dart_tool
-          key: ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ hashFiles('**/pubspec.yaml') }}
+          key: ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ matrix.backend }}-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ matrix.backend }}-
             ${{ runner.os }}-dart-${{ matrix.sdk }}-
             ${{ runner.os }}-dart-
 
@@ -56,38 +57,38 @@ jobs:
           dart pub global activate melos
           melos bootstrap
 
-      - name: Generate integration test code
-        run: ./scripts/setup_integration_tests.sh
+      - name: Generate integration test code (${{ matrix.backend }})
+        run: ./scripts/setup_integration_tests.sh --backend "${{ matrix.backend }}"
         shell: bash
 
-      - name: Archive generated code
+      - name: Archive generated code (${{ matrix.backend }})
         shell: bash
-        run: |
-          tar -czf generated-integration-code.tar.gz \
-            $(find integration_test -type d -name '*_api' -print)
+        run: ./scripts/archive_generated_integration_packages.sh "${{ matrix.backend }}"
 
-      - name: Upload generated code
+      - name: Upload generated code (${{ matrix.backend }})
         uses: actions/upload-artifact@v7
         with:
-          name: generated-integration-code-${{ matrix.os }}-${{ matrix.sdk }}
+          name: generated-integration-code-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
           path: generated-integration-code.tar.gz
           compression-level: 0
           retention-days: 1
 
-      - name: Upload Imposter JAR
+      - name: Upload Imposter JAR (${{ matrix.backend }})
         uses: actions/upload-artifact@v7
         with:
-          name: imposter-jar-${{ matrix.os }}-${{ matrix.sdk }}
+          name: imposter-jar-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
           path: integration_test/imposter.jar
           compression-level: 0
           retention-days: 1
 
   analyze-generated:
+    name: Analyze (${{ matrix.backend }}, shard ${{ matrix.shard }})
     needs: generate-integration
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
+        backend: [dio, http]
         shard: [0, 1, 2]
 
     steps:
@@ -98,42 +99,34 @@ jobs:
         with:
           sdk: stable
 
-      - name: Download generated code
+      - name: Download generated code (${{ matrix.backend }})
         uses: actions/download-artifact@v8
         with:
-          name: generated-integration-code-ubuntu-latest-stable
+          name: generated-integration-code-${{ matrix.backend }}-ubuntu-latest-stable
 
-      - name: Extract generated code
+      - name: Extract generated code (${{ matrix.backend }})
         run: tar -xzf generated-integration-code.tar.gz
 
-      - name: Analyze generated code
-        run: |
-          find integration_test -name pubspec.yaml -print |
-            sort |
-            awk -v shard=${{ matrix.shard }} \
-              '(NR - 1) % 3 == shard' |
-            xargs -n 1 -P 2 bash -c \
-              'cd "$(dirname "$1")" && dart pub get && dart analyze --fatal-infos --fatal-warnings' _
+      - name: Analyze packages (${{ matrix.backend }}, shard ${{ matrix.shard }})
+        shell: bash
+        run: ./scripts/analyze_integration_packages.sh "${{ matrix.backend }}" "${{ matrix.shard }}"
 
   test:
+    name: Test (${{ matrix.backend }}, ${{ matrix.os }}, Dart ${{ matrix.sdk }}, shard ${{ matrix.shard }})
     needs: generate-integration
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
+        backend: [dio, http]
         os: [ubuntu-latest, macos-latest, windows-latest]
-        sdk: [stable]
+        sdk: [stable, beta]
         shard: [0, 1, 2]
-        include:
-          - os: ubuntu-latest
+        exclude:
+          - os: macos-latest
             sdk: beta
-            shard: 0
-          - os: ubuntu-latest
+          - os: windows-latest
             sdk: beta
-            shard: 1
-          - os: ubuntu-latest
-            sdk: beta
-            shard: 2
 
     steps:
       - uses: actions/checkout@v7
@@ -143,36 +136,60 @@ jobs:
         with:
           sdk: ${{ matrix.sdk }}
 
-      - name: Download generated code
+      - name: Download generated code (${{ matrix.backend }})
         uses: actions/download-artifact@v8
         with:
-          name: generated-integration-code-${{ matrix.os }}-${{ matrix.sdk }}
+          name: generated-integration-code-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
 
-      - name: Extract generated code
+      - name: Extract generated code (${{ matrix.backend }})
         run: tar -xzf generated-integration-code.tar.gz
         shell: bash
 
-      - name: Download Imposter JAR
+      - name: Download Imposter JAR (${{ matrix.backend }})
         uses: actions/download-artifact@v8
         with:
-          name: imposter-jar-${{ matrix.os }}-${{ matrix.sdk }}
+          name: imposter-jar-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
           path: integration_test
 
       - name: Cache Dart pub dependencies
         uses: actions/cache@v6
         with:
           path: ~/.pub-cache
-          key: ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ hashFiles('**/pubspec.yaml') }}
+          key: ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ matrix.backend }}-${{ hashFiles('**/pubspec.yaml') }}
           restore-keys: |
+            ${{ runner.os }}-dart-${{ matrix.sdk }}-${{ matrix.backend }}-
             ${{ runner.os }}-dart-${{ matrix.sdk }}-
             ${{ runner.os }}-dart-
 
-      - name: Run integration tests
+      - name: Run integration tests (${{ matrix.backend }}, shard ${{ matrix.shard }})
         shell: bash
-        run: |
-          find integration_test -path '*_test/pubspec.yaml' -print |
-            sort |
-            awk -v shard=${{ matrix.shard }} \
-              '(NR - 1) % 3 == shard' |
-            xargs -n 1 bash -c \
-              'cd "$(dirname "$1")" && dart pub get && dart test --concurrency=2' _
+        run: ./scripts/test_integration_packages.sh "${{ matrix.backend }}" "${{ matrix.shard }}"
+
+  dependencies:
+    name: Dependencies (${{ matrix.backend }}, ubuntu-latest, Dart stable)
+    needs: generate-integration
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        backend: [dio, http]
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Setup Dart
+        uses: dart-lang/setup-dart@v1
+        with:
+          sdk: stable
+
+      - name: Download generated code (${{ matrix.backend }})
+        uses: actions/download-artifact@v8
+        with:
+          name: generated-integration-code-${{ matrix.backend }}-ubuntu-latest-stable
+
+      - name: Extract generated code (${{ matrix.backend }})
+        run: tar -xzf generated-integration-code.tar.gz
+
+      - name: Verify dependency isolation (${{ matrix.backend }})
+        shell: bash
+        run: ./scripts/check_integration_dependencies.sh "${{ matrix.backend }}"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,6 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
-    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,7 @@ on:
     branches: [ main ]
   pull_request:
     branches: [ main ]
+    types: [ opened, synchronize, reopened, ready_for_review ]
 
 permissions:
   contents: read

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -168,10 +168,7 @@ class ParseGenerator {
         return _caseWithGuards(
           'case (var status, $contentTypePattern)',
           [
-            Code(
-              'status != null '
-              '&& status >= ${status.min} && status <= ${status.max}',
-            ),
+            backendGenerator.responseStatusCodeRangeGuard(status),
             ?mediaTypeGuard,
           ],
         );

--- a/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/dio_backend_generator.dart
@@ -70,6 +70,12 @@ final class DioBackendGenerator implements TransportBackendGenerator {
       response.property('statusCode');
 
   @override
+  Code responseStatusCodeRangeGuard(RangeResponseStatus status) => Code(
+    'status != null '
+    '&& status >= ${status.min} && status <= ${status.max}',
+  );
+
+  @override
   Expression responseContentType(Expression response) => response
       .property('headers')
       .property('value')

--- a/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
@@ -46,6 +46,9 @@ class HttpBodyGenerator {
       );
       final requestBodyUrl = sourceFileUrl(package, 'request_body', baseName);
       final cases = <Code>[];
+      final multipartHeaderInfos = extractOperationMultipartHeaderParamInfo(
+        operation,
+      );
 
       for (final item in content) {
         final variantName = subclassNames[item.rawContentType]!;
@@ -75,6 +78,7 @@ class HttpBodyGenerator {
                     buildHttpMultipartBodyStatements(
                       item,
                       'value.value',
+                      headerParameters: multipartHeaderInfos,
                     ),
                   ),
               ).closure.call([]).awaited.code
@@ -133,6 +137,9 @@ class HttpBodyGenerator {
     final item = content.single;
     if (item.contentType == ContentType.multipart) {
       final multipartHeaderParameters = _multipartHeaderParameters(operation);
+      final multipartHeaderInfos = extractOperationMultipartHeaderParamInfo(
+        operation,
+      );
       return Method(
         (b) => b
           ..name = '_data'
@@ -162,7 +169,11 @@ class HttpBodyGenerator {
           ..lambda = false
           ..body = Block.of([
             if (!isRequired) const Code('if (body == null) return null;'),
-            ...buildHttpMultipartBodyStatements(item, 'body'),
+            ...buildHttpMultipartBodyStatements(
+              item,
+              'body',
+              headerParameters: multipartHeaderInfos,
+            ),
           ]),
       );
     }

--- a/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_body_generator.dart
@@ -50,6 +50,7 @@ class HttpBodyGenerator {
       for (final item in content) {
         final variantName = subclassNames[item.rawContentType]!;
         final isMultipart = item.contentType == ContentType.multipart;
+        final bindsValue = !isMultipart || item.model.resolved is ClassModel;
         final built = isMultipart
             ? null
             : _bodyBytesExpression(
@@ -57,13 +58,14 @@ class HttpBodyGenerator {
                 content: item,
                 valueName: 'value.value',
                 helperContext: helperContext,
+                receiverIsPromotedNonNull: false,
               );
         if (built != null) inlineHelpers.addAll(built.inlineFunctions);
         cases.add(
           Block.of([
-            const Code('final '),
+            if (bindsValue) const Code('final '),
             refer(variantName, requestBodyUrl).code,
-            const Code(' value => '),
+            Code(bindsValue ? ' value => ' : ' _ => '),
             if (isMultipart)
               Method(
                 (builder) => builder
@@ -169,6 +171,7 @@ class HttpBodyGenerator {
       content: item,
       valueName: 'body',
       helperContext: helperContext,
+      receiverIsPromotedNonNull: !isRequired,
     );
     inlineHelpers.addAll(built.inlineFunctions);
 
@@ -207,6 +210,7 @@ class HttpBodyGenerator {
     required RequestContent content,
     required String valueName,
     required InlineHelperContext helperContext,
+    required bool receiverIsPromotedNonNull,
   }) {
     final value = refer(valueName);
     switch (content.contentType) {
@@ -227,6 +231,7 @@ class HttpBodyGenerator {
           helperContext: helperContext,
           contextClass: operation.operationId,
           contextProperty: 'body',
+          receiverIsPromotedNonNull: receiverIsPromotedNonNull,
         );
         return BuiltExpression(
           body: refer('utf8', 'dart:convert').property('encode').call([

--- a/packages/tonik_generate/lib/src/transport/http/http_headers_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_headers_generator.dart
@@ -40,7 +40,10 @@ class HttpHeadersGenerator {
           .index(specLiteralString('Content-Type'))
           .assign(generated.contentType!)
           .statement;
-      if (requestBody!.isRequired && content.length == 1) {
+      final contentTypeIsRequired =
+          requestBody!.isRequired &&
+          content.every((item) => item.contentType != ContentType.multipart);
+      if (contentTypeIsRequired) {
         statements.add(assignContentType);
       } else {
         statements.add(

--- a/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http/http_multipart_generator.dart
@@ -1,6 +1,7 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
+import 'package:tonik_generate/src/transport/multipart_header_plan.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dart';
@@ -12,8 +13,9 @@ import 'package:tonik_generate/src/util/to_simple_value_expression_generator.dar
 /// preserve duplicate names or ordering relative to file parts.
 List<Code> buildHttpMultipartBodyStatements(
   RequestContent content,
-  String bodyAccessor,
-) {
+  String bodyAccessor, {
+  List<MultipartHeaderParamInfo>? headerParameters,
+}) {
   final model = content.model.resolved;
   if (model is! ClassModel) {
     return [
@@ -29,12 +31,27 @@ List<Code> buildHttpMultipartBodyStatements(
     ];
   }
 
+  final normalizedHeaderParameters =
+      (headerParameters ?? extractMultipartHeaderParamInfo(content))
+          .where((parameter) => identical(parameter.content, content))
+          .toList();
+  final usesCustomParts = normalizedHeaderParameters.isNotEmpty;
+  final target = (
+    variableName: usesCustomParts ? r'_$multipartParts' : r'_$multipartFiles',
+    usesCustomParts: usesCustomParts,
+  );
+  final partType = usesCustomParts
+      ? refer(
+          'TonikMultipartPart',
+          'package:tonik_util/tonik_util.dart',
+        )
+      : refer('MultipartFile', 'package:http/http.dart');
   final statements = <Code>[
-    declareFinal(r'_$multipartFiles')
+    declareFinal(target.variableName)
         .assign(
           literalList(
             [],
-            refer('MultipartFile', 'package:http/http.dart'),
+            partType,
           ),
         )
         .statement,
@@ -47,12 +64,24 @@ List<Code> buildHttpMultipartBodyStatements(
     final isNullable = property.isNullable || !property.isRequired;
     final accessor = refer(bodyAccessor).property(normalizedName);
     final value = isNullable ? accessor.nullChecked : accessor;
+    final headerResult = _buildHeaderMapStatements(
+      content,
+      normalizedName,
+      content.multipartEncoding?[property],
+      headerParameters: normalizedHeaderParameters,
+      isPropertyOptional: isNullable,
+    );
     final part = _buildPart(
       property.model,
       property.name,
       value,
       encoding: content.multipartEncoding?[property],
+      target: target,
+      headers: headerResult == null ? null : refer(headerResult.variableName),
     );
+    final encodedPart = headerResult == null
+        ? part
+        : Block.of([...headerResult.statements, part]);
 
     if (isNullable) {
       statements.add(
@@ -60,24 +89,35 @@ List<Code> buildHttpMultipartBodyStatements(
           const Code('if ('),
           accessor.code,
           const Code(' != null) {'),
-          part,
+          encodedPart,
           const Code('}'),
         ]),
       );
     } else {
-      statements.add(part);
+      statements.add(encodedPart);
     }
   }
 
-  statements.add(refer(r'_$multipartFiles').returned.statement);
+  statements.add(
+    usesCustomParts
+        ? refer(
+            'TonikMultipartBody',
+            'package:tonik_util/tonik_util.dart',
+          ).newInstance([refer(target.variableName)]).returned.statement
+        : refer(target.variableName).returned.statement,
+  );
   return statements;
 }
+
+typedef _MultipartTarget = ({String variableName, bool usesCustomParts});
 
 Code _buildPart(
   Model model,
   String rawName,
   Expression value, {
   required PartEncoding? encoding,
+  required _MultipartTarget target,
+  required Expression? headers,
 }) {
   final resolved = model.resolved;
   return switch (resolved) {
@@ -88,12 +128,16 @@ Code _buildPart(
         encoding,
         'application/octet-stream',
       ),
+      target: target,
+      headers: headers,
     ),
     ListModel() => _buildListParts(
       rawName,
       value,
       resolved,
       encoding: encoding,
+      target: target,
+      headers: headers,
     ),
     NeverModel() => generateEncodingExceptionExpression(
       "Cannot encode NeverModel property '$rawName' - this type does not "
@@ -104,6 +148,8 @@ Code _buildPart(
       rawName,
       value,
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     ),
     AnyModel() => _addTextPart(
       rawName,
@@ -114,24 +160,29 @@ Code _buildPart(
         ).call([value]),
       ]),
       rawContentType: _rawContentType(encoding, 'application/json'),
+      target: target,
+      headers: headers,
     ),
     MapModel() => _addTextPart(
       rawName,
       refer('jsonEncode', 'dart:convert').call([value]),
       rawContentType: _rawContentType(encoding, 'application/json'),
+      target: target,
+      headers: headers,
     ),
-    ClassModel() || CompositeModel() => _addTextPart(
+    ClassModel() || CompositeModel() => _buildObjectPart(
       rawName,
-      refer(
-        'jsonEncode',
-        'dart:convert',
-      ).call([value.property('toJson').call([])]),
-      rawContentType: _rawContentType(encoding, 'application/json'),
+      value,
+      encoding: encoding,
+      target: target,
+      headers: headers,
     ),
     EnumModel() => _addTextPart(
       rawName,
       _enumText(value, resolved, encoding?.contentType),
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     ),
     DateTimeModel() => _addTextPart(
       rawName,
@@ -141,11 +192,15 @@ Code _buildPart(
         method: 'toTimeZonedIso8601String',
       ),
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     ),
     PrimitiveModel() => _addTextPart(
       rawName,
       _primitiveText(value, encoding?.contentType, method: 'toString'),
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     ),
     NamedModel() => generateEncodingExceptionExpression(
       "Cannot encode cyclic AliasModel property '$rawName'.",
@@ -159,6 +214,8 @@ Code _buildListParts(
   Expression value,
   ListModel model, {
   required PartEncoding? encoding,
+  required _MultipartTarget target,
+  required Expression? headers,
 }) {
   final content = model.content.resolved;
   if (content is ListModel) {
@@ -189,6 +246,8 @@ Code _buildListParts(
           encoding,
           'application/octet-stream',
         ),
+        target: target,
+        headers: headers,
       ),
       const Code('}'),
     ]);
@@ -213,6 +272,8 @@ Code _buildListParts(
         _jsonListValue(value, content),
       ]),
       rawContentType: _rawContentType(encoding, 'application/json'),
+      target: target,
+      headers: headers,
     );
   }
 
@@ -238,6 +299,8 @@ Code _buildListParts(
         rawName,
         refer('jsonEncode', 'dart:convert').call([itemJson]),
         rawContentType: _rawContentType(encoding, 'application/json'),
+        target: target,
+        headers: headers,
       ),
       const Code('}'),
     ]);
@@ -245,6 +308,17 @@ Code _buildListParts(
 
   final explode = encoding?.explode ?? true;
   if (!explode) {
+    if (encoding?.style == EncodingStyle.pipeDelimited ||
+        encoding?.style == EncodingStyle.spaceDelimited) {
+      return _buildDelimitedListParts(
+        rawName,
+        value,
+        content,
+        encoding: encoding!,
+        target: target,
+        headers: headers,
+      );
+    }
     final serialized = buildSimpleValueExpression(
       value,
       model,
@@ -255,6 +329,8 @@ Code _buildListParts(
       rawName,
       serialized,
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     );
   }
 
@@ -266,6 +342,223 @@ Code _buildListParts(
       rawName,
       _listItemText(refer('item'), content, encoding?.contentType),
       rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
+    ),
+    const Code('}'),
+  ]);
+}
+
+Code _buildObjectPart(
+  String rawName,
+  Expression value, {
+  required PartEncoding? encoding,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) {
+  if (encoding?.style == EncodingStyle.deepObject) {
+    return _buildDeepObjectParts(
+      rawName,
+      value,
+      encoding: encoding!,
+      target: target,
+      headers: headers,
+    );
+  }
+
+  if (encoding?.isStyleBased ?? false) {
+    if (encoding?.style == EncodingStyle.form) {
+      return _buildRawStyleObjectParts(
+        rawName,
+        value,
+        explode: encoding?.explode ?? true,
+        target: target,
+        headers: headers,
+      );
+    }
+    return generateEncodingExceptionExpression(
+      '${encoding?.style?.name ?? 'unknown'} style is not supported for '
+      'object multipart part $rawName',
+      raw: true,
+    ).statement;
+  }
+
+  if (encoding?.contentType == ContentType.form) {
+    return _buildUrlEncodedObjectPart(
+      rawName,
+      value,
+      rawContentType: _rawContentType(
+        encoding,
+        'application/x-www-form-urlencoded',
+      ),
+      target: target,
+      headers: headers,
+    );
+  }
+
+  return _addTextPart(
+    rawName,
+    refer(
+      'jsonEncode',
+      'dart:convert',
+    ).call([value.property('toJson').call([])]),
+    rawContentType: _rawContentType(encoding, 'application/json'),
+    target: target,
+    headers: headers,
+  );
+}
+
+Code _buildDeepObjectParts(
+  String rawName,
+  Expression value, {
+  required PartEncoding encoding,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) {
+  final namedArguments = <String, Expression>{
+    'explode': literalTrue,
+    'allowEmpty': literalTrue,
+    if (encoding.allowReserved ?? false) 'allowReserved': literalTrue,
+  };
+  final entries = value.property('toDeepObject').call(
+    [specLiteralString(rawName)],
+    namedArguments,
+  );
+  return Block.of([
+    const Code('for (final entry in '),
+    entries.code,
+    const Code(') {'),
+    _addTextPartExpression(
+      refer('entry').property('name'),
+      refer('entry').property('value'),
+      rawContentType: 'application/x-www-form-urlencoded',
+      target: target,
+      headers: headers,
+    ),
+    const Code('}'),
+  ]);
+}
+
+Code _buildUrlEncodedObjectPart(
+  String rawName,
+  Expression value, {
+  required String rawContentType,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) {
+  final entries = value
+      .property('toForm')
+      .call(
+        [specLiteralString(rawName)],
+        {
+          'explode': literalTrue,
+          'allowEmpty': literalTrue,
+          'useQueryComponent': literalTrue,
+        },
+      );
+  final joined = entries
+      .property('map')
+      .call([
+        Method(
+          (builder) => builder
+            ..lambda = true
+            ..requiredParameters.add(Parameter((p) => p..name = 'entry'))
+            ..body = const Code(r"'${entry.name}=${entry.value}'"),
+        ).closure,
+      ])
+      .property('join')
+      .call([literalString('&')]);
+  return _addTextPart(
+    rawName,
+    joined,
+    rawContentType: rawContentType,
+    target: target,
+    headers: headers,
+  );
+}
+
+Code _buildRawStyleObjectParts(
+  String rawName,
+  Expression value, {
+  required bool explode,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) {
+  final entries = value
+      .property('parameterProperties')
+      .call([], {'allowEmpty': literalTrue})
+      .property('toRawStyleParts')
+      .call(
+        [specLiteralString(rawName)],
+        {'explode': literalBool(explode)},
+      );
+  return Block.of([
+    const Code('for (final entry in '),
+    entries.code,
+    const Code(') {'),
+    _addTextPartExpression(
+      refer('entry').property('name'),
+      refer('entry').property('value'),
+      rawContentType: 'text/plain',
+      target: target,
+      headers: headers,
+    ),
+    const Code('}'),
+  ]);
+}
+
+Code _buildDelimitedListParts(
+  String rawName,
+  Expression value,
+  Model content, {
+  required PartEncoding encoding,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) {
+  final needsMapping = content is! StringModel;
+  final list = needsMapping
+      ? value
+            .property('map')
+            .call([
+              Method(
+                (builder) => builder
+                  ..lambda = true
+                  ..requiredParameters.add(Parameter((p) => p..name = 'item'))
+                  ..body = _listItemText(
+                    refer('item'),
+                    content,
+                    encoding.contentType,
+                  ).code,
+              ).closure,
+            ])
+            .property('toList')
+            .call([])
+      : value;
+  final isSpaceDelimited = encoding.style == EncodingStyle.spaceDelimited;
+  final encoded = list
+      .property(
+        isSpaceDelimited ? 'toSpaceDelimited' : 'toPipeDelimited',
+      )
+      .call(
+        [],
+        {
+          'explode': literalFalse,
+          'allowEmpty': literalTrue,
+          'alreadyEncoded': literalTrue,
+          if (isSpaceDelimited) 'percentEncodeDelimiter': literalFalse,
+          if (encoding.allowReserved ?? false) 'allowReserved': literalTrue,
+        },
+      );
+  return Block.of([
+    const Code('for (final item in '),
+    encoded.code,
+    const Code(') {'),
+    _addTextPart(
+      rawName,
+      refer('item'),
+      rawContentType: _rawContentType(encoding, 'text/plain'),
+      target: target,
+      headers: headers,
     ),
     const Code('}'),
   ]);
@@ -385,17 +678,37 @@ Code _addFilePart(
   String rawName,
   Expression file, {
   required String rawContentType,
+  required _MultipartTarget target,
+  required Expression? headers,
 }) => _addPart(
-  rawName,
+  specLiteralString(rawName),
   file.property('toBytes').call([]),
   rawContentType: rawContentType,
   filename: file.property('fileName').ifNullThen(specLiteralString(rawName)),
+  target: target,
+  headers: headers,
 );
 
 Code _addTextPart(
   String rawName,
   Expression text, {
   required String rawContentType,
+  required _MultipartTarget target,
+  required Expression? headers,
+}) => _addTextPartExpression(
+  specLiteralString(rawName),
+  text,
+  rawContentType: rawContentType,
+  target: target,
+  headers: headers,
+);
+
+Code _addTextPartExpression(
+  Expression name,
+  Expression text, {
+  required String rawContentType,
+  required _MultipartTarget target,
+  required Expression? headers,
 }) {
   final encoding = _encoding(rawContentType);
   if (encoding == null) {
@@ -404,18 +717,40 @@ Code _addTextPart(
     ).statement;
   }
   return _addPart(
-    rawName,
+    name,
     encoding.property('encode').call([text]),
     rawContentType: rawContentType,
+    target: target,
+    headers: headers,
   );
 }
 
 Code _addPart(
-  String rawName,
+  Expression name,
   Expression bytes, {
   required String rawContentType,
+  required _MultipartTarget target,
+  required Expression? headers,
   Expression? filename,
 }) {
+  if (target.usesCustomParts) {
+    return refer(target.variableName).property('add').call([
+      refer(
+        'TonikMultipartPart',
+        'package:tonik_util/tonik_util.dart',
+      ).newInstance(
+        [],
+        {
+          'name': name,
+          'bytes': bytes,
+          'contentType': specLiteralString(rawContentType),
+          'filename': ?filename,
+          'headers': ?headers,
+        },
+      ),
+    ]).statement;
+  }
+
   final namedArguments = <String, Expression>{
     'filename': ?filename,
     'contentType': refer(
@@ -423,15 +758,86 @@ Code _addPart(
       'package:http/http.dart',
     ).property('parse').call([specLiteralString(rawContentType)]),
   };
-  return refer(r'_$multipartFiles').property('add').call([
+  return refer(target.variableName).property('add').call([
     refer(
       'MultipartFile',
       'package:http/http.dart',
     ).property('fromBytes').call(
-      [specLiteralString(rawName), bytes],
+      [name, bytes],
       namedArguments,
     ),
   ]).statement;
+}
+
+final class _HeaderMapResult {
+  const _HeaderMapResult(this.statements, this.variableName);
+
+  final List<Code> statements;
+  final String variableName;
+}
+
+_HeaderMapResult? _buildHeaderMapStatements(
+  RequestContent content,
+  String normalizedPropertyName,
+  PartEncoding? encoding, {
+  required List<MultipartHeaderParamInfo> headerParameters,
+  required bool isPropertyOptional,
+}) {
+  final entries = encoding?.headers?.entries
+      .where((entry) => entry.key.toLowerCase() != 'content-type')
+      .toList();
+  if (entries == null || entries.isEmpty) return null;
+
+  final variableName = '_\$${normalizedPropertyName}Headers';
+  final statements = <Code>[
+    declareFinal(variableName)
+        .assign(
+          literalMap(
+            {},
+            refer('String', 'dart:core'),
+            refer('String', 'dart:core'),
+          ),
+        )
+        .statement,
+  ];
+
+  for (final entry in entries) {
+    final header = entry.value.resolve();
+    final parameter = headerParameters.firstWhere(
+      (parameter) =>
+          identical(parameter.content, content) &&
+          parameter.normalizedPropertyName == normalizedPropertyName &&
+          parameter.rawHeaderName == entry.key,
+    );
+    final parameterReference = isPropertyOptional && header.isRequired
+        ? refer(parameter.name).nullChecked
+        : refer(parameter.name);
+    final serialized = buildSimpleValueExpression(
+      parameterReference,
+      header.model,
+      explode: header.explode,
+      allowEmpty: true,
+    ).unsafeRawBody;
+    final assignment = refer(
+      variableName,
+    ).index(specLiteralString(entry.key)).assign(serialized).statement;
+
+    if (header.isRequired) {
+      statements.add(assignment);
+    } else {
+      statements.add(
+        Block.of([
+          const Code('if ('),
+          refer(parameter.name).code,
+          const Code(' != null) {'),
+          assignment,
+          const Code('}'),
+        ]),
+      );
+    }
+  }
+
+  return _HeaderMapResult(statements, variableName);
 }
 
 Expression? _encoding(String rawContentType) =>

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -62,6 +62,10 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
       response.property('statusCode');
 
   @override
+  Code responseStatusCodeRangeGuard(RangeResponseStatus status) =>
+      Code('status >= ${status.min} && status <= ${status.max}');
+
+  @override
   Expression responseContentType(Expression response) =>
       response.property('headers').index(literalString('content-type'));
 

--- a/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/http_backend_generator.dart
@@ -264,6 +264,10 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
         ..url = 'dart:core'
         ..types.add(refer('MultipartFile', 'package:http/http.dart')),
     );
+    final multipartBodyType = refer(
+      'TonikMultipartBody',
+      'package:tonik_util/tonik_util.dart',
+    );
     final isRequiredMultipart = switch (plan.body) {
       MultipartBodyPlan(:final isRequired) => isRequired,
       _ => false,
@@ -275,9 +279,7 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
       ),
       _ => false,
     };
-    final requestType = isRequiredMultipart
-        ? refer('AbortableMultipartRequest', 'package:http/http.dart')
-        : canBeMultipart
+    final requestType = canBeMultipart
         ? refer('BaseRequest', 'package:http/http.dart')
         : refer('AbortableRequest', 'package:http/http.dart');
 
@@ -356,6 +358,8 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
             plan: plan,
             request: request,
             cancellation: cancellation,
+            multipartFilesType: multipartFilesType,
+            multipartBodyType: multipartBodyType,
           )
         else if (canBeMultipart)
           ..._selectedRequestStatements(
@@ -364,6 +368,7 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
             cancellation: cancellation,
             bodyBytesType: bodyBytesType,
             multipartFilesType: multipartFilesType,
+            multipartBodyType: multipartBodyType,
           )
         else
           ..._ordinaryRequestStatements(
@@ -374,11 +379,19 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
         refer(request).property('headers').property('addAll').call([
           refer(r'_$options'),
         ]).statement,
-        if (isRequiredMultipart)
-          refer(request).property('files').property('addAll').call([
-            refer(r'_$data').asA(multipartFilesType),
-          ]).statement
-        else if (!canBeMultipart)
+        if (canBeMultipart)
+          Block.of([
+            const Code(r'if (_$data is '),
+            multipartBodyType.code,
+            const Code(') {'),
+            refer(request)
+                .property('headers')
+                .index(literalString('content-type'))
+                .assign(refer(r'_$data').property('contentType'))
+                .statement,
+            const Code('}'),
+          ])
+        else
           Block.of([
             const Code(r'if (_$data != null) {'),
             refer(request)
@@ -536,21 +549,55 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     required OperationRequestPlan plan,
     required String request,
     required Expression cancellation,
-  }) => [
-    refer(request)
-        .assign(
-          refer(
-            'AbortableMultipartRequest',
-            'package:http/http.dart',
-          ).newInstance(
-            [literalString(plan.methodName), plan.uri],
-            {
-              'abortTrigger': cancellation.nullSafeProperty('whenCancelled'),
-            },
-          ),
-        )
-        .statement,
-  ];
+    required TypeReference multipartFilesType,
+    required Reference multipartBodyType,
+  }) {
+    const bodyRequest = r'_$bodyRequest';
+    const multipartRequest = r'_$multipartRequest';
+    final abortTrigger = <String, Expression>{
+      'abortTrigger': cancellation.nullSafeProperty('whenCancelled'),
+    };
+    return [
+      Block.of([
+        const Code(r'if (_$data is '),
+        multipartBodyType.code,
+        const Code(') {'),
+        declareFinal(bodyRequest)
+            .assign(
+              refer(
+                'AbortableRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                abortTrigger,
+              ),
+            )
+            .statement,
+        refer(bodyRequest)
+            .property('bodyBytes')
+            .assign(refer(r'_$data').property('bodyBytes'))
+            .statement,
+        refer(request).assign(refer(bodyRequest)).statement,
+        const Code('} else {'),
+        declareFinal(multipartRequest)
+            .assign(
+              refer(
+                'AbortableMultipartRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                abortTrigger,
+              ),
+            )
+            .statement,
+        refer(multipartRequest).property('files').property('addAll').call([
+          refer(r'_$data').asA(multipartFilesType),
+        ]).statement,
+        refer(request).assign(refer(multipartRequest)).statement,
+        const Code('}'),
+      ]),
+    ];
+  }
 
   List<Code> _ordinaryRequestStatements({
     required OperationRequestPlan plan,
@@ -578,12 +625,37 @@ final class HttpBackendGenerator implements TransportBackendGenerator {
     required Expression cancellation,
     required TypeReference bodyBytesType,
     required TypeReference multipartFilesType,
+    required Reference multipartBodyType,
   }) {
+    const bodyRequest = r'_$bodyRequest';
     const multipartRequest = r'_$multipartRequest';
     const ordinaryRequest = r'_$ordinaryRequest';
     return [
       Block.of([
         const Code(r'if (_$data is '),
+        multipartBodyType.code,
+        const Code(') {'),
+        declareFinal(bodyRequest)
+            .assign(
+              refer(
+                'AbortableRequest',
+                'package:http/http.dart',
+              ).newInstance(
+                [literalString(plan.methodName), plan.uri],
+                {
+                  'abortTrigger': cancellation.nullSafeProperty(
+                    'whenCancelled',
+                  ),
+                },
+              ),
+            )
+            .statement,
+        refer(bodyRequest)
+            .property('bodyBytes')
+            .assign(refer(r'_$data').property('bodyBytes'))
+            .statement,
+        refer(request).assign(refer(bodyRequest)).statement,
+        const Code(r'} else if (_$data is '),
         multipartFilesType.code,
         const Code(') {'),
         declareFinal(multipartRequest)

--- a/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/transport_backend_generator.dart
@@ -44,6 +44,8 @@ abstract interface class TransportBackendGenerator {
 
   Expression responseStatusCode(Expression response);
 
+  Code responseStatusCodeRangeGuard(RangeResponseStatus status);
+
   Expression responseContentType(Expression response);
 
   Expression responseBodyBytes(Expression response);

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -29,6 +29,7 @@ BuiltExpression buildToJsonPropertyExpression(
   String? contextClass,
   String? contextProperty,
   bool forceNonNullReceiver = false,
+  bool receiverIsPromotedNonNull = false,
   bool useImmutableCollections = false,
 }) {
   final model = property.model;
@@ -44,6 +45,7 @@ BuiltExpression buildToJsonPropertyExpression(
     contextClass: contextClass,
     contextProperty: contextProperty,
     forceNonNullReceiver: forceNonNullReceiver,
+    receiverIsPromotedNonNull: receiverIsPromotedNonNull,
     useImmutableCollections: useImmutableCollections,
   );
 }
@@ -156,11 +158,13 @@ BuiltExpression _buildSerializationExpression(
   String? contextClass,
   String? contextProperty,
   bool forceNonNullReceiver = false,
+  bool receiverIsPromotedNonNull = false,
   bool useImmutableCollections = false,
 }) {
   final directReceiver = forceNonNullReceiver ? receiver.nullChecked : receiver;
   final useNullAware =
       !forceNonNullReceiver &&
+      !receiverIsPromotedNonNull &&
       (isNullable ||
           (model is EnumModel && model.isNullable) ||
           model.isEffectivelyNullable);
@@ -218,7 +222,7 @@ BuiltExpression _buildSerializationExpression(
       return _handleListExpression(
         receiver,
         model,
-        isNullable,
+        !receiverIsPromotedNonNull && isNullable,
         nameManager: nameManager,
         package: package,
         helperContext: helperContext,
@@ -231,7 +235,7 @@ BuiltExpression _buildSerializationExpression(
       return _handleMapExpression(
         receiver,
         model,
-        isNullable || model.isNullable,
+        !receiverIsPromotedNonNull && (isNullable || model.isNullable),
         nameManager: nameManager,
         package: package,
         helperContext: helperContext,
@@ -251,6 +255,7 @@ BuiltExpression _buildSerializationExpression(
         contextClass: contextClass,
         contextProperty: contextProperty,
         forceNonNullReceiver: forceNonNullReceiver,
+        receiverIsPromotedNonNull: receiverIsPromotedNonNull,
         useImmutableCollections: useImmutableCollections,
       );
     case PrimitiveModel():

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -5068,6 +5068,67 @@ String _parseResponse(Response response) {
         );
       });
 
+      test('omits nullable guard for range status', () {
+        final operation = Operation(
+          operationId: 'httpRangeResponse',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/http-range',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          responses: {
+            const RangeResponseStatus(min: 400, max: 499): ResponseObject(
+              name: null,
+              context: context,
+              headers: const {},
+              description: '',
+              bodies: {
+                ResponseBody(
+                  model: StringModel(context: context),
+                  rawContentType: 'application/json',
+                  contentType: ContentType.json,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+          securitySchemes: const {},
+        );
+
+        final method = httpGenerator.generateParseResponseMethod(operation);
+        const expectedMethod = r'''
+String _parseResponse(Response response) {
+  final _$mediaType = extractMediaType(response.headers['content-type']);
+  switch ((response.statusCode, _$mediaType)) {
+    case (var status, r'application/json')
+        when status >= 400 && status <= 499:
+      final _$json = decodeResponseJson<Object?>(response.bodyBytes);
+      final _$body = _$json.decodeJsonString();
+      return _$body;
+    default:
+      final _$content =
+          response.headers['content-type'] ?? 'not specified';
+      final _$matched = _$mediaType ?? 'none';
+      final _$status = response.statusCode;
+      throw ResponseDecodingException(
+        'Unexpected content type: ${_$content} (matched as: ${_$matched}) for status code: ${_$status}',
+      );
+  }
+}
+''';
+
+        expect(
+          collapseWhitespace(format(method.accept(emitter).toString())),
+          collapseWhitespace(format(expectedMethod)),
+        );
+      });
+
       test('decodes typed headers from lower-cased split values', () {
         final operation = Operation(
           operationId: 'httpHeaderResponse',

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -244,6 +244,41 @@ Object? _data({String? body}) {
     );
   });
 
+  test('uses a promoted optional nullable JSON model directly', () {
+    final model = ClassModel(
+      name: 'NullablePayload',
+      properties: const [],
+      context: context,
+      isDeprecated: false,
+      isNullable: true,
+      examples: const [],
+    );
+    final method = generator.generateBodyMethod(
+      _operation(
+        context,
+        requestBody: _body(
+          context,
+          model: model,
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+          isRequired: false,
+        ),
+      ),
+    );
+
+    const expected = '''
+Object? _data({NullablePayload? body}) {
+  if (body == null) return null;
+  return utf8.encode(jsonEncode(body.toJson()));
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
   group('form-urlencoded bodies', () {
     test('UTF-8 encodes a scalar without inventing a field name', () {
       final method = generator.generateBodyMethod(
@@ -582,6 +617,50 @@ Future<Object?> _data({required Payload body}) async {
         ),
       );
       return _$multipartFiles;
+    }(),
+  };
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
+  test('does not bind an unsupported multipart variant', () {
+    final requestBody = RequestBodyObject(
+      name: 'payload',
+      context: context,
+      description: null,
+      isRequired: true,
+      content: {
+        RequestContent(
+          model: StringModel(context: context),
+          contentType: ContentType.json,
+          rawContentType: 'application/json',
+          examples: const [],
+        ),
+        RequestContent(
+          model: BinaryModel(context: context),
+          contentType: ContentType.multipart,
+          rawContentType: 'multipart/form-data',
+          examples: const [],
+        ),
+      },
+    );
+    final method = generator.generateBodyMethod(
+      _operation(context, requestBody: requestBody),
+    );
+
+    const expected = '''
+Future<Object?> _data({required Payload body}) async {
+  return switch (body) {
+    final PayloadJson value => utf8.encode(jsonEncode(value.value)),
+    PayloadFormData _ => await () async {
+      throw UnsupportedError(
+        'Multipart request bodies require an object schema (ClassModel). Got: BinaryModel.',
+      );
     }(),
   };
 }

--- a/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_body_generator_test.dart
@@ -970,7 +970,7 @@ Future<Object?> _data({required UnsupportedTextUpload body}) async {
       );
     });
 
-    test('adds required per-part header parameters to the body method', () {
+    test('attaches required per-part headers to the encoded body', () {
       final value = _formProperty(
         context,
         name: 'value',
@@ -1022,15 +1022,21 @@ Future<Object?> _data({
   required HeaderUpload body,
   required int valueTrace,
 }) async {
-  final _$multipartFiles = <MultipartFile>[];
-  _$multipartFiles.add(
-    MultipartFile.fromBytes(
-      r'value',
-      utf8.encode(body.value),
-      contentType: MediaType.parse(r'text/plain'),
+  final _$multipartParts = <TonikMultipartPart>[];
+  final _$valueHeaders = <String, String>{};
+  _$valueHeaders[r'X-Trace'] = valueTrace.toSimple(
+    explode: false,
+    allowEmpty: true,
+  );
+  _$multipartParts.add(
+    TonikMultipartPart(
+      name: r'value',
+      bytes: utf8.encode(body.value),
+      contentType: r'text/plain',
+      headers: _$valueHeaders,
     ),
   );
-  return _$multipartFiles;
+  return TonikMultipartBody(_$multipartParts);
 }
 ''';
 

--- a/packages/tonik_generate/test/src/transport/http/http_headers_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_headers_generator_test.dart
@@ -89,6 +89,54 @@ Map<String, String> _options({String? body}) {
     );
   });
 
+  test('sets content type directly for required non-multipart variants', () {
+    final method = generator.generateHeadersMethod(
+      _operation(
+        context,
+        requestBody: RequestBodyObject(
+          name: 'payload',
+          context: context,
+          description: null,
+          isRequired: true,
+          content: {
+            RequestContent(
+              model: StringModel(context: context),
+              contentType: ContentType.json,
+              rawContentType: 'application/json',
+              examples: const [],
+            ),
+            RequestContent(
+              model: StringModel(context: context),
+              contentType: ContentType.json,
+              rawContentType: 'application/merge-patch+json',
+              examples: const [],
+            ),
+          },
+        ),
+      ),
+      const [],
+      const [],
+    );
+
+    const expected = r'''
+Map<String, String> _options({required Payload body}) {
+  final _$contentType = switch (body) {
+    PayloadJson _ => r'application/json',
+    PayloadMergePatchJson _ => r'application/merge-patch+json',
+  };
+  final _$headers = <String, String>{};
+  _$headers['Accept'] = r'*/*';
+  _$headers[r'Content-Type'] = _$contentType;
+  return _$headers;
+}
+''';
+
+    expect(
+      collapseWhitespace(format('${method.accept(emitter)}')),
+      collapseWhitespace(format(expected)),
+    );
+  });
+
   test('preserves encoded headers and multiple cookies', () {
     final header = RequestHeaderObject(
       name: 'X-Trace',

--- a/packages/tonik_generate/test/src/transport/http/http_multipart_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http/http_multipart_generator_test.dart
@@ -232,6 +232,61 @@ Object? test() {
       });
     }
 
+    test('emits deepObject entries as bracket-named parts', () {
+      expectPropertyCode(
+        _classModel(context, 'Nested'),
+        r'''
+  for (final entry in body.value.toDeepObject(
+    r'value',
+    explode: true,
+    allowEmpty: true,
+  )) {
+    _$multipartFiles.add(
+      MultipartFile.fromBytes(
+        entry.name,
+        utf8.encode(entry.value),
+        contentType: MediaType.parse(r'application/x-www-form-urlencoded'),
+      ),
+    );
+  }''',
+        encoding: _encoding(
+          style: EncodingStyle.deepObject,
+          explode: true,
+          allowReserved: false,
+        ),
+      );
+    });
+
+    test('form-encodes an object in content-based mode', () {
+      expectPropertyCode(
+        _classModel(context, 'Nested'),
+        r'''
+  _$multipartFiles.add(
+    MultipartFile.fromBytes(
+      r'value',
+      utf8.encode(
+        body.value
+            .toForm(
+              r'value',
+              explode: true,
+              allowEmpty: true,
+              useQueryComponent: true,
+            )
+            .map((entry) => '${entry.name}=${entry.value}')
+            .join('&'),
+      ),
+      contentType: MediaType.parse(
+        r'application/x-www-form-urlencoded',
+      ),
+    ),
+  );''',
+        encoding: _encoding(
+          contentType: ContentType.form,
+          rawContentType: 'application/x-www-form-urlencoded',
+        ),
+      );
+    });
+
     test('uses plain and JSON encodings for string enums', () {
       final model = _stringEnum(context);
       expectPropertyCode(
@@ -558,6 +613,39 @@ Object? test() {
         ),
       );
     });
+
+    for (final entry in <({EncodingStyle style, String method})>[
+      (style: EncodingStyle.pipeDelimited, method: 'toPipeDelimited'),
+      (style: EncodingStyle.spaceDelimited, method: 'toSpaceDelimited'),
+    ]) {
+      test('honors ${entry.style.name} for a non-exploded string array', () {
+        final delimiterArgument = entry.style == EncodingStyle.spaceDelimited
+            ? '\n    percentEncodeDelimiter: false,'
+            : '';
+        expectPropertyCode(
+          _list(context, StringModel(context: context)),
+          '''
+  for (final item in body.value.${entry.method}(
+    explode: false,
+    allowEmpty: true,
+    alreadyEncoded: true,$delimiterArgument
+  )) {
+    _\$multipartFiles.add(
+      MultipartFile.fromBytes(
+        r'value',
+        utf8.encode(item),
+        contentType: MediaType.parse(r'text/plain'),
+      ),
+    );
+  }''',
+          encoding: _encoding(
+            style: entry.style,
+            explode: false,
+            allowReserved: false,
+          ),
+        );
+      });
+    }
 
     for (final entry
         in <

--- a/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
+++ b/packages/tonik_generate/test/src/transport/http_backend_generator_test.dart
@@ -1194,15 +1194,29 @@ Future<TonikResult<void, Response>> dispatch() async {
     );
   }
 
-  late final AbortableMultipartRequest _$request;
+  late final BaseRequest _$request;
   try {
-    _$request = AbortableMultipartRequest(
-      'POST',
-      _$uri,
-      abortTrigger: cancellation?.whenCancelled,
-    );
+    if (_$data is TonikMultipartBody) {
+      final _$bodyRequest = AbortableRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$bodyRequest.bodyBytes = _$data.bodyBytes;
+      _$request = _$bodyRequest;
+    } else {
+      final _$multipartRequest = AbortableMultipartRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$multipartRequest.files.addAll((_$data as List<MultipartFile>));
+      _$request = _$multipartRequest;
+    }
     _$request.headers.addAll(_$options);
-    _$request.files.addAll((_$data as List<MultipartFile>));
+    if (_$data is TonikMultipartBody) {
+      _$request.headers['content-type'] = _$data.contentType;
+    }
   } on Object catch (exception, stackTrace) {
     return TonikError<void, Response>(
       exception,
@@ -1301,7 +1315,15 @@ Future<TonikResult<void, Response>> dispatch() async {
 
   late final BaseRequest _$request;
   try {
-    if (_$data is List<MultipartFile>) {
+    if (_$data is TonikMultipartBody) {
+      final _$bodyRequest = AbortableRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$bodyRequest.bodyBytes = _$data.bodyBytes;
+      _$request = _$bodyRequest;
+    } else if (_$data is List<MultipartFile>) {
       final _$multipartRequest = AbortableMultipartRequest(
         'POST',
         _$uri,
@@ -1321,6 +1343,9 @@ Future<TonikResult<void, Response>> dispatch() async {
       _$request = _$ordinaryRequest;
     }
     _$request.headers.addAll(_$options);
+    if (_$data is TonikMultipartBody) {
+      _$request.headers['content-type'] = _$data.contentType;
+    }
   } on Object catch (exception, stackTrace) {
     return TonikError<void, Response>(
       exception,
@@ -1429,7 +1454,15 @@ Future<TonikResult<void, Response>> dispatch() async {
 
   late final BaseRequest _$request;
   try {
-    if (_$data is List<MultipartFile>) {
+    if (_$data is TonikMultipartBody) {
+      final _$bodyRequest = AbortableRequest(
+        'POST',
+        _$uri,
+        abortTrigger: cancellation?.whenCancelled,
+      );
+      _$bodyRequest.bodyBytes = _$data.bodyBytes;
+      _$request = _$bodyRequest;
+    } else if (_$data is List<MultipartFile>) {
       final _$multipartRequest = AbortableMultipartRequest(
         'POST',
         _$uri,
@@ -1449,6 +1482,9 @@ Future<TonikResult<void, Response>> dispatch() async {
       _$request = _$ordinaryRequest;
     }
     _$request.headers.addAll(_$options);
+    if (_$data is TonikMultipartBody) {
+      _$request.headers['content-type'] = _$data.contentType;
+    }
   } on Object catch (exception, stackTrace) {
     return TonikError<void, Response>(
       exception,

--- a/packages/tonik_util/lib/src/multipart/tonik_multipart_body.dart
+++ b/packages/tonik_util/lib/src/multipart/tonik_multipart_body.dart
@@ -1,0 +1,138 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:typed_data';
+
+import 'package:meta/meta.dart';
+
+/// One ordered part in a [TonikMultipartBody].
+@immutable
+final class TonikMultipartPart {
+  /// Creates a multipart part from its already-encoded body bytes.
+  TonikMultipartPart({
+    required this.name,
+    required List<int> bytes,
+    required this.contentType,
+    this.filename,
+    Map<String, String> headers = const {},
+  }) : bytes = List.unmodifiable(bytes),
+       headers = Map.unmodifiable(headers);
+
+  /// The multipart form field name.
+  final String name;
+
+  /// The encoded body bytes for this part.
+  final List<int> bytes;
+
+  /// The media type emitted for this part.
+  final String contentType;
+
+  /// The optional uploaded filename.
+  final String? filename;
+
+  /// Additional headers emitted for this part.
+  final Map<String, String> headers;
+}
+
+/// A transport-neutral, fully encoded multipart request body.
+@immutable
+final class TonikMultipartBody {
+  /// Creates a multipart body while preserving part order and duplicate names.
+  TonikMultipartBody(
+    List<TonikMultipartPart> parts, {
+    String? boundary,
+  }) : parts = List.unmodifiable(parts),
+       boundary = boundary ?? _newBoundary() {
+    _validateBoundary(this.boundary);
+  }
+
+  static final Random _random = Random();
+  static const _boundaryCharacters =
+      '0123456789abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
+  /// The ordered multipart parts.
+  final List<TonikMultipartPart> parts;
+
+  /// The boundary separating the encoded parts.
+  final String boundary;
+
+  /// The request Content-Type value, including [boundary].
+  String get contentType => 'multipart/form-data; boundary=$boundary';
+
+  /// The complete RFC 7578 request body.
+  late final List<int> bodyBytes = _encode();
+
+  List<int> _encode() {
+    final bytes = BytesBuilder(copy: false);
+    for (final part in parts) {
+      _validatePart(part);
+      bytes
+        ..add(ascii.encode('--$boundary\r\n'))
+        ..add(
+          latin1.encode(
+            _partHeaders(part),
+          ),
+        )
+        ..add(part.bytes)
+        ..add(const [13, 10]);
+    }
+    bytes.add(ascii.encode('--$boundary--\r\n'));
+    return bytes.takeBytes();
+  }
+
+  String _partHeaders(TonikMultipartPart part) {
+    final filename = part.filename == null
+        ? ''
+        : '; filename="${_browserEncode(part.filename!)}"';
+    final buffer = StringBuffer()
+      ..writeln(
+        'content-disposition: form-data; '
+        'name="${_browserEncode(part.name)}"$filename\r',
+      )
+      ..writeln('content-type: ${part.contentType}\r');
+    for (final entry in part.headers.entries) {
+      buffer.writeln('${entry.key}: ${entry.value}\r');
+    }
+    buffer.writeln('\r');
+    return buffer.toString();
+  }
+
+  static void _validateBoundary(String boundary) {
+    if (boundary.isEmpty ||
+        boundary.length > 70 ||
+        boundary.contains('\r') ||
+        boundary.contains('\n')) {
+      throw FormatException('Invalid multipart boundary: $boundary');
+    }
+  }
+
+  static void _validatePart(TonikMultipartPart part) {
+    _validateHeaderValue('content-type', part.contentType);
+    for (final entry in part.headers.entries) {
+      if (!_headerName.hasMatch(entry.key)) {
+        throw FormatException('Invalid multipart header name: ${entry.key}');
+      }
+      _validateHeaderValue(entry.key, entry.value);
+    }
+  }
+
+  static final RegExp _headerName = RegExp(
+    r"^[!#$%&'*+.^_`|~0-9A-Za-z-]+$",
+  );
+
+  static void _validateHeaderValue(String name, String value) {
+    if (value.contains('\r') || value.contains('\n')) {
+      throw FormatException('Invalid line break in multipart header $name');
+    }
+  }
+
+  static String _browserEncode(String value) =>
+      value.replaceAll(RegExp(r'\r\n|\r|\n'), '%0D%0A').replaceAll('"', '%22');
+
+  static String _newBoundary() {
+    final suffix = List.generate(
+      48,
+      (_) => _boundaryCharacters[_random.nextInt(_boundaryCharacters.length)],
+    ).join();
+    return 'tonik-$suffix';
+  }
+}

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -30,6 +30,7 @@ export 'src/encoding/string_map_delimited_encoder_extensions.dart';
 export 'src/encoding/unknown_value_encoding.dart';
 export 'src/encoding/uri_encoder_extensions.dart';
 export 'src/encoding_shape.dart';
+export 'src/multipart/tonik_multipart_body.dart';
 export 'src/offset_date_time.dart';
 export 'src/server_config.dart';
 export 'src/tonik_cancellation.dart';

--- a/packages/tonik_util/test/src/multipart/tonik_multipart_body_test.dart
+++ b/packages/tonik_util/test/src/multipart/tonik_multipart_body_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('encodes ordered duplicate multipart parts with custom headers', () {
+    final body = TonikMultipartBody(
+      [
+        TonikMultipartPart(
+          name: 'item',
+          bytes: utf8.encode('first'),
+          contentType: 'text/plain',
+          headers: const {'X-Part-Meta': 'alpha'},
+        ),
+        TonikMultipartPart(
+          name: 'item',
+          bytes: const [0, 1, 2],
+          contentType: 'application/octet-stream',
+          filename: 'item.bin',
+          headers: const {'X-File-Hash': 'abc123'},
+        ),
+      ],
+      boundary: 'tonik-test-boundary',
+    );
+
+    expect(
+      body.contentType,
+      'multipart/form-data; boundary=tonik-test-boundary',
+    );
+    expect(
+      latin1.decode(body.bodyBytes),
+      '--tonik-test-boundary\r\n'
+      'content-disposition: form-data; name="item"\r\n'
+      'content-type: text/plain\r\n'
+      'X-Part-Meta: alpha\r\n'
+      '\r\n'
+      'first\r\n'
+      '--tonik-test-boundary\r\n'
+      'content-disposition: form-data; name="item"; filename="item.bin"\r\n'
+      'content-type: application/octet-stream\r\n'
+      'X-File-Hash: abc123\r\n'
+      '\r\n'
+      '\u0000\u0001\u0002\r\n'
+      '--tonik-test-boundary--\r\n',
+    );
+  });
+
+  test('rejects line breaks in custom header values', () {
+    final body = TonikMultipartBody(
+      [
+        TonikMultipartPart(
+          name: 'item',
+          bytes: const [],
+          contentType: 'text/plain',
+          headers: const {'X-Part-Meta': 'safe\r\ninjected: value'},
+        ),
+      ],
+      boundary: 'tonik-test-boundary',
+    );
+
+    expect(() => body.bodyBytes, throwsFormatException);
+  });
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -258,49 +258,13 @@ melos:
         cd integration_test/recursive_map/recursive_map_test
         dart test
 
+    test-integration-current:
+      run: ./scripts/test_current_integration.sh
+
     test-integration-all:
       run: |
         set -e
-        for backend in dio http; do
-          ./scripts/setup_integration_tests.sh --backend "$backend"
-          melos run test-integration-additional-properties
-          melos run test-integration-defaulted
-          melos run test-integration-petstore
-          melos run test-integration-petstore-config
-          melos run test-integration-music-streaming
-          melos run test-integration-gov
-          melos run test-integration-simple-encoding
-          melos run test-integration-fastify-type-provider-zod
-          melos run test-integration-composition
-          melos run test-integration-query-parameters
-          melos run test-integration-allow-reserved
-          melos run test-integration-path-encoding
-          melos run test-integration-binary-models
-          melos run test-integration-structured-syntax-suffix
-          melos run test-integration-form-urlencoded
-          melos run test-integration-boolean-schemas
-          melos run test-integration-type-arrays
-          melos run test-integration-medama
-          melos run test-integration-inference
-          melos run test-integration-ref-siblings
-          melos run test-integration-defs
-          melos run test-integration-server-variables
-          melos run test-integration-cookies
-          melos run test-integration-read-write-only
-          melos run test-integration-nullable-bodies
-          melos run test-integration-multipart
-          melos run test-integration-adversarial-strings
-          melos run test-integration-figma
-          melos run test-integration-stripe
-          melos run test-integration-github
-          melos run test-integration-openai
-          melos run test-integration-asana
-          melos run test-integration-twilio
-          melos run test-integration-shopify
-          melos run test-integration-kubernetes
-          melos run test-integration-cloudflare
-          melos run test-integration-totem
-          melos run test-integration-immutable-collections
-          melos run test-integration-naming
-          melos run test-integration-recursive-map
-        done
+        ./scripts/setup_integration_tests.sh --backend dio
+        melos run test-integration-current
+        ./scripts/setup_integration_tests.sh --backend http
+        melos run test-integration-current

--- a/scripts/analyze_integration_packages.sh
+++ b/scripts/analyze_integration_packages.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_package_utils.sh"
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 dio|http shard" >&2
+  exit 64
+fi
+
+backend="$1"
+shard="$2"
+validate_integration_backend "$backend"
+validate_integration_shard "$shard"
+discover_integration_packages "$backend"
+
+all_packages=(
+  "${GENERATED_INTEGRATION_PACKAGES[@]}"
+  "${INTEGRATION_TEST_PACKAGES[@]}"
+)
+shard_packages=()
+for index in "${!all_packages[@]}"; do
+  if [ $((index % 3)) -eq "$shard" ]; then
+    shard_packages+=("${all_packages[$index]}")
+  fi
+done
+
+if [ "$shard" -eq 0 ]; then
+  if [ ! -d "$INTEGRATION_TEST_ROOT/test_helpers" ]; then
+    echo "Error: integration test helper package is missing." >&2
+    exit 1
+  fi
+  shard_packages+=(integration_test/test_helpers)
+fi
+if [ "${#shard_packages[@]}" -eq 0 ]; then
+  echo "Error: analysis shard $shard is empty for $backend." >&2
+  exit 1
+fi
+
+echo "Analysis shard: backend=$backend shard=$shard packages=${#shard_packages[@]}"
+for package_dir in "${shard_packages[@]}"; do
+  echo "Analyzing $package_dir"
+  (
+    cd "$INTEGRATION_REPO_ROOT/$package_dir"
+    dart pub get
+    dart analyze --fatal-infos --fatal-warnings
+  )
+done

--- a/scripts/archive_generated_integration_packages.sh
+++ b/scripts/archive_generated_integration_packages.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_package_utils.sh"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 dio|http" >&2
+  exit 64
+fi
+
+backend="$1"
+validate_integration_backend "$backend"
+discover_integration_packages "$backend"
+
+cd "$INTEGRATION_REPO_ROOT"
+tar -czf generated-integration-code.tar.gz \
+  "${GENERATED_INTEGRATION_PACKAGES[@]}"
+echo "Archived ${#GENERATED_INTEGRATION_PACKAGES[@]} generated packages for $backend."

--- a/scripts/check_integration_dependencies.sh
+++ b/scripts/check_integration_dependencies.sh
@@ -31,10 +31,27 @@ dependency_names() {
     | if $packages[$target] == null then
         error("Package \($target) is missing from dart pub deps output")
       else
-        ($packages[$target].directDependencies // [])[]
-        | recurse($packages[.].directDependencies[]?)
+        {
+          pending: ($packages[$target].directDependencies // []),
+          seen: {}
+        }
+        | until(
+            (.pending | length) == 0;
+            .pending[0] as $dependency
+            | .pending = .pending[1:]
+            | if .seen[$dependency] then
+                .
+              else
+                .seen[$dependency] = true
+                | .pending += (
+                    $packages[$dependency].directDependencies // []
+                  )
+              end
+          )
+        | .seen
+        | keys[]
       end
-  ' | sort -u
+  '
 }
 
 require_dependency() {

--- a/scripts/check_integration_dependencies.sh
+++ b/scripts/check_integration_dependencies.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_package_utils.sh"
+
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 dio|http" >&2
+  exit 64
+fi
+
+backend="$1"
+validate_integration_backend "$backend"
+case "$backend" in
+  dio) unselected_backend=http ;;
+  http) unselected_backend=dio ;;
+esac
+discover_integration_packages "$backend"
+
+dependency_names() {
+  local package_dir="$1"
+  local package_name="${package_dir##*/}"
+  (
+    cd "$INTEGRATION_REPO_ROOT/$package_dir"
+    if ! dart pub get 1>&2; then
+      exit 1
+    fi
+    dart pub deps --json
+  ) | python3 -c \
+    'import json, sys
+data = json.load(sys.stdin)
+target = sys.argv[1]
+packages = {package["name"]: package for package in data["packages"]}
+if target not in packages:
+    raise SystemExit(f"Package {target} is missing from dart pub deps output")
+seen = set()
+pending = list(packages[target].get("directDependencies", []))
+while pending:
+    dependency = pending.pop()
+    if dependency in seen:
+        continue
+    seen.add(dependency)
+    package = packages.get(dependency)
+    if package is not None:
+        pending.extend(package.get("directDependencies", []))
+print("\n".join(sorted(seen)))' \
+    "$package_name"
+}
+
+require_dependency() {
+  local package_dir="$1"
+  local dependency="$2"
+  local names="$3"
+  if ! printf '%s\n' "$names" | grep -Fxq "$dependency"; then
+    echo "Error: $package_dir must resolve $dependency for backend=$backend." >&2
+    exit 1
+  fi
+}
+
+reject_dependency() {
+  local package_dir="$1"
+  local dependency="$2"
+  local names="$3"
+  if printf '%s\n' "$names" | grep -Fxq "$dependency"; then
+    echo "Error: $package_dir unexpectedly resolves $dependency for backend=$backend." >&2
+    exit 1
+  fi
+}
+
+for package_dir in "${GENERATED_INTEGRATION_PACKAGES[@]}"; do
+  echo "Checking generated dependencies: backend=$backend package=$package_dir"
+  names="$(dependency_names "$package_dir")"
+  require_dependency "$package_dir" "$backend" "$names"
+  reject_dependency "$package_dir" "$unselected_backend" "$names"
+  if [ "$backend" = http ]; then
+    reject_dependency "$package_dir" dio_web_adapter "$names"
+  fi
+done
+
+handwritten_packages=(
+  packages/tonik_util
+  packages/tonik_core
+  packages/tonik_parse
+  packages/tonik_generate
+  packages/tonik
+)
+for package_dir in "${handwritten_packages[@]}"; do
+  echo "Checking handwritten dependencies: backend=$backend package=$package_dir"
+  names="$(dependency_names "$package_dir")"
+  reject_dependency "$package_dir" dio "$names"
+  reject_dependency "$package_dir" dio_web_adapter "$names"
+  reject_dependency "$package_dir" http "$names"
+done
+
+echo "Dependency isolation passed: backend=$backend generated=${#GENERATED_INTEGRATION_PACKAGES[@]} handwritten=${#handwritten_packages[@]}"

--- a/scripts/check_integration_dependencies.sh
+++ b/scripts/check_integration_dependencies.sh
@@ -26,25 +26,15 @@ dependency_names() {
       exit 1
     fi
     dart pub deps --json
-  ) | python3 -c \
-    'import json, sys
-data = json.load(sys.stdin)
-target = sys.argv[1]
-packages = {package["name"]: package for package in data["packages"]}
-if target not in packages:
-    raise SystemExit(f"Package {target} is missing from dart pub deps output")
-seen = set()
-pending = list(packages[target].get("directDependencies", []))
-while pending:
-    dependency = pending.pop()
-    if dependency in seen:
-        continue
-    seen.add(dependency)
-    package = packages.get(dependency)
-    if package is not None:
-        pending.extend(package.get("directDependencies", []))
-print("\n".join(sorted(seen)))' \
-    "$package_name"
+  ) | jq -r --arg target "$package_name" '
+    INDEX(.packages[]; .name) as $packages
+    | if $packages[$target] == null then
+        error("Package \($target) is missing from dart pub deps output")
+      else
+        ($packages[$target].directDependencies // [])[]
+        | recurse($packages[.].directDependencies[]?)
+      end
+  ' | sort -u
 }
 
 require_dependency() {

--- a/scripts/integration_package_utils.sh
+++ b/scripts/integration_package_utils.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+
+INTEGRATION_SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+INTEGRATION_REPO_ROOT="$(cd "$INTEGRATION_SCRIPT_DIR/.." && pwd)"
+INTEGRATION_TEST_ROOT="$INTEGRATION_REPO_ROOT/integration_test"
+EXPECTED_GENERATED_INTEGRATION_PACKAGES=44
+EXPECTED_INTEGRATION_TEST_PACKAGES=40
+
+validate_integration_backend() {
+  local backend="$1"
+  if [ "$backend" != "dio" ] && [ "$backend" != "http" ]; then
+    echo "Error: backend must be either 'dio' or 'http'." >&2
+    exit 64
+  fi
+}
+
+validate_integration_shard() {
+  local shard="$1"
+  case "$shard" in
+    0 | 1 | 2) ;;
+    *)
+      echo "Error: shard must be 0, 1, or 2." >&2
+      exit 64
+      ;;
+  esac
+}
+
+discover_integration_packages() {
+  local backend="$1"
+
+  GENERATED_INTEGRATION_PACKAGES=()
+  while IFS= read -r package_dir; do
+    GENERATED_INTEGRATION_PACKAGES+=("$package_dir")
+  done < <(
+    cd "$INTEGRATION_REPO_ROOT"
+    find integration_test -mindepth 2 -maxdepth 2 \
+      -type d -name '*_api' -print | sort
+  )
+
+  INTEGRATION_TEST_PACKAGES=()
+  while IFS= read -r package_dir; do
+    INTEGRATION_TEST_PACKAGES+=("$package_dir")
+  done < <(
+    cd "$INTEGRATION_REPO_ROOT"
+    find integration_test -mindepth 2 -maxdepth 2 \
+      -type d -name '*_test' -print | sort
+  )
+
+  echo "Package discovery: backend=$backend generated=${#GENERATED_INTEGRATION_PACKAGES[@]} tests=${#INTEGRATION_TEST_PACKAGES[@]}"
+  if [ "${#GENERATED_INTEGRATION_PACKAGES[@]}" -eq 0 ] || \
+    [ "${#INTEGRATION_TEST_PACKAGES[@]}" -eq 0 ]; then
+    echo "Error: generated and test package selections must not be empty for $backend." >&2
+    exit 1
+  fi
+  if [ "${#GENERATED_INTEGRATION_PACKAGES[@]}" -ne \
+    "$EXPECTED_GENERATED_INTEGRATION_PACKAGES" ] || \
+    [ "${#INTEGRATION_TEST_PACKAGES[@]}" -ne \
+      "$EXPECTED_INTEGRATION_TEST_PACKAGES" ]; then
+    echo "Error: expected $EXPECTED_GENERATED_INTEGRATION_PACKAGES generated and $EXPECTED_INTEGRATION_TEST_PACKAGES test packages for $backend." >&2
+    exit 1
+  fi
+}

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -76,16 +76,16 @@ run_commands() {
 }
 
 add_tonik_util_override() {
-  local manifest="$1"
+  local pubspec="$1"
   local relative_path="$2"
 
-  if [ ! -f "$manifest" ]; then
-    echo "Error: package manifest not found: $manifest" >&2
+  if [ ! -f "$pubspec" ]; then
+    echo "Error: package pubspec not found: $pubspec" >&2
     return 1
   fi
-  if ! grep -q '^dependency_overrides:' "$manifest"; then
+  if ! grep -q '^dependency_overrides:' "$pubspec"; then
     printf '\ndependency_overrides:\n  tonik_util:\n    path: %s\n' \
-      "$relative_path" >>"$manifest"
+      "$relative_path" >>"$pubspec"
   fi
 }
 
@@ -210,13 +210,13 @@ for directory in "${GENERATED_DIRS[@]}"; do
   generated_count=$((generated_count + 1))
 done
 
-TEST_MANIFESTS=()
-while IFS= read -r manifest; do
-  TEST_MANIFESTS+=("$manifest")
-done < <(find . -mindepth 3 -maxdepth 3 -type f -path '*_test/pubspec.yaml' -print | sort)
+TEST_DIRS=()
+while IFS= read -r directory; do
+  TEST_DIRS+=("$directory")
+done < <(find . -mindepth 2 -maxdepth 2 -type d -name '*_test' -print | sort)
 
-if [ "${#TEST_MANIFESTS[@]}" -ne 40 ]; then
-  echo "Error: expected 40 checked-in test packages, found ${#TEST_MANIFESTS[@]}." >&2
+if [ "${#TEST_DIRS[@]}" -ne 40 ]; then
+  echo "Error: expected 40 checked-in test packages, found ${#TEST_DIRS[@]}." >&2
   exit 1
 fi
 
@@ -225,9 +225,9 @@ for directory in "${GENERATED_DIRS[@]}"; do
   add_tonik_util_override "$directory/pubspec.yaml" "../../../packages/tonik_util"
   PUB_GET_COMMANDS+=("cd '$directory' && dart pub get")
 done
-for manifest in "${TEST_MANIFESTS[@]}"; do
-  add_tonik_util_override "$manifest" "../../../packages/tonik_util"
-  PUB_GET_COMMANDS+=("cd '${manifest%/pubspec.yaml}' && dart pub get")
+for directory in "${TEST_DIRS[@]}"; do
+  add_tonik_util_override "$directory/pubspec.yaml" "../../../packages/tonik_util"
+  PUB_GET_COMMANDS+=("cd '$directory' && dart pub get")
 done
 PUB_GET_COMMANDS+=("cd 'test_helpers' && dart pub get")
 
@@ -246,4 +246,4 @@ if ! java -jar imposter.jar --version >/dev/null 2>&1; then
   exit 1
 fi
 
-echo "Setup complete: backend=$BACKEND generated=$generated_count tests=${#TEST_MANIFESTS[@]}"
+echo "Setup complete: backend=$BACKEND generated=$generated_count tests=${#TEST_DIRS[@]}"

--- a/scripts/test_current_integration.sh
+++ b/scripts/test_current_integration.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_package_utils.sh"
+
+discover_integration_packages current
+if [ ! -d "$INTEGRATION_TEST_ROOT/test_helpers" ]; then
+  echo "Error: integration test helper package is missing." >&2
+  exit 1
+fi
+
+all_packages=(
+  "${GENERATED_INTEGRATION_PACKAGES[@]}"
+  "${INTEGRATION_TEST_PACKAGES[@]}"
+  integration_test/test_helpers
+)
+for package_dir in "${all_packages[@]}"; do
+  echo "Analyzing $package_dir"
+  (
+    cd "$INTEGRATION_REPO_ROOT/$package_dir"
+    dart pub get
+    dart analyze --fatal-infos --fatal-warnings
+  )
+done
+
+for package_dir in "${INTEGRATION_TEST_PACKAGES[@]}"; do
+  echo "Testing $package_dir"
+  (
+    cd "$INTEGRATION_REPO_ROOT/$package_dir"
+    dart test
+  )
+done

--- a/scripts/test_integration_packages.sh
+++ b/scripts/test_integration_packages.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_package_utils.sh"
+
+if [ "$#" -ne 2 ]; then
+  echo "Usage: $0 dio|http shard" >&2
+  exit 64
+fi
+
+backend="$1"
+shard="$2"
+validate_integration_backend "$backend"
+validate_integration_shard "$shard"
+discover_integration_packages "$backend"
+
+shard_packages=()
+for index in "${!INTEGRATION_TEST_PACKAGES[@]}"; do
+  if [ $((index % 3)) -eq "$shard" ]; then
+    shard_packages+=("${INTEGRATION_TEST_PACKAGES[$index]}")
+  fi
+done
+if [ "${#shard_packages[@]}" -eq 0 ]; then
+  echo "Error: test shard $shard is empty for $backend." >&2
+  exit 1
+fi
+
+echo "Test shard: backend=$backend shard=$shard packages=${#shard_packages[@]}"
+for package_dir in "${shard_packages[@]}"; do
+  echo "Testing $package_dir"
+  (
+    cd "$INTEGRATION_REPO_ROOT/$package_dir"
+    dart pub get
+    dart test --concurrency=2
+  )
+done


### PR DESCRIPTION
## Summary

- run integration generation, analysis, behavior tests, and dependency isolation for both `dio` and `http`
- preserve the stable Linux/macOS/Windows and beta Linux matrix with three analysis/test shards
- archive only the selected backend's generated API packages and include the backend in job, artifact, cache, and log names
- move package discovery, archiving, analysis, testing, and dependency checks into reusable shell scripts
- fix analyzer issues exposed by the full generated HTTP corpus and add focused generator tests

## Why

HTTP-13 requires both transport backends to exercise the existing integration CI matrix independently and verifies that generated packages resolve only the selected backend.

## Validation

- `tonik_generate` analysis passes with fatal infos and warnings
- all 3,018 `tonik_generate` tests pass
- Dio generation, analysis, and all 40 integration packages pass
- HTTP generation and analysis pass for all 44 generated and 40 test packages
- 39 of 40 HTTP integration packages pass
- HTTP dependency isolation passes for 44 generated and five handwritten packages
- workflow YAML, embedded command length, shell syntax, archive contents, shard distribution, and invalid arguments checked locally

## Known prerequisite

The HTTP multipart package still has nine behavioral failures covering `pipeDelimited`, `deepObject`, URL-encoded object parts, and per-part headers. HTTP-13 depends on HTTP-12 and explicitly excludes new product behavior, so this draft keeps that prerequisite visible rather than expanding the CI work package.
