### PR TITLE
docs: document HTTP backend selection and migration

### DIFF
--- a/docs/authentication.md
+++ b/docs/authentication.md
@@ -1,374 +1,98 @@
 # Authentication Guide
 
-This guide explains how to handle authentication when using Tonik-generated API clients.
+Tonik documents OpenAPI security requirements in generated library and method
+comments. It does not generate authentication code. Configure authentication
+on the selected HTTP client and pass that client through `ServerConfig`.
 
-## Overview
+## Dio
 
-Tonik generates API client classes that work with Server objects.
-Authentication is configured on a Dio client supplied through
-`ServerConfig<Dio>`, keeping authentication logic separate from generated API
-code.
-
-Use `clientFactory` for Dio options, interceptors, and adapters:
-
-```dart
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () => Dio(
-    BaseOptions(connectTimeout: const Duration(seconds: 10)),
-  )..interceptors.add(AuthInterceptor('your-jwt-token-here')),
-);
-```
-
-The factory is called lazily at most once per server, and the returned Dio is
-cached. The generated server applies its URL after the factory returns, so a
-`BaseOptions.baseUrl` supplied by the factory cannot override the server URL.
-
-You can instead inject an existing Dio:
-
-```dart
-final dio = Dio()..interceptors.add(AuthInterceptor('your-jwt-token-here'));
-final serverConfig = ServerConfig<Dio>.client(dio);
-```
-
-An injected client is borrowed. A factory-created client, or the default Dio
-created when neither option is supplied, is conceptually owned by the generated
-server. Generated servers do not currently close either borrowed or owned
-clients.
-
-## Basic Authentication Setup
-
-### 1. Bearer Token Authentication
+Use a client factory for Dio options, interceptors, and adapters:
 
 ```dart
 import 'package:dio/dio.dart';
-import 'package:tonik/your_api_client.dart'; // Your generated client
 import 'package:tonik_util/tonik_util.dart';
+import 'package:your_api/your_api.dart';
 
-class AuthInterceptor extends Interceptor {
-  AuthInterceptor(this._token);
-  
+final token = 'your-token';
+
+final server = CustomServer(
+  baseUrl: 'https://api.example.com',
+  serverConfig: ServerConfig<Dio>.clientFactory(
+    () => Dio(
+      BaseOptions(connectTimeout: const Duration(seconds: 10)),
+    )..interceptors.add(
+        InterceptorsWrapper(
+          onRequest: (options, handler) {
+            options.headers['Authorization'] = 'Bearer $token';
+            handler.next(options);
+          },
+        ),
+      ),
+  ),
+);
+```
+
+The factory is called lazily at most once per server. The generated server owns
+the returned Dio instance and closes it when `server.close()` is called. The
+generated server URL is applied after the factory returns, so it takes
+precedence over `BaseOptions.baseUrl`.
+
+If the application already owns a configured Dio instance, borrow it instead:
+
+```dart
+final dio = Dio()..interceptors.add(authInterceptor);
+final config = ServerConfig<Dio>.client(dio);
+```
+
+The application remains responsible for closing an injected client.
+
+## `package:http`
+
+Wrap `http.Client` to add authentication to each request:
+
+```dart
+import 'package:http/http.dart' as http;
+import 'package:tonik_util/tonik_util.dart';
+import 'package:your_api/your_api.dart';
+
+final class AuthClient extends http.BaseClient {
+  AuthClient(this._token) : _inner = http.Client();
+
   final String _token;
+  final http.Client _inner;
 
   @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    if (_token.isNotEmpty) {
-      options.headers['Authorization'] = 'Bearer $_token';
-    }
-    handler.next(options);
+  Future<http.StreamedResponse> send(http.BaseRequest request) {
+    request.headers['Authorization'] = 'Bearer $_token';
+    return _inner.send(request);
   }
+
+  @override
+  void close() => _inner.close();
 }
 
-// Setup with ServerConfig
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () => Dio()
-    ..interceptors.add(AuthInterceptor('your-jwt-token-here')),
+final server = CustomServer(
+  baseUrl: 'https://api.example.com',
+  serverConfig: ServerConfig<http.Client>.clientFactory(
+    () => AuthClient('your-token'),
+  ),
 );
-
-final server = YourServer(serverConfig: serverConfig);
-final apiClient = YourApiClient(server);
-final users = await apiClient.getUsers();
 ```
 
-### 2. API Key Authentication
-
-```dart
-class ApiKeyService {
-  ApiKeyService(this._apiKey);
-
-  final String _apiKey;
-
-  String get apiKey => _apiKey;
-
-  Interceptor createAuthInterceptor() {
-    return _ApiKeyInterceptor(this);
-  }
-}
-
-class _ApiKeyInterceptor extends Interceptor {
-  _ApiKeyInterceptor(this._apiKeyService);
-
-  final ApiKeyService _apiKeyService;
-
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    if (_apiKeyService.apiKey.isNotEmpty) {
-      // Add as query parameter
-      options.queryParameters['api_key'] = _apiKeyService.apiKey;
-
-      // Or add as header
-      // options.headers['X-API-Key'] = _apiKeyService.apiKey;
-    }
-    handler.next(options);
-  }
-}
-
-// Setup with ServerConfig
-final apiKeyService = ApiKeyService('your-api-key-here');
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () => Dio()
-    ..interceptors.add(apiKeyService.createAuthInterceptor()),
-);
-
-final server = YourServer(serverConfig: serverConfig);
-final apiClient = YourApiClient(server);
-```
-
-### 3. OAuth2 Flow
-
-```dart
-class OAuth2Service {
-  OAuth2Service({
-    required this.clientId,
-    required this.clientSecret,
-    required this.tokenUrl,
-  });
-
-  String? _accessToken;
-  final String _clientId;
-  final String _clientSecret;
-  final String _tokenUrl;
-
-  String? get accessToken => _accessToken;
-
-  Future<void> _refreshToken() async {
-    final response = await Dio().post(
-      _tokenUrl,
-      data: {
-        'grant_type': 'client_credentials',
-        'client_id': _clientId,
-        'client_secret': _clientSecret,
-      },
-    );
-
-    _accessToken = response.data['access_token'];
-  }
-
-  Interceptor createAuthInterceptor() {
-    return _OAuth2Interceptor(this);
-  }
-}
-
-class _OAuth2Interceptor extends Interceptor {
-  _OAuth2Interceptor(this._oauth2Service);
-
-  final OAuth2Service _oauth2Service;
-
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) async {
-    if (_oauth2Service.accessToken == null) {
-      await _oauth2Service._refreshToken();
-    }
-
-    if (_oauth2Service.accessToken != null) {
-      options.headers['Authorization'] = 'Bearer ${_oauth2Service.accessToken}';
-    }
-    handler.next(options);
-  }
-}
-
-// Setup with ServerConfig
-final oauth2Service = OAuth2Service(
-  clientId: 'your-client-id',
-  clientSecret: 'your-client-secret',
-  tokenUrl: 'https://auth.example.com/oauth/token',
-);
-
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () => Dio()
-    ..interceptors.add(oauth2Service.createAuthInterceptor()),
-);
-
-final server = YourServer(serverConfig: serverConfig);
-final apiClient = YourApiClient(server);
-```
-
-### 4. Mutual TLS (mTLS) Authentication
-
-```dart
-class MutualTlsService {
-  MutualTlsService(this._certificatePath, this._keyPath);
-
-  final String _certificatePath;
-  final String _keyPath;
-
-  Interceptor createAuthInterceptor() {
-    return _MutualTlsInterceptor(this);
-  }
-}
-
-class _MutualTlsInterceptor extends Interceptor {
-  _MutualTlsInterceptor(this._tlsService);
-
-  final MutualTlsService _tlsService;
-
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    // Note: Mutual TLS is typically configured at the HTTP client level
-    // This is a simplified example showing the pattern
-    // In practice, you'd configure the SecurityContext for the underlying
-    // HTTP client (e.g., dart:io HttpClient or similar)
-    handler.next(options);
-  }
-}
-
-// Setup with ServerConfig
-final tlsService = MutualTlsService(
-  '/path/to/client-cert.pem',
-  '/path/to/client-key.pem',
-);
-
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () {
-    final dio = Dio()
-      ..interceptors.add(tlsService.createAuthInterceptor());
-    // Configure dio.httpClientAdapter for the target platform here.
-    return dio;
-  },
-);
-
-final server = YourServer(serverConfig: serverConfig);
-final apiClient = YourApiClient(server);
-```
-
-**Note**: Mutual TLS authentication requires client certificates to be configured at the HTTP client level. The above example shows the interceptor pattern for consistency, but actual mTLS setup typically involves configuring the underlying HTTP client's `SecurityContext` with client certificates and private keys.
-
-## Advanced Authentication Patterns
-
-### Token Refresh with Retry
-
-```dart
-class TokenRefreshService {
-  TokenRefreshService(this._tokenUrl);
-
-  String? _accessToken;
-  String? _refreshToken;
-  final String _tokenUrl;
-
-  String? get accessToken => _accessToken;
-  String? get refreshToken => _refreshToken;
-
-  Future<void> _refreshAccessToken() async {
-    final response = await Dio().post(
-      _tokenUrl,
-      data: {
-        'grant_type': 'refresh_token',
-        'refresh_token': _refreshToken,
-      },
-    );
-
-    _accessToken = response.data['access_token'];
-    _refreshToken = response.data['refresh_token'];
-  }
-
-  Interceptor createAuthInterceptor() {
-    return _TokenRefreshInterceptor(this);
-  }
-}
-
-class _TokenRefreshInterceptor extends Interceptor {
-  _TokenRefreshInterceptor(this._tokenService);
-
-  final TokenRefreshService _tokenService;
-
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    if (_tokenService.accessToken != null) {
-      options.headers['Authorization'] = 'Bearer ${_tokenService.accessToken}';
-    }
-    handler.next(options);
-  }
-
-  @override
-  void onError(DioException err, ErrorInterceptorHandler handler) async {
-    if (err.response?.statusCode == 401 && _tokenService.refreshToken != null) {
-      try {
-        // Try to refresh token
-        await _tokenService._refreshAccessToken();
-        // Retry the original request
-        final response = await Dio().request(
-          err.requestOptions.path,
-          options: Options(
-            method: err.requestOptions.method,
-            headers: err.requestOptions.headers,
-          ).compose(
-            err.requestOptions.extra['dio'] as BaseOptions?,
-            err.requestOptions.path,
-            data: err.requestOptions.data,
-            queryParameters: err.requestOptions.queryParameters,
-          ),
-        );
-        handler.resolve(response);
-      } catch (e) {
-        handler.reject(err);
-      }
-    } else {
-      handler.reject(err);
-    }
-  }
-}
-```
-
-### Multiple Authentication Methods
-
-```dart
-class MultiAuthService {
-  MultiAuthService(this._authHeaders);
-
-  final Map<String, String> _authHeaders;
-  Map<String, String> get authHeaders => _authHeaders;
-
-  Interceptor createAuthInterceptor() {
-    return _MultiAuthInterceptor(this);
-  }
-}
-
-class _MultiAuthInterceptor extends Interceptor {
-  _MultiAuthInterceptor(this._authService);
-
-  final MultiAuthService _authService;
-
-  @override
-  void onRequest(RequestOptions options, RequestInterceptorHandler handler) {
-    // Add all authentication headers
-    options.headers.addAll(_authService.authHeaders);
-    handler.next(options);
-  }
-}
-
-// Setup for multiple auth methods
-final multiAuthService = MultiAuthService({
-  'Authorization': 'Bearer your-jwt-token',
-  'X-API-Key': 'your-api-key',
-  'X-Client-ID': 'your-client-id',
-});
-
-final serverConfig = ServerConfig<Dio>.clientFactory(
-  () => Dio()
-    ..interceptors.add(multiAuthService.createAuthInterceptor()),
-);
-
-final server = YourServer(serverConfig: serverConfig);
-final apiClient = YourApiClient(server);
-```
-
-## Security Scheme Documentation
-
-While Tonik doesn't generate authentication code, it does parse and expose security scheme information from the OpenAPI specification. This information is automatically included in the generated API documentation:
-
-- **Library-level documentation** - All available security schemes are documented in the main library file
-- **Method-level documentation** - Individual API methods include their specific security requirements in doc comments
-
-You can use this information to:
-
-1. **Understand authentication requirements** from the generated documentation
-2. **Configure interceptors** based on the documented security schemes
-3. **Reference security information** when implementing authentication
-
-## Best Practices
-
-1. **Create dedicated authentication services** that provide interceptor factories
-2. **Configure authentication in a `ServerConfig<Dio>` client factory**
-3. **Keep authentication logic completely separate** from generated API client code
-4. **Handle token refresh** gracefully with retry logic in your service classes
-5. **Consider security scheme information** from the OpenAPI spec for documentation
-6. **Test authentication flows** thoroughly with mocked services
+The generated server owns and closes the factory-created wrapper. Pass an
+existing wrapper with `ServerConfig<http.Client>.client(...)` when the
+application should retain ownership.
+
+Token refresh, retries, OAuth flows, API-key placement, and TLS configuration
+belong in the interceptor or client wrapper. Tonik does not interpret security
+schemes at runtime.
+
+## Generated Security Documentation
+
+Generated library documentation lists the security schemes declared by the
+OpenAPI document. Generated API methods list their applicable schemes and
+OAuth scopes. Use those comments to configure the client; they do not imply
+runtime authentication support.
+
+See [HTTP Backends](http_backends.md) for backend selection, client ownership,
+and migration guidance.

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -15,6 +15,10 @@ outputDir: ./generated        # Output directory (--output-dir, -o)
 packageName: my_api_client    # Package name (--package-name, -p)
 logLevel: warn                # Log level: verbose, info, warn, silent (--log-level)
 
+# Generated HTTP client. Defaults to dio.
+transport:
+  backend: dio               # dio or http (--backend)
+
 nameOverrides:
   schemas:
     # Remove unnecessary suffixes
@@ -117,8 +121,29 @@ tonik --output-dir ./other-location
 | `--output-dir`, `-o` | `outputDir` | Directory for generated code (defaults to `.`) |
 | `--package-name`, `-p` | `packageName` | Name of the generated package (required) |
 | `--log-level` | `logLevel` | Logging verbosity: `verbose`, `info`, `warn`, `silent` (defaults to `warn`) |
+| `--backend` | `transport.backend` | Generated HTTP backend: `dio` or `http` (defaults to `dio`) |
 | `--immutable-collections` | `immutableCollections` | Use `IList`/`IMap` instead of `List`/`Map` (defaults to `false`) |
 | `--workers` | `workerCount` | Number of worker isolates for parallel model file generation (defaults to auto) |
+
+## HTTP Backend
+
+Tonik generates one backend for the whole output package. Dio is the default.
+Select `package:http` in `tonik.yaml`:
+
+```yaml
+transport:
+  backend: http
+```
+
+Or override the file from the command line:
+
+```bash
+tonik --backend http
+```
+
+There is no runtime, server-level, or operation-level backend switch. Change
+the setting and regenerate the package. See [HTTP Backends](http_backends.md)
+for client setup and migration guidance.
 
 ## Name Overrides
 

--- a/docs/features.md
+++ b/docs/features.md
@@ -14,6 +14,7 @@ Tonik is a Dart code generator for OpenAPI 3 specifications. This document provi
 | **Text response charsets** | Decodes legacy response encodings declared by `Content-Type`, including ISO-8859, Windows code pages, and common East Asian encodings |
 | **readOnly / writeOnly** | Properties excluded from the correct serialization direction automatically |
 | **Server variables** | URL templating with enum constraints and runtime substitution |
+| **HTTP backends** | Generates one package backed by Dio (default) or `package:http` |
 | **Immutable collections** | Optional `IList`/`IMap` from [fast_immutable_collections](https://pub.dev/packages/fast_immutable_collections) with automatic serialization |
 | **Pure Dart** | No Java, no Docker, no external tooling |
 
@@ -24,6 +25,7 @@ Tonik is a Dart code generator for OpenAPI 3 specifications. This document provi
   - [Table of Contents](#table-of-contents)
   - [How Generated Code Works](#how-generated-code-works)
     - [Architecture Overview](#architecture-overview)
+    - [HTTP Backends](#http-backends)
     - [Custom Encoding \& Scoped Emission](#custom-encoding--scoped-emission)
     - [Naming Resolution](#naming-resolution)
     - [Response Handling](#response-handling)
@@ -55,13 +57,14 @@ Tonik is a Dart code generator for OpenAPI 3 specifications. This document provi
 
 ### Architecture Overview
 
-Generated code uses [Dio](https://pub.dev/packages/dio) as the HTTP client. Each API operation is encapsulated in its own class for request building and response parsing.
+Generated code uses the selected HTTP backend. Each API operation is
+encapsulated in its own class for request building and response parsing.
 
 ```
-┌─────────────────┐     ┌─────────────────┐     ┌─────────────────┐
-│   API Client    │────▶│   Operations    │────▶│      Dio        │
-│  (per tag)      │     │ (per endpoint)  │     │  (HTTP layer)   │
-└─────────────────┘     └─────────────────┘     └─────────────────┘
+┌─────────────────┐     ┌─────────────────┐     ┌──────────────────┐
+│   API Client    │────▶│   Operations    │────▶│ Selected backend │
+│  (per tag)      │     │ (per endpoint)  │     │ Dio or http      │
+└─────────────────┘     └─────────────────┘     └──────────────────┘
                                │
                                ▼
                   ┌───────────────────────┐
@@ -70,6 +73,14 @@ Generated code uses [Dio](https://pub.dev/packages/dio) as the HTTP client. Each
                   │   encode/decode)      │
                   └───────────────────────┘
 ```
+
+### HTTP Backends
+
+Dio is the default; `package:http` can be selected for the whole generated
+package. Models, API-client methods, decoded values, cancellation, and error
+categories are portable. Custom client setup and raw response access use the
+selected backend's types. See [HTTP Backends](http_backends.md) for selection,
+ownership, and migration guidance.
 
 ### Custom Encoding & Scoped Emission
 
@@ -340,8 +351,8 @@ Each operation generates a sealed response class. Every status code and content 
 | Operation-level `security` | ✅ (documented in comments) |
 
 **Security:** Tonik documents security requirements but does not generate
-authentication code. Configure Dio in a `ServerConfig<Dio>` client factory.
-See [Authentication Guide](authentication.md).
+authentication code. Configure the selected client with a Dio interceptor or a
+wrapped `http.Client`. See [Authentication Guide](authentication.md).
 
 ---
 
@@ -393,6 +404,7 @@ Tonik supports an optional `tonik.yaml` for customizing code generation:
 - **Filtering** - Include/exclude by tags, operations, or schemas
 - **Deprecation handling** - `annotate`, `exclude`, or `ignore`
 - **Content type mapping** - Map custom types to `json`, `form`, `text`, `bytes`
+- **HTTP backend** - Generate with Dio or `package:http`
 - **Enum unknown case** - Forward-compatible enum handling
 
 See [Configuration](configuration.md) for full details and examples.

--- a/docs/http_backends.md
+++ b/docs/http_backends.md
@@ -1,0 +1,151 @@
+# HTTP Backends
+
+Tonik generates a client backed by either
+[`package:dio`](https://pub.dev/packages/dio) or
+[`package:http`](https://pub.dev/packages/http). Dio is the default.
+
+Backend selection happens during generation and applies to the whole generated
+package. To switch, change the configuration and regenerate. See
+[Configuration](configuration.md#http-backend).
+
+## Portable API
+
+Models, servers, API clients, operation parameters, decoded values,
+`TonikCancellation`, and error categories have the same shape with both
+backends:
+
+```dart
+import 'package:tonik_util/tonik_util.dart';
+import 'package:your_api/your_api.dart';
+
+final server = CustomServer(baseUrl: 'https://api.example.com');
+final api = PetApi(server);
+final cancellation = TonikCancellation();
+
+try {
+  final result = await api.getPetById(
+    petId: 1,
+    cancellation: cancellation,
+  );
+
+  switch (result) {
+    case TonikSuccess(:final value):
+      print(value);
+    case TonikError(:final type):
+      print(type);
+  }
+} finally {
+  server.close();
+}
+```
+
+Code that only uses this surface can switch backends without changing its API
+calls or result handling.
+
+## Client Configuration and Ownership
+
+Generated servers accept the shared `ServerConfig<Client>` type:
+
+| Configuration | Client lifetime | Closed by `server.close()` |
+|---|---|---|
+| `const ServerConfig()` | Created lazily by the server | Yes |
+| `ServerConfig.client(client)` | Supplied and owned by the caller | No |
+| `ServerConfig.clientFactory(factory)` | Created lazily and cached by the server | Yes |
+
+`server.close()` is safe to call more than once. A closed server cannot be used
+for another request.
+
+## Native Boundary
+
+Client customization and raw response inspection use backend-native types:
+
+| | Dio | `package:http` |
+|---|---|---|
+| Server configuration | `ServerConfig<Dio>` | `ServerConfig<http.Client>` |
+| Resolved client | `server.dio` | `server.client` |
+| Result response | `dio.Response<Object?>` | `http.Response` |
+
+`TonikSuccess.response` contains the completed native response.
+`TonikError.response` contains it when the backend produced a complete
+response, otherwise it is `null`. Code that reads these fields is intentionally
+backend-specific.
+
+For authentication and other request customization, see the
+[Authentication Guide](authentication.md).
+
+With `package:http`, a custom client controls whether it honors request
+cancellation. Response headers use `headersSplitValues`; the original
+distinction between repeated field lines and comma-separated values cannot
+always be recovered.
+
+## Migrating Existing Clients
+
+Regenerate the client package before updating application code. Regeneration
+provides the selected backend, portable cancellation, lifecycle handling, and
+the curated public exports.
+
+Then update affected call sites:
+
+1. Move Dio configuration into a client factory:
+
+   ```dart
+   // Before
+   final config = ServerConfig(
+     baseOptions: BaseOptions(connectTimeout: const Duration(seconds: 10)),
+     interceptors: [authInterceptor],
+   );
+
+   // After
+   final config = ServerConfig<Dio>.clientFactory(
+     () => Dio(
+       BaseOptions(connectTimeout: const Duration(seconds: 10)),
+     )..interceptors.add(authInterceptor),
+   );
+   ```
+
+2. Replace Dio cancellation tokens with `TonikCancellation`:
+
+   ```dart
+   // Before
+   final cancellation = CancelToken();
+   final result = await api.getPetById(
+     petId: 1,
+     cancelToken: cancellation,
+   );
+
+   // After
+   final cancellation = TonikCancellation();
+   final result = await api.getPetById(
+     petId: 1,
+     cancellation: cancellation,
+   );
+   ```
+
+   `cancellation.cancel()` still cancels the request.
+
+3. Call operations through generated API clients. Replace direct construction
+   of classes such as `GetPetById` with `PetApi(server).getPetById(...)`.
+   Low-level operation classes are no longer exported from the package root.
+
+4. Add the native response type to explicit result annotations:
+
+   ```dart
+   // Before
+   TonikResult<GetPetByIdResponse>
+
+   // Dio output
+   TonikResult<GetPetByIdResponse, dio.Response<Object?>>
+
+   // package:http output
+   TonikResult<GetPetByIdResponse, http.Response>
+   ```
+
+   Inferred result variables and patterns that only read `value`, `error`, or
+   `type` usually need no change.
+
+Application code that imports a backend type directly should also declare that
+backend package as a direct dependency.
+
+To move an existing generated package from Dio to `package:http`, select the
+new backend and regenerate. Only custom client setup and code that inspects the
+native response should require backend-specific changes.

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -44,7 +44,7 @@
 - Example Object `externalValue` URL fetching - external example resolution requires network access at build time; only inline `value` examples are supported
 
 **Other:**
-- Direct security/authentication code generation - authentication must be handled through a `ServerConfig<Dio>` client factory (see [Authentication Guide](authentication.md))
+- Direct security/authentication code generation - authentication is configured on the selected HTTP client (see [Authentication Guide](authentication.md))
 - Code generation for [webhooks](https://spec.openapis.org/oas/v3.1.0.html#oasWebhooks) - server→client callbacks, not relevant for client libs
 - Callback Objects - server→client callbacks, same as webhooks
 - Link Objects - HATEOAS navigation metadata, rarely used in practice

--- a/packages/tonik/README.md
+++ b/packages/tonik/README.md
@@ -64,7 +64,7 @@ See [Composite Data Types](https://github.com/t-unit/tonik/blob/main/docs/compos
 
 ### No Name Conflicts
 
-Use `Error`, `Response`, `List`, or any Dart built-in as schema names. Tonik uses scoped code emission to properly qualify all type references - no naming collisions with `dart:core` or Dio.
+Use `Error`, `Response`, `List`, or any Dart built-in as schema names. Tonik uses scoped code emission to properly qualify all type references - no naming collisions with `dart:core` or transport dependencies.
 
 ### Integer and String Enums
 
@@ -85,20 +85,30 @@ Path, query, and header parameters support all OpenAPI styles: `simple`, `label`
 
 Install with `dart pub global activate tonik` and run. No JVM, no Docker, no external dependencies.
 
-### Universal Platform Support
+### Choice of HTTP Backend
 
-Generated packages are pure Dart with no platform dependencies. Use them in Flutter apps targeting iOS, Android, web, desktop, or in server-side Dart - the same generated code works everywhere.
+Generate clients with Dio (the default) or `package:http`. Selection is
+generation-time and applies to the whole generated package; ordinary models,
+API calls, and result handling keep the same shape.
+
+### Platform Support
+
+Generated packages are pure Dart with no native plugin dependency. The current
+dual-backend compatibility suite targets the Dart VM. Browser behavior depends
+on the selected backend and is not part of the current compatibility
+certification.
 
 ## Documentation
 
 - [Features Overview](https://github.com/t-unit/tonik/blob/main/docs/features.md) – Complete feature reference
+- [HTTP Backends](https://github.com/t-unit/tonik/blob/main/docs/http_backends.md) – Backend selection, client ownership, and migration
 - [Configuration](https://github.com/t-unit/tonik/blob/main/docs/configuration.md) – `tonik.yaml` options, name overrides, filtering
 - [Data Types](https://github.com/t-unit/tonik/blob/main/docs/data_types.md) – OpenAPI to Dart type mappings
 - [Composite Data Types](https://github.com/t-unit/tonik/blob/main/docs/composite_data_types.md) – `oneOf`, `anyOf`, `allOf` usage
 - [Defaults](https://github.com/t-unit/tonik/blob/main/docs/defaults.md) – `default` keyword handling and generated constants
 - [Additional Properties](https://github.com/t-unit/tonik/blob/main/docs/additional_properties.md) – `additionalProperties` support and pure maps
 - [Multipart](https://github.com/t-unit/tonik/blob/main/docs/multipart.md) – `multipart/form-data` request bodies
-- [Authentication](https://github.com/t-unit/tonik/blob/main/docs/authentication.md) – Interceptor patterns for auth
+- [Authentication](https://github.com/t-unit/tonik/blob/main/docs/authentication.md) – Dio interceptors and `http.Client` wrappers
 - [URI Encoding](https://github.com/t-unit/tonik/blob/main/docs/uri_encoding.md) – query/body encoding and `allowReserved`
 
 ## Quick Start
@@ -121,12 +131,14 @@ Add the generated package to your project:
 
 ```bash
 dart pub add my_api:{'path':'./my_api'}
+dart pub add tonik_util
 ```
 
 Then import and use:
 
 ```dart
 import 'package:my_api/my_api.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 final api = PetApi(CustomServer(baseUrl: 'https://api.example.com'));
 
@@ -152,7 +164,7 @@ See the [petstore integration tests](https://github.com/t-unit/tonik/blob/main/i
 | **Request Bodies** | `application/json`, `application/x-www-form-urlencoded`, `application/octet-stream`, `text/plain` |
 | **Multipart** | `multipart/form-data` with primitive, file, JSON, and array parts; per-part `encoding` and content types |
 | **Schema** | `readOnly`/`writeOnly` enforcement, `nullable`, `required`, `deprecated`, boolean schemas, `additionalProperties` |
-| **Configuration** | Name overrides, filtering by tag/operation/schema, deprecation handling, content-type mapping, parallel generation tuning |
+| **Configuration** | HTTP backend selection, name overrides, filtering by tag/operation/schema, deprecation handling, content-type mapping, parallel generation tuning |
 | **OAS 3.1** | `$ref` with siblings, `$defs` local definitions, boolean schemas, nullable type arrays, `contentEncoding`/`contentMediaType` |
 
 ## Acknowledgments

--- a/packages/tonik_generate/README.md
+++ b/packages/tonik_generate/README.md
@@ -19,7 +19,7 @@ For complete documentation and usage examples, see the main [Tonik package](http
 - Generates API client classes with methods for each operation
 - Handles various content types and serialization formats
 - Generates request and response wrapper classes
-- Supports authentication schemes
+- Documents authentication schemes on generated libraries and methods
 
 ## License
 

--- a/packages/tonik_util/README.md
+++ b/packages/tonik_util/README.md
@@ -6,7 +6,12 @@ This package provides encoding, decoding, and serialization functionality requir
 
 ## Usage
 
-This package is automatically included as a dependency when you use Tonik-generated code. You typically don't need to add it manually to your `pubspec.yaml`.
+Generated packages depend on `tonik_util`. Add it as a direct dependency when
+application code imports `TonikResult`, `TonikCancellation`, or `ServerConfig`:
+
+```bash
+dart pub add tonik_util
+```
 
 ## Documentation
 
@@ -19,6 +24,7 @@ For complete documentation and usage examples, see the main [Tonik package](http
 - Simple encoding for path and query parameters
 - Support for various OpenAPI parameter styles
 - DateTime and Date handling with timezone support
+- Backend-neutral results, cancellation, and client configuration
 - Custom exception types for encoding/decoding errors
 
 ## License

--- a/packages/tonik_util/lib/src/server_config.dart
+++ b/packages/tonik_util/lib/src/server_config.dart
@@ -4,8 +4,7 @@ import 'package:meta/meta.dart';
 ///
 /// An injected [client] is borrowed: generated servers never close it.
 /// A client returned by [clientFactory], or a default client created when
-/// neither field is provided, is conceptually owned by the generated server.
-/// Generated servers currently do not close owned clients either.
+/// neither field is provided, is owned and closed by the generated server.
 @immutable
 class ServerConfig<Client extends Object> {
   /// Creates configuration that lets the generated server create its default
@@ -25,9 +24,9 @@ class ServerConfig<Client extends Object> {
   /// it.
   final Client? client;
 
-  /// Creates the client conceptually owned by the generated server.
+  /// Creates the client owned by the generated server.
   ///
-  /// Generated servers invoke this lazily and cache the returned client. They
-  /// currently do not close it.
+  /// Generated servers invoke this lazily, cache the returned client, and
+  /// close it when the server is closed.
   final Client Function()? clientFactory;
 }


### PR DESCRIPTION
## Summary

- add a concise guide for backend selection, client ownership, native response boundaries, and migration
- update configuration, feature, roadmap, and package documentation for Dio and `package:http`
- replace the Dio-only authentication guide with focused examples for both backends
- correct `ServerConfig` lifecycle documentation and related package guidance

## Why

Backend support was implemented, but the user documentation still described Dio as the only transport and contained stale ownership and authentication guidance. This gives users one canonical migration path without duplicating the generated API reference.

## User impact

Dio remains the default. Users can select `package:http` at generation time, understand which APIs remain portable, and migrate cancellation, operation calls, client configuration, and explicit result annotations.

## Validation

- `fvm dart analyze --fatal-infos --fatal-warnings` in `packages/tonik_util`
- `fvm dart test` in `packages/tonik_util` (1,551 tests)
- `git diff --check`
- stale Dio-only documentation audit
