### PR TITLE
refactor: share object parameter encoding across generated models

### DIFF
--- a/integration_test/defaulted/defaulted_test/test/defaulted_test.dart
+++ b/integration_test/defaulted/defaulted_test/test/defaulted_test.dart
@@ -20,6 +20,15 @@ void main() {
   });
 
   group('DefaultedPrimitives — primitive const defaults', () {
+    test('const defaults feed the inherited parameter encoder', () {
+      const ParameterEncodable value = DefaultedPrimitives();
+      expect(value, isA<ObjectParameterEncodable>());
+      expect(
+        value.toSimple(explode: true, allowEmpty: false),
+        'name=anon,count=0,rate=1.5,active=true,title=Mx.',
+      );
+    });
+
     test('constructor with no args yields all defaults', () {
       const value = DefaultedPrimitives();
       expect(value.name, 'anon');

--- a/integration_test/immutable_collections/immutable_collections_test/test/filters_defaults_test.dart
+++ b/integration_test/immutable_collections/immutable_collections_test/test/filters_defaults_test.dart
@@ -1,8 +1,46 @@
+import 'dart:convert';
+
 import 'package:fast_immutable_collections/fast_immutable_collections.dart';
 import 'package:immutable_collections_api/immutable_collections_api.dart';
 import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 void main() {
+  test(
+    'inherited form encoding reads an immutable array from the model hook',
+    () {
+      const ObjectParameterEncodable value = ItemSummary(
+        id: 1,
+        name: 'item',
+        categories: IListConst(['a,b', 'c']),
+      );
+      expect(
+        value.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: false,
+          textEncoding: utf8,
+        ),
+        [
+          (name: 'id', value: '1'),
+          (name: 'name', value: 'item'),
+          (name: 'categories', value: 'a%2Cb,c'),
+        ],
+      );
+    },
+  );
+
+  test('inherited encoding reads immutable additional properties', () {
+    const ObjectParameterEncodable value = BucketWithExtras(
+      label: 'primary',
+      additionalProperties: IMapConst({'x': 1}),
+    );
+    expect(
+      value.toSimple(explode: true, allowEmpty: false),
+      'label=primary,x=1',
+    );
+  });
+
   group('Filters — collection const defaults under immutableCollections', () {
     test('defaults are IListConst / IMapConst typed', () {
       const value = Filters();

--- a/integration_test/naming/naming_test/test/naming_test.dart
+++ b/integration_test/naming/naming_test/test/naming_test.dart
@@ -15,6 +15,7 @@ import 'package:naming_api/src/model/keyword_enum.dart';
 import 'package:naming_api/src/model/keyword_property_names.dart';
 import 'package:naming_api/src/model/multipart_name_collision_form.dart';
 import 'package:naming_api/src/model/object_method_collider.dart';
+import 'package:naming_api/src/model/object_parameter_encodable.dart' as naming;
 import 'package:naming_api/src/model/self_referencer.dart';
 import 'package:naming_api/src/model/simple_result.dart';
 import 'package:naming_api/src/model/user.dart';
@@ -283,7 +284,38 @@ void main() {
     });
   });
 
+  test(
+    'schema named ObjectParameterEncodable inherits the runtime superclass',
+    () {
+      const model = naming.ObjectParameterEncodable(value: 'a/b');
+      const ParameterEncodable parameter = model;
+      expect(model, isA<ObjectParameterEncodable>());
+      expect(model.toSimple(explode: true, allowEmpty: false), 'value=a%2Fb');
+      expect(
+        parameter.toLabel(explode: false, allowEmpty: false),
+        '.value,a%2Fb',
+      );
+      expect(model.toJson(), {'value': 'a/b'});
+    },
+  );
+
   group('generated method name collisions', () {
+    test('inherited encoding dispatches to the hook beside escaped fields', () {
+      const model = GeneratedMethodCollider(
+        $toSimple: 'method',
+        $parameterProperties: 'field',
+      );
+      expect(model.$parameterProperties, 'field');
+      expect(model.parameterProperties().keys, [
+        'toSimple',
+        'parameterProperties',
+      ]);
+      expect(
+        model.toSimple(explode: true, allowEmpty: false),
+        'toSimple=method,parameterProperties=field',
+      );
+    });
+
     test('GeneratedMethodCollider has escaped field names', () {
       const model = GeneratedMethodCollider(
         $call: 'invoke',

--- a/integration_test/naming/openapi.yaml
+++ b/integration_test/naming/openapi.yaml
@@ -1970,3 +1970,11 @@ components:
           $ref: '#/components/schemas/$User'
         second:
           $ref: '#/components/schemas/$$User'
+
+    ObjectParameterEncodable:
+      type: object
+      required:
+        - value
+      properties:
+        value:
+          type: string

--- a/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
+++ b/integration_test/read_write_only/read_write_only_test/test/read_write_only_api_test.dart
@@ -380,7 +380,13 @@ void main() {
       const status = ServerStatus(uptime: 1, version: '1.0');
       expect(
         () => status.toSimple(explode: false, allowEmpty: true),
-        throwsA(isA<EncodingException>()),
+        throwsA(
+          isA<EncodingException>().having(
+            (error) => error.message,
+            'message',
+            'ServerStatus is read-only and cannot be encoded.',
+          ),
+        ),
       );
     });
 

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_nullable_test.dart
@@ -1,6 +1,7 @@
 import 'package:simple_encoding_api/simple_encoding_api.dart';
 import 'package:test/test.dart';
 import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 void main() {
   late ImposterServer imposterServer;
@@ -21,6 +22,18 @@ void main() {
       ),
     );
   }
+
+  test(
+    'nullable object alias constructs a const model with inherited encoding',
+    () {
+      const ParameterEncodable value = NullableObject(name: 'a/b', count: 2);
+      expect(value, isA<ObjectParameterEncodable>());
+      expect(
+        value.toSimple(explode: true, allowEmpty: false),
+        'name=a%2Fb,count=2',
+      );
+    },
+  );
 
   group('Header Roundtrip Nullable', () {
     group('Nullable String', () {

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -9,7 +9,6 @@ import 'package:tonik_generate/src/naming/property_name_normalizer.dart';
 import 'package:tonik_generate/src/util/additional_properties_builders.dart';
 import 'package:tonik_generate/src/util/additional_properties_helpers.dart';
 import 'package:tonik_generate/src/util/built_expression.dart';
-import 'package:tonik_generate/src/util/composite_guard_builders.dart';
 import 'package:tonik_generate/src/util/copy_with_method_generator.dart';
 import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 import 'package:tonik_generate/src/util/default_resolution.dart';
@@ -191,8 +190,9 @@ class const ClassGenerator({
         ..name = className
         ..docs.addAll(formatDocsWithExamples(model.description, model.examples))
         ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
-        ..implements.add(
-          refer('ParameterEncodable', 'package:tonik_util/tonik_util.dart'),
+        ..extend = refer(
+          'ObjectParameterEncodable',
+          'package:tonik_util/tonik_util.dart',
         )
         ..implements.add(
           refer('UriEncodable', 'package:tonik_util/tonik_util.dart'),
@@ -260,13 +260,6 @@ class const ClassGenerator({
           model,
           normalizedProperties.where((p) => !p.property.isReadOnly).toList(),
         ),
-        _buildToSimpleMethod(),
-        _buildToFormMethod(),
-        _buildToLabelMethod(),
-        _buildToMatrixMethod(),
-        _buildToDeepObjectMethod(),
-        buildToPipeDelimitedMethod(),
-        buildToSpaceDelimitedMethod(),
         _buildUriEncodeMethod(className),
       ]);
 
@@ -1085,6 +1078,7 @@ class const ClassGenerator({
     if (model.isReadOnly) {
       return Method(
         (b) => b
+          ..annotations.add(refer('override', 'dart:core'))
           ..name = 'parameterProperties'
           ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(_buildParameterPropertiesParameters())
@@ -1222,6 +1216,7 @@ class const ClassGenerator({
         activeApPolicy(model.additionalPropertiesPolicy) == null) {
       return Method(
         (b) => b
+          ..annotations.add(refer('override', 'dart:core'))
           ..name = 'parameterProperties'
           ..returns = buildMapStringPropertyValueType()
           ..optionalParameters.addAll(_buildParameterPropertiesParameters())
@@ -1274,6 +1269,7 @@ class const ClassGenerator({
 
     return Method(
       (b) => b
+        ..annotations.add(refer('override', 'dart:core'))
         ..name = 'parameterProperties'
         ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
@@ -1357,6 +1353,7 @@ class const ClassGenerator({
 
     return Method(
       (b) => b
+        ..annotations.add(refer('override', 'dart:core'))
         ..name = 'parameterProperties'
         ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
@@ -1370,6 +1367,7 @@ class const ClassGenerator({
   ) {
     return Method(
       (b) => b
+        ..annotations.add(refer('override', 'dart:core'))
         ..name = 'parameterProperties'
         ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
@@ -1500,32 +1498,13 @@ class const ClassGenerator({
 
     return Method(
       (b) => b
+        ..annotations.add(refer('override', 'dart:core'))
         ..name = 'parameterProperties'
         ..returns = buildMapStringPropertyValueType()
         ..optionalParameters.addAll(_buildParameterPropertiesParameters())
         ..body = Block.of(methodBody),
     );
   }
-
-  Method _buildToSimpleMethod() => Method(
-    (b) => b
-      ..annotations.add(refer('override', 'dart:core'))
-      ..name = 'toSimple'
-      ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll(buildSimpleEncodingParameters())
-      ..body = Block.of([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toSimple')
-            .call([], {
-              'explode': refer('explode'),
-              'allowEmpty': refer('allowEmpty'),
-              'literal': refer('literal'),
-            })
-            .returned
-            .statement,
-      ]),
-  );
 
   Constructor _buildFromFormConstructor(
     String className,
@@ -1740,121 +1719,6 @@ class const ClassGenerator({
 
     return Block.of(codes);
   }
-
-  Method _buildToFormMethod() => Method(
-    (b) => b
-      ..annotations.add(refer('override', 'dart:core'))
-      ..name = 'toForm'
-      ..returns = buildParameterEntryListType()
-      ..requiredParameters.add(
-        Parameter(
-          (b) => b
-            ..name = 'paramName'
-            ..type = refer('String', 'dart:core'),
-        ),
-      )
-      ..optionalParameters.addAll(buildFormEncodingParameters())
-      ..body = Block.of([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toForm')
-            .call(
-              [refer('paramName')],
-              {
-                'explode': refer('explode'),
-                'allowEmpty': refer('allowEmpty'),
-                'useQueryComponent': refer('useQueryComponent'),
-                'allowReserved': refer('allowReserved'),
-                'fieldEncodings': refer('fieldEncodings'),
-                'textEncoding': refer('textEncoding'),
-              },
-            )
-            .returned
-            .statement,
-      ]),
-  );
-
-  Method _buildToLabelMethod() => Method(
-    (b) => b
-      ..annotations.add(refer('override', 'dart:core'))
-      ..name = 'toLabel'
-      ..returns = refer('String', 'dart:core')
-      ..optionalParameters.addAll(buildEncodingParameters())
-      ..body = Block.of([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toLabel')
-            .call([], {
-              'explode': refer('explode'),
-              'allowEmpty': refer('allowEmpty'),
-            })
-            .returned
-            .statement,
-      ]),
-  );
-
-  Method _buildToMatrixMethod() => Method(
-    (b) => b
-      ..annotations.add(refer('override', 'dart:core'))
-      ..name = 'toMatrix'
-      ..returns = refer('String', 'dart:core')
-      ..requiredParameters.add(
-        Parameter(
-          (b) => b
-            ..name = 'paramName'
-            ..type = refer('String', 'dart:core'),
-        ),
-      )
-      ..optionalParameters.addAll(buildEncodingParameters())
-      ..body = Block.of([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toMatrix')
-            .call(
-              [refer('paramName')],
-              {'explode': refer('explode'), 'allowEmpty': refer('allowEmpty')},
-            )
-            .returned
-            .statement,
-      ]),
-  );
-
-  Method _buildToDeepObjectMethod() => Method(
-    (b) => b
-      ..annotations.add(refer('override', 'dart:core'))
-      ..name = 'toDeepObject'
-      ..returns = TypeReference(
-        (b) => b
-          ..symbol = 'List'
-          ..url = 'dart:core'
-          ..types.add(
-            refer('ParameterEntry', 'package:tonik_util/tonik_util.dart'),
-          ),
-      )
-      ..requiredParameters.add(
-        Parameter(
-          (b) => b
-            ..name = 'paramName'
-            ..type = refer('String', 'dart:core'),
-        ),
-      )
-      ..optionalParameters.addAll(buildDeepObjectEncodingParameters())
-      ..body = Block.of([
-        refer('parameterProperties')
-            .call([], {'allowEmpty': refer('allowEmpty')})
-            .property('toDeepObject')
-            .call(
-              [refer('paramName')],
-              {
-                'explode': refer('explode'),
-                'allowEmpty': refer('allowEmpty'),
-                'allowReserved': refer('allowReserved'),
-              },
-            )
-            .returned
-            .statement,
-      ]),
-  );
 
   Method _buildUriEncodeMethod(String className) => Method(
     (b) => b

--- a/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
@@ -1,5 +1,3 @@
-import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/model/class_generator.dart';
@@ -7,132 +5,49 @@ import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 
 void main() {
-  final format = DartFormatter(
-    languageVersion: DartFormatter.latestLanguageVersion,
-  ).format;
-
-  group('ClassGenerator delimited generation', () {
-    late ClassGenerator generator;
-    late NameManager nameManager;
-    late NameGenerator nameGenerator;
-    late Context context;
-    late DartEmitter emitter;
-
-    setUp(() {
-      nameGenerator = NameGenerator();
-      nameManager = NameManager(
-        generator: nameGenerator,
-        stableModelSorter: StableModelSorter(),
-      );
-      generator = ClassGenerator(nameManager: nameManager, package: 'example');
-      context = Context.initial();
-      emitter = DartEmitter(useNullSafetySyntax: true);
-    });
-
-    ClassModel singlePropertyModel() => ClassModel(
-      isDeprecated: false,
-      name: 'TestModel',
-      properties: [
-        Property(
-          name: 'name',
-          model: StringModel(context: context),
-          isRequired: true,
-          isNullable: false,
-          isDeprecated: false,
-          examples: const [],
-          defaultValue: null,
+  test(
+    'object models inherit both delimited encoders through the typed hook',
+    () {
+      final context = Context.initial();
+      final generator = ClassGenerator(
+        nameManager: NameManager(
+          generator: NameGenerator(),
+          stableModelSorter: StableModelSorter(),
         ),
-      ],
-      context: context,
-      examples: const [],
-    );
-
-    test('toPipeDelimited has the delimited signature', () {
-      final result = generator.generateClass(singlePropertyModel());
-      final method = result.methods.firstWhere(
-        (m) => m.name == 'toPipeDelimited',
+        package: 'example',
       );
-
-      expect(
-        method.returns?.accept(emitter).toString(),
-        'List<ParameterEntry>',
-      );
-      expect(method.requiredParameters.length, 1);
-      expect(method.requiredParameters.first.name, 'paramName');
-      expect(
-        method.requiredParameters.first.type?.accept(emitter).toString(),
-        'String',
-      );
-      expect(method.optionalParameters.length, 2);
-      expect(method.optionalParameters.first.name, 'allowEmpty');
-      expect(method.optionalParameters.first.required, isTrue);
-      expect(method.optionalParameters.first.named, isTrue);
-      expect(method.optionalParameters.last.name, 'allowReserved');
-      expect(method.optionalParameters.last.required, isFalse);
-      expect(method.optionalParameters.last.named, isTrue);
-    });
-
-    test('toSpaceDelimited has the delimited signature', () {
-      final result = generator.generateClass(singlePropertyModel());
-      final method = result.methods.firstWhere(
-        (m) => m.name == 'toSpaceDelimited',
-      );
-
-      expect(
-        method.returns?.accept(emitter).toString(),
-        'List<ParameterEntry>',
-      );
-      expect(method.requiredParameters.length, 1);
-      expect(method.requiredParameters.first.name, 'paramName');
-      expect(method.optionalParameters.length, 2);
-      expect(method.optionalParameters.first.name, 'allowEmpty');
-      expect(method.optionalParameters.last.name, 'allowReserved');
-    });
-
-    test('toPipeDelimited delegates to the parameterProperties encoder', () {
-      final result = generator.generateClass(singlePropertyModel());
-
-      const expectedMethod = '''
-        List<ParameterEntry> toPipeDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
-      expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedMethod))),
-      );
-    });
-
-    test('toSpaceDelimited delegates to the parameterProperties encoder', () {
-      final result = generator.generateClass(singlePropertyModel());
-
-      const expectedMethod = '''
-        List<ParameterEntry> toSpaceDelimited(String paramName, {required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited(paramName, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
-      expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedMethod))),
-      );
-    });
-
-    test('delimited methods carry the @override annotation', () {
-      final result = generator.generateClass(singlePropertyModel());
-
-      for (final methodName in ['toPipeDelimited', 'toSpaceDelimited']) {
-        final method = result.methods.firstWhere((m) => m.name == methodName);
-        expect(
-          method.annotations.any(
-            (a) => a.accept(emitter).toString().contains('override'),
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'TestModel',
+        properties: [
+          Property(
+            name: 'name',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
           ),
-          isTrue,
-        );
-      }
-    });
-  });
+        ],
+        context: context,
+        examples: const [],
+      );
+
+      final generatedClass = generator.generateClass(model);
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
+      expect(
+        generatedClass.methods.any(
+          (method) => method.name == 'toPipeDelimited',
+        ),
+        isFalse,
+      );
+      expect(
+        generatedClass.methods.any(
+          (method) => method.name == 'toSpaceDelimited',
+        ),
+        isFalse,
+      );
+    },
+  );
 }

--- a/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_delimited_generator_test.dart
@@ -36,18 +36,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any(
-          (method) => method.name == 'toPipeDelimited',
-        ),
-        isFalse,
-      );
-      expect(
-        generatedClass.methods.any(
-          (method) => method.name == 'toSpaceDelimited',
-        ),
-        isFalse,
-      );
     },
   );
 }

--- a/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
@@ -51,10 +51,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('inherits toDeepObject method for empty model', () {
@@ -68,10 +64,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method inherits encoding for single '
@@ -96,10 +88,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method inherits encoding for multiple '
@@ -142,10 +130,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method inherits encoding through '
@@ -174,10 +158,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method works with nullable required properties', () {
@@ -201,10 +181,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method works with optional properties', () {
@@ -228,10 +204,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method works with mixed simple and complex types', () {
@@ -280,10 +252,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
 
     test('toDeepObject method is inherited from ObjectParameterEncodable', () {
@@ -307,10 +275,6 @@ void main() {
 
       final result = generator.generateClass(model);
       expect(result.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        result.methods.any((method) => method.name == 'toDeepObject'),
-        isFalse,
-      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_deep_object_test.dart
@@ -1,5 +1,3 @@
-import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/model/class_generator.dart';
@@ -7,16 +5,11 @@ import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
 
 void main() {
-  final format = DartFormatter(
-    languageVersion: DartFormatter.latestLanguageVersion,
-  ).format;
-
   group('ClassGenerator toDeepObject generation', () {
     late ClassGenerator generator;
     late NameManager nameManager;
     late NameGenerator nameGenerator;
     late Context context;
-    late DartEmitter emitter;
 
     setUp(() {
       nameGenerator = NameGenerator();
@@ -26,10 +19,9 @@ void main() {
       );
       generator = ClassGenerator(nameManager: nameManager, package: 'example');
       context = Context.initial();
-      emitter = DartEmitter(useNullSafetySyntax: true);
     });
 
-    test('generates toDeepObject method with correct signature', () {
+    test('inherits toDeepObject method through the typed hook', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'SimpleModel',
@@ -58,47 +50,14 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      final toDeepObjectMethod = result.methods.firstWhere(
-        (m) => m.name == 'toDeepObject',
-      );
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        toDeepObjectMethod.returns?.accept(emitter).toString(),
-        'List<ParameterEntry>',
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
-      expect(toDeepObjectMethod.requiredParameters.length, 1);
-      expect(toDeepObjectMethod.requiredParameters.first.name, 'paramName');
-      expect(
-        toDeepObjectMethod.requiredParameters.first.type
-            ?.accept(emitter)
-            .toString(),
-        'String',
-      );
-      expect(toDeepObjectMethod.optionalParameters.length, 3);
-      expect(toDeepObjectMethod.optionalParameters.first.name, 'explode');
-      expect(toDeepObjectMethod.optionalParameters.first.required, isTrue);
-      expect(toDeepObjectMethod.optionalParameters.first.named, isTrue);
-      expect(
-        toDeepObjectMethod.optionalParameters.first.type
-            ?.accept(emitter)
-            .toString(),
-        'bool',
-      );
-      expect(toDeepObjectMethod.optionalParameters[1].name, 'allowEmpty');
-      expect(toDeepObjectMethod.optionalParameters[1].required, isTrue);
-      expect(toDeepObjectMethod.optionalParameters[1].named, isTrue);
-      expect(
-        toDeepObjectMethod.optionalParameters[1].type
-            ?.accept(emitter)
-            .toString(),
-        'bool',
-      );
-      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowReserved');
-      expect(toDeepObjectMethod.optionalParameters.last.required, isFalse);
-      expect(toDeepObjectMethod.optionalParameters.last.named, isTrue);
     });
 
-    test('generates toDeepObject method for empty model', () {
+    test('inherits toDeepObject method for empty model', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'EmptyModel',
@@ -108,33 +67,14 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-      final toDeepObjectMethod = result.methods.firstWhere(
-        (m) => m.name == 'toDeepObject',
-      );
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        toDeepObjectMethod.returns?.accept(emitter).toString(),
-        'List<ParameterEntry>',
-      );
-      expect(toDeepObjectMethod.requiredParameters.length, 1);
-      expect(toDeepObjectMethod.requiredParameters.first.name, 'paramName');
-      expect(toDeepObjectMethod.optionalParameters.length, 3);
-      expect(toDeepObjectMethod.optionalParameters.first.name, 'explode');
-      expect(toDeepObjectMethod.optionalParameters.last.name, 'allowReserved');
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
-      expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
-    test('toDeepObject method generates proper method body for single '
+    test('toDeepObject method inherits encoding for single '
         'property model', () {
       final model = ClassModel(
         isDeprecated: false,
@@ -155,31 +95,14 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      final toDeepObjectMethod = result.methods.firstWhere(
-        (m) => m.name == 'toDeepObject',
-      );
-      expect(toDeepObjectMethod.name, 'toDeepObject');
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        toDeepObjectMethod.returns?.accept(emitter).toString(),
-        'List<ParameterEntry>',
-      );
-      expect(toDeepObjectMethod.lambda, isNot(isTrue));
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
-      expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
-    test('toDeepObject method generates proper method body for multiple '
+    test('toDeepObject method inherits encoding for multiple '
         'properties model', () {
       final model = ClassModel(
         isDeprecated: false,
@@ -218,60 +141,44 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
-    test(
-      'toDeepObject method delegates to the parameterProperties encoder',
-      () {
-        final model = ClassModel(
-          isDeprecated: false,
-          name: 'ModelWithList',
-          properties: [
-            Property(
-              name: 'tags',
-              model: ListModel(
-                content: StringModel(context: context),
-                context: context,
-                examples: const [],
-              ),
-              isRequired: true,
-              isNullable: false,
-              isDeprecated: false,
+    test('toDeepObject method inherits encoding through '
+        'the parameterProperties encoder', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'ModelWithList',
+        properties: [
+          Property(
+            name: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
               examples: const [],
-              defaultValue: null,
             ),
-          ],
-          context: context,
-          examples: const [],
-        );
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
 
-        final result = generator.generateClass(model);
-
-        const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-        final generatedCode = result.accept(emitter).toString();
-        expect(
-          collapseWhitespace(format(generatedCode)),
-          contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
-        );
-      },
-    );
+      final result = generator.generateClass(model);
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
+      expect(
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
+      );
+    });
 
     test('toDeepObject method works with nullable required properties', () {
       final model = ClassModel(
@@ -293,17 +200,10 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
@@ -327,17 +227,10 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
@@ -386,21 +279,14 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
 
-    test('toDeepObject method forwards allowReserved to the encoder', () {
+    test('toDeepObject method is inherited from ObjectParameterEncodable', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'EncodedModel',
@@ -420,17 +306,10 @@ void main() {
       );
 
       final result = generator.generateClass(model);
-
-      const expectedToDeepObjectMethod = '''
-        List<ParameterEntry> toDeepObject(String paramName, {required bool explode, required bool allowEmpty, bool allowReserved = false, }) {
-          return parameterProperties(allowEmpty: allowEmpty).toDeepObject(paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, );
-        }
-      ''';
-
-      final generatedCode = result.accept(emitter).toString();
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(format(generatedCode)),
-        contains(collapseWhitespace(format(expectedToDeepObjectMethod))),
+        result.methods.any((method) => method.name == 'toDeepObject'),
+        isFalse,
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -1941,10 +1941,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toForm'),
-        isFalse,
-      );
     });
 
     test('generates null-safe toJson and fromJson for required property '

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -53,6 +53,10 @@ void main() {
         (m) => m.name == 'parameterProperties',
       );
 
+      expect(
+        parameterPropertiesMethod.annotations.single.accept(emitter).toString(),
+        'override',
+      );
       expect(parameterPropertiesMethod.type, isNot(MethodType.getter));
       expect(
         parameterPropertiesMethod.returns?.accept(emitter).toString(),
@@ -100,6 +104,7 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'id'] = PropertyValue.scalar(id.toString());
@@ -129,6 +134,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { return <String, PropertyValue>{}; }
 ''';
 
@@ -170,6 +176,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { retur
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (nullableName != null) {
@@ -222,6 +229,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
   throw EncodingException(
     r'parameterProperties not supported for User: contains complex types',
@@ -289,6 +297,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (value.currentEncodingShape == EncodingShape.simple) {
@@ -363,6 +372,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (data.currentEncodingShape == EncodingShape.simple) {
@@ -434,6 +444,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (combined.currentEncodingShape == EncodingShape.simple) {
@@ -489,6 +500,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);
@@ -545,6 +557,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
     throw EncodingException(
       r'parameterProperties not supported for ComplexContainer: contains complex types',
@@ -610,6 +623,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (value != null) {
@@ -795,6 +809,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);
@@ -877,6 +892,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         expect(parameterPropertiesMethod, isNotNull);
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (tags != null) {
@@ -940,6 +956,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       expect(parameterPropertiesMethod, isNotNull);
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (ids != null) {
@@ -994,6 +1011,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       expect(parameterPropertiesMethod, isNotNull);
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'tags'] = PropertyValue.array(tags);
@@ -1050,6 +1068,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       expect(parameterPropertiesMethod, isNotNull);
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'id'] = PropertyValue.scalar(id.toString());
@@ -1117,6 +1136,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       expect(parameterPropertiesMethod, isNotNull);
 
       const expectedMethod = '''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
     throw EncodingException(
       r'parameterProperties not supported for ComplexListContainer: contains complex types',
@@ -1174,6 +1194,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
       expect(parameterPropertiesMethod, isNotNull);
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (statuses != null) {
@@ -1230,6 +1251,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(result.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (items != null) {
@@ -1281,6 +1303,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'tags'] = PropertyValue.array(tags);
@@ -1325,6 +1348,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (tags != null) {
@@ -1378,6 +1402,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);
@@ -1427,6 +1452,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);
@@ -1550,6 +1576,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'ratio'] = PropertyValue.scalar(ratio.toString());
@@ -1597,6 +1624,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (data != null) {
@@ -1648,6 +1676,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (data != null) {
@@ -1703,6 +1732,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'label'] = PropertyValue.scalar(label);
@@ -1759,6 +1789,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         // Should generate null-aware encoding because the model is nullable
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (description != null) {
@@ -1863,6 +1894,7 @@ if (description != null) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (items != null) {
@@ -1879,7 +1911,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       },
     );
 
-    test('toForm calls parameterProperties with useQueryComponent', () {
+    test('toForm inherits encoding through parameterProperties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'FormData',
@@ -1908,30 +1940,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       );
 
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-List<ParameterEntry> toForm(
-  String paramName, {
-  required bool explode,
-  required bool allowEmpty,
-  required Encoding textEncoding, bool useQueryComponent = false,
-  bool allowReserved = false,
-  Map<String, FormFieldEncoding> fieldEncodings = const {},
-}) {
-  return parameterProperties(allowEmpty: allowEmpty).toForm(
-    paramName,
-    explode: explode,
-    allowEmpty: allowEmpty,
-    useQueryComponent: useQueryComponent,
-    allowReserved: allowReserved, fieldEncodings: fieldEncodings, textEncoding: textEncoding,
-  );
-}
-''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toForm'),
+        isFalse,
       );
     });
 
@@ -2054,6 +2066,7 @@ List<ParameterEntry> toForm(
         // Should generate null-aware encoding because the nested alias
         // is nullable
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (label != null) {
@@ -2095,6 +2108,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String());
@@ -2134,6 +2148,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (signature != null) {
@@ -2175,6 +2190,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   if (signature != null) {
@@ -2221,6 +2237,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classCode = format(generatedClass.accept(emitter).toString());
 
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'declared'] = PropertyValue.scalar(declared);
@@ -2271,6 +2288,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);
@@ -2332,6 +2350,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final methodCode = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String());
@@ -2413,6 +2432,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final methodCode = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'signature'] = PropertyValue.scalar(signature.toBase64String());
@@ -2472,6 +2492,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       final methodCode = format(method.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'name'] = PropertyValue.scalar(name);

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -79,21 +79,6 @@ void main() {
         'package:tonik_util/tonik_util.dart',
       );
 
-      for (final methodName in [
-        'toSimple',
-        'toForm',
-        'toLabel',
-        'toMatrix',
-        'toDeepObject',
-        'toPipeDelimited',
-        'toSpaceDelimited',
-      ]) {
-        expect(
-          result.methods.any((method) => method.name == methodName),
-          isFalse,
-        );
-      }
-
       final hook = result.methods.singleWhere(
         (method) => method.name == 'parameterProperties',
       );
@@ -1504,10 +1489,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
 
         expect(
           collapseWhitespace(generatedCode),
@@ -1580,10 +1561,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
       });
 
       test('inherits toForm method for complex properties', () {
@@ -1611,10 +1588,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
       });
 
       test('array property uses the inherited form encoder', () {
@@ -1642,10 +1615,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
       });
 
       test('inherits toForm method for empty model', () {
@@ -1659,10 +1628,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
       });
 
       test('generates fromForm constructor with mixed property types', () {
@@ -1893,10 +1858,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toForm'),
-          isFalse,
-        );
       });
 
       test('generates fromForm constructor with all primitive types', () {
@@ -2082,10 +2043,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toMatrix'),
-          isFalse,
-        );
       });
 
       test('inherits toMatrix method for complex properties', () {
@@ -2134,10 +2091,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toMatrix'),
-          isFalse,
-        );
       });
 
       test('inherits toMatrix method for empty model', () {
@@ -2151,10 +2104,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toMatrix'),
-          isFalse,
-        );
       });
 
       test('toMatrix method inherits encoding for single '
@@ -2179,10 +2128,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
         expect(result.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          result.methods.any((method) => method.name == 'toMatrix'),
-          isFalse,
-        );
       });
 
       test('model-specific hook and toJson override inherited contracts', () {
@@ -2240,10 +2185,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final classSpec = classes[0] as Class;
         expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          classSpec.methods.any((method) => method.name == 'toSimple'),
-          isFalse,
-        );
         expect(classSpec.name, r'$RawUser');
       });
 
@@ -2282,10 +2223,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final classSpec = classes[0] as Class;
         expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          classSpec.methods.any((method) => method.name == 'toSimple'),
-          isFalse,
-        );
         expect(classSpec.name, 'Order');
       });
 
@@ -2327,10 +2264,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final classSpec = classes[0] as Class;
         expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          classSpec.methods.any((method) => method.name == 'toSimple'),
-          isFalse,
-        );
         expect(classSpec.name, r'$RawAccount');
         expect(classSpec.fields.length, 1);
         expect(classSpec.fields.first.name, 'id');

--- a/packages/tonik_generate/test/src/model/class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_test.dart
@@ -58,27 +58,51 @@ void main() {
       expect(annotation.accept(emitter).toString(), 'immutable');
     });
 
-    test(
-      'generates class implementing ParameterEncodable and UriEncodable',
-      () {
-        final model = ClassModel(
-          isDeprecated: false,
-          name: 'User',
-          properties: const [],
-          context: context,
-          examples: const [],
+    test('generates class extending ObjectParameterEncodable '
+        'and implementing UriEncodable', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'User',
+        properties: const [],
+        context: context,
+        examples: const [],
+      );
+
+      final result = generator.generateClass(model);
+
+      expect(result.extend?.symbol, 'ObjectParameterEncodable');
+      expect(result.extend?.url, 'package:tonik_util/tonik_util.dart');
+      expect(result.implements, hasLength(1));
+      expect(result.implements.single.symbol, 'UriEncodable');
+      expect(
+        result.implements.single.url,
+        'package:tonik_util/tonik_util.dart',
+      );
+
+      for (final methodName in [
+        'toSimple',
+        'toForm',
+        'toLabel',
+        'toMatrix',
+        'toDeepObject',
+        'toPipeDelimited',
+        'toSpaceDelimited',
+      ]) {
+        expect(
+          result.methods.any((method) => method.name == methodName),
+          isFalse,
         );
+      }
 
-        final result = generator.generateClass(model);
-
-        expect(result.implements.length, 2);
-        final implementsNames = result.implements
-            .map((i) => i.accept(emitter).toString())
-            .toList();
-        expect(implementsNames, contains('ParameterEncodable'));
-        expect(implementsNames, contains('UriEncodable'));
-      },
-    );
+      final hook = result.methods.singleWhere(
+        (method) => method.name == 'parameterProperties',
+      );
+      expect(
+        hook.returns?.accept(emitter).toString(),
+        'Map<String,PropertyValue>',
+      );
+      expect(hook.annotations.single.accept(emitter).toString(), 'override');
+    });
 
     group('Never property decoding', () {
       ClassModel buildShape() => ClassModel(
@@ -1465,29 +1489,8 @@ factory ModelWithSimpleListRoundtrip.fromForm(
   }
           ''';
 
-        const expectedToFormMethod = '''
-            List<ParameterEntry> toForm(
-              String paramName, {
-              required bool explode,
-              required bool allowEmpty,
-              required Encoding textEncoding,
-              bool useQueryComponent = false,
-              bool allowReserved = false,
-              Map<String, FormFieldEncoding> fieldEncodings = const {},
-            }) {
-              return parameterProperties(allowEmpty: allowEmpty).toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-                fieldEncodings: fieldEncodings,
-                textEncoding: textEncoding,
-              );
-            }
-          ''';
-
         const expectedParameterPropertiesMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
   final _$result = <String, PropertyValue>{};
   _$result[r'tags'] = PropertyValue.array(tags);
@@ -1500,9 +1503,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
           contains(collapseWhitespace(expectedFromFormConstructor)),
         );
 
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(generatedCode),
-          contains(collapseWhitespace(expectedToFormMethod)),
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
 
         expect(
@@ -1546,7 +1550,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
       });
 
-      test('generates toForm method for simple properties', () {
+      test('inherits toForm method for simple properties', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'SimpleModel',
@@ -1575,36 +1579,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        final toFormMethod = result.methods.firstWhere(
-          (m) => m.name == 'toForm',
-        );
-
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          toFormMethod.returns?.accept(emitter).toString(),
-          'List<ParameterEntry>',
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
-        expect(toFormMethod.requiredParameters.length, 1);
-        expect(toFormMethod.requiredParameters[0].name, 'paramName');
-        expect(toFormMethod.optionalParameters.length, 6);
-        expect(toFormMethod.optionalParameters[0].name, 'explode');
-        expect(toFormMethod.optionalParameters[0].required, isTrue);
-        expect(toFormMethod.optionalParameters[0].named, isTrue);
-        expect(toFormMethod.optionalParameters[1].name, 'allowEmpty');
-        expect(toFormMethod.optionalParameters[1].required, isTrue);
-        expect(toFormMethod.optionalParameters[1].named, isTrue);
-        expect(toFormMethod.optionalParameters[2].name, 'textEncoding');
-        expect(toFormMethod.optionalParameters[2].required, isTrue);
-        expect(toFormMethod.optionalParameters[2].named, isTrue);
-        expect(toFormMethod.optionalParameters[3].name, 'useQueryComponent');
-        expect(toFormMethod.optionalParameters[3].required, isFalse);
-        expect(toFormMethod.optionalParameters[3].named, isTrue);
-        expect(toFormMethod.optionalParameters[4].name, 'allowReserved');
-        expect(toFormMethod.optionalParameters[4].required, isFalse);
-        expect(toFormMethod.optionalParameters[4].named, isTrue);
       });
 
-      test('generates toForm method for complex properties', () {
+      test('inherits toForm method for complex properties', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'ComplexModel',
@@ -1628,41 +1610,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        const expectedToFormBody = '''
-          @override
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            required Encoding textEncoding,
-            bool useQueryComponent = false,
-            bool allowReserved = false,
-            Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-              fieldEncodings: fieldEncodings,
-              textEncoding: textEncoding,
-            );
-          }
-        ''';
-
-        final toFormMethod = result.methods.singleWhere(
-          (method) => method.name == 'toForm',
-        );
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedToFormBody)),
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
       });
 
-      test('array property still comma-joins because toForm emits no explode '
-          'descriptor', () {
+      test('array property uses the inherited form encoder', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'TagContainer',
@@ -1686,40 +1641,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        const expectedToFormBody = '''
-          @override
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            required Encoding textEncoding,
-            bool useQueryComponent = false,
-            bool allowReserved = false,
-            Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-              fieldEncodings: fieldEncodings,
-              textEncoding: textEncoding,
-            );
-          }
-        ''';
-
-        final toFormMethod = result.methods.singleWhere(
-          (method) => method.name == 'toForm',
-        );
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedToFormBody)),
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
       });
 
-      test('generates toForm method for empty model', () {
+      test('inherits toForm method for empty model', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'EmptyModel',
@@ -1729,36 +1658,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        const expectedToFormMethod = '''
-          @override
-          List<ParameterEntry> toForm(
-            String paramName, {
-            required bool explode,
-            required bool allowEmpty,
-            required Encoding textEncoding,
-            bool useQueryComponent = false,
-            bool allowReserved = false,
-            Map<String, FormFieldEncoding> fieldEncodings = const {},
-          }) {
-            return parameterProperties(allowEmpty: allowEmpty).toForm(
-              paramName,
-              explode: explode,
-              allowEmpty: allowEmpty,
-              useQueryComponent: useQueryComponent,
-              allowReserved: allowReserved,
-              fieldEncodings: fieldEncodings,
-              textEncoding: textEncoding,
-            );
-          }
-        ''';
-
-        final toFormMethod = result.methods.singleWhere(
-          (method) => method.name == 'toForm',
-        );
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedToFormMethod)),
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
       });
 
@@ -1951,7 +1854,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         },
       );
 
-      test('generates toForm method with mixed property types', () {
+      test('inherits toForm method with mixed property types', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'UserForm',
@@ -1989,36 +1892,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        const expectedToFormMethod = '''
-            @override
-            List<ParameterEntry> toForm(
-              String paramName, {
-              required bool explode,
-              required bool allowEmpty,
-              required Encoding textEncoding,
-              bool useQueryComponent = false,
-              bool allowReserved = false,
-              Map<String, FormFieldEncoding> fieldEncodings = const {},
-            }) {
-              return parameterProperties(allowEmpty: allowEmpty).toForm(
-                paramName,
-                explode: explode,
-                allowEmpty: allowEmpty,
-                useQueryComponent: useQueryComponent,
-                allowReserved: allowReserved,
-                fieldEncodings: fieldEncodings,
-                textEncoding: textEncoding,
-              );
-            }
-          ''';
-
-        final toFormMethod = result.methods.singleWhere(
-          (method) => method.name == 'toForm',
-        );
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(toFormMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedToFormMethod)),
+          result.methods.any((method) => method.name == 'toForm'),
+          isFalse,
         );
       });
 
@@ -2175,7 +2052,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
     });
 
     group('toMatrix method', () {
-      test('generates toMatrix method for simple properties', () {
+      test('inherits toMatrix method for simple properties', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'SimpleModel',
@@ -2204,53 +2081,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        final toMatrixMethod = result.methods.firstWhere(
-          (m) => m.name == 'toMatrix',
-        );
-        expect(toMatrixMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toMatrixMethod.requiredParameters.length, 1);
-        expect(toMatrixMethod.requiredParameters.first.name, 'paramName');
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          toMatrixMethod.requiredParameters.first.type
-              ?.accept(emitter)
-              .toString(),
-          'String',
-        );
-        expect(toMatrixMethod.optionalParameters.length, 2);
-        expect(toMatrixMethod.optionalParameters.first.name, 'explode');
-        expect(toMatrixMethod.optionalParameters.first.required, isTrue);
-        expect(toMatrixMethod.optionalParameters.first.named, isTrue);
-        expect(
-          toMatrixMethod.optionalParameters.first.type
-              ?.accept(emitter)
-              .toString(),
-          'bool',
-        );
-        expect(toMatrixMethod.optionalParameters.last.name, 'allowEmpty');
-        expect(toMatrixMethod.optionalParameters.last.required, isTrue);
-        expect(toMatrixMethod.optionalParameters.last.named, isTrue);
-        expect(
-          toMatrixMethod.optionalParameters.last.type
-              ?.accept(emitter)
-              .toString(),
-          'bool',
-        );
-
-        const expectedToMatrixMethod = '''
-          String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
-          }
-        ''';
-
-        final generatedCode = result.accept(emitter).toString();
-        expect(
-          collapseWhitespace(format(generatedCode)),
-          contains(collapseWhitespace(format(expectedToMatrixMethod))),
+          result.methods.any((method) => method.name == 'toMatrix'),
+          isFalse,
         );
       });
 
-      test('generates toMatrix method for complex properties', () {
+      test('inherits toMatrix method for complex properties', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'ComplexModel',
@@ -2295,32 +2133,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        // Test method signature
-        final toMatrixMethod = result.methods.firstWhere(
-          (m) => m.name == 'toMatrix',
-        );
-        expect(toMatrixMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toMatrixMethod.requiredParameters.length, 1);
-        expect(toMatrixMethod.requiredParameters.first.name, 'paramName');
-        expect(toMatrixMethod.optionalParameters.length, 2);
-        expect(toMatrixMethod.optionalParameters.first.name, 'explode');
-        expect(toMatrixMethod.optionalParameters.last.name, 'allowEmpty');
-
-        const expectedToMatrixMethod = '''
-          String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
-          }
-        ''';
-
-        final generatedCode = result.accept(emitter).toString();
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(generatedCode)),
-          contains(collapseWhitespace(format(expectedToMatrixMethod))),
+          result.methods.any((method) => method.name == 'toMatrix'),
+          isFalse,
         );
       });
 
-      test('generates toMatrix method for empty model', () {
+      test('inherits toMatrix method for empty model', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'EmptyModel',
@@ -2330,30 +2150,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-        final toMatrixMethod = result.methods.firstWhere(
-          (m) => m.name == 'toMatrix',
-        );
-        expect(toMatrixMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toMatrixMethod.requiredParameters.length, 1);
-        expect(toMatrixMethod.requiredParameters.first.name, 'paramName');
-        expect(toMatrixMethod.optionalParameters.length, 2);
-        expect(toMatrixMethod.optionalParameters.first.name, 'explode');
-        expect(toMatrixMethod.optionalParameters.last.name, 'allowEmpty');
-
-        const expectedToMatrixMethod = '''
-          String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
-          }
-        ''';
-
-        final generatedCode = result.accept(emitter).toString();
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(generatedCode)),
-          contains(collapseWhitespace(format(expectedToMatrixMethod))),
+          result.methods.any((method) => method.name == 'toMatrix'),
+          isFalse,
         );
       });
 
-      test('toMatrix method generates proper method body for single '
+      test('toMatrix method inherits encoding for single '
           'property model', () {
         final model = ClassModel(
           isDeprecated: false,
@@ -2374,28 +2178,14 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         );
 
         final result = generator.generateClass(model);
-
-        final toMatrixMethod = result.methods.firstWhere(
-          (m) => m.name == 'toMatrix',
-        );
-        expect(toMatrixMethod.name, 'toMatrix');
-        expect(toMatrixMethod.returns?.accept(emitter).toString(), 'String');
-        expect(toMatrixMethod.lambda, isNot(isTrue));
-
-        const expectedToMatrixMethod = '''
-          String toMatrix(String paramName, {required bool explode, required bool allowEmpty, }) {
-            return parameterProperties(allowEmpty: allowEmpty).toMatrix(paramName, explode: explode, allowEmpty: allowEmpty, );
-          }
-        ''';
-
-        final generatedCode = result.accept(emitter).toString();
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(format(generatedCode)),
-          contains(collapseWhitespace(format(expectedToMatrixMethod))),
+          result.methods.any((method) => method.name == 'toMatrix'),
+          isFalse,
         );
       });
 
-      test('encoding methods have @override annotation', () {
+      test('model-specific hook and toJson override inherited contracts', () {
         final model = ClassModel(
           isDeprecated: false,
           name: 'TestModel',
@@ -2416,47 +2206,10 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
 
         final result = generator.generateClass(model);
 
-        // Verify toSimple has @override
-        final toSimple = result.methods.firstWhere((m) => m.name == 'toSimple');
-        expect(toSimple.annotations, hasLength(1));
-        expect(
-          toSimple.annotations.first.code.accept(emitter).toString(),
-          'override',
+        final hook = result.methods.singleWhere(
+          (method) => method.name == 'parameterProperties',
         );
-
-        // Verify toForm has @override
-        final toForm = result.methods.firstWhere((m) => m.name == 'toForm');
-        expect(toForm.annotations, hasLength(1));
-        expect(
-          toForm.annotations.first.code.accept(emitter).toString(),
-          'override',
-        );
-
-        // Verify toLabel has @override
-        final toLabel = result.methods.firstWhere((m) => m.name == 'toLabel');
-        expect(toLabel.annotations, hasLength(1));
-        expect(
-          toLabel.annotations.first.code.accept(emitter).toString(),
-          'override',
-        );
-
-        // Verify toMatrix has @override
-        final toMatrix = result.methods.firstWhere((m) => m.name == 'toMatrix');
-        expect(toMatrix.annotations, hasLength(1));
-        expect(
-          toMatrix.annotations.first.code.accept(emitter).toString(),
-          'override',
-        );
-
-        // Verify toDeepObject has @override
-        final toDeepObject = result.methods.firstWhere(
-          (m) => m.name == 'toDeepObject',
-        );
-        expect(toDeepObject.annotations, hasLength(1));
-        expect(
-          toDeepObject.annotations.first.code.accept(emitter).toString(),
-          'override',
-        );
+        expect(hook.annotations.single.accept(emitter).toString(), 'override');
 
         // Verify toJson has @override
         final toJson = result.methods.firstWhere((m) => m.name == 'toJson');
@@ -2486,6 +2239,11 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         expect(classes[1], isA<TypeDef>());
 
         final classSpec = classes[0] as Class;
+        expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
+        expect(
+          classSpec.methods.any((method) => method.name == 'toSimple'),
+          isFalse,
+        );
         expect(classSpec.name, r'$RawUser');
       });
 
@@ -2523,6 +2281,11 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         expect(classes.whereType<TypeDef>().length, 0);
 
         final classSpec = classes[0] as Class;
+        expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
+        expect(
+          classSpec.methods.any((method) => method.name == 'toSimple'),
+          isFalse,
+        );
         expect(classSpec.name, 'Order');
       });
 
@@ -2563,6 +2326,11 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
         final classes = generator.generateClasses(model);
 
         final classSpec = classes[0] as Class;
+        expect(classSpec.extend?.symbol, 'ObjectParameterEncodable');
+        expect(
+          classSpec.methods.any((method) => method.name == 'toSimple'),
+          isFalse,
+        );
         expect(classSpec.name, r'$RawAccount');
         expect(classSpec.fields.length, 1);
         expect(classSpec.fields.first.name, 'id');
@@ -3096,6 +2864,7 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
           );
 
           const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); const _$knownKeys = {r'name'}; for (final _$e in additionalProperties.entries) { if (_$knownKeys.contains(_$e.key)) { throw EncodingException( r'Additional property keys must not collide with declared wire keys of Counts', ); } _$result[_$e.key] = PropertyValue.scalar(_$e.value.toString()); } return _$result; }
 ''';
 
@@ -3139,7 +2908,8 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
             );
 
             const expectedMethod = r"""
-  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  @override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
     final _$result = <String, PropertyValue>{};
     _$result[r'version'] = PropertyValue.scalar(version.toString());
     if (additionalProperties.isNotEmpty) {

--- a/packages/tonik_generate/test/src/model/class_immutable_collections_test.dart
+++ b/packages/tonik_generate/test/src/model/class_immutable_collections_test.dart
@@ -72,6 +72,7 @@ void main() {
 
       test('generates IList field type', () {
         final result = generator.generateClass(model);
+        expect(result.extend?.symbol, 'ObjectParameterEncodable');
         final field = result.fields.firstWhere((f) => f.name == 'tags');
         final typeRef = field.type! as TypeReference;
         expect(typeRef.symbol, 'IList');

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -1364,6 +1364,7 @@ void main() {
 
       test('generates parameterProperties with AP loop', () {
         const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); const _$knownKeys = {r'name'}; for (final _$e in additionalProperties.entries) { if (_$knownKeys.contains(_$e.key)) { throw EncodingException( r'Additional property keys must not collide with declared wire keys of Config', ); } final _$v = _$e.value; if (_$v == null) continue; _$result[_$e.key] = PropertyValue.scalar( encodeUnknownFlatScalar(_$v, context: r'Config.additionalProperties'), ); } return _$result; }
 ''';
 

--- a/packages/tonik_generate/test/src/model/class_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_label_generator_test.dart
@@ -1,5 +1,3 @@
-import 'package:code_builder/code_builder.dart';
-import 'package:dart_style/dart_style.dart';
 import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/model/class_generator.dart';
@@ -11,10 +9,6 @@ void main() {
   late NameManager nameManager;
   late NameGenerator nameGenerator;
   late Context context;
-  late DartEmitter emitter;
-  final format = DartFormatter(
-    languageVersion: DartFormatter.latestLanguageVersion,
-  ).format;
 
   setUp(() {
     nameGenerator = NameGenerator();
@@ -24,11 +18,10 @@ void main() {
     );
     generator = ClassGenerator(nameManager: nameManager, package: 'example');
     context = Context.initial();
-    emitter = DartEmitter(useNullSafetySyntax: true);
   });
 
   group('ClassGenerator toLabel generation', () {
-    test('generates toLabel for class with only simple properties', () {
+    test('inherits toLabel for class with only simple properties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'SimpleClass',
@@ -57,32 +50,15 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final toLabelMethod = generatedClass.methods.firstWhere(
-        (m) => m.name == 'toLabel',
-      );
-
-      expect(toLabelMethod.returns?.accept(emitter).toString(), 'String');
-      expect(toLabelMethod.optionalParameters.length, 2);
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        toLabelMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty']),
-      );
-
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
-      expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
 
     test(
-      'generates toLabel that throws for class with nested class property',
+      'inherits toLabel that throws for class with nested class property',
       () {
         final model = ClassModel(
           isDeprecated: false,
@@ -119,23 +95,17 @@ void main() {
         );
 
         final generatedClass = generator.generateClass(model);
-        final classCode = format(generatedClass.accept(emitter).toString());
-        const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
+        expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
         expect(
-          collapseWhitespace(classCode),
-          contains(collapseWhitespace(expectedMethod)),
+          generatedClass.methods.any((method) => method.name == 'toLabel'),
+          isFalse,
         );
       },
     );
   });
 
   group('ClassGenerator toLabel method for label encoding', () {
-    test('generates toLabel for class with only simple properties', () {
+    test('inherits toLabel for class with only simple properties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'SimpleClass',
@@ -164,20 +134,14 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
 
-    test('generates toLabel for class with composite properties requiring '
+    test('inherits toLabel for class with composite properties requiring '
         'runtime checks', () {
       final model = ClassModel(
         isDeprecated: false,
@@ -223,20 +187,14 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
 
-    test('generates toLabel for class with mixed properties including '
+    test('inherits toLabel for class with mixed properties including '
         'nullable composites', () {
       final model = ClassModel(
         isDeprecated: false,
@@ -282,20 +240,14 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
 
-    test('generates toLabel for empty class', () {
+    test('inherits toLabel for empty class', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'EmptyClass',
@@ -305,16 +257,10 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/class_label_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_label_generator_test.dart
@@ -51,10 +51,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
 
     test(
@@ -96,10 +92,6 @@ void main() {
 
         final generatedClass = generator.generateClass(model);
         expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          generatedClass.methods.any((method) => method.name == 'toLabel'),
-          isFalse,
-        );
       },
     );
   });
@@ -135,10 +127,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
 
     test('inherits toLabel for class with composite properties requiring '
@@ -188,10 +176,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
 
     test('inherits toLabel for class with mixed properties including '
@@ -241,10 +225,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
 
     test('inherits toLabel for empty class', () {
@@ -258,10 +238,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -382,6 +382,7 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = r'''
+@override
 Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final _$result = <String, PropertyValue>{}; _$result[r'name'] = PropertyValue.scalar(name); if (password == null) { throw EncodingException(r'Required property password is null.'); } _$result[r'password'] = PropertyValue.scalar(password!); return _$result; }
 ''';
 
@@ -393,116 +394,66 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
   });
 
   group('readOnly/writeOnly toSimple', () {
-    test('toSimple delegates to filtered parameterProperties', () {
+    test('toSimple inherits encoding through filtered parameterProperties', () {
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-        String toSimple({
-          required bool explode,
-          required bool allowEmpty,
-          bool literal = false,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
-        }
-      ''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toSimple'),
+        isFalse,
       );
     });
   });
 
   group('readOnly/writeOnly toForm', () {
-    test('toForm delegates to filtered parameterProperties', () {
+    test('toForm inherits encoding through filtered parameterProperties', () {
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-        List<ParameterEntry> toForm(
-          String paramName, {
-          required bool explode,
-          required bool allowEmpty,
-          required Encoding textEncoding,
-          bool useQueryComponent = false,
-          bool allowReserved = false,
-          Map<String, FormFieldEncoding> fieldEncodings = const {},
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty).toForm(
-            paramName,
-            explode: explode,
-            allowEmpty: allowEmpty,
-            useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved,
-            fieldEncodings: fieldEncodings,
-            textEncoding: textEncoding,
-          );
-        }
-      ''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toForm'),
+        isFalse,
       );
     });
   });
 
   group('readOnly/writeOnly toLabel', () {
-    test('toLabel delegates to filtered parameterProperties', () {
+    test('toLabel inherits encoding through filtered parameterProperties', () {
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-        String toLabel({required bool explode, required bool allowEmpty}) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toLabel(explode: explode, allowEmpty: allowEmpty);
-        }
-      ''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toLabel'),
+        isFalse,
       );
     });
   });
 
   group('readOnly/writeOnly toMatrix', () {
-    test('toMatrix delegates to filtered parameterProperties', () {
+    test('toMatrix inherits encoding through filtered parameterProperties', () {
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-String toMatrix( String paramName, { required bool explode, required bool allowEmpty, }) { return parameterProperties(allowEmpty: allowEmpty) .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty); }
-''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toMatrix'),
+        isFalse,
       );
     });
   });
 
   group('readOnly/writeOnly toDeepObject', () {
-    test('toDeepObject delegates to filtered parameterProperties', () {
-      final model = buildMixedModel(context);
-      final generatedClass = generator.generateClass(model);
-      final classCode = format(generatedClass.accept(emitter).toString());
-
-      const expectedMethod = '''
-List<ParameterEntry> toDeepObject( String paramName, { required bool explode, required bool allowEmpty, bool allowReserved = false, }) { return parameterProperties(allowEmpty: allowEmpty).toDeepObject( paramName, explode: explode, allowEmpty: allowEmpty, allowReserved: allowReserved, ); }
-''';
-
-      expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
-      );
-    });
+    test(
+      'toDeepObject inherits encoding through filtered parameterProperties',
+      () {
+        final model = buildMixedModel(context);
+        final generatedClass = generator.generateClass(model);
+        expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
+        expect(
+          generatedClass.methods.any((method) => method.name == 'toDeepObject'),
+          isFalse,
+        );
+      },
+    );
   });
 
   group('readOnly/writeOnly fields and constructor', () {

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -398,10 +398,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toSimple'),
-        isFalse,
-      );
     });
   });
 
@@ -410,10 +406,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toForm'),
-        isFalse,
-      );
     });
   });
 
@@ -422,10 +414,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toLabel'),
-        isFalse,
-      );
     });
   });
 
@@ -434,10 +422,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
       final model = buildMixedModel(context);
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toMatrix'),
-        isFalse,
-      );
     });
   });
 
@@ -448,10 +432,6 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) { final
         final model = buildMixedModel(context);
         final generatedClass = generator.generateClass(model);
         expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-        expect(
-          generatedClass.methods.any((method) => method.name == 'toDeepObject'),
-          isFalse,
-        );
       },
     );
   });

--- a/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_schema_level_read_write_only_test.dart
@@ -213,7 +213,8 @@ void main() {
       final classCode = format(generatedClass.accept(emitter).toString());
 
       const expectedMethod = '''
-        Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
+        @override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) => throw EncodingException(
           r'ServerStatus is read-only and cannot be encoded.',
         );
       ''';

--- a/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
@@ -1161,10 +1161,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toSimple'),
-        isFalse,
-      );
     });
 
     test('inherits toSimple for class with complex properties', () {
@@ -1203,10 +1199,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toSimple'),
-        isFalse,
-      );
     });
 
     test('inherits toSimple for empty class', () {
@@ -1220,10 +1212,6 @@ void main() {
 
       final generatedClass = generator.generateClass(model);
       expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
-      expect(
-        generatedClass.methods.any((method) => method.name == 'toSimple'),
-        isFalse,
-      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_simple_generator_test.dart
@@ -1131,7 +1131,7 @@ void main() {
   });
 
   group('ClassGenerator toSimple generation', () {
-    test('generates toSimple for class with only simple properties', () {
+    test('inherits toSimple for class with only simple properties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'SimpleClass',
@@ -1160,42 +1160,14 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final toSimpleMethod = generatedClass.methods.firstWhere(
-        (m) => m.name == 'toSimple',
-      );
-
-      expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-      expect(toSimpleMethod.optionalParameters, hasLength(3));
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        toSimpleMethod.optionalParameters.map((p) => p.name),
-        containsAll(['explode', 'allowEmpty', 'literal']),
-      );
-      expect(
-        toSimpleMethod.optionalParameters
-            .where((p) => p.name != 'literal')
-            .every((p) => p.required),
-        isTrue,
-      );
-
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toSimple({
-          required bool explode,
-          required bool allowEmpty,
-          bool literal = false,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
-        }
-      ''';
-
-      expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toSimple'),
+        isFalse,
       );
     });
 
-    test('generates toSimple for class with complex properties', () {
+    test('inherits toSimple for class with complex properties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'ComplexClass',
@@ -1230,31 +1202,14 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final toSimpleMethod = generatedClass.methods.firstWhere(
-        (m) => m.name == 'toSimple',
-      );
-
-      expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toSimple({
-          required bool explode,
-          required bool allowEmpty,
-          bool literal = false,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
-        }
-      ''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toSimple'),
+        isFalse,
       );
     });
 
-    test('generates toSimple for empty class', () {
+    test('inherits toSimple for empty class', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'EmptyClass',
@@ -1264,27 +1219,10 @@ void main() {
       );
 
       final generatedClass = generator.generateClass(model);
-      final toSimpleMethod = generatedClass.methods.firstWhere(
-        (m) => m.name == 'toSimple',
-      );
-
-      expect(toSimpleMethod.returns?.accept(emitter).toString(), 'String');
-
-      final classCode = format(generatedClass.accept(emitter).toString());
-      const expectedMethod = '''
-        String toSimple({
-          required bool explode,
-          required bool allowEmpty,
-          bool literal = false,
-        }) {
-          return parameterProperties(allowEmpty: allowEmpty)
-            .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
-        }
-      ''';
-
+      expect(generatedClass.extend?.symbol, 'ObjectParameterEncodable');
       expect(
-        collapseWhitespace(classCode),
-        contains(collapseWhitespace(expectedMethod)),
+        generatedClass.methods.any((method) => method.name == 'toSimple'),
+        isFalse,
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/core_prefixed_class_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/core_prefixed_class_generator_test.dart
@@ -3,6 +3,7 @@ import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/model/class_generator.dart';
 import 'package:tonik_generate/src/naming/name_generator.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/core_prefixed_allocator.dart';
 
 void main() {
   group('ClassGenerator with CorePrefixedAllocator', () {
@@ -19,6 +20,27 @@ void main() {
       );
       generator = ClassGenerator(nameManager: nameManager, package: 'example');
       context = Context.initial();
+    });
+
+    test('qualifies the superclass when the model has the same name', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'ObjectParameterEncodable',
+        properties: const [],
+        context: context,
+        examples: const [],
+      );
+      final generatedClass = generator.generateClass(model);
+      expect(generatedClass.extend?.url, 'package:tonik_util/tonik_util.dart');
+      expect(generatedClass.name, 'ObjectParameterEncodable');
+
+      final allocator = CorePrefixedAllocator(
+        additionalImports: ['package:tonik_util/tonik_util.dart'],
+      );
+      expect(
+        allocator.allocate(generatedClass.extend!),
+        '_i1.ObjectParameterEncodable',
+      );
     });
 
     test('generates code with prefixed dart:core types', () {

--- a/packages/tonik_util/lib/src/encoding/object_parameter_encodable.dart
+++ b/packages/tonik_util/lib/src/encoding/object_parameter_encodable.dart
@@ -1,0 +1,105 @@
+import 'dart:convert';
+
+import 'package:tonik_util/src/encoding/encodable.dart';
+import 'package:tonik_util/src/encoding/form_field_encoding.dart';
+import 'package:tonik_util/src/encoding/parameter_entry.dart';
+import 'package:tonik_util/src/encoding/property_value.dart';
+import 'package:tonik_util/src/encoding/property_value_form_encoder.dart';
+import 'package:tonik_util/src/encoding/property_value_style_encoders.dart';
+
+/// Shared parameter encoding for object models with typed property values.
+///
+/// Subclasses supply their property values and JSON representation. Each
+/// encoding call obtains its property map through [parameterProperties].
+abstract class const ObjectParameterEncodable() implements ParameterEncodable {
+  /// Returns raw property values for the requested empty-value policy.
+  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true});
+
+  @override
+  String toSimple({
+    required bool explode,
+    required bool allowEmpty,
+    bool literal = false,
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty)
+        .toSimple(explode: explode, allowEmpty: allowEmpty, literal: literal);
+  }
+
+  @override
+  List<ParameterEntry> toForm(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+    required Encoding textEncoding,
+    bool useQueryComponent = false,
+    bool allowReserved = false,
+    Map<String, FormFieldEncoding> fieldEncodings = const {},
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty).toForm(
+      paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      useQueryComponent: useQueryComponent,
+      allowReserved: allowReserved,
+      fieldEncodings: fieldEncodings,
+      textEncoding: textEncoding,
+    );
+  }
+
+  @override
+  String toLabel({required bool explode, required bool allowEmpty}) {
+    return parameterProperties(allowEmpty: allowEmpty)
+        .toLabel(explode: explode, allowEmpty: allowEmpty);
+  }
+
+  @override
+  String toMatrix(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty)
+        .toMatrix(paramName, explode: explode, allowEmpty: allowEmpty);
+  }
+
+  @override
+  List<ParameterEntry> toDeepObject(
+    String paramName, {
+    required bool explode,
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty).toDeepObject(
+      paramName,
+      explode: explode,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+
+  @override
+  List<ParameterEntry> toPipeDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty).toPipeDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+
+  @override
+  List<ParameterEntry> toSpaceDelimited(
+    String paramName, {
+    required bool allowEmpty,
+    bool allowReserved = false,
+  }) {
+    return parameterProperties(allowEmpty: allowEmpty).toSpaceDelimited(
+      paramName,
+      allowEmpty: allowEmpty,
+      allowReserved: allowReserved,
+    );
+  }
+}

--- a/packages/tonik_util/lib/tonik_util.dart
+++ b/packages/tonik_util/lib/tonik_util.dart
@@ -19,6 +19,7 @@ export 'src/encoding/form_encoder_extensions.dart';
 export 'src/encoding/form_field_encoding.dart';
 export 'src/encoding/label_encoder_extensions.dart';
 export 'src/encoding/matrix_encoder_extensions.dart';
+export 'src/encoding/object_parameter_encodable.dart';
 export 'src/encoding/parameter_entry.dart';
 export 'src/encoding/pipe_delimited_encoder_extensions.dart';
 export 'src/encoding/property_value.dart';

--- a/packages/tonik_util/test/src/encoding/object_parameter_encodable_test.dart
+++ b/packages/tonik_util/test/src/encoding/object_parameter_encodable_test.dart
@@ -1,0 +1,484 @@
+import 'dart:convert';
+
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+class const _Object(final Map<String, PropertyValue> properties)
+    extends ObjectParameterEncodable {
+  @override
+  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
+      properties;
+
+  @override
+  Object? toJson() => const <String, Object?>{};
+}
+
+class const _HookObject(
+  final Map<String, PropertyValue> Function({required bool allowEmpty})
+  onProperties,
+) extends ObjectParameterEncodable {
+  @override
+  Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) =>
+      onProperties(allowEmpty: allowEmpty);
+
+  @override
+  Object? toJson() => null;
+}
+
+void main() {
+  const object = _Object({
+    'na me': PropertyValue.scalar('a/b,c'),
+    'tags': PropertyValue.array(['x,y', 'z']),
+  });
+  final encoders =
+      <String, Object Function(ParameterEncodable, {required bool allowEmpty})>{
+        'simple': (value, {required bool allowEmpty}) =>
+            value.toSimple(explode: true, allowEmpty: allowEmpty),
+        'form': (value, {required bool allowEmpty}) => value.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: allowEmpty,
+          textEncoding: utf8,
+        ),
+        'label': (value, {required bool allowEmpty}) =>
+            value.toLabel(explode: true, allowEmpty: allowEmpty),
+        'matrix': (value, {required bool allowEmpty}) =>
+            value.toMatrix('filter', explode: true, allowEmpty: allowEmpty),
+        'deepObject': (value, {required bool allowEmpty}) =>
+            value.toDeepObject('filter', explode: true, allowEmpty: allowEmpty),
+        'pipeDelimited': (value, {required bool allowEmpty}) =>
+            value.toPipeDelimited('filter', allowEmpty: allowEmpty),
+        'spaceDelimited': (value, {required bool allowEmpty}) =>
+            value.toSpaceDelimited('filter', allowEmpty: allowEmpty),
+      };
+
+  test('const subclass is assignable to ParameterEncodable', () {
+    const ParameterEncodable value = _Object({
+      'name': PropertyValue.scalar('pet'),
+    });
+    expect(
+      identical(value, const _Object({'name': PropertyValue.scalar('pet')})),
+      isTrue,
+    );
+    expect(value.toSimple(explode: true, allowEmpty: false), 'name=pet');
+    expect(value.toJson(), <String, Object?>{});
+  });
+
+  group('simple', () {
+    test('escapes scalar commas but preserves array element boundaries', () {
+      expect(
+        object.toSimple(explode: true, allowEmpty: false),
+        'na%20me=a%2Fb%2Cc,tags=x%2Cy,z',
+      );
+      expect(
+        object.toSimple(explode: false, allowEmpty: false),
+        'na%20me,a%2Fb%2Cc,tags,x%2Cy,z',
+      );
+    });
+
+    test('literal bypasses escaping for keys, scalars, and array elements', () {
+      expect(
+        object.toSimple(explode: true, allowEmpty: false, literal: true),
+        'na me=a/b,c,tags=x,y,z',
+      );
+      expect(
+        object.toSimple(explode: false, allowEmpty: false, literal: true),
+        'na me,a/b,c,tags,x,y,z',
+      );
+    });
+  });
+
+  group('form', () {
+    test('defaults encode keys and comma-join array elements', () {
+      expect(
+        object.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: false,
+          textEncoding: utf8,
+        ),
+        [
+          (name: 'na%20me', value: 'a%2Fb%2Cc'),
+          (name: 'tags', value: 'x%2Cy,z'),
+        ],
+      );
+      expect(
+        object.toForm(
+          'filter',
+          explode: false,
+          allowEmpty: false,
+          textEncoding: utf8,
+        ),
+        [(name: 'filter', value: 'na%20me,a%2Fb%2Cc,tags,x%2Cy,z')],
+      );
+    });
+
+    const encoded = _Object({
+      'a/b': PropertyValue.scalar('café /&=+'),
+      'tags': PropertyValue.array(['a,b', 'c/d']),
+      'plain': PropertyValue.scalar('/value'),
+    });
+    const fields = {
+      'a/b': FormFieldEncoding(),
+      'tags': FormFieldEncoding(explode: true, allowReserved: true),
+    };
+
+    test('forwards charset, query spaces, reserved and field overrides', () {
+      expect(
+        encoded.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: false,
+          textEncoding: latin1,
+          useQueryComponent: true,
+          allowReserved: true,
+          fieldEncodings: fields,
+        ),
+        [
+          (name: 'a/b', value: 'caf%E9+%2F%26%3D%2B'),
+          (name: 'tags', value: 'a,b'),
+          (name: 'tags', value: 'c/d'),
+          (name: 'plain', value: '/value'),
+        ],
+      );
+    });
+
+    test('collapsed objects ignore field overrides and join arrays', () {
+      expect(
+        encoded.toForm(
+          'filter',
+          explode: false,
+          allowEmpty: false,
+          textEncoding: latin1,
+          useQueryComponent: true,
+          allowReserved: true,
+          fieldEncodings: fields,
+        ),
+        [
+          (
+            name: 'filter',
+            value: 'a/b,caf%E9+/%26%3D%2B,tags,a,b,c/d,plain,/value',
+          ),
+        ],
+      );
+    });
+
+    test('field explode distinguishes a scalar comma from array elements', () {
+      const value = _Object({
+        'scalar': PropertyValue.scalar('a,b'),
+        'array': PropertyValue.array(['a', 'b']),
+      });
+      expect(
+        value.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: false,
+          textEncoding: utf8,
+          fieldEncodings: const {
+            'scalar': FormFieldEncoding(explode: true),
+            'array': FormFieldEncoding(explode: true),
+          },
+        ),
+        [
+          (name: 'scalar', value: 'a%2Cb'),
+          (name: 'array', value: 'a'),
+          (name: 'array', value: 'b'),
+        ],
+      );
+    });
+  });
+
+  test('label forwards explode and escapes typed property values', () {
+    expect(
+      object.toLabel(explode: true, allowEmpty: false),
+      '.na%20me=a%2Fb%2Cc.tags=x%2Cy,z',
+    );
+    expect(
+      object.toLabel(explode: false, allowEmpty: false),
+      '.na%20me,a%2Fb%2Cc,tags,x%2Cy,z',
+    );
+  });
+
+  test('matrix forwards parameter name and explode', () {
+    expect(
+      object.toMatrix('filter', explode: true, allowEmpty: false),
+      ';na%20me=a%2Fb%2Cc;tags=x%2Cy,z',
+    );
+    expect(
+      object.toMatrix('filter', explode: false, allowEmpty: false),
+      ';filter=na%20me,a%2Fb%2Cc,tags,x%2Cy,z',
+    );
+  });
+
+  group('deepObject', () {
+    const value = _Object({'a/b': PropertyValue.scalar('/path?x=1&y=+')});
+
+    test(
+      'escapes keys even when reserved characters are allowed in values',
+      () {
+        expect(value.toDeepObject('filter', explode: true, allowEmpty: false), [
+          (name: 'filter[a%2Fb]', value: '%2Fpath%3Fx%3D1%26y%3D%2B'),
+        ]);
+        expect(
+          value.toDeepObject(
+            'filter',
+            explode: true,
+            allowEmpty: false,
+            allowReserved: true,
+          ),
+          [(name: 'filter[a%2Fb]', value: '/path?x%3D1%26y%3D%2B')],
+        );
+      },
+    );
+
+    test('rejects non-exploded objects with the existing exception', () {
+      expect(
+        () => value.toDeepObject('filter', explode: false, allowEmpty: true),
+        throwsA(
+          isA<EncodingException>().having(
+            (error) => error.message,
+            'message',
+            'deepObject style requires explode=true',
+          ),
+        ),
+      );
+    });
+
+    test('rejects array properties instead of treating them as scalars', () {
+      expect(
+        () => object.toDeepObject('filter', explode: true, allowEmpty: true),
+        throwsA(
+          isA<EncodingException>().having(
+            (error) => error.message,
+            'message',
+            'Lists are not supported in this encoding style',
+          ),
+        ),
+      );
+    });
+  });
+
+  test('pipeDelimited preserves array tokens and forwards allowReserved', () {
+    expect(object.toPipeDelimited('filter', allowEmpty: false), [
+      (name: 'filter', value: 'na%20me|a%2Fb%2Cc|tags|x%2Cy|z'),
+    ]);
+    expect(
+      object.toPipeDelimited('filter', allowEmpty: false, allowReserved: true),
+      [(name: 'filter', value: 'na%20me|a/b,c|tags|x,y|z')],
+    );
+  });
+
+  test('spaceDelimited preserves array tokens and forwards allowReserved', () {
+    expect(object.toSpaceDelimited('filter', allowEmpty: false), [
+      (name: 'filter', value: 'na%20me%20a%2Fb%2Cc%20tags%20x%2Cy%20z'),
+    ]);
+    expect(
+      object.toSpaceDelimited('filter', allowEmpty: false, allowReserved: true),
+      [(name: 'filter', value: 'na%20me%20a/b,c%20tags%20x,y%20z')],
+    );
+  });
+
+  group('empty values', () {
+    const empty = _Object({});
+    const emptyValues = _Object({
+      'scalar': PropertyValue.scalar(''),
+      'array': PropertyValue.array([]),
+    });
+
+    test('empty objects preserve each style response when allowed', () {
+      expect(empty.toSimple(explode: true, allowEmpty: true), '');
+      expect(empty.toLabel(explode: true, allowEmpty: true), '.');
+      expect(
+        empty.toMatrix('filter', explode: false, allowEmpty: true),
+        ';filter',
+      );
+      expect(
+        empty.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: true,
+          textEncoding: utf8,
+        ),
+        <ParameterEntry>[],
+      );
+      expect(
+        empty.toDeepObject('filter', explode: true, allowEmpty: true),
+        <ParameterEntry>[],
+      );
+      expect(
+        empty.toPipeDelimited('filter', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+      expect(
+        empty.toSpaceDelimited('filter', allowEmpty: true),
+        <ParameterEntry>[],
+      );
+    });
+
+    for (final entry in encoders.entries) {
+      test(
+        '${entry.key} preserves the empty-object policy when disallowed',
+        () {
+          if (entry.key == 'form') {
+            expect(entry.value(empty, allowEmpty: false), <ParameterEntry>[]);
+          } else {
+            expect(
+              () => entry.value(empty, allowEmpty: false),
+              throwsA(isA<EmptyValueException>()),
+            );
+          }
+        },
+      );
+    }
+
+    test(
+      'empty scalar and array properties remain valid for simple styles',
+      () {
+        expect(
+          emptyValues.toSimple(explode: true, allowEmpty: false),
+          'scalar,array',
+        );
+        expect(
+          emptyValues.toSimple(explode: false, allowEmpty: false),
+          'scalar,,array,',
+        );
+        expect(
+          emptyValues.toLabel(explode: true, allowEmpty: false),
+          '.scalar.array',
+        );
+        expect(
+          emptyValues.toLabel(explode: false, allowEmpty: false),
+          '.scalar,,array,',
+        );
+        expect(
+          emptyValues.toMatrix('filter', explode: true, allowEmpty: false),
+          ';scalar;array',
+        );
+        expect(
+          emptyValues.toMatrix('filter', explode: false, allowEmpty: false),
+          ';filter=scalar,,array,',
+        );
+        expect(emptyValues.toPipeDelimited('filter', allowEmpty: false), [
+          (name: 'filter', value: 'scalar||array|'),
+        ]);
+        expect(emptyValues.toSpaceDelimited('filter', allowEmpty: false), [
+          (name: 'filter', value: 'scalar%20%20array%20'),
+        ]);
+      },
+    );
+
+    test(
+      'form omits empty arrays when exploded and preserves empty scalars',
+      () {
+        expect(
+          emptyValues.toForm(
+            'filter',
+            explode: true,
+            allowEmpty: true,
+            textEncoding: utf8,
+          ),
+          [(name: 'scalar', value: '')],
+        );
+        expect(
+          emptyValues.toForm(
+            'filter',
+            explode: false,
+            allowEmpty: true,
+            textEncoding: utf8,
+          ),
+          [(name: 'filter', value: 'scalar,,array,')],
+        );
+        expect(
+          emptyValues.toForm(
+            'filter',
+            explode: true,
+            allowEmpty: true,
+            textEncoding: utf8,
+            fieldEncodings: const {'scalar': FormFieldEncoding(explode: true)},
+          ),
+          <ParameterEntry>[],
+        );
+        for (final explode in [true, false]) {
+          expect(
+            () => emptyValues.toForm(
+              'filter',
+              explode: explode,
+              allowEmpty: false,
+              textEncoding: utf8,
+            ),
+            throwsA(isA<EmptyValueException>()),
+          );
+        }
+      },
+    );
+
+    test(
+      'deepObject accepts an empty scalar but rejects even an empty array',
+      () {
+        const scalar = _Object({'scalar': PropertyValue.scalar('')});
+        expect(
+          scalar.toDeepObject('filter', explode: true, allowEmpty: false),
+          [(name: 'filter[scalar]', value: '')],
+        );
+        expect(
+          () => emptyValues.toDeepObject(
+            'filter',
+            explode: true,
+            allowEmpty: true,
+          ),
+          throwsA(
+            isA<EncodingException>().having(
+              (error) => error.message,
+              'message',
+              'Lists are not supported in this encoding style',
+            ),
+          ),
+        );
+      },
+    );
+  });
+
+  group('subclass dispatch', () {
+    for (final entry in encoders.entries) {
+      test('${entry.key} calls the hook once per call with allowEmpty', () {
+        final calls = <bool>[];
+        final value = _HookObject(({required allowEmpty}) {
+          calls.add(allowEmpty);
+          return const {'name': PropertyValue.scalar('pet')};
+        });
+        entry.value(value, allowEmpty: false);
+        entry.value(value, allowEmpty: true);
+        expect(calls, [false, true]);
+      });
+
+      test('${entry.key} propagates the original hook exception', () {
+        const error = EncodingException('Model-specific hook failure');
+        final value = _HookObject(({required allowEmpty}) => throw error);
+        expect(
+          () => entry.value(value, allowEmpty: false),
+          throwsA(same(error)),
+        );
+      });
+    }
+
+    test('inherited calls observe each fresh hook result', () {
+      var count = 0;
+      final value = _HookObject(
+        ({required allowEmpty}) => {
+          'count': PropertyValue.scalar('${++count}'),
+        },
+      );
+      expect(value.toSimple(explode: true, allowEmpty: false), 'count=1');
+      expect(value.toSimple(explode: true, allowEmpty: false), 'count=2');
+    });
+
+    test('hook runs before deepObject validates explode', () {
+      const error = EncodingException('Read-only model');
+      final value = _HookObject(({required allowEmpty}) => throw error);
+      expect(
+        () => value.toDeepObject('filter', explode: false, allowEmpty: false),
+        throwsA(same(error)),
+      );
+    });
+  });
+}


### PR DESCRIPTION
Generated object models repeat seven parameter-encoding implementations. This change puts those implementations in a stateless, const `ObjectParameterEncodable` superclass and makes `ClassGenerator` objects inherit them through their model-specific typed `parameterProperties` hook.

The generated class ancestry changes, while encoding signatures/defaults, empty-value behavior, exceptions, const construction, and `ParameterEncodable` assignability remain intact. Models still implement `UriEncodable` directly. Nullable/raw and worker-generated objects use the same path; composite generators and their shared helpers remain unchanged.

Validation:

- Complete root package analysis passed.
- All five unit suites passed: 5,956 tests, including the final cleanup to direct test assertions.
- Official full generation produced all 44 clients for each backend. Dio and HTTP each passed analysis of all 85 packages and all 4,086 integration tests across 40 packages, retaining all existing integration tests and test-owned Imposter lifecycles.
- Runtime tests cover all seven methods, non-default options, scalar/array distinctions, escaping, empty values, dispatch, and exception propagation. Integration additions cover defaults, nullable models, immutable collections/additional properties, and superclass-name collisions.
- Changed Dart files are formatted. The full local format traversal reported only the same 44 pre-existing ignored generated-barrel differences.

Across the full client corpus, 25,746 existing object models lose 180,222 forwarding declarations. Generated Dart decreases by 63,148,563 bytes per backend (about 13.1%), including one new naming-collision fixture model. No existing classes disappear, and no forwarding declarations remain on eligible objects. Versioning, release scripts, CI configuration, and concurrency are unchanged.

Performance is provisional. The complete local test pipeline took 37m48s before and 44m23s after, including external census instrumentation, with substantial background CPU contention and existing caches. These observations do not establish a speedup. The later assertion-only test cleanup leaves production and integration inputs unchanged.

This draft enables the existing CI generation, analysis, and test jobs to provide comparable stage timings. The successful baseline [main integration run](https://github.com/t-unit/tonik/actions/runs/34021675462) is for the starting commit `cffa2195b475397be6ce7e513fcbb9aa65c00b2d` and took 25m35s overall. Compare matching backend/OS/SDK jobs and their individual steps; CI and local elapsed times have different hardware, caches, and concurrency.
