### PR TITLE
ci: download Imposter directly in test jobs

### DIFF
--- a/.github/workflows/integration_tests.yml
+++ b/.github/workflows/integration_tests.yml
@@ -45,20 +45,13 @@ jobs:
             ${{ runner.os }}-dart-${{ matrix.sdk }}-
             ${{ runner.os }}-dart-
 
-      - name: Cache Imposter JAR
-        uses: actions/cache@v6
-        with:
-          path: integration_test/imposter.jar
-          key: imposter-4.6.8
-          restore-keys: imposter-
-
       - name: Install dependencies
         run: |
           dart pub global activate melos
           melos bootstrap
 
       - name: Generate integration test code (${{ matrix.backend }})
-        run: ./scripts/setup_integration_tests.sh --backend "${{ matrix.backend }}"
+        run: ./scripts/setup_integration_tests.sh --backend "${{ matrix.backend }}" --skip-imposter
         shell: bash
 
       - name: Archive generated code (${{ matrix.backend }})
@@ -70,14 +63,6 @@ jobs:
         with:
           name: generated-integration-code-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
           path: generated-integration-code.tar.gz
-          compression-level: 0
-          retention-days: 1
-
-      - name: Upload Imposter JAR (${{ matrix.backend }})
-        uses: actions/upload-artifact@v7
-        with:
-          name: imposter-jar-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
-          path: integration_test/imposter.jar
           compression-level: 0
           retention-days: 1
 
@@ -146,10 +131,8 @@ jobs:
         shell: bash
 
       - name: Download Imposter JAR (${{ matrix.backend }})
-        uses: actions/download-artifact@v8
-        with:
-          name: imposter-jar-${{ matrix.backend }}-${{ matrix.os }}-${{ matrix.sdk }}
-          path: integration_test
+        run: bash ./scripts/setup_imposter.sh
+        shell: bash
 
       - name: Cache Dart pub dependencies
         uses: actions/cache@v6

--- a/scripts/setup_imposter.sh
+++ b/scripts/setup_imposter.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+IMPOSTER_JAR="$REPO_ROOT/integration_test/imposter.jar"
+
+if ! command -v java >/dev/null 2>&1; then
+  echo "Error: Java is not installed. Please install Java to run the tests." >&2
+  exit 1
+fi
+
+JAVA_VERSION="$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')"
+JAVA_MAJOR="$(printf '%s' "$JAVA_VERSION" | cut -d. -f1)"
+if [ "$JAVA_MAJOR" -lt 11 ]; then
+  echo "Error: Java 11 or higher is required. Found version $JAVA_VERSION" >&2
+  exit 1
+fi
+
+if [ ! -f "$IMPOSTER_JAR" ]; then
+  echo "Downloading Imposter JAR..."
+  trap 'rm -f "$IMPOSTER_JAR.part"' EXIT
+  curl -fL --retry 3 \
+    https://github.com/imposter-project/imposter-jvm-engine/releases/download/v4.6.8/imposter-4.6.8.jar \
+    -o "$IMPOSTER_JAR.part"
+  mv "$IMPOSTER_JAR.part" "$IMPOSTER_JAR"
+fi
+
+if ! java -jar "$IMPOSTER_JAR" --version >/dev/null 2>&1; then
+  echo "Error: failed to execute Imposter JAR." >&2
+  exit 1
+fi

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -2,13 +2,27 @@
 set -euo pipefail
 
 BACKEND="dio"
-if [ "$#" -gt 0 ]; then
-  if [ "$#" -ne 2 ] || [ "$1" != "--backend" ]; then
-    echo "Usage: $0 [--backend dio|http]" >&2
-    exit 64
-  fi
-  BACKEND="$2"
-fi
+SKIP_IMPOSTER=false
+while [ "$#" -gt 0 ]; do
+  case "$1" in
+    --backend)
+      if [ "$#" -lt 2 ]; then
+        echo "Error: --backend requires dio or http." >&2
+        exit 64
+      fi
+      BACKEND="$2"
+      shift 2
+      ;;
+    --skip-imposter)
+      SKIP_IMPOSTER=true
+      shift
+      ;;
+    *)
+      echo "Usage: $0 [--backend dio|http] [--skip-imposter]" >&2
+      exit 64
+      ;;
+  esac
+done
 
 if [ "$BACKEND" != "dio" ] && [ "$BACKEND" != "http" ]; then
   echo "Error: backend must be either 'dio' or 'http'." >&2
@@ -19,18 +33,6 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATION_TEST_DIR="$REPO_ROOT/integration_test"
 TONIK_BINARY="$REPO_ROOT/.dart_tool/tonik_compiled"
-
-if ! command -v java >/dev/null 2>&1; then
-  echo "Error: Java is not installed. Please install Java to run the tests." >&2
-  exit 1
-fi
-
-JAVA_VERSION="$(java -version 2>&1 | awk -F '"' '/version/ {print $2}')"
-JAVA_MAJOR="$(printf '%s' "$JAVA_VERSION" | cut -d. -f1)"
-if [ "$JAVA_MAJOR" -lt 11 ]; then
-  echo "Error: Java 11 or higher is required. Found version $JAVA_VERSION" >&2
-  exit 1
-fi
 
 if command -v nproc >/dev/null 2>&1; then
   SETUP_JOBS="$(nproc)"
@@ -234,16 +236,8 @@ PUB_GET_COMMANDS+=("cd 'test_helpers' && dart pub get")
 echo "Resolving dependencies for 44 generated, 40 test, and 1 helper package..."
 run_commands "$SETUP_JOBS" "${PUB_GET_COMMANDS[@]}"
 
-if [ ! -f imposter.jar ]; then
-  echo "Downloading Imposter JAR..."
-  curl -fL \
-    https://github.com/imposter-project/imposter-jvm-engine/releases/download/v4.6.8/imposter-4.6.8.jar \
-    -o imposter.jar
-fi
-
-if ! java -jar imposter.jar --version >/dev/null 2>&1; then
-  echo "Error: failed to execute Imposter JAR." >&2
-  exit 1
+if [ "$SKIP_IMPOSTER" = false ]; then
+  bash "$SCRIPT_DIR/setup_imposter.sh"
 fi
 
 echo "Setup complete: backend=$BACKEND generated=$generated_count tests=${#TEST_DIRS[@]}"


### PR DESCRIPTION
The integration generation matrix uploads eight identical 90.8 MiB Imposter JARs per workflow run, in addition to caching the JAR. Remove those artifact uploads and the Imposter cache, saving about 726 MiB of artifact storage per run.

Each integration test job now downloads the pinned 4.6.8 JAR directly from the upstream release server through a shared setup script. Downloads retry transient failures and remove incomplete files. Generation jobs skip Imposter and Java checks; local integration setup still prepares and validates Imposter by default.

Validation: Bash syntax checks, workflow YAML parsing, and git diff whitespace checks passed. Focused checks covered the pinned download URL and retries, paths containing spaces, reuse of an existing local JAR, cleanup after download failure, and invalid setup arguments. The upstream URL returned HTTP 200. Full integration tests will run in PR CI.
