### PR TITLE
docs(tonik): fix generated response example

### DIFF
--- a/packages/tonik/README.md
+++ b/packages/tonik/README.md
@@ -145,7 +145,7 @@ final api = PetApi(CustomServer(baseUrl: 'https://api.example.com'));
 final response = await api.getPetById(petId: 1);
 switch (response) {
   case TonikSuccess(:final value):
-    print('Pet: ${value.body.name}');
+    print('Response: $value');
   case TonikError(:final error):
     print('Failed: $error');
 }


### PR DESCRIPTION
## Summary

Replace the README's invalid `value.body.name` access with output that works for the generated response union.

## Why

`value` is a generated `GetPetByIdResponse`, whose response variants do not expose a shared `body` getter. The old example therefore failed static analysis for both supported HTTP backends.

## Impact

Users can copy the request example without immediately encountering an analyzer error, regardless of whether their generated client uses `package:http` or Dio.

## Validation

- Analyzed and compiled the documentation fixture against generated HTTP output
- Analyzed and compiled the documentation fixture against generated Dio output
- Ran `git diff --check`
