### PR TITLE
test: format generated code expectations

### DIFF
--- a/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_form_generator_test.dart
@@ -140,8 +140,26 @@ void main() {
       final combinedClass = generator.generateClass(model);
 
       const expectedToFormMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          return parameterProperties(allowEmpty: allowEmpty).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+            fieldEncodings: fieldEncodings,
+            textEncoding: textEncoding,
+          );
+        }
+      ''';
 
       expect(
         collapseWhitespace(format(combinedClass.accept(emitter).toString())),
@@ -214,8 +232,31 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { if (currentEncodingShape == EncodingShape.mixed) { throw EncodingException( r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported', ); } return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
+          );
+        }
+        return parameterProperties(allowEmpty: allowEmpty).toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          fieldEncodings: fieldEncodings,
+          textEncoding: textEncoding,
+        );
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -239,13 +280,22 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final combinedClass = generator.generateClass(model);
 
       const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
           return bigDecimal.toForm(
             paramName,
             explode: explode,
             allowEmpty: allowEmpty,
             useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
+            allowReserved: allowReserved,
+            textEncoding: textEncoding,
           );
         }
       ''';
@@ -317,16 +367,25 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final combinedClass = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          return status.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-        }
-      ''';
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return status.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
+            );
+          }
+        ''';
 
         expect(
           collapseWhitespace(format(combinedClass.accept(emitter).toString())),
@@ -450,7 +509,15 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final combinedClass = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-          List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
             throw EncodingException(
               'Form encoding not supported: contains complex types',
             );
@@ -511,40 +578,50 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException(
-              r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
-            );
-          }
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$intForm = int.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
           );
-          _$entryLists.add(_$intForm);
-          _$values.add(_$intForm.map((e) => e.value).join(','));
-          final _$choiceForm = choice.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$choiceForm);
-          _$values.add(_$choiceForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding for Combined: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
         }
-      ''';
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$intForm = int.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$intForm);
+        _$values.add(_$intForm.map((e) => e.value).join(','));
+        final _$choiceForm = choice.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$choiceForm);
+        _$values.add(_$choiceForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding for Combined: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -689,49 +766,60 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException(
-              r'Cannot encode MultiDynamic: mixing simple values (primitives/enums) and complex types is not supported',
-            );
-          }
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$flexibleAForm = flexibleA.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            r'Cannot encode MultiDynamic: mixing simple values (primitives/enums) and complex types is not supported',
           );
-          _$entryLists.add(_$flexibleAForm);
-          _$values.add(_$flexibleAForm.map((e) => e.value).join(','));
-          final _$flexibleBForm = flexibleB.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$flexibleBForm);
-          _$values.add(_$flexibleBForm.map((e) => e.value).join(','));
-          final _$stringForm = string.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$stringForm);
-          _$values.add(_$stringForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding for MultiDynamic: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
         }
-      ''';
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$flexibleAForm = flexibleA.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$flexibleAForm);
+        _$values.add(_$flexibleAForm.map((e) => e.value).join(','));
+        final _$flexibleBForm = flexibleB.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$flexibleBForm);
+        _$values.add(_$flexibleBForm.map((e) => e.value).join(','));
+        final _$stringForm = string.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$stringForm);
+        _$values.add(_$stringForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding for MultiDynamic: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -818,58 +906,70 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException(
-              r'Cannot encode ComplexMixed: mixing simple values (primitives/enums) and complex types is not supported',
-            );
-          }
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$flexibleValueForm = flexibleValue.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            r'Cannot encode ComplexMixed: mixing simple values (primitives/enums) and complex types is not supported',
           );
-          _$entryLists.add(_$flexibleValueForm);
-          _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
-          final _$bigDecimalForm = bigDecimal.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$bigDecimalForm);
-          _$values.add(_$bigDecimalForm.map((e) => e.value).join(','));
-          final _$choiceForm = choice.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$choiceForm);
-          _$values.add(_$choiceForm.map((e) => e.value).join(','));
-          final _$stringForm = string.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$stringForm);
-          _$values.add(_$stringForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding for ComplexMixed: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
         }
-      ''';
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$flexibleValueForm = flexibleValue.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$flexibleValueForm);
+        _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
+        final _$bigDecimalForm = bigDecimal.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$bigDecimalForm);
+        _$values.add(_$bigDecimalForm.map((e) => e.value).join(','));
+        final _$choiceForm = choice.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$choiceForm);
+        _$values.add(_$choiceForm.map((e) => e.value).join(','));
+        final _$stringForm = string.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$stringForm);
+        _$values.add(_$stringForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding for ComplexMixed: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -896,8 +996,44 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$listForm = list .map( (e) => e.uriEncode( allowEmpty: allowEmpty, textEncoding: textEncoding, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, textEncoding: textEncoding, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } return _$entryLists.first; }
-''';
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$listForm = list
+            .map(
+              (e) => e.uriEncode(
+                allowEmpty: allowEmpty,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
+              ),
+            )
+            .toList()
+            .toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              textEncoding: textEncoding,
+              alreadyEncoded: true,
+            );
+        _$entryLists.add(_$listForm);
+        _$values.add(_$listForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -924,8 +1060,44 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToForm = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$listForm = list .map( (e) => e.uriEncode( allowEmpty: allowEmpty, textEncoding: textEncoding, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, textEncoding: textEncoding, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } return _$entryLists.first; }
-''';
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$listForm = list
+            .map(
+              (e) => e.uriEncode(
+                allowEmpty: allowEmpty,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
+              ),
+            )
+            .toList()
+            .toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              textEncoding: textEncoding,
+              alreadyEncoded: true,
+            );
+        _$entryLists.add(_$listForm);
+        _$values.add(_$listForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),
@@ -979,40 +1151,50 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
     final generated = format(combinedClass.accept(emitter).toString());
 
     const expectedToFormMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          if (currentEncodingShape == EncodingShape.mixed) {
-            throw EncodingException(
-              r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
-            );
-          }
-          final _$entryLists = <List<ParameterEntry>>[];
-          final _$values = <String>{};
-          final _$flexibleValueForm = flexibleValue.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
+      List<ParameterEntry> toForm(
+        String paramName, {
+        required bool explode,
+        required bool allowEmpty,
+        required Encoding textEncoding,
+        bool useQueryComponent = false,
+        bool allowReserved = false,
+        Map<String, FormFieldEncoding> fieldEncodings = const {},
+      }) {
+        if (currentEncodingShape == EncodingShape.mixed) {
+          throw EncodingException(
+            r'Cannot encode Combined: mixing simple values (primitives/enums) and complex types is not supported',
           );
-          _$entryLists.add(_$flexibleValueForm);
-          _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
-          final _$intForm = int.toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved, textEncoding: textEncoding,
-          );
-          _$entryLists.add(_$intForm);
-          _$values.add(_$intForm.map((e) => e.value).join(','));
-          if (_$values.length > 1) {
-            throw EncodingException(
-              r'Inconsistent allOf form encoding for Combined: all values must encode to the same result',
-            );
-          }
-          return _$entryLists.first;
         }
-      ''';
+        final _$entryLists = <List<ParameterEntry>>[];
+        final _$values = <String>{};
+        final _$flexibleValueForm = flexibleValue.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$flexibleValueForm);
+        _$values.add(_$flexibleValueForm.map((e) => e.value).join(','));
+        final _$intForm = int.toForm(
+          paramName,
+          explode: explode,
+          allowEmpty: allowEmpty,
+          useQueryComponent: useQueryComponent,
+          allowReserved: allowReserved,
+          textEncoding: textEncoding,
+        );
+        _$entryLists.add(_$intForm);
+        _$values.add(_$intForm.map((e) => e.value).join(','));
+        if (_$values.length > 1) {
+          throw EncodingException(
+            r'Inconsistent allOf form encoding for Combined: all values must encode to the same result',
+          );
+        }
+        return _$entryLists.first;
+      }
+    ''';
 
     expect(
       collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/all_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_generator_test.dart
@@ -1357,8 +1357,32 @@ void main() {
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToMatrix = r'''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfDateTimeList: all values must encode to the same result', ); } return _$values.first; }
-''';
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          final _$values = <String>{};
+          final _$listMatrix = list
+              .map<String>(
+                (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+              )
+              .toList()
+              .toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                alreadyEncoded: true,
+              );
+          _$values.add(_$listMatrix);
+          if (_$values.length > 1) {
+            throw EncodingException(
+              r'Inconsistent allOf matrix encoding for AllOfDateTimeList: all values must encode to the same result',
+            );
+          }
+          return _$values.first;
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -1416,9 +1440,52 @@ String toSimple({ required bool explode, required bool allowEmpty, bool literal 
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToForm = r'''
-@override
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; if (list != null) { final _$listForm = list! .map( (e) => e.uriEncode( allowEmpty: allowEmpty, textEncoding: textEncoding, useQueryComponent: useQueryComponent, ), ) .toList() .toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, textEncoding: textEncoding, alreadyEncoded: true, ); _$entryLists.add(_$listForm); _$values.add(_$listForm.map((e) => e.value).join(',')); } if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf form encoding: all values must encode to the same result', ); } if (_$entryLists.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$entryLists.first; }
-''';
+        @override
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$entryLists = <List<ParameterEntry>>[];
+          final _$values = <String>{};
+          if (list != null) {
+            final _$listForm = list!
+                .map(
+                  (e) => e.uriEncode(
+                    allowEmpty: allowEmpty,
+                    textEncoding: textEncoding,
+                    useQueryComponent: useQueryComponent,
+                  ),
+                )
+                .toList()
+                .toForm(
+                  paramName,
+                  explode: explode,
+                  allowEmpty: allowEmpty,
+                  useQueryComponent: useQueryComponent,
+                  textEncoding: textEncoding,
+                  alreadyEncoded: true,
+                );
+            _$entryLists.add(_$listForm);
+            _$values.add(_$listForm.map((e) => e.value).join(','));
+          }
+          if (_$values.length > 1) {
+            throw EncodingException(
+              r'Inconsistent allOf form encoding: all values must encode to the same result',
+            );
+          }
+          if (_$entryLists.isEmpty) {
+            throw EncodingException(
+              r'Cannot encode AllOfNullableList to encoding: all properties are null',
+            );
+          }
+          return _$entryLists.first;
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -1446,9 +1513,33 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToLabel = r'''
-@override
-String toLabel({required bool explode, required bool allowEmpty}) { final _$values = <String>{}; if (list != null) { final _$listLabel = list! .map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8)) .toList() .toLabel( explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listLabel); } if (_$values.length > 1) { throw EncodingException( 'Inconsistent allOf label encoding: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$values.first; }
-''';
+        @override
+        String toLabel({required bool explode, required bool allowEmpty}) {
+          final _$values = <String>{};
+          if (list != null) {
+            final _$listLabel = list!
+                .map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8))
+                .toList()
+                .toLabel(
+                  explode: explode,
+                  allowEmpty: allowEmpty,
+                  alreadyEncoded: true,
+                );
+            _$values.add(_$listLabel);
+          }
+          if (_$values.length > 1) {
+            throw EncodingException(
+              'Inconsistent allOf label encoding: all values must encode to the same result',
+            );
+          }
+          if (_$values.isEmpty) {
+            throw EncodingException(
+              r'Cannot encode AllOfNullableList to encoding: all properties are null',
+            );
+          }
+          return _$values.first;
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -1476,9 +1567,40 @@ String toLabel({required bool explode, required bool allowEmpty}) { final _$valu
       final generated = format(combinedClass.accept(emitter).toString());
 
       const expectedToMatrix = r'''
-@override
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfNullableList: all values must encode to the same result', ); } if (_$values.isEmpty) { throw EncodingException( r'Cannot encode AllOfNullableList to encoding: all properties are null', ); } return _$values.first; }
-''';
+        @override
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          final _$values = <String>{};
+          if (list != null) {
+            final _$listMatrix = list!
+                .map<String>(
+                  (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                )
+                .toList()
+                .toMatrix(
+                  paramName,
+                  explode: explode,
+                  allowEmpty: allowEmpty,
+                  alreadyEncoded: true,
+                );
+            _$values.add(_$listMatrix);
+          }
+          if (_$values.length > 1) {
+            throw EncodingException(
+              r'Inconsistent allOf matrix encoding for AllOfNullableList: all values must encode to the same result',
+            );
+          }
+          if (_$values.isEmpty) {
+            throw EncodingException(
+              r'Cannot encode AllOfNullableList to encoding: all properties are null',
+            );
+          }
+          return _$values.first;
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -2302,12 +2424,18 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => thro
 
         const expectedUriEncode = r'''
           @override
-          String uriEncode({ required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, }) {
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
             final _$values = <String>{};
             if (nullableInt != null) {
               final _$nullableIntEncoded = nullableInt!.uriEncode(
                 allowEmpty: allowEmpty,
-                textEncoding: textEncoding, useQueryComponent: useQueryComponent,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
                 allowReserved: allowReserved,
               );
               _$values.add(_$nullableIntEncoded);
@@ -2367,12 +2495,18 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => thro
 
         const expectedUriEncode = r'''
           @override
-          String uriEncode({ required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, }) {
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
             final _$values = <String>{};
             if (signature != null) {
               final _$signatureEncoded = signature!.toBase64String().uriEncode(
                 allowEmpty: allowEmpty,
-                textEncoding: textEncoding, useQueryComponent: useQueryComponent,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
                 allowReserved: allowReserved,
               );
               _$values.add(_$signatureEncoded);
@@ -2454,20 +2588,26 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => thro
         final methodCode = format(method.accept(emitter).toString());
 
         const expectedUriEncode = '''
-@override
-String uriEncode({ required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, }) {
-  if (currentEncodingShape != EncodingShape.simple) {
-    throw EncodingException(
-      r'Cannot uriEncode DynamicByte: contains complex types',
-    );
-  }
-  return signature!.toBase64String().uriEncode(
-    allowEmpty: allowEmpty,
-    textEncoding: textEncoding,useQueryComponent: useQueryComponent,
-    allowReserved: allowReserved,
-  );
-}
-''';
+          @override
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
+            if (currentEncodingShape != EncodingShape.simple) {
+              throw EncodingException(
+                r'Cannot uriEncode DynamicByte: contains complex types',
+              );
+            }
+            return signature!.toBase64String().uriEncode(
+              allowEmpty: allowEmpty,
+              textEncoding: textEncoding,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+            );
+          }
+        ''';
 
         expect(
           collapseWhitespace(methodCode),
@@ -2686,25 +2826,25 @@ String toLabel({required bool explode, required bool allowEmpty}) {
 
     test('toMatrix throws for binary member', () {
       const expected = r'''
-@override
-String toMatrix(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-}) {
-  final _$values = <String>{};
-  final _$tonikFileMatrix = throw EncodingException(
-    'Binary data cannot be matrix-encoded',
-  );
-  _$values.add(_$tonikFileMatrix);
-  if (_$values.length > 1) {
-    throw EncodingException(
-      r'Inconsistent allOf matrix encoding for AllOfBinary: all values must encode to the same result',
-    );
-  }
-  return _$values.first;
-}
-''';
+        @override
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          final _$values = <String>{};
+          final _$tonikFileMatrix = throw EncodingException(
+            'Binary data cannot be matrix-encoded',
+          );
+          _$values.add(_$tonikFileMatrix);
+          if (_$values.length > 1) {
+            throw EncodingException(
+              r'Inconsistent allOf matrix encoding for AllOfBinary: all values must encode to the same result',
+            );
+          }
+          return _$values.first;
+        }
+      ''';
 
       expect(
         collapseWhitespace(methodSource(binaryModel(), 'toMatrix')),
@@ -2823,8 +2963,10 @@ String toMatrix(
             String paramName, {
             required bool explode,
             required bool allowEmpty,
-            required Encoding textEncoding, bool useQueryComponent = false,
-            bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
           }) {
             if (currentEncodingShape == EncodingShape.mixed) {
               throw EncodingException(
@@ -2839,7 +2981,8 @@ String toMatrix(
                 explode: explode,
                 allowEmpty: allowEmpty,
                 useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved, textEncoding: textEncoding,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
               );
               _$entryLists.add(_$statusForm);
               _$values.add(_$statusForm.map((e) => e.value).join(','));
@@ -2849,7 +2992,8 @@ String toMatrix(
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));

--- a/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_matrix_generator_test.dart
@@ -527,8 +527,32 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfIntList: all values must encode to the same result', ); } return _$values.first; }
-''';
+          String toMatrix(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+          }) {
+            final _$values = <String>{};
+            final _$listMatrix = list
+                .map<String>(
+                  (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                )
+                .toList()
+                .toMatrix(
+                  paramName,
+                  explode: explode,
+                  allowEmpty: allowEmpty,
+                  alreadyEncoded: true,
+                );
+            _$values.add(_$listMatrix);
+            if (_$values.length > 1) {
+              throw EncodingException(
+                r'Inconsistent allOf matrix encoding for AllOfIntList: all values must encode to the same result',
+              );
+            }
+            return _$values.first;
+          }
+        ''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),
@@ -636,8 +660,38 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; final _$listMatrix = list .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); final _$list2Matrix = list2.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$list2Matrix); if (_$values.length > 1) { throw EncodingException( r'Inconsistent allOf matrix encoding for AllOfMultipleLists: all values must encode to the same result', ); } return _$values.first; }
-''';
+          String toMatrix(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+          }) {
+            final _$values = <String>{};
+            final _$listMatrix = list
+                .map<String>(
+                  (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                )
+                .toList()
+                .toMatrix(
+                  paramName,
+                  explode: explode,
+                  allowEmpty: allowEmpty,
+                  alreadyEncoded: true,
+                );
+            _$values.add(_$listMatrix);
+            final _$list2Matrix = list2.toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+            );
+            _$values.add(_$list2Matrix);
+            if (_$values.length > 1) {
+              throw EncodingException(
+                r'Inconsistent allOf matrix encoding for AllOfMultipleLists: all values must encode to the same result',
+              );
+            }
+            return _$values.first;
+          }
+        ''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -587,7 +587,15 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
           final _$entryLists = <List<ParameterEntry>>[];
           final _$values = <String>{};
           if (int != null) {
@@ -596,7 +604,8 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             );
             _$entryLists.add(_$intForm);
             _$values.add(_$intForm.map((e) => e.value).join(','));
@@ -607,7 +616,8 @@ void main() {
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             );
             _$entryLists.add(_$stringForm);
             _$values.add(_$stringForm.map((e) => e.value).join(','));
@@ -658,8 +668,35 @@ void main() {
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$mapValues = <Map<String, PropertyValue>>[]; if (a != null) { final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aForm); } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$mapValues = <Map<String, PropertyValue>>[];
+          if (a != null) {
+            final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty);
+            _$mapValues.add(_$aForm);
+          }
+          final _$map = <String, PropertyValue>{};
+          for (final _$m in _$mapValues) {
+            _$map.addAll(_$m);
+          }
+          return _$map.toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+            fieldEncodings: fieldEncodings,
+            textEncoding: textEncoding,
+          );
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -720,8 +757,46 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$mapValues = <Map<String, PropertyValue>>[]; String? _$discriminatorValue; if (a != null) { final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$aForm); _$discriminatorValue ??= r'a'; } if (b != null) { final _$bForm = b!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$bForm); _$discriminatorValue ??= r'b'; } final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } final _$discValue = _$discriminatorValue; if (_$discValue != null) { _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue)); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$mapValues = <Map<String, PropertyValue>>[];
+          String? _$discriminatorValue;
+          if (a != null) {
+            final _$aForm = a!.parameterProperties(allowEmpty: allowEmpty);
+            _$mapValues.add(_$aForm);
+            _$discriminatorValue ??= r'a';
+          }
+          if (b != null) {
+            final _$bForm = b!.parameterProperties(allowEmpty: allowEmpty);
+            _$mapValues.add(_$bForm);
+            _$discriminatorValue ??= r'b';
+          }
+          final _$map = <String, PropertyValue>{};
+          for (final _$m in _$mapValues) {
+            _$map.addAll(_$m);
+          }
+          final _$discValue = _$discriminatorValue;
+          if (_$discValue != null) {
+            _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
+          }
+          return _$map.toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+            fieldEncodings: fieldEncodings,
+            textEncoding: textEncoding,
+          );
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -763,8 +838,61 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final generated = format(klass.accept(emitter).toString());
 
       const expectedMethod = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (data != null) { final _$dataForm = data!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$dataForm); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for Mixed: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$entryLists = <List<ParameterEntry>>[];
+          final _$values = <String>{};
+          final _$mapValues = <Map<String, PropertyValue>>[];
+          if (data != null) {
+            final _$dataForm = data!.parameterProperties(allowEmpty: allowEmpty);
+            _$mapValues.add(_$dataForm);
+          }
+          if (string != null) {
+            final _$stringForm = string!.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
+            );
+            _$entryLists.add(_$stringForm);
+            _$values.add(_$stringForm.map((e) => e.value).join(','));
+          }
+          if (_$values.isEmpty && _$mapValues.isEmpty) {
+            return const <ParameterEntry>[];
+          }
+          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+            throw EncodingException(
+              r'Ambiguous anyOf form encoding for Mixed: mixing simple and complex values',
+            );
+          }
+          if (_$values.isNotEmpty) {
+            return _$entryLists.first;
+          } else {
+            final _$map = <String, PropertyValue>{};
+            for (final _$m in _$mapValues) {
+              _$map.addAll(_$m);
+            }
+            return _$map.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
+          }
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -884,8 +1012,83 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (innerChoice != null) { switch (innerChoice!.currentEncodingShape) { case EncodingShape.simple: final _$innerChoiceForm = innerChoice!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$innerChoiceForm); _$values.add(_$innerChoiceForm.map((e) => e.value).join(',')); break; case EncodingShape.complex: final _$innerChoiceForm = innerChoice!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$innerChoiceForm); break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            final _$entryLists = <List<ParameterEntry>>[];
+            final _$values = <String>{};
+            final _$mapValues = <Map<String, PropertyValue>>[];
+            if (innerChoice != null) {
+              switch (innerChoice!.currentEncodingShape) {
+                case EncodingShape.simple:
+                  final _$innerChoiceForm = innerChoice!.toForm(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
+                    textEncoding: textEncoding,
+                  );
+                  _$entryLists.add(_$innerChoiceForm);
+                  _$values.add(_$innerChoiceForm.map((e) => e.value).join(','));
+                  break;
+                case EncodingShape.complex:
+                  final _$innerChoiceForm = innerChoice!.parameterProperties(
+                    allowEmpty: allowEmpty,
+                  );
+                  _$mapValues.add(_$innerChoiceForm);
+                  break;
+                case EncodingShape.mixed:
+                  throw EncodingException(
+                    'Cannot encode field with mixed encoding shape',
+                  );
+              }
+            }
+            if (string != null) {
+              final _$stringForm = string!.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              );
+              _$entryLists.add(_$stringForm);
+              _$values.add(_$stringForm.map((e) => e.value).join(','));
+            }
+            if (_$values.isEmpty && _$mapValues.isEmpty) {
+              return const <ParameterEntry>[];
+            }
+            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+              throw EncodingException(
+                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
+              );
+            }
+            if (_$values.isNotEmpty) {
+              return _$entryLists.first;
+            } else {
+              final _$map = <String, PropertyValue>{};
+              for (final _$m in _$mapValues) {
+                _$map.addAll(_$m);
+              }
+              return _$map.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          }
+        ''';
 
         expect(
           collapseWhitespace(generated),
@@ -939,8 +1142,83 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (innerAnyOf != null) { switch (innerAnyOf!.currentEncodingShape) { case EncodingShape.simple: final _$innerAnyOfForm = innerAnyOf!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$innerAnyOfForm); _$values.add(_$innerAnyOfForm.map((e) => e.value).join(',')); break; case EncodingShape.complex: final _$innerAnyOfForm = innerAnyOf!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$innerAnyOfForm); break; case EncodingShape.mixed: throw EncodingException( 'Cannot encode field with mixed encoding shape', ); } } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            final _$entryLists = <List<ParameterEntry>>[];
+            final _$values = <String>{};
+            final _$mapValues = <Map<String, PropertyValue>>[];
+            if (innerAnyOf != null) {
+              switch (innerAnyOf!.currentEncodingShape) {
+                case EncodingShape.simple:
+                  final _$innerAnyOfForm = innerAnyOf!.toForm(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    useQueryComponent: useQueryComponent,
+                    allowReserved: allowReserved,
+                    textEncoding: textEncoding,
+                  );
+                  _$entryLists.add(_$innerAnyOfForm);
+                  _$values.add(_$innerAnyOfForm.map((e) => e.value).join(','));
+                  break;
+                case EncodingShape.complex:
+                  final _$innerAnyOfForm = innerAnyOf!.parameterProperties(
+                    allowEmpty: allowEmpty,
+                  );
+                  _$mapValues.add(_$innerAnyOfForm);
+                  break;
+                case EncodingShape.mixed:
+                  throw EncodingException(
+                    'Cannot encode field with mixed encoding shape',
+                  );
+              }
+            }
+            if (string != null) {
+              final _$stringForm = string!.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              );
+              _$entryLists.add(_$stringForm);
+              _$values.add(_$stringForm.map((e) => e.value).join(','));
+            }
+            if (_$values.isEmpty && _$mapValues.isEmpty) {
+              return const <ParameterEntry>[];
+            }
+            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+              throw EncodingException(
+                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
+              );
+            }
+            if (_$values.isNotEmpty) {
+              return _$entryLists.first;
+            } else {
+              final _$map = <String, PropertyValue>{};
+              for (final _$m in _$mapValues) {
+                _$map.addAll(_$m);
+              }
+              return _$map.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          }
+        ''';
 
         expect(
           collapseWhitespace(generated),
@@ -984,12 +1262,81 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (myClass != null) { final _$myClassForm = myClass!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$myClassForm); } if (int != null) { final _$intForm = int!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$intForm); _$values.add(_$intForm.map((e) => e.value).join(',')); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            final _$entryLists = <List<ParameterEntry>>[];
+            final _$values = <String>{};
+            final _$mapValues = <Map<String, PropertyValue>>[];
+            if (myClass != null) {
+              final _$myClassForm = myClass!.parameterProperties(allowEmpty: allowEmpty);
+              _$mapValues.add(_$myClassForm);
+            }
+            if (int != null) {
+              final _$intForm = int!.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              );
+              _$entryLists.add(_$intForm);
+              _$values.add(_$intForm.map((e) => e.value).join(','));
+            }
+            if (string != null) {
+              final _$stringForm = string!.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              );
+              _$entryLists.add(_$stringForm);
+              _$values.add(_$stringForm.map((e) => e.value).join(','));
+            }
+            if (_$values.isEmpty && _$mapValues.isEmpty) {
+              return const <ParameterEntry>[];
+            }
+            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+              throw EncodingException(
+                r'Ambiguous anyOf form encoding for TestAnyOf: mixing simple and complex values',
+              );
+            }
+            if (_$values.isNotEmpty) {
+              return _$entryLists.first;
+            } else {
+              final _$map = <String, PropertyValue>{};
+              for (final _$m in _$mapValues) {
+                _$map.addAll(_$m);
+              }
+              return _$map.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          }
+        ''';
 
+        final toFormMethod = klass.methods.singleWhere(
+          (method) => method.name == 'toForm',
+        );
         expect(
-          collapseWhitespace(generated),
-          contains(collapseWhitespace(expected)),
+          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
+          collapseWhitespace(format(expected)),
         );
       });
 

--- a/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_form_generator_test.dart
@@ -1259,7 +1259,6 @@ void main() {
         );
 
         final klass = generator.generateClass(model);
-        final generated = format(klass.accept(emitter).toString());
 
         const expected = r'''
           @override

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -856,37 +856,47 @@ String toSimple({
         final generated = format(toFormMethod.accept(emitter).toString());
 
         const expectedMethod = r'''
-@override
-List<ParameterEntry> toForm(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-  required Encoding textEncoding,bool useQueryComponent = false,
-  bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  final _$mapValues = <Map<String, PropertyValue>>[];
-  String? _$discriminatorValue;
-  if (company != null) {
-    final _$companyForm = company!.parameterProperties(allowEmpty: allowEmpty);
-    _$mapValues.add(_$companyForm);
-    _$discriminatorValue ??= r'company';
-  }
-  if (person != null) {
-    final _$personForm = person!.parameterProperties(allowEmpty: allowEmpty);
-    _$mapValues.add(_$personForm);
-    _$discriminatorValue ??= r'person';
-  }
-  final _$map = <String, PropertyValue>{};
-  for (final _$m in _$mapValues) {
-    _$map.addAll(_$m);
-  }
-  final _$discValue = _$discriminatorValue;
-  if (_$discValue != null) {
-    _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
-  }
-  return _$map.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding,);
-}
-      ''';
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            final _$mapValues = <Map<String, PropertyValue>>[];
+            String? _$discriminatorValue;
+            if (company != null) {
+              final _$companyForm = company!.parameterProperties(allowEmpty: allowEmpty);
+              _$mapValues.add(_$companyForm);
+              _$discriminatorValue ??= r'company';
+            }
+            if (person != null) {
+              final _$personForm = person!.parameterProperties(allowEmpty: allowEmpty);
+              _$mapValues.add(_$personForm);
+              _$discriminatorValue ??= r'person';
+            }
+            final _$map = <String, PropertyValue>{};
+            for (final _$m in _$mapValues) {
+              _$map.addAll(_$m);
+            }
+            final _$discValue = _$discriminatorValue;
+            if (_$discValue != null) {
+              _$map.putIfAbsent(r'type', () => PropertyValue.scalar(_$discValue));
+            }
+            return _$map.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
+          }
+        ''';
 
         expect(generated.trim(), format(expectedMethod).trim());
       },
@@ -1145,7 +1155,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
 
       expect(
         collapseWhitespace(generated),
-        collapseWhitespace(expectedMethod),
+        collapseWhitespace(format(expectedMethod)),
       );
     });
 
@@ -2356,9 +2366,61 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final generated = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
-@override
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (map != null) { throw EncodingException('Map types cannot be form-encoded'); } if (string != null) { final _$stringForm = string!.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$stringForm); _$values.add(_$stringForm.map((e) => e.value).join(',')); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for FlexValue: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+        @override
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$entryLists = <List<ParameterEntry>>[];
+          final _$values = <String>{};
+          final _$mapValues = <Map<String, PropertyValue>>[];
+          if (map != null) {
+            throw EncodingException('Map types cannot be form-encoded');
+          }
+          if (string != null) {
+            final _$stringForm = string!.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
+            );
+            _$entryLists.add(_$stringForm);
+            _$values.add(_$stringForm.map((e) => e.value).join(','));
+          }
+          if (_$values.isEmpty && _$mapValues.isEmpty) {
+            return const <ParameterEntry>[];
+          }
+          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+            throw EncodingException(
+              r'Ambiguous anyOf form encoding for FlexValue: mixing simple and complex values',
+            );
+          }
+          if (_$values.isNotEmpty) {
+            return _$entryLists.first;
+          } else {
+            final _$map = <String, PropertyValue>{};
+            for (final _$m in _$mapValues) {
+              _$map.addAll(_$m);
+            }
+            return _$map.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
+          }
+        }
+      ''';
 
       expect(
         collapseWhitespace(generated),
@@ -2948,9 +3010,62 @@ String toSimple({
         final generated = format(toFormMethod.accept(emitter).toString());
 
         const expectedMethod = r'''
-@override
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (tonikFile != null) { final _$tonikFileForm = tonikFile!.toBase64String().toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ); _$entryLists.add(_$tonikFileForm); _$values.add(_$tonikFileForm.map((e) => e.value).join(',')); } if (text != null) { final _$textForm = text!.parameterProperties(allowEmpty: allowEmpty); _$mapValues.add(_$textForm); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for AnyOfBase64: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            final _$entryLists = <List<ParameterEntry>>[];
+            final _$values = <String>{};
+            final _$mapValues = <Map<String, PropertyValue>>[];
+            if (tonikFile != null) {
+              final _$tonikFileForm = tonikFile!.toBase64String().toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              );
+              _$entryLists.add(_$tonikFileForm);
+              _$values.add(_$tonikFileForm.map((e) => e.value).join(','));
+            }
+            if (text != null) {
+              final _$textForm = text!.parameterProperties(allowEmpty: allowEmpty);
+              _$mapValues.add(_$textForm);
+            }
+            if (_$values.isEmpty && _$mapValues.isEmpty) {
+              return const <ParameterEntry>[];
+            }
+            if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+              throw EncodingException(
+                r'Ambiguous anyOf form encoding for AnyOfBase64: mixing simple and complex values',
+              );
+            }
+            if (_$values.isNotEmpty) {
+              return _$entryLists.first;
+            } else {
+              final _$map = <String, PropertyValue>{};
+              for (final _$m in _$mapValues) {
+                _$map.addAll(_$m);
+              }
+              return _$map.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          }
+        ''';
 
         expect(generated.trim(), format(expectedMethod).trim());
       },
@@ -3074,23 +3189,29 @@ String toLabel({required bool explode, required bool allowEmpty}) {
         final generated = format(uriEncodeMethod.accept(emitter).toString());
 
         const expectedMethod = '''
-@override
-String uriEncode({ required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, }) {
-  if (tonikFile != null) {
-    return tonikFile!.toBase64String().uriEncode(
-      allowEmpty: allowEmpty,
-      textEncoding: textEncoding,useQueryComponent: useQueryComponent,
-      allowReserved: allowReserved,
-    );
-  }
-  if (text != null) {
-    throw EncodingException(
-      r'Cannot uriEncode AnyOfBase64: contains complex type',
-    );
-  }
-  throw EncodingException(r'Cannot uriEncode AnyOfBase64: no value set');
-}
-''';
+          @override
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
+            if (tonikFile != null) {
+              return tonikFile!.toBase64String().uriEncode(
+                allowEmpty: allowEmpty,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+              );
+            }
+            if (text != null) {
+              throw EncodingException(
+                r'Cannot uriEncode AnyOfBase64: contains complex type',
+              );
+            }
+            throw EncodingException(r'Cannot uriEncode AnyOfBase64: no value set');
+          }
+        ''';
 
         expect(generated.trim(), format(expectedMethod).trim());
       },
@@ -3256,9 +3377,57 @@ String toSimple({
       final generated = format(method.accept(emitter).toString());
 
       const expected = r'''
-@override
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { final _$entryLists = <List<ParameterEntry>>[]; final _$values = <String>{}; final _$mapValues = <Map<String, PropertyValue>>[]; if (object != null) { throw EncodingException( r'AnyModel variant of MixedFilter cannot be form-encoded', ); } if (detailedFilter != null) { final _$detailedFilterForm = detailedFilter!.parameterProperties( allowEmpty: allowEmpty, ); _$mapValues.add(_$detailedFilterForm); } if (_$values.isEmpty && _$mapValues.isEmpty) { return const <ParameterEntry>[]; } if (_$mapValues.isNotEmpty && _$values.isNotEmpty) { throw EncodingException( r'Ambiguous anyOf form encoding for MixedFilter: mixing simple and complex values', ); } if (_$values.isNotEmpty) { return _$entryLists.first; } else { final _$map = <String, PropertyValue>{}; for (final _$m in _$mapValues) { _$map.addAll(_$m); } return _$map.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); } }
-''';
+        @override
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          final _$entryLists = <List<ParameterEntry>>[];
+          final _$values = <String>{};
+          final _$mapValues = <Map<String, PropertyValue>>[];
+          if (object != null) {
+            throw EncodingException(
+              r'AnyModel variant of MixedFilter cannot be form-encoded',
+            );
+          }
+          if (detailedFilter != null) {
+            final _$detailedFilterForm = detailedFilter!.parameterProperties(
+              allowEmpty: allowEmpty,
+            );
+            _$mapValues.add(_$detailedFilterForm);
+          }
+          if (_$values.isEmpty && _$mapValues.isEmpty) {
+            return const <ParameterEntry>[];
+          }
+          if (_$mapValues.isNotEmpty && _$values.isNotEmpty) {
+            throw EncodingException(
+              r'Ambiguous anyOf form encoding for MixedFilter: mixing simple and complex values',
+            );
+          }
+          if (_$values.isNotEmpty) {
+            return _$entryLists.first;
+          } else {
+            final _$map = <String, PropertyValue>{};
+            for (final _$m in _$mapValues) {
+              _$map.addAll(_$m);
+            }
+            return _$map.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
+          }
+        }
+      ''';
 
       expect(generated.trim(), format(expected).trim());
     });
@@ -3364,21 +3533,26 @@ String toMatrix(
       final generated = format(method.accept(emitter).toString());
 
       const expected = '''
-@override
-String uriEncode({ required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, }) {
-  if (object != null) {
-    throw EncodingException(
-      r'AnyModel variant of MixedFilter cannot be URI encoded',
-    );
-  }
-  if (detailedFilter != null) {
-    throw EncodingException(
-      r'Cannot uriEncode MixedFilter: contains complex type',
-    );
-  }
-  throw EncodingException(r'Cannot uriEncode MixedFilter: no value set');
-}
-''';
+        @override
+        String uriEncode({
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+        }) {
+          if (object != null) {
+            throw EncodingException(
+              r'AnyModel variant of MixedFilter cannot be URI encoded',
+            );
+          }
+          if (detailedFilter != null) {
+            throw EncodingException(
+              r'Cannot uriEncode MixedFilter: contains complex type',
+            );
+          }
+          throw EncodingException(r'Cannot uriEncode MixedFilter: no value set');
+        }
+      ''';
 
       expect(generated.trim(), format(expected).trim());
     });

--- a/packages/tonik_generate/test/src/model/any_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_matrix_generator_test.dart
@@ -575,8 +575,38 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (string != null) { final _$stringMatrix = string!.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$stringMatrix); } if (_$values.isEmpty) return ''; return _$values.first; }
-''';
+          String toMatrix(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+          }) {
+            final _$values = <String>{};
+            if (list != null) {
+              final _$listMatrix = list!
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  );
+              _$values.add(_$listMatrix);
+            }
+            if (string != null) {
+              final _$stringMatrix = string!.toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+              );
+              _$values.add(_$stringMatrix);
+            }
+            if (_$values.isEmpty) return '';
+            return _$values.first;
+          }
+        ''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),
@@ -610,8 +640,38 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { final _$values = <String>{}; if (list != null) { final _$listMatrix = list! .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ); _$values.add(_$listMatrix); } if (list2 != null) { final _$list2Matrix = list2!.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ); _$values.add(_$list2Matrix); } if (_$values.isEmpty) return ''; return _$values.first; }
-''';
+          String toMatrix(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+          }) {
+            final _$values = <String>{};
+            if (list != null) {
+              final _$listMatrix = list!
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  );
+              _$values.add(_$listMatrix);
+            }
+            if (list2 != null) {
+              final _$list2Matrix = list2!.toMatrix(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+              );
+              _$values.add(_$list2Matrix);
+            }
+            if (_$values.isEmpty) return '';
+            return _$values.first;
+          }
+        ''';
         expect(
           collapseWhitespace(classCode),
           contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -220,7 +220,12 @@ void main() {
 
         const expectedUriEncode = '''
           @override
-          String uriEncode({ required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, }) {
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
             throw EncodingException(
               r'Cannot uriEncode User: complex types cannot be URI-encoded',
             );
@@ -247,7 +252,12 @@ void main() {
 
         const expectedUriEncode = '''
           @override
-          String uriEncode({ required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, }) {
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
             throw EncodingException(
               r'Cannot uriEncode Empty: complex types cannot be URI-encoded',
             );
@@ -1479,8 +1489,26 @@ factory ModelWithSimpleListRoundtrip.fromForm(
           ''';
 
           const expectedToFormMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+            List<ParameterEntry> toForm(
+              String paramName, {
+              required bool explode,
+              required bool allowEmpty,
+              required Encoding textEncoding,
+              bool useQueryComponent = false,
+              bool allowReserved = false,
+              Map<String, FormFieldEncoding> fieldEncodings = const {},
+            }) {
+              return parameterProperties(allowEmpty: allowEmpty).toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          ''';
 
           const expectedParameterPropertiesMethod = r'''
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
@@ -1614,14 +1642,34 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final result = generator.generateClass(model);
 
         const expectedToFormBody = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {},  }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, );
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return parameterProperties(allowEmpty: allowEmpty).toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
           }
         ''';
 
+        final toFormMethod = result.methods.singleWhere(
+          (method) => method.name == 'toForm',
+        );
         expect(
-          collapseWhitespace(result.accept(emitter).toString()),
-          contains(collapseWhitespace(expectedToFormBody)),
+          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
+          collapseWhitespace(format(expectedToFormBody)),
         );
       });
 
@@ -1652,14 +1700,34 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final result = generator.generateClass(model);
 
         const expectedToFormBody = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {},  }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, );
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return parameterProperties(allowEmpty: allowEmpty).toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
           }
         ''';
 
+        final toFormMethod = result.methods.singleWhere(
+          (method) => method.name == 'toForm',
+        );
         expect(
-          collapseWhitespace(result.accept(emitter).toString()),
-          contains(collapseWhitespace(expectedToFormBody)),
+          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
+          collapseWhitespace(format(expectedToFormBody)),
         );
       });
 
@@ -1675,14 +1743,34 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final result = generator.generateClass(model);
 
         const expectedToFormMethod = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {},  }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, );
+          @override
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return parameterProperties(allowEmpty: allowEmpty).toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              fieldEncodings: fieldEncodings,
+              textEncoding: textEncoding,
+            );
           }
         ''';
 
+        final toFormMethod = result.methods.singleWhere(
+          (method) => method.name == 'toForm',
+        );
         expect(
-          collapseWhitespace(result.accept(emitter).toString()),
-          contains(collapseWhitespace(expectedToFormMethod)),
+          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
+          collapseWhitespace(format(expectedToFormMethod)),
         );
       });
 
@@ -1923,14 +2011,36 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
           final result = generator.generateClass(model);
 
           const expectedToFormMethod = '''
-          List<ParameterEntry> toForm(String paramName, {required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String,FormFieldEncoding> fieldEncodings = const {},  }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, );
-          }
-        ''';
+            @override
+            List<ParameterEntry> toForm(
+              String paramName, {
+              required bool explode,
+              required bool allowEmpty,
+              required Encoding textEncoding,
+              bool useQueryComponent = false,
+              bool allowReserved = false,
+              Map<String, FormFieldEncoding> fieldEncodings = const {},
+            }) {
+              return parameterProperties(allowEmpty: allowEmpty).toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              );
+            }
+          ''';
 
+          final toFormMethod = result.methods.singleWhere(
+            (method) => method.name == 'toForm',
+          );
           expect(
-            collapseWhitespace(result.accept(emitter).toString()),
-            contains(collapseWhitespace(expectedToFormMethod)),
+            collapseWhitespace(
+              format(toFormMethod.accept(emitter).toString()),
+            ),
+            collapseWhitespace(format(expectedToFormMethod)),
           );
         },
       );

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -429,8 +429,26 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return parameterProperties(allowEmpty: allowEmpty).toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ); }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          return parameterProperties(allowEmpty: allowEmpty).toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+            fieldEncodings: fieldEncodings,
+            textEncoding: textEncoding,
+          );
+        }
+      ''';
 
       expect(
         collapseWhitespace(classCode),

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -15,6 +15,8 @@ void main() {
     languageVersion: DartFormatter.latestLanguageVersion,
   ).format;
 
+  String formatBody(String body) => format('void test() {$body}');
+
   String formatConstructor(Constructor constructor, String className) {
     final clazz = Class(
       (b) => b
@@ -2304,9 +2306,19 @@ void main() {
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return _$rawValue.toForm(paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding);
+          return _$rawValue.toForm(
+            paramName,
+            explode: explode,
+            allowEmpty: allowEmpty,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+            textEncoding: textEncoding,
+          );
         ''';
-        expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
+        expect(
+          collapseWhitespace(formatBody(body)),
+          collapseWhitespace(formatBody(expectedBody)),
+        );
       });
 
       test('uses custom fallback name from nameOverride', () {
@@ -2437,9 +2449,17 @@ void main() {
           if (this == Status.unknown) {
             throw EncodingException(r'Cannot encode unknown enum value');
           }
-          return _$rawValue.uriEncode(allowEmpty: allowEmpty, textEncoding: textEncoding, useQueryComponent: useQueryComponent, allowReserved: allowReserved);
+          return _$rawValue.uriEncode(
+            allowEmpty: allowEmpty,
+            textEncoding: textEncoding,
+            useQueryComponent: useQueryComponent,
+            allowReserved: allowReserved,
+          );
         ''';
-        expect(collapseWhitespace(body), collapseWhitespace(expectedBody));
+        expect(
+          collapseWhitespace(formatBody(body)),
+          collapseWhitespace(formatBody(expectedBody)),
+        );
       });
 
       test('toMatrix throws when encoding fallback case', () {

--- a/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_form_generator_test.dart
@@ -55,21 +55,31 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Result');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
           return switch (this) {
             ResultError(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             ),
             ResultSuccess(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             ),
           };
         }
@@ -122,8 +132,40 @@ void main() {
       final baseClass = classes.firstWhere((c) => c.name == 'Response');
 
       const expectedMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return switch (this) { ResponseMessage(:final value) => value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ), ResponseUser(:final value) => { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'user'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ), }; }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          return switch (this) {
+            ResponseMessage(:final value) => value.toForm(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              useQueryComponent: useQueryComponent,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
+            ),
+            ResponseUser(:final value) =>
+              {
+                ...value.parameterProperties(allowEmpty: allowEmpty),
+                r'type': PropertyValue.scalar(r'user'),
+              }.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                fieldEncodings: fieldEncodings,
+                textEncoding: textEncoding,
+              ),
+          };
+        }
+      ''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -442,14 +484,23 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
           return switch (this) {
             OuterInner(:final value) => value.toForm(
               paramName,
               explode: explode,
               allowEmpty: allowEmpty,
               useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
+              allowReserved: allowReserved,
+              textEncoding: textEncoding,
             ),
           };
         }
@@ -507,8 +558,41 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
       final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
       const expectedMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return switch (this) { OuterInner(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'inner'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ), }; }
-''';
+        List<ParameterEntry> toForm(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+          required Encoding textEncoding,
+          bool useQueryComponent = false,
+          bool allowReserved = false,
+          Map<String, FormFieldEncoding> fieldEncodings = const {},
+        }) {
+          return switch (this) {
+            OuterInner(:final value) =>
+              value.currentEncodingShape == EncodingShape.complex
+                  ? {
+                      ...value.parameterProperties(allowEmpty: allowEmpty),
+                      r'type': PropertyValue.scalar(r'inner'),
+                    }.toForm(
+                      paramName,
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved: allowReserved,
+                      fieldEncodings: fieldEncodings,
+                      textEncoding: textEncoding,
+                    )
+                  : value.toForm(
+                      paramName,
+                      explode: explode,
+                      allowEmpty: allowEmpty,
+                      useQueryComponent: useQueryComponent,
+                      allowReserved: allowReserved,
+                      textEncoding: textEncoding,
+                    ),
+          };
+        }
+      ''';
 
       expect(
         collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -595,8 +679,63 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final baseClass = classes.firstWhere((c) => c.name == 'Outer');
 
         const expectedMethod = '''
-List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) { return switch (this) { OuterInnerA(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'a'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ), OuterInnerB(:final value) => value.currentEncodingShape == EncodingShape.complex ? { ...value.parameterProperties(allowEmpty: allowEmpty), r'type': PropertyValue.scalar(r'b'), }.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding, ) : value.toForm( paramName, explode: explode, allowEmpty: allowEmpty, useQueryComponent: useQueryComponent, allowReserved: allowReserved, textEncoding: textEncoding, ), }; }
-''';
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return switch (this) {
+              OuterInnerA(:final value) =>
+                value.currentEncodingShape == EncodingShape.complex
+                    ? {
+                        ...value.parameterProperties(allowEmpty: allowEmpty),
+                        r'type': PropertyValue.scalar(r'a'),
+                      }.toForm(
+                        paramName,
+                        explode: explode,
+                        allowEmpty: allowEmpty,
+                        useQueryComponent: useQueryComponent,
+                        allowReserved: allowReserved,
+                        fieldEncodings: fieldEncodings,
+                        textEncoding: textEncoding,
+                      )
+                    : value.toForm(
+                        paramName,
+                        explode: explode,
+                        allowEmpty: allowEmpty,
+                        useQueryComponent: useQueryComponent,
+                        allowReserved: allowReserved,
+                        textEncoding: textEncoding,
+                      ),
+              OuterInnerB(:final value) =>
+                value.currentEncodingShape == EncodingShape.complex
+                    ? {
+                        ...value.parameterProperties(allowEmpty: allowEmpty),
+                        r'type': PropertyValue.scalar(r'b'),
+                      }.toForm(
+                        paramName,
+                        explode: explode,
+                        allowEmpty: allowEmpty,
+                        useQueryComponent: useQueryComponent,
+                        allowReserved: allowReserved,
+                        fieldEncodings: fieldEncodings,
+                        textEncoding: textEncoding,
+                      )
+                    : value.toForm(
+                        paramName,
+                        explode: explode,
+                        allowEmpty: allowEmpty,
+                        useQueryComponent: useQueryComponent,
+                        allowReserved: allowReserved,
+                        textEncoding: textEncoding,
+                      ),
+            };
+          }
+        ''';
 
         expect(
           collapseWhitespace(format(baseClass.accept(emitter).toString())),
@@ -630,21 +769,30 @@ List<ParameterEntry> toForm( String paramName, { required bool explode, required
         final generated = format(baseClass.accept(emitter).toString());
 
         const expectedMethod = '''
-        List<ParameterEntry> toForm( String paramName, { required bool explode, required bool allowEmpty, required Encoding textEncoding, bool useQueryComponent = false, bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},  }) {
-          return switch (this) {
-            WithBinaryBinary() => throw EncodingException(
-              'Binary data cannot be form-encoded',
-            ),
-            WithBinaryText(:final value) => value.toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved, textEncoding: textEncoding,
-            ),
-          };
-        }
-      ''';
+          List<ParameterEntry> toForm(
+            String paramName, {
+            required bool explode,
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+            Map<String, FormFieldEncoding> fieldEncodings = const {},
+          }) {
+            return switch (this) {
+              WithBinaryBinary() => throw EncodingException(
+                'Binary data cannot be form-encoded',
+              ),
+              WithBinaryText(:final value) => value.toForm(
+                paramName,
+                explode: explode,
+                allowEmpty: allowEmpty,
+                useQueryComponent: useQueryComponent,
+                allowReserved: allowReserved,
+                textEncoding: textEncoding,
+              ),
+            };
+          }
+        ''';
 
         expect(
           collapseWhitespace(generated),

--- a/packages/tonik_generate/test/src/model/one_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_generator_test.dart
@@ -2032,22 +2032,26 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
                 String paramName, {
                 required bool explode,
                 required bool allowEmpty,
-                required Encoding textEncoding, bool useQueryComponent = false,
-                bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+                required Encoding textEncoding,
+                bool useQueryComponent = false,
+                bool allowReserved = false,
+                Map<String, FormFieldEncoding> fieldEncodings = const {},
               }) {
                 return switch (this) {
                   ValueList(:final value) => value.toForm(
                     paramName,
                     explode: explode,
                     allowEmpty: allowEmpty,
-                    useQueryComponent: useQueryComponent, textEncoding: textEncoding,
+                    useQueryComponent: useQueryComponent,
+                    textEncoding: textEncoding,
                   ),
                   ValueStr(:final value) => value.toForm(
                     paramName,
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
-                    allowReserved: allowReserved, textEncoding: textEncoding,
+                    allowReserved: allowReserved,
+                    textEncoding: textEncoding,
                   ),
                 };
               }
@@ -2101,8 +2105,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
                 String paramName, {
                 required bool explode,
                 required bool allowEmpty,
-                required Encoding textEncoding, bool useQueryComponent = false,
-                bool allowReserved = false, Map<String, FormFieldEncoding> fieldEncodings = const {},
+                required Encoding textEncoding,
+                bool useQueryComponent = false,
+                bool allowReserved = false,
+                Map<String, FormFieldEncoding> fieldEncodings = const {},
               }) {
                 return switch (this) {
                   ValueList() => throw EncodingException(
@@ -2113,7 +2119,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
                     explode: explode,
                     allowEmpty: allowEmpty,
                     useQueryComponent: useQueryComponent,
-                    allowReserved: allowReserved, textEncoding: textEncoding,
+                    allowReserved: allowReserved,
+                    textEncoding: textEncoding,
                   ),
                 };
               }
@@ -4043,11 +4050,17 @@ bool operator ==(Object other) {
 
         const expectedMethod = '''
           @override
-          String uriEncode({ required bool allowEmpty, required Encoding textEncoding,bool useQueryComponent = false, bool allowReserved = false, }) {
+          String uriEncode({
+            required bool allowEmpty,
+            required Encoding textEncoding,
+            bool useQueryComponent = false,
+            bool allowReserved = false,
+          }) {
             return switch (this) {
               ValueBase64(:final value) => value.toBase64String().uriEncode(
                 allowEmpty: allowEmpty,
-                textEncoding: textEncoding,useQueryComponent: useQueryComponent,
+                textEncoding: textEncoding,
+                useQueryComponent: useQueryComponent,
                 allowReserved: allowReserved,
               ),
               ValueText() => throw EncodingException(

--- a/packages/tonik_generate/test/src/model/one_of_matrix_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/one_of_matrix_generator_test.dart
@@ -663,8 +663,32 @@ void main() {
 
       // For List<int>, should map each element to string then call toMatrix
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrIntListList(:final value) => value .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrIntListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
-''';
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          return switch (this) {
+            StringOrIntListList(:final value) =>
+              value
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  ),
+            StringOrIntListString(:final value) => value.toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+            ),
+          };
+        }
+      ''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -698,8 +722,32 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
       // For List<DateTime>, should map each element to string then
       // call toMatrix
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrDateTimeListList(:final value) => value .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrDateTimeListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
-''';
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          return switch (this) {
+            StringOrDateTimeListList(:final value) =>
+              value
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  ),
+            StringOrDateTimeListString(:final value) => value.toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+            ),
+          };
+        }
+      ''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -741,8 +789,32 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
 
       // For List<Enum>, should map each element to string then call toMatrix
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringOrEnumListList(:final value) => value .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringOrEnumListString(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
-''';
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          return switch (this) {
+            StringOrEnumListList(:final value) =>
+              value
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  ),
+            StringOrEnumListString(:final value) => value.toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+            ),
+          };
+        }
+      ''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),
@@ -835,8 +907,32 @@ String toMatrix( String paramName, { required bool explode, required bool allowE
       final generated = format(baseClass.accept(emitter).toString());
 
       const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return switch (this) { StringListOrIntListList(:final value) => value .map<String>( (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8), ) .toList() .toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true, ), StringListOrIntListListModel(:final value) => value.toMatrix( paramName, explode: explode, allowEmpty: allowEmpty, ), }; }
-''';
+        String toMatrix(
+          String paramName, {
+          required bool explode,
+          required bool allowEmpty,
+        }) {
+          return switch (this) {
+            StringListOrIntListList(:final value) =>
+              value
+                  .map<String>(
+                    (e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+                  )
+                  .toList()
+                  .toMatrix(
+                    paramName,
+                    explode: explode,
+                    allowEmpty: allowEmpty,
+                    alreadyEncoded: true,
+                  ),
+            StringListOrIntListListModel(:final value) => value.toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+            ),
+          };
+        }
+      ''';
       expect(
         collapseWhitespace(generated),
         contains(collapseWhitespace(expectedMethod)),

--- a/packages/tonik_generate/test/src/operation/cookie_parameter_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/cookie_parameter_generator_test.dart
@@ -456,7 +456,12 @@ void main() {
             if (optionalSession != null) {
               _$cookieParts.addAll(
                 optionalSession
-                    .toForm( r'optional_session', explode: false, allowEmpty: true, textEncoding: utf8, )
+                    .toForm(
+                      r'optional_session',
+                      explode: false,
+                      allowEmpty: true,
+                      textEncoding: utf8,
+                    )
                     .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}'),
               );
             }

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -1250,7 +1250,13 @@ void main() {
         const expectedMethod = r'''
           Object? _data({required Pet body}) {
             return body
-                .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
+                .toForm(
+                  '',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  textEncoding: utf8,
+                )
                 .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                 .join('&');
           }
@@ -1370,7 +1376,13 @@ Object? _data({required String body}) {
           Object? _data({Pet? body}) {
             if (body == null) return null;
             return body
-                .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
+                .toForm(
+                  '',
+                  explode: true,
+                  allowEmpty: true,
+                  useQueryComponent: true,
+                  textEncoding: utf8,
+                )
                 .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                 .join('&');
           }
@@ -1620,7 +1632,13 @@ Object? _data({required String body}) {
           const expectedMethod = r'''
             Object? _data({required PlainForm body}) {
               return body
-                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
+                  .toForm(
+                    '',
+                    explode: true,
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                    textEncoding: utf8,
+                  )
                   .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                   .join('&');
             }
@@ -2420,7 +2438,13 @@ Object? _data({required String body}) {
           const expectedMethod = r'''
             Object? _data({required ReadOnlyForm body}) {
               return body
-                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
+                  .toForm(
+                    '',
+                    explode: true,
+                    allowEmpty: true,
+                    useQueryComponent: true,
+                    textEncoding: utf8,
+                  )
                   .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
                   .join('&');
             }
@@ -3042,10 +3066,17 @@ Object? _data({required String body}) {
           Object? _data({required CreateUser body}) {
             return switch (body) {
               final CreateUserJson value => value.value.toJson(),
-              final CreateUserXWwwFormUrlencoded value => value.value
-                  .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
-                  .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
-                  .join('&'),
+              final CreateUserXWwwFormUrlencoded value =>
+                value.value
+                    .toForm(
+                      '',
+                      explode: true,
+                      allowEmpty: true,
+                      useQueryComponent: true,
+                      textEncoding: utf8,
+                    )
+                    .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                    .join('&'),
             };
           }
         ''';
@@ -3117,10 +3148,17 @@ Object? _data({required String body}) {
               if (body == null) return null;
               return switch (body) {
                 final UpdateItemJson value => value.value.toJson(),
-                final UpdateItemXWwwFormUrlencoded value => value.value
-                    .toForm('', explode: true, allowEmpty: true, useQueryComponent: true, textEncoding: utf8,)
-                    .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
-                    .join('&'),
+                final UpdateItemXWwwFormUrlencoded value =>
+                  value.value
+                      .toForm(
+                        '',
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      )
+                      .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                      .join('&'),
               };
             }
           ''';

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -1173,10 +1173,21 @@ void main() {
     );
 
     const expectedMethod = '''
-        List<String> _path({required List<int> ids}) {
-          return [r'data', ids.map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8, )).toList().toMatrix(r'ids', explode: true, allowEmpty: false, alreadyEncoded: true, ), ];
-        }
-      ''';
+      List<String> _path({required List<int> ids}) {
+        return [
+          r'data',
+          ids
+              .map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
+              .toList()
+              .toMatrix(
+                r'ids',
+                explode: true,
+                allowEmpty: false,
+                alreadyEncoded: true,
+              ),
+        ];
+      }
+    ''';
 
     final pathParameters =
         <({String normalizedName, PathParameterObject parameter})>[
@@ -1196,8 +1207,8 @@ void main() {
       ),
     );
     expect(
-      collapseWhitespace(method.accept(emitter).toString()),
-      collapseWhitespace(expectedMethod),
+      collapseWhitespace(format(method.accept(emitter).toString())),
+      collapseWhitespace(format(expectedMethod)),
     );
   });
 
@@ -1253,10 +1264,21 @@ void main() {
     );
 
     const expectedMethod = '''
-        List<String> _path({required List<AnonymousModel> statuses}) {
-          return [r'data', statuses.map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8, )).toList().toMatrix(r'statuses', explode: true, allowEmpty: false, alreadyEncoded: true, ), ];
-        }
-      ''';
+      List<String> _path({required List<AnonymousModel> statuses}) {
+        return [
+          r'data',
+          statuses
+              .map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
+              .toList()
+              .toMatrix(
+                r'statuses',
+                explode: true,
+                allowEmpty: false,
+                alreadyEncoded: true,
+              ),
+        ];
+      }
+    ''';
 
     final pathParameters =
         <({String normalizedName, PathParameterObject parameter})>[
@@ -1276,8 +1298,8 @@ void main() {
       ),
     );
     expect(
-      collapseWhitespace(method.accept(emitter).toString()),
-      collapseWhitespace(expectedMethod),
+      collapseWhitespace(format(method.accept(emitter).toString())),
+      collapseWhitespace(format(expectedMethod)),
     );
   });
 

--- a/packages/tonik_generate/test/src/operation/query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/query_generator_test.dart
@@ -168,12 +168,21 @@ void main() {
         String? _queryParameters({AnonymousModel? filter}) {
           final _$entries = <ParameterEntry>[];
           if (filter != null) {
-            _$entries.addAll(filter.toForm(r'filter', explode: false, allowEmpty: true, textEncoding: utf8,),);
+            _$entries.addAll(
+              filter.toForm(
+                r'filter',
+                explode: false,
+                allowEmpty: true,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -743,7 +752,14 @@ void main() {
         String? _queryParameters({AnonymousModel? filter, List<String>? tags}) {
           final _$entries = <ParameterEntry>[];
           if (filter != null) {
-            _$entries.addAll(filter.toForm(r'filter', explode: true, allowEmpty: true, textEncoding: utf8,),);
+            _$entries.addAll(
+              filter.toForm(
+                r'filter',
+                explode: true,
+                allowEmpty: true,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (tags != null) {
             for (final value in tags.toSpaceDelimited(
@@ -756,7 +772,9 @@ void main() {
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -820,11 +838,20 @@ void main() {
       const expectedMethod = r'''
         String? _queryParameters({required AnonymousModel filter}) {
           final _$entries = <ParameterEntry>[];
-          _$entries.addAll(filter.toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8,),);
+          _$entries.addAll(
+            filter.toForm(
+              r'filter',
+              explode: false,
+              allowEmpty: false,
+              textEncoding: utf8,
+            ),
+          );
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -888,12 +915,21 @@ void main() {
         String? _queryParameters({AnonymousModel? filter}) {
           final _$entries = <ParameterEntry>[];
           if (filter != null) {
-            _$entries.addAll(filter.toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              filter.toForm(
+                r'filter',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -1009,21 +1045,46 @@ void main() {
         }) {
           final _$entries = <ParameterEntry>[];
           if (name != null) {
-            _$entries.addAll(name.toForm(r'name', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              name.toForm(
+                r'name',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (tags != null) {
-            _$entries.addAll(tags.toForm(r'tags', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              tags.toForm(
+                r'tags',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (age != null) {
-            _$entries.addAll(age.toForm(r'age', explode: false, allowEmpty: false, textEncoding: utf8),);
+            _$entries.addAll(
+              age.toForm(r'age', explode: false, allowEmpty: false, textEncoding: utf8),
+            );
           }
           if (active != null) {
-            _$entries.addAll(active.toForm(r'active', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              active.toForm(
+                r'active',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -1111,15 +1172,31 @@ void main() {
         String? _queryParameters({AnonymousModel? filter, AnonymousModel2? range}) {
           final _$entries = <ParameterEntry>[];
           if (filter != null) {
-            _$entries.addAll(filter.toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              filter.toForm(
+                r'filter',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (range != null) {
-            _$entries.addAll(range.toForm(r'range', explode: false, allowEmpty: false, textEncoding: utf8,),);
+            _$entries.addAll(
+              range.toForm(
+                r'range',
+                explode: false,
+                allowEmpty: false,
+                textEncoding: utf8,
+              ),
+            );
           }
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -1281,37 +1358,48 @@ void main() {
         }) {
           final _$entries = <ParameterEntry>[];
           if (color != null) {
-            _$entries.addAll(color.toForm(r'color', explode: false, allowEmpty: true, textEncoding: utf8,),);
+            _$entries.addAll(
+              color.toForm(
+                r'color',
+                explode: false,
+                allowEmpty: true,
+                textEncoding: utf8,
+              ),
+            );
           }
           _$entries.addAll(
             value.toDeepObject(r'value', explode: false, allowEmpty: true),
           );
           if (ids != null) {
-            for (final value in ids
-                .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8))
-                .toList()
-                .toSpaceDelimited(
-              explode: false,
-              allowEmpty: true,
-                  alreadyEncoded: true,
-                )) {
+            for (final value
+                in ids
+                    .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8))
+                    .toList()
+                    .toSpaceDelimited(
+                      explode: false,
+                      allowEmpty: true,
+                      alreadyEncoded: true,
+                    )) {
               _$entries.add((name: r'ids', value: value));
             }
           }
-          for (final value in categories
-              .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8))
-              .toList()
-              .toPipeDelimited(
-            explode: false,
-            allowEmpty: true,
-                alreadyEncoded: true,
-          )) {
+          for (final value
+              in categories
+                  .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8))
+                  .toList()
+                  .toPipeDelimited(
+                    explode: false,
+                    allowEmpty: true,
+                    alreadyEncoded: true,
+                  )) {
             _$entries.add((name: r'categories', value: value));
           }
           if (_$entries.isEmpty) {
             return null;
           }
-          return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
         }
       ''';
 
@@ -1388,25 +1476,28 @@ void main() {
       );
 
       const expectedMethod = r'''
-         String? _queryParameters({required List<AnonymousModel> colors}) {
-            final _$entries = <ParameterEntry>[];
-            _$entries.addAll(
-              colors
-                  .map((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
-                  .toList()
-                  .toForm(
-                    r'colors',
-                    explode: true,
-                    allowEmpty: false,
-                    textEncoding: utf8,alreadyEncoded: true,
-                  ),
-            );
-            if (_$entries.isEmpty) {
-              return null;
-            }
-            return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+        String? _queryParameters({required List<AnonymousModel> colors}) {
+          final _$entries = <ParameterEntry>[];
+          _$entries.addAll(
+            colors
+                .map((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
+                .toList()
+                .toForm(
+                  r'colors',
+                  explode: true,
+                  allowEmpty: false,
+                  textEncoding: utf8,
+                  alreadyEncoded: true,
+                ),
+          );
+          if (_$entries.isEmpty) {
+            return null;
           }
-        ''';
+          return _$entries
+              .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+              .join('&');
+        }
+      ''';
 
       final queryParameters =
           <({String normalizedName, QueryParameterObject parameter})>[
@@ -1646,31 +1737,34 @@ void main() {
         );
 
         const expectedMethod = r'''
-           String? _queryParameters({required List<MixedOneOf> values}) {
-             final _$entries = <ParameterEntry>[];
-             for (final item in values) {
-               if (item.currentEncodingShape != EncodingShape.simple) {
-                 throw EncodingException(
-                   r'Parameter values: pipeDelimited encoding requires simple encoding shape',
-                 );
-               }
-             }
-             for (final value in values
-                 .map((item) => item.uriEncode(allowEmpty: false, textEncoding: utf8))
-                 .toList()
-                 .toPipeDelimited(
-                   explode: false,
-                   allowEmpty: false,
-                   alreadyEncoded: true,
-                 )) {
-               _$entries.add((name: r'values', value: value));
-             }
-             if (_$entries.isEmpty) {
-               return null;
-             }
-             return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
-           }
-         ''';
+          String? _queryParameters({required List<MixedOneOf> values}) {
+            final _$entries = <ParameterEntry>[];
+            for (final item in values) {
+              if (item.currentEncodingShape != EncodingShape.simple) {
+                throw EncodingException(
+                  r'Parameter values: pipeDelimited encoding requires simple encoding shape',
+                );
+              }
+            }
+            for (final value
+                in values
+                    .map((item) => item.uriEncode(allowEmpty: false, textEncoding: utf8))
+                    .toList()
+                    .toPipeDelimited(
+                      explode: false,
+                      allowEmpty: false,
+                      alreadyEncoded: true,
+                    )) {
+              _$entries.add((name: r'values', value: value));
+            }
+            if (_$entries.isEmpty) {
+              return null;
+            }
+            return _$entries
+                .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                .join('&');
+          }
+        ''';
 
         final queryParameters =
             <({String normalizedName, QueryParameterObject parameter})>[
@@ -1750,22 +1844,27 @@ void main() {
         );
 
         const expectedMethod = r'''
-           String? _queryParameters({required List<SimpleOneOf> items}) {
-             final _$entries = <ParameterEntry>[];
-             for (final item in items) {
-               if (item.currentEncodingShape != EncodingShape.simple) {
-                 throw EncodingException(
-                   r'Parameter items: spaceDelimited encoding requires simple encoding shape',
-                 );
-               }
-               _$entries.add((name: r'items', value: item.uriEncode(allowEmpty: false, textEncoding: utf8),));
-             }
-             if (_$entries.isEmpty) {
-               return null;
-             }
-             return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
-           }
-         ''';
+          String? _queryParameters({required List<SimpleOneOf> items}) {
+            final _$entries = <ParameterEntry>[];
+            for (final item in items) {
+              if (item.currentEncodingShape != EncodingShape.simple) {
+                throw EncodingException(
+                  r'Parameter items: spaceDelimited encoding requires simple encoding shape',
+                );
+              }
+              _$entries.add((
+                name: r'items',
+                value: item.uriEncode(allowEmpty: false, textEncoding: utf8),
+              ));
+            }
+            if (_$entries.isEmpty) {
+              return null;
+            }
+            return _$entries
+                .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                .join('&');
+          }
+        ''';
 
         final queryParameters =
             <({String normalizedName, QueryParameterObject parameter})>[
@@ -2482,13 +2581,16 @@ void main() {
                 r'tags',
                 explode: false,
                 allowEmpty: false,
-                textEncoding: utf8,allowReserved: true,
+                textEncoding: utf8,
+                allowReserved: true,
               ),
             );
             if (_$entries.isEmpty) {
               return null;
             }
-            return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+            return _$entries
+                .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}')
+                .join('&');
           }
         ''';
 

--- a/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_delimited_query_parameter_expression_generator_test.dart
@@ -669,14 +669,21 @@ void main() {
           collapseWhitespace(
             format(r'''
               void test() {
-                for (final value in ids
-                    .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8,allowReserved: true,),)
-                    .toList()
-                    .toSpaceDelimited(
-                      explode: false,
-                      allowEmpty: true,
-                      alreadyEncoded: true,
-                    )) {
+                for (final value
+                    in ids
+                        .map(
+                          (e) => e.uriEncode(
+                            allowEmpty: true,
+                            textEncoding: utf8,
+                            allowReserved: true,
+                          ),
+                        )
+                        .toList()
+                        .toSpaceDelimited(
+                          explode: false,
+                          allowEmpty: true,
+                          alreadyEncoded: true,
+                        )) {
                   _$entries.add((name: r'ids', value: value));
                 }
               }
@@ -716,18 +723,23 @@ void main() {
             collapseWhitespace(
               format(r'''
                 void test() {
-                  for (final value in tags
-                      .map(
-                        (e) => e == null
-                            ? ''
-                            : e.uriEncode(allowEmpty: true, textEncoding: utf8,allowReserved: true,),
-                      )
-                      .toList()
-                      .toSpaceDelimited(
-                        explode: false,
-                        allowEmpty: true,
-                        alreadyEncoded: true,
-                      )) {
+                  for (final value
+                      in tags
+                          .map(
+                            (e) => e == null
+                                ? ''
+                                : e.uriEncode(
+                                    allowEmpty: true,
+                                    textEncoding: utf8,
+                                    allowReserved: true,
+                                  ),
+                          )
+                          .toList()
+                          .toSpaceDelimited(
+                            explode: false,
+                            allowEmpty: true,
+                            alreadyEncoded: true,
+                          )) {
                     _$entries.add((name: r'tags', value: value));
                   }
                 }
@@ -768,18 +780,23 @@ void main() {
             collapseWhitespace(
               format(r'''
                 void test() {
-                  for (final value in tags
-                      .map(
-                        (e) => e == null
-                            ? ''
-                            : e.uriEncode(allowEmpty: true, textEncoding: utf8,allowReserved: true,),
-                      )
-                      .toList()
-                      .toPipeDelimited(
-                        explode: false,
-                        allowEmpty: true,
-                        alreadyEncoded: true,
-                      )) {
+                  for (final value
+                      in tags
+                          .map(
+                            (e) => e == null
+                                ? ''
+                                : e.uriEncode(
+                                    allowEmpty: true,
+                                    textEncoding: utf8,
+                                    allowReserved: true,
+                                  ),
+                          )
+                          .toList()
+                          .toPipeDelimited(
+                            explode: false,
+                            allowEmpty: true,
+                            alreadyEncoded: true,
+                          )) {
                     _$entries.add((name: r'tags', value: value));
                   }
                 }
@@ -826,19 +843,26 @@ void main() {
             collapseWhitespace(code),
             collapseWhitespace(
               format(r'''
-              void test() {
-                for (final value in priorities
-                    .map((e) => e.uriEncode(allowEmpty: true, textEncoding: utf8,allowReserved: true,),)
-                    .toList()
-                    .toSpaceDelimited(
-                      explode: false,
-                      allowEmpty: true,
-                      alreadyEncoded: true,
-                    )) {
-                  _$entries.add((name: r'priorities', value: value));
+                void test() {
+                  for (final value
+                      in priorities
+                          .map(
+                            (e) => e.uriEncode(
+                              allowEmpty: true,
+                              textEncoding: utf8,
+                              allowReserved: true,
+                            ),
+                          )
+                          .toList()
+                          .toSpaceDelimited(
+                            explode: false,
+                            allowEmpty: true,
+                            alreadyEncoded: true,
+                          )) {
+                    _$entries.add((name: r'priorities', value: value));
+                  }
                 }
-              }
-            '''),
+              '''),
             ),
           );
         },
@@ -894,14 +918,21 @@ void main() {
                     );
                   }
                 }
-                for (final value in items
-                    .map((item) => item.uriEncode(allowEmpty: true, textEncoding: utf8,allowReserved: true,),)
-                    .toList()
-                    .toSpaceDelimited(
-                      explode: false,
-                      allowEmpty: true,
-                      alreadyEncoded: true,
-                    )) {
+                for (final value
+                    in items
+                        .map(
+                          (item) => item.uriEncode(
+                            allowEmpty: true,
+                            textEncoding: utf8,
+                            allowReserved: true,
+                          ),
+                        )
+                        .toList()
+                        .toSpaceDelimited(
+                          explode: false,
+                          allowEmpty: true,
+                          alreadyEncoded: true,
+                        )) {
                   _$entries.add((name: r'items', value: value));
                 }
               }

--- a/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_label_parameter_expression_generator_test.dart
@@ -209,7 +209,10 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8)).toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value
+            .map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8))
+            .toList()
+            .toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(
@@ -234,7 +237,14 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => e == null ? '' : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),).toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value
+            .map(
+              (e) => e == null
+                  ? ''
+                  : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+            )
+            .toList()
+            .toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(
@@ -259,7 +269,14 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => e == null ? '' : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),).toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value
+            .map(
+              (e) => e == null
+                  ? ''
+                  : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+            )
+            .toList()
+            .toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(
@@ -319,7 +336,10 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8)).toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value
+            .map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8))
+            .toList()
+            .toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(
@@ -478,7 +498,10 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty, textEncoding: utf8)).toList().toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
+        final result = value
+            .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty, textEncoding: utf8))
+            .toList()
+            .toLabel(explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true);
       ''';
 
       expect(
@@ -605,7 +628,7 @@ void main() {
 
       expect(
         collapseWhitespace(generated),
-        collapseWhitespace(expected),
+        collapseWhitespace(format(expected)),
       );
     });
 

--- a/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_matrix_parameter_expression_generator_test.dart
@@ -217,7 +217,15 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map<String>((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8)).toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true,);
+        final result = value
+            .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8))
+            .toList()
+            .toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              alreadyEncoded: true,
+            );
       ''';
 
       expect(
@@ -243,7 +251,19 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map<String>((e) => e == null ? '' : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),).toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true,);
+        final result = value
+            .map<String>(
+              (e) => e == null
+                  ? ''
+                  : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+            )
+            .toList()
+            .toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              alreadyEncoded: true,
+            );
       ''';
 
       expect(
@@ -269,7 +289,19 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map<String>((e) => e == null ? '' : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),).toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true,);
+        final result = value
+            .map<String>(
+              (e) => e == null
+                  ? ''
+                  : e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8),
+            )
+            .toList()
+            .toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              alreadyEncoded: true,
+            );
       ''';
 
       expect(
@@ -331,7 +363,15 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map<String>((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8)).toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true,);
+        final result = value
+            .map<String>((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8))
+            .toList()
+            .toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              alreadyEncoded: true,
+            );
       ''';
 
       expect(
@@ -495,7 +535,17 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.map<String>((e) => encodeAnyToUri(e, allowEmpty: allowEmpty, textEncoding: utf8),).toList().toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, alreadyEncoded: true,);
+        final result = value
+            .map<String>(
+              (e) => encodeAnyToUri(e, allowEmpty: allowEmpty, textEncoding: utf8),
+            )
+            .toList()
+            .toMatrix(
+              paramName,
+              explode: explode,
+              allowEmpty: allowEmpty,
+              alreadyEncoded: true,
+            );
       ''';
 
       expect(
@@ -629,7 +679,7 @@ void main() {
 
         expect(
           collapseWhitespace(generated),
-          collapseWhitespace(expected),
+          collapseWhitespace(format(expected)),
         );
       },
     );

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -156,12 +156,20 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            _$formData.files.add(MapEntry(r'name', MultipartFile.fromBytes(latin1.encode(body.name), contentType: DioMediaType.parse(r'text/plain; charset=us-ascii'))));
-            return _$formData;
-          }
-        '''),
+            void test() {
+              final _$formData = FormData();
+              _$formData.files.add(
+                MapEntry(
+                  r'name',
+                  MultipartFile.fromBytes(
+                    latin1.encode(body.name),
+                    contentType: DioMediaType.parse(r'text/plain; charset=us-ascii'),
+                  ),
+                ),
+              );
+              return _$formData;
+            }
+          '''),
         ),
       );
     });
@@ -5306,14 +5314,14 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              throw EncodingException(
-                r"deepObject style is not supported for map multipart properties (property: it's-meta). Maps do not implement ParameterEncodable.toDeepObject().",
-              );
-              return _$formData;
-            }
-          '''),
+              void test() {
+                final _$formData = FormData();
+                throw EncodingException(
+                  r"deepObject style is not supported for map multipart properties (property: it's-meta). Maps do not implement ParameterEncodable.toDeepObject().",
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },
@@ -5375,41 +5383,48 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              final metadataParts = <String>[];
-              for (final entry in ((body.metadata as Map)).entries) {
-                final value = entry.value;
-                if (value == null) continue;
-                if (value is Map || value is List) {
-                  throw EncodingException(
-                    'Standard URL encoding does not support nested values (property: ' r'metadata' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+              void test() {
+                final _$formData = FormData();
+                final metadataParts = <String>[];
+                for (final entry in ((body.metadata as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: '
+                      r'metadata'
+                      ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  metadataParts.add(
+                    [
+                      entry.key.toString().uriEncode(
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                      encodeAnyToForm(
+                        value,
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                    ].join('='),
                   );
                 }
-                metadataParts.add(
-                  [
-                    entry.key.toString().uriEncode( allowEmpty: true, useQueryComponent: true, textEncoding: utf8,),
-                    encodeAnyToForm(
-                      value,
-                      explode: true,
-                      allowEmpty: true,
-                      useQueryComponent: true,
-                    textEncoding: utf8,),
-                  ].join('='),
-                );
-              }
-              _$formData.files.add(MapEntry(
-                r'metadata',
-                MultipartFile.fromString(
-                  metadataParts.join('&'),
-                  contentType: DioMediaType.parse(
-                    r'application/x-www-form-urlencoded'),
+                _$formData.files.add(
+                  MapEntry(
+                    r'metadata',
+                    MultipartFile.fromString(
+                      metadataParts.join('&'),
+                      contentType: DioMediaType.parse(r'application/x-www-form-urlencoded'),
+                    ),
                   ),
-                ),
-              );
-              return _$formData;
-            }
-          '''),
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },
@@ -5471,43 +5486,50 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              if (body.metadata != null) {
-                final metadataParts = <String>[];
-                for (final entry in ((body.metadata! as Map)).entries) {
-                  final value = entry.value;
-                  if (value == null) continue;
-                  if (value is Map || value is List) {
-                    throw EncodingException(
-                      'Standard URL encoding does not support nested values (property: ' r'metadata' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+              void test() {
+                final _$formData = FormData();
+                if (body.metadata != null) {
+                  final metadataParts = <String>[];
+                  for (final entry in ((body.metadata! as Map)).entries) {
+                    final value = entry.value;
+                    if (value == null) continue;
+                    if (value is Map || value is List) {
+                      throw EncodingException(
+                        'Standard URL encoding does not support nested values (property: '
+                        r'metadata'
+                        ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                      );
+                    }
+                    metadataParts.add(
+                      [
+                        entry.key.toString().uriEncode(
+                          allowEmpty: true,
+                          useQueryComponent: true,
+                          textEncoding: utf8,
+                        ),
+                        encodeAnyToForm(
+                          value,
+                          explode: true,
+                          allowEmpty: true,
+                          useQueryComponent: true,
+                          textEncoding: utf8,
+                        ),
+                      ].join('='),
                     );
                   }
-                  metadataParts.add(
-                    [
-                      entry.key.toString().uriEncode( allowEmpty: true, useQueryComponent: true, textEncoding: utf8,),
-                      encodeAnyToForm(
-                        value,
-                        explode: true,
-                        allowEmpty: true,
-                        useQueryComponent: true,
-                      textEncoding: utf8,),
-                    ].join('='),
+                  _$formData.files.add(
+                    MapEntry(
+                      r'metadata',
+                      MultipartFile.fromString(
+                        metadataParts.join('&'),
+                        contentType: DioMediaType.parse(r'application/x-www-form-urlencoded'),
+                      ),
+                    ),
                   );
                 }
-                _$formData.files.add(MapEntry(
-                  r'metadata',
-                  MultipartFile.fromString(
-                    metadataParts.join('&'),
-                    contentType: DioMediaType.parse(
-                      r'application/x-www-form-urlencoded'),
-                    ),
-                  ),
-                );
+                return _$formData;
               }
-              return _$formData;
-            }
-          '''),
+            '''),
           ),
         );
       },
@@ -5570,41 +5592,48 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              final itsMetaParts = <String>[];
-              for (final entry in ((body.itsMeta as Map)).entries) {
-                final value = entry.value;
-                if (value == null) continue;
-                if (value is Map || value is List) {
-                  throw EncodingException(
-                    'Standard URL encoding does not support nested values (property: ' r"it's-meta" ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+              void test() {
+                final _$formData = FormData();
+                final itsMetaParts = <String>[];
+                for (final entry in ((body.itsMeta as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: '
+                      r"it's-meta"
+                      ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  itsMetaParts.add(
+                    [
+                      entry.key.toString().uriEncode(
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                      encodeAnyToForm(
+                        value,
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                    ].join('='),
                   );
                 }
-                itsMetaParts.add(
-                  [
-                    entry.key.toString().uriEncode( allowEmpty: true, useQueryComponent: true, textEncoding: utf8,),
-                    encodeAnyToForm(
-                      value,
-                      explode: true,
-                      allowEmpty: true,
-                      useQueryComponent: true,
-                    textEncoding: utf8,),
-                  ].join('='),
-                );
-              }
-              _$formData.files.add(MapEntry(
-                r"it's-meta",
-                MultipartFile.fromString(
-                  itsMetaParts.join('&'),
-                  contentType: DioMediaType.parse(
-                    r'application/x-www-form-urlencoded'),
+                _$formData.files.add(
+                  MapEntry(
+                    r"it's-meta",
+                    MultipartFile.fromString(
+                      itsMetaParts.join('&'),
+                      contentType: DioMediaType.parse(r'application/x-www-form-urlencoded'),
+                    ),
                   ),
-                ),
-              );
-              return _$formData;
-            }
-          '''),
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },
@@ -5667,41 +5696,48 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              final pathBackslashToParts = <String>[];
-              for (final entry in ((body.pathBackslashTo as Map)).entries) {
-                final value = entry.value;
-                if (value == null) continue;
-                if (value is Map || value is List) {
-                  throw EncodingException(
-                    'Standard URL encoding does not support nested values (property: ' r'path\to' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+              void test() {
+                final _$formData = FormData();
+                final pathBackslashToParts = <String>[];
+                for (final entry in ((body.pathBackslashTo as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: '
+                      r'path\to'
+                      ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  pathBackslashToParts.add(
+                    [
+                      entry.key.toString().uriEncode(
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                      encodeAnyToForm(
+                        value,
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                    ].join('='),
                   );
                 }
-                pathBackslashToParts.add(
-                  [
-                    entry.key.toString().uriEncode( allowEmpty: true, useQueryComponent: true, textEncoding: utf8,),
-                    encodeAnyToForm(
-                      value,
-                      explode: true,
-                      allowEmpty: true,
-                      useQueryComponent: true,
-                    textEncoding: utf8,),
-                  ].join('='),
-                );
-              }
-              _$formData.files.add(MapEntry(
-                r'path\to',
-                MultipartFile.fromString(
-                  pathBackslashToParts.join('&'),
-                  contentType: DioMediaType.parse(
-                    r'application/x-www-form-urlencoded'),
+                _$formData.files.add(
+                  MapEntry(
+                    r'path\to',
+                    MultipartFile.fromString(
+                      pathBackslashToParts.join('&'),
+                      contentType: DioMediaType.parse(r'application/x-www-form-urlencoded'),
+                    ),
                   ),
-                ),
-              );
-              return _$formData;
-            }
-          '''),
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },
@@ -5764,41 +5800,48 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-            void test() {
-              final _$formData = FormData();
-              final $totalParts = <String>[];
-              for (final entry in ((body.$total as Map)).entries) {
-                final value = entry.value;
-                if (value == null) continue;
-                if (value is Map || value is List) {
-                  throw EncodingException(
-                    'Standard URL encoding does not support nested values (property: ' r'$total' ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+              void test() {
+                final _$formData = FormData();
+                final $totalParts = <String>[];
+                for (final entry in ((body.$total as Map)).entries) {
+                  final value = entry.value;
+                  if (value == null) continue;
+                  if (value is Map || value is List) {
+                    throw EncodingException(
+                      'Standard URL encoding does not support nested values (property: '
+                      r'$total'
+                      ', key: ${entry.key}). Only flat key=value pairs are allowed.',
+                    );
+                  }
+                  $totalParts.add(
+                    [
+                      entry.key.toString().uriEncode(
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                      encodeAnyToForm(
+                        value,
+                        explode: true,
+                        allowEmpty: true,
+                        useQueryComponent: true,
+                        textEncoding: utf8,
+                      ),
+                    ].join('='),
                   );
                 }
-                $totalParts.add(
-                  [
-                    entry.key.toString().uriEncode( allowEmpty: true, useQueryComponent: true, textEncoding: utf8,),
-                    encodeAnyToForm(
-                      value,
-                      explode: true,
-                      allowEmpty: true,
-                      useQueryComponent: true,
-                    textEncoding: utf8,),
-                  ].join('='),
-                );
-              }
-              _$formData.files.add(MapEntry(
-                r'$total',
-                MultipartFile.fromString(
-                  $totalParts.join('&'),
-                  contentType: DioMediaType.parse(
-                    r'application/x-www-form-urlencoded'),
+                _$formData.files.add(
+                  MapEntry(
+                    r'$total',
+                    MultipartFile.fromString(
+                      $totalParts.join('&'),
+                      contentType: DioMediaType.parse(r'application/x-www-form-urlencoded'),
+                    ),
                   ),
-                ),
-              );
-              return _$formData;
-            }
-          '''),
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },
@@ -6069,12 +6112,21 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            _$formData.fields.add(MapEntry(r'tags', body.tags.uriEncode(allowEmpty: true, textEncoding: utf8,alreadyEncoded: true,),),);
-            return _$formData;
-          }
-        '''),
+            void test() {
+              final _$formData = FormData();
+              _$formData.fields.add(
+                MapEntry(
+                  r'tags',
+                  body.tags.uriEncode(
+                    allowEmpty: true,
+                    textEncoding: utf8,
+                    alreadyEncoded: true,
+                  ),
+                ),
+              );
+              return _$formData;
+            }
+          '''),
         ),
       );
     });
@@ -6406,14 +6458,19 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            for (final item in body.statuses) {
-              _$formData.fields.add(MapEntry(r'statuses', item.uriEncode(allowEmpty: true, textEncoding: utf8),),);
+            void test() {
+              final _$formData = FormData();
+              for (final item in body.statuses) {
+                _$formData.fields.add(
+                  MapEntry(
+                    r'statuses',
+                    item.uriEncode(allowEmpty: true, textEncoding: utf8),
+                  ),
+                );
+              }
+              return _$formData;
             }
-            return _$formData;
-          }
-        '''),
+          '''),
         ),
       );
     });
@@ -6482,12 +6539,24 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            _$formData.fields.add(MapEntry(r'codes', body.codes.map((item) => item.uriEncode(allowEmpty: true, textEncoding: utf8)).toList().uriEncode(allowEmpty: true, textEncoding: utf8,alreadyEncoded: true,),),);
-            return _$formData;
-          }
-        '''),
+            void test() {
+              final _$formData = FormData();
+              _$formData.fields.add(
+                MapEntry(
+                  r'codes',
+                  body.codes
+                      .map((item) => item.uriEncode(allowEmpty: true, textEncoding: utf8))
+                      .toList()
+                      .uriEncode(
+                        allowEmpty: true,
+                        textEncoding: utf8,
+                        alreadyEncoded: true,
+                      ),
+                ),
+              );
+              return _$formData;
+            }
+          '''),
         ),
       );
     });
@@ -6674,12 +6743,24 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            _$formData.fields.add(MapEntry(r'scores', body.scores.map((item) => jsonEncode(item)).toList().uriEncode(allowEmpty: true, textEncoding: utf8,alreadyEncoded: true,),),);
-            return _$formData;
-          }
-        '''),
+            void test() {
+              final _$formData = FormData();
+              _$formData.fields.add(
+                MapEntry(
+                  r'scores',
+                  body.scores
+                      .map((item) => jsonEncode(item))
+                      .toList()
+                      .uriEncode(
+                        allowEmpty: true,
+                        textEncoding: utf8,
+                        alreadyEncoded: true,
+                      ),
+                ),
+              );
+              return _$formData;
+            }
+          '''),
         ),
       );
     });
@@ -7881,14 +7962,19 @@ $expectedPartCode
             collapseWhitespace(code),
             collapseWhitespace(
               format(r'''
-              void test() {
-                final _$formData = FormData();
-                for (final item in body.priorities) {
-                  _$formData.fields.add(MapEntry(r'priorities', item.uriEncode(allowEmpty: true, textEncoding: utf8),),);
+                void test() {
+                  final _$formData = FormData();
+                  for (final item in body.priorities) {
+                    _$formData.fields.add(
+                      MapEntry(
+                        r'priorities',
+                        item.uriEncode(allowEmpty: true, textEncoding: utf8),
+                      ),
+                    );
+                  }
+                  return _$formData;
                 }
-                return _$formData;
-              }
-            '''),
+              '''),
             ),
           );
         },
@@ -9368,14 +9454,28 @@ $expectedPartCode
         collapseWhitespace(code),
         collapseWhitespace(
           format(r'''
-          void test() {
-            final _$formData = FormData();
-            final _$tagsHeaders = <String, List<String>>{};
-            _$tagsHeaders[r'X-Custom'] = [tagsCustom.toSimple(explode: false, allowEmpty: true),];
-            _$formData.files.add(MapEntry(r'tags', MultipartFile.fromString(body.tags.uriEncode(allowEmpty: true, textEncoding: utf8,alreadyEncoded: true,), headers: _$tagsHeaders,),),);
-            return _$formData;
-          }
-        '''),
+            void test() {
+              final _$formData = FormData();
+              final _$tagsHeaders = <String, List<String>>{};
+              _$tagsHeaders[r'X-Custom'] = [
+                tagsCustom.toSimple(explode: false, allowEmpty: true),
+              ];
+              _$formData.files.add(
+                MapEntry(
+                  r'tags',
+                  MultipartFile.fromString(
+                    body.tags.uriEncode(
+                      allowEmpty: true,
+                      textEncoding: utf8,
+                      alreadyEncoded: true,
+                    ),
+                    headers: _$tagsHeaders,
+                  ),
+                ),
+              );
+              return _$formData;
+            }
+          '''),
         ),
       );
     });
@@ -10192,14 +10292,31 @@ $expectedPartCode
           collapseWhitespace(code),
           collapseWhitespace(
             format(r'''
-          void test() {
-            final _$formData = FormData();
-            final _$datesHeaders = <String, List<String>>{};
-            _$datesHeaders[r'X-Custom'] = [datesCustom.toSimple(explode: false, allowEmpty: true),];
-            _$formData.files.add(MapEntry(r'dates', MultipartFile.fromString(body.dates.map((item) => item.toTimeZonedIso8601String()).toList().uriEncode(allowEmpty: true, textEncoding: utf8,alreadyEncoded: true,), headers: _$datesHeaders,),),);
-            return _$formData;
-          }
-        '''),
+              void test() {
+                final _$formData = FormData();
+                final _$datesHeaders = <String, List<String>>{};
+                _$datesHeaders[r'X-Custom'] = [
+                  datesCustom.toSimple(explode: false, allowEmpty: true),
+                ];
+                _$formData.files.add(
+                  MapEntry(
+                    r'dates',
+                    MultipartFile.fromString(
+                      body.dates
+                          .map((item) => item.toTimeZonedIso8601String())
+                          .toList()
+                          .uriEncode(
+                            allowEmpty: true,
+                            textEncoding: utf8,
+                            alreadyEncoded: true,
+                          ),
+                      headers: _$datesHeaders,
+                    ),
+                  ),
+                );
+                return _$formData;
+              }
+            '''),
           ),
         );
       },

--- a/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/uri_encode_expression_generator_test.dart
@@ -56,7 +56,11 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,);
+        final result = value.uriEncode(
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+          allowReserved: true,
+        );
       ''';
 
       expect(
@@ -87,7 +91,11 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,);
+        final result = value.uriEncode(
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+          allowReserved: true,
+        );
       ''';
 
       expect(
@@ -114,7 +122,11 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,);
+        final result = value.uriEncode(
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+          allowReserved: true,
+        );
       ''';
 
       expect(
@@ -264,7 +276,10 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.toBase64String().uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,);
+        final result = value.toBase64String().uriEncode(
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+        );
       ''';
 
       expect(
@@ -462,7 +477,11 @@ void main() {
 
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
-        final result = value.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,);
+        final result = value.uriEncode(
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+          allowReserved: true,
+        );
       ''';
 
       expect(
@@ -516,9 +535,15 @@ void main() {
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
         final result = value
-            .map((e) => e.uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,),)
+            .map(
+              (e) => e.uriEncode(
+                allowEmpty: allowEmpty,
+                textEncoding: utf8,
+                allowReserved: true,
+              ),
+            )
             .toList()
-            .uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true);
+            .uriEncode(allowEmpty: allowEmpty, textEncoding: utf8, allowReserved: true);
       ''';
 
       expect(
@@ -718,9 +743,16 @@ void main() {
       final generated = format('final result = ${expression.accept(emitter)};');
       const expected = '''
         final result = value
-            .map((e) => encodeAnyToUri(e, allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true,),)
+            .map(
+              (e) => encodeAnyToUri(
+                e,
+                allowEmpty: allowEmpty,
+                textEncoding: utf8,
+                allowReserved: true,
+              ),
+            )
             .toList()
-            .uriEncode(allowEmpty: allowEmpty, textEncoding: utf8,allowReserved: true);
+            .uriEncode(allowEmpty: allowEmpty, textEncoding: utf8, allowReserved: true);
       ''';
 
       expect(
@@ -1025,7 +1057,7 @@ void main() {
 
         expect(
           collapseWhitespace(generated),
-          collapseWhitespace(expected),
+          collapseWhitespace(format(expected)),
         );
       },
     );


### PR DESCRIPTION
## Summary

- format generated Dart expectations as readable multiline code
- canonicalize formatter-sensitive comparisons on both sides
- compare generated methods directly where class-level formatting changes wrapping

## Testing

- `fvm dart test test` from `packages/tonik_generate`