### PR TITLE
ci: remove integration test sharding

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -82,14 +82,13 @@ jobs:
           retention-days: 1
 
   analyze-generated:
-    name: Analyze (${{ matrix.backend }}, shard ${{ matrix.shard }})
+    name: Analyze (${{ matrix.backend }})
     needs: generate-integration
     runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
         backend: [dio, http]
-        shard: [0, 1, 2]
 
     steps:
       - uses: actions/checkout@v7
@@ -107,12 +106,12 @@ jobs:
       - name: Extract generated code (${{ matrix.backend }})
         run: tar -xzf generated-integration-code.tar.gz
 
-      - name: Analyze packages (${{ matrix.backend }}, shard ${{ matrix.shard }})
+      - name: Analyze packages (${{ matrix.backend }})
         shell: bash
-        run: ./scripts/analyze_integration_packages.sh "${{ matrix.backend }}" "${{ matrix.shard }}"
+        run: ./scripts/analyze_integration_packages.sh "${{ matrix.backend }}"
 
   test:
-    name: Test (${{ matrix.backend }}, ${{ matrix.os }}, Dart ${{ matrix.sdk }}, shard ${{ matrix.shard }})
+    name: Test (${{ matrix.backend }}, ${{ matrix.os }}, Dart ${{ matrix.sdk }})
     needs: generate-integration
     runs-on: ${{ matrix.os }}
     strategy:
@@ -121,7 +120,6 @@ jobs:
         backend: [dio, http]
         os: [ubuntu-latest, macos-latest, windows-latest]
         sdk: [stable, beta]
-        shard: [0, 1, 2]
         exclude:
           - os: macos-latest
             sdk: beta
@@ -161,9 +159,9 @@ jobs:
             ${{ runner.os }}-dart-${{ matrix.sdk }}-
             ${{ runner.os }}-dart-
 
-      - name: Run integration tests (${{ matrix.backend }}, shard ${{ matrix.shard }})
+      - name: Run integration tests (${{ matrix.backend }})
         shell: bash
-        run: ./scripts/test_integration_packages.sh "${{ matrix.backend }}" "${{ matrix.shard }}"
+        run: ./scripts/test_integration_packages.sh "${{ matrix.backend }}"
 
   dependencies:
     name: Dependencies (${{ matrix.backend }}, ubuntu-latest, Dart stable)

--- a/scripts/analyze_integration_packages.sh
+++ b/scripts/analyze_integration_packages.sh
@@ -4,42 +4,28 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/integration_package_utils.sh"
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 dio|http shard" >&2
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 dio|http" >&2
   exit 64
 fi
 
 backend="$1"
-shard="$2"
 validate_integration_backend "$backend"
-validate_integration_shard "$shard"
 discover_integration_packages "$backend"
+
+if [ ! -d "$INTEGRATION_TEST_ROOT/test_helpers" ]; then
+  echo "Error: integration test helper package is missing." >&2
+  exit 1
+fi
 
 all_packages=(
   "${GENERATED_INTEGRATION_PACKAGES[@]}"
   "${INTEGRATION_TEST_PACKAGES[@]}"
+  integration_test/test_helpers
 )
-shard_packages=()
-for index in "${!all_packages[@]}"; do
-  if [ $((index % 3)) -eq "$shard" ]; then
-    shard_packages+=("${all_packages[$index]}")
-  fi
-done
 
-if [ "$shard" -eq 0 ]; then
-  if [ ! -d "$INTEGRATION_TEST_ROOT/test_helpers" ]; then
-    echo "Error: integration test helper package is missing." >&2
-    exit 1
-  fi
-  shard_packages+=(integration_test/test_helpers)
-fi
-if [ "${#shard_packages[@]}" -eq 0 ]; then
-  echo "Error: analysis shard $shard is empty for $backend." >&2
-  exit 1
-fi
-
-echo "Analysis shard: backend=$backend shard=$shard packages=${#shard_packages[@]}"
-for package_dir in "${shard_packages[@]}"; do
+echo "Analysis: backend=$backend packages=${#all_packages[@]}"
+for package_dir in "${all_packages[@]}"; do
   echo "Analyzing $package_dir"
   (
     cd "$INTEGRATION_REPO_ROOT/$package_dir"

--- a/scripts/integration_package_utils.sh
+++ b/scripts/integration_package_utils.sh
@@ -14,17 +14,6 @@ validate_integration_backend() {
   fi
 }
 
-validate_integration_shard() {
-  local shard="$1"
-  case "$shard" in
-    0 | 1 | 2) ;;
-    *)
-      echo "Error: shard must be 0, 1, or 2." >&2
-      exit 64
-      ;;
-  esac
-}
-
 discover_integration_packages() {
   local backend="$1"
 

--- a/scripts/test_integration_packages.sh
+++ b/scripts/test_integration_packages.sh
@@ -4,30 +4,17 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "$SCRIPT_DIR/integration_package_utils.sh"
 
-if [ "$#" -ne 2 ]; then
-  echo "Usage: $0 dio|http shard" >&2
+if [ "$#" -ne 1 ]; then
+  echo "Usage: $0 dio|http" >&2
   exit 64
 fi
 
 backend="$1"
-shard="$2"
 validate_integration_backend "$backend"
-validate_integration_shard "$shard"
 discover_integration_packages "$backend"
 
-shard_packages=()
-for index in "${!INTEGRATION_TEST_PACKAGES[@]}"; do
-  if [ $((index % 3)) -eq "$shard" ]; then
-    shard_packages+=("${INTEGRATION_TEST_PACKAGES[$index]}")
-  fi
-done
-if [ "${#shard_packages[@]}" -eq 0 ]; then
-  echo "Error: test shard $shard is empty for $backend." >&2
-  exit 1
-fi
-
-echo "Test shard: backend=$backend shard=$shard packages=${#shard_packages[@]}"
-for package_dir in "${shard_packages[@]}"; do
+echo "Tests: backend=$backend packages=${#INTEGRATION_TEST_PACKAGES[@]}"
+for package_dir in "${INTEGRATION_TEST_PACKAGES[@]}"; do
   echo "Testing $package_dir"
   (
     cd "$INTEGRATION_REPO_ROOT/$package_dir"


### PR DESCRIPTION
Remove the three-way shard matrices from integration tests and generated-code analysis to reduce runner usage. The integration workflow now schedules 20 jobs instead of 40, preserving all backend, OS, and Dart-version combinations.

The analysis and test scripts now process every package in one run, and the unused shard validation helper is removed.

Validation:
- Workflow YAML parses and expands to 20 jobs.
- Shell syntax and `git diff --check` pass.
- With Dart stubbed, both backends analyze all 85 packages and test all 40 test packages exactly once.
- Full integration tests were not run locally.
