### PR TITLE
fix: preserve defaults on compound schemas

### DIFF
--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -11,8 +11,14 @@ Defaults are supported on:
 - model class properties (`components.schemas.*.properties.*.default`),
 - operation parameters (the parameter's `schema.default`) for path, query,
   header, and cookie locations,
+- referenced `allOf`, `oneOf`, and `anyOf` schemas with an enclosing
+  `default`, including references through aliases,
 - `$ref` siblings — a property `$ref`-ing another schema can carry a
   sibling `default` that overrides the target's default (OAS 3.1+).
+
+Defaults declared on individual composition branches are not inherited by the
+composition. A local property or parameter default takes precedence over the
+referenced schema's default.
 
 ## Behaviour
 

--- a/integration_test/defaulted/defaulted_test/test/compound_defaults_test.dart
+++ b/integration_test/defaulted/defaulted_test/test/compound_defaults_test.dart
@@ -3,61 +3,118 @@ import 'package:defaulted_api/src/operation/get_compound_defaults.dart';
 import 'package:test/test.dart';
 
 void main() {
-  final decoders = <String, Object? Function(Map<String, Object?>)>{
-    'allOf': (json) => AllOfDefaults.fromJson(json).toJson(),
-    'oneOf': (json) => OneOfDefaults.fromJson(json).toJson(),
-    'anyOf': (json) => AnyOfDefaults.fromJson(json).toJson(),
-  };
-  const defaults = {
-    'single': 3,
-    'multiple': 3,
-    'aliased': 3,
-    'aliasOverride': 2,
-    'overridden': 0,
-    'inline': 3,
-    'nullable': 3,
-    'zero': 0,
-    'disabled': false,
-  };
+  test('allOf defaults apply to missing properties', () {
+    final value = AllOfDefaults.fromJson(const <String, Object?>{});
 
-  for (final MapEntry(key: kind, value: decode) in decoders.entries) {
-    group('$kind enclosing defaults', () {
-      test(
-        'missing keys use defaults for single, multiple, and alias schemas',
-        () {
-          expect(decode({}), defaults);
-        },
-      );
+    expect(value.single?.toJson(), 3);
+    expect(value.multiple?.toJson(), 3);
+    expect(value.aliased?.toJson(), 3);
+    expect(value.aliasOverride?.toJson(), 2);
+    expect(value.overridden?.toJson(), 0);
+    expect(value.inline?.toJson(), 3);
+    expect(value.nullable?.toJson(), 3);
+    expect(value.zero?.toJson(), 0);
+    expect(value.disabled?.toJson(), isFalse);
+    expect(value.nullDefault, isNull);
+    expect(value.noDefault, isNull);
+  });
 
-      test('supplied values override defaults', () {
-        final supplied = {
-          for (final key in defaults.keys) key: key == 'disabled' ? true : 9,
-        };
-        expect(decode(supplied), supplied);
-      });
+  test('oneOf defaults apply to missing properties', () {
+    final value = OneOfDefaults.fromJson(const <String, Object?>{});
 
-      test('nullable explicit null wins over the non-null default', () {
-        expect(decode({'nullable': null}), {
-          for (final entry in defaults.entries)
-            if (entry.key != 'nullable') entry.key: entry.value,
-        });
-      });
+    expect(value.single?.toJson(), 3);
+    expect(value.multiple?.toJson(), 3);
+    expect(value.aliased?.toJson(), 3);
+    expect(value.aliasOverride?.toJson(), 2);
+    expect(value.overridden?.toJson(), 0);
+    expect(value.inline?.toJson(), 3);
+    expect(value.nullable?.toJson(), 3);
+    expect(value.zero?.toJson(), 0);
+    expect(value.disabled?.toJson(), isFalse);
+    expect(value.nullDefault, isNull);
+    expect(value.noDefault, isNull);
+  });
 
-      test('null defaults and absent defaults retain no-default behavior', () {
-        expect(decode({'nullDefault': null}), defaults);
-        expect(decode({'nullDefault': 4, 'noDefault': 5}), {
-          ...defaults,
-          'nullDefault': 4,
-          'noDefault': 5,
-        });
-      });
+  test('anyOf defaults apply to missing properties', () {
+    final value = AnyOfDefaults.fromJson(const <String, Object?>{});
 
-      test('defaults survive a JSON round-trip', () {
-        final encoded = decode({})! as Map<String, Object?>;
-        expect(decode(encoded), encoded);
-      });
+    expect(value.single?.toJson(), 3);
+    expect(value.multiple?.toJson(), 3);
+    expect(value.aliased?.toJson(), 3);
+    expect(value.aliasOverride?.toJson(), 2);
+    expect(value.overridden?.toJson(), 0);
+    expect(value.inline?.toJson(), 3);
+    expect(value.nullable?.toJson(), 3);
+    expect(value.zero?.toJson(), 0);
+    expect(value.disabled?.toJson(), isFalse);
+    expect(value.nullDefault, isNull);
+    expect(value.noDefault, isNull);
+  });
+
+  test('supplied values override compound defaults', () {
+    final allOf = AllOfDefaults.fromJson(const {'single': 9, 'disabled': true});
+    final oneOf = OneOfDefaults.fromJson(const {'multiple': 9, 'aliased': 8});
+    final anyOf = AnyOfDefaults.fromJson(const {'overridden': 9, 'zero': 8});
+
+    expect(allOf.single?.toJson(), 9);
+    expect(allOf.disabled?.toJson(), isTrue);
+    expect(oneOf.multiple?.toJson(), 9);
+    expect(oneOf.aliased?.toJson(), 8);
+    expect(anyOf.overridden?.toJson(), 9);
+    expect(anyOf.zero?.toJson(), 8);
+  });
+
+  test('explicit null wins over nullable compound defaults', () {
+    final allOf = AllOfDefaults.fromJson(const {'nullable': null});
+    final oneOf = OneOfDefaults.fromJson(const {'nullable': null});
+    final anyOf = AnyOfDefaults.fromJson(const {'nullable': null});
+
+    expect(allOf.nullable, isNull);
+    expect(oneOf.nullable, isNull);
+    expect(anyOf.nullable, isNull);
+  });
+
+  test('null schema defaults leave explicit null unchanged', () {
+    final allOf = AllOfDefaults.fromJson(const {'nullDefault': null});
+    final oneOf = OneOfDefaults.fromJson(const {'nullDefault': null});
+    final anyOf = AnyOfDefaults.fromJson(const {'nullDefault': null});
+
+    expect(allOf.nullDefault, isNull);
+    expect(oneOf.nullDefault, isNull);
+    expect(anyOf.nullDefault, isNull);
+  });
+
+  test('properties without defaults accept supplied values', () {
+    final allOf = AllOfDefaults.fromJson(const {
+      'nullDefault': 4,
+      'noDefault': 5,
     });
-  }
+    final oneOf = OneOfDefaults.fromJson(const {
+      'nullDefault': 4,
+      'noDefault': 5,
+    });
+    final anyOf = AnyOfDefaults.fromJson(const {
+      'nullDefault': 4,
+      'noDefault': 5,
+    });
+
+    expect(allOf.nullDefault?.toJson(), 4);
+    expect(allOf.noDefault?.toJson(), 5);
+    expect(oneOf.nullDefault?.toJson(), 4);
+    expect(oneOf.noDefault?.toJson(), 5);
+    expect(anyOf.nullDefault?.toJson(), 4);
+    expect(anyOf.noDefault?.toJson(), 5);
+  });
+
+  test('compound defaults survive a JSON round-trip', () {
+    final allOf = AllOfDefaults.fromJson(const <String, Object?>{});
+    final oneOf = OneOfDefaults.fromJson(const <String, Object?>{});
+    final anyOf = AnyOfDefaults.fromJson(const <String, Object?>{});
+
+    expect(AllOfDefaults.fromJson(allOf.toJson()), allOf);
+    expect(OneOfDefaults.fromJson(oneOf.toJson()), oneOf);
+    expect(AnyOfDefaults.fromJson(anyOf.toJson()), anyOf);
+  });
 
   test('compound defaults are public computed getters', () {
     expect(AllOfDefaults.singleDefault.toJson(), 3);

--- a/integration_test/defaulted/defaulted_test/test/compound_defaults_test.dart
+++ b/integration_test/defaulted/defaulted_test/test/compound_defaults_test.dart
@@ -1,0 +1,78 @@
+import 'package:defaulted_api/defaulted_api.dart';
+import 'package:defaulted_api/src/operation/get_compound_defaults.dart';
+import 'package:test/test.dart';
+
+void main() {
+  final decoders = <String, Object? Function(Map<String, Object?>)>{
+    'allOf': (json) => AllOfDefaults.fromJson(json).toJson(),
+    'oneOf': (json) => OneOfDefaults.fromJson(json).toJson(),
+    'anyOf': (json) => AnyOfDefaults.fromJson(json).toJson(),
+  };
+  const defaults = {
+    'single': 3,
+    'multiple': 3,
+    'aliased': 3,
+    'aliasOverride': 2,
+    'overridden': 0,
+    'inline': 3,
+    'nullable': 3,
+    'zero': 0,
+    'disabled': false,
+  };
+
+  for (final MapEntry(key: kind, value: decode) in decoders.entries) {
+    group('$kind enclosing defaults', () {
+      test(
+        'missing keys use defaults for single, multiple, and alias schemas',
+        () {
+          expect(decode({}), defaults);
+        },
+      );
+
+      test('supplied values override defaults', () {
+        final supplied = {
+          for (final key in defaults.keys) key: key == 'disabled' ? true : 9,
+        };
+        expect(decode(supplied), supplied);
+      });
+
+      test('nullable explicit null wins over the non-null default', () {
+        expect(decode({'nullable': null}), {
+          for (final entry in defaults.entries)
+            if (entry.key != 'nullable') entry.key: entry.value,
+        });
+      });
+
+      test('null defaults and absent defaults retain no-default behavior', () {
+        expect(decode({'nullDefault': null}), defaults);
+        expect(decode({'nullDefault': 4, 'noDefault': 5}), {
+          ...defaults,
+          'nullDefault': 4,
+          'noDefault': 5,
+        });
+      });
+
+      test('defaults survive a JSON round-trip', () {
+        final encoded = decode({})! as Map<String, Object?>;
+        expect(decode(encoded), encoded);
+      });
+    });
+  }
+
+  test('compound defaults are public computed getters', () {
+    expect(AllOfDefaults.singleDefault.toJson(), 3);
+    expect(OneOfDefaults.multipleDefault.toJson(), 3);
+    expect(AnyOfDefaults.aliasedDefault.toJson(), 3);
+    expect(
+      identical(AllOfDefaults.singleDefault, AllOfDefaults.singleDefault),
+      isFalse,
+    );
+  });
+
+  test('operation parameters expose referenced compound defaults', () {
+    expect(GetCompoundDefaults.retriesDefault.toJson(), 3);
+    expect(GetCompoundDefaults.choiceDefault.toJson(), 3);
+    expect(GetCompoundDefaults.combinationDefault.toJson(), 3);
+    expect(GetCompoundDefaults.enabledDefault.toJson(), isFalse);
+  });
+}

--- a/integration_test/defaulted/openapi.yaml
+++ b/integration_test/defaulted/openapi.yaml
@@ -118,6 +118,31 @@ paths:
                 items:
                   $ref: '#/components/schemas/Subscription'
 
+  /compound/{retries}:
+    get:
+      operationId: getCompoundDefaults
+      parameters:
+        - name: retries
+          in: path
+          required: true
+          schema:
+            $ref: '#/components/schemas/AllOfDefaultAlias'
+        - name: choice
+          in: query
+          schema:
+            $ref: '#/components/schemas/OneOfSingleDefault'
+        - name: combination
+          in: header
+          schema:
+            $ref: '#/components/schemas/AnyOfSingleDefault'
+        - name: enabled
+          in: cookie
+          schema:
+            $ref: '#/components/schemas/AllOfFalseDefault'
+      responses:
+        '200':
+          description: OK
+
 components:
   schemas:
     DefaultedPrimitives:
@@ -496,3 +521,184 @@ components:
           type: string
           format: byte
           default: "SGVsbG8="
+    CompoundBranchDefault:
+      type: integer
+      default: 7
+    AllOfSingleDefault:
+      type: integer
+      allOf: [{type: integer}]
+      default: 3
+    AllOfMultipleDefault:
+      allOf: [{type: integer}, {type: number}]
+      default: 3
+    AllOfDefaultAlias:
+      $ref: '#/components/schemas/AllOfSingleDefault'
+    AllOfDefaultOuterAlias:
+      $ref: '#/components/schemas/AllOfDefaultAlias'
+    AllOfOverridingAlias:
+      $ref: '#/components/schemas/AllOfDefaultAlias'
+      default: 2
+    AllOfNullableDefault:
+      type: integer
+      allOf: [{type: integer}]
+      nullable: true
+      default: 3
+    AllOfNullDefault:
+      type: integer
+      allOf: [{type: integer}]
+      nullable: true
+      default: null
+    AllOfNoDefault:
+      allOf:
+        - $ref: '#/components/schemas/CompoundBranchDefault'
+    AllOfZeroDefault:
+      allOf: [{type: integer}]
+      default: 0
+    AllOfFalseDefault:
+      allOf: [{type: boolean}]
+      default: false
+    AllOfDefaults:
+      type: object
+      properties:
+        single:
+          $ref: '#/components/schemas/AllOfSingleDefault'
+        multiple:
+          $ref: '#/components/schemas/AllOfMultipleDefault'
+        aliased:
+          $ref: '#/components/schemas/AllOfDefaultOuterAlias'
+        aliasOverride:
+          $ref: '#/components/schemas/AllOfOverridingAlias'
+        overridden:
+          $ref: '#/components/schemas/AllOfDefaultOuterAlias'
+          default: 0
+        inline:
+          allOf: [{type: integer}]
+          default: 3
+        nullable:
+          $ref: '#/components/schemas/AllOfNullableDefault'
+        nullDefault:
+          $ref: '#/components/schemas/AllOfNullDefault'
+        noDefault:
+          $ref: '#/components/schemas/AllOfNoDefault'
+        zero:
+          $ref: '#/components/schemas/AllOfZeroDefault'
+        disabled:
+          $ref: '#/components/schemas/AllOfFalseDefault'
+    OneOfSingleDefault:
+      oneOf: [{type: integer}]
+      default: 3
+    OneOfMultipleDefault:
+      oneOf: [{type: integer}, {type: string}]
+      default: 3
+    OneOfDefaultAlias:
+      $ref: '#/components/schemas/OneOfSingleDefault'
+    OneOfDefaultOuterAlias:
+      $ref: '#/components/schemas/OneOfDefaultAlias'
+    OneOfOverridingAlias:
+      $ref: '#/components/schemas/OneOfDefaultAlias'
+      default: 2
+    OneOfNullableDefault:
+      type: integer
+      oneOf: [{type: integer}]
+      nullable: true
+      default: 3
+    OneOfNullDefault:
+      type: integer
+      oneOf: [{type: integer}]
+      nullable: true
+      default: null
+    OneOfNoDefault:
+      oneOf:
+        - $ref: '#/components/schemas/CompoundBranchDefault'
+    OneOfZeroDefault:
+      oneOf: [{type: integer}]
+      default: 0
+    OneOfFalseDefault:
+      oneOf: [{type: boolean}]
+      default: false
+    OneOfDefaults:
+      type: object
+      properties:
+        single:
+          $ref: '#/components/schemas/OneOfSingleDefault'
+        multiple:
+          $ref: '#/components/schemas/OneOfMultipleDefault'
+        aliased:
+          $ref: '#/components/schemas/OneOfDefaultOuterAlias'
+        aliasOverride:
+          $ref: '#/components/schemas/OneOfOverridingAlias'
+        overridden:
+          $ref: '#/components/schemas/OneOfDefaultOuterAlias'
+          default: 0
+        inline:
+          oneOf: [{type: integer}]
+          default: 3
+        nullable:
+          $ref: '#/components/schemas/OneOfNullableDefault'
+        nullDefault:
+          $ref: '#/components/schemas/OneOfNullDefault'
+        noDefault:
+          $ref: '#/components/schemas/OneOfNoDefault'
+        zero:
+          $ref: '#/components/schemas/OneOfZeroDefault'
+        disabled:
+          $ref: '#/components/schemas/OneOfFalseDefault'
+    AnyOfSingleDefault:
+      anyOf: [{type: integer}]
+      default: 3
+    AnyOfMultipleDefault:
+      anyOf: [{type: integer}, {type: string}]
+      default: 3
+    AnyOfDefaultAlias:
+      $ref: '#/components/schemas/AnyOfSingleDefault'
+    AnyOfDefaultOuterAlias:
+      $ref: '#/components/schemas/AnyOfDefaultAlias'
+    AnyOfOverridingAlias:
+      $ref: '#/components/schemas/AnyOfDefaultAlias'
+      default: 2
+    AnyOfNullableDefault:
+      type: integer
+      anyOf: [{type: integer}]
+      nullable: true
+      default: 3
+    AnyOfNullDefault:
+      type: integer
+      anyOf: [{type: integer}]
+      nullable: true
+      default: null
+    AnyOfNoDefault:
+      anyOf:
+        - $ref: '#/components/schemas/CompoundBranchDefault'
+    AnyOfZeroDefault:
+      anyOf: [{type: integer}]
+      default: 0
+    AnyOfFalseDefault:
+      anyOf: [{type: boolean}]
+      default: false
+    AnyOfDefaults:
+      type: object
+      properties:
+        single:
+          $ref: '#/components/schemas/AnyOfSingleDefault'
+        multiple:
+          $ref: '#/components/schemas/AnyOfMultipleDefault'
+        aliased:
+          $ref: '#/components/schemas/AnyOfDefaultOuterAlias'
+        aliasOverride:
+          $ref: '#/components/schemas/AnyOfOverridingAlias'
+        overridden:
+          $ref: '#/components/schemas/AnyOfDefaultOuterAlias'
+          default: 0
+        inline:
+          anyOf: [{type: integer}]
+          default: 3
+        nullable:
+          $ref: '#/components/schemas/AnyOfNullableDefault'
+        nullDefault:
+          $ref: '#/components/schemas/AnyOfNullDefault'
+        noDefault:
+          $ref: '#/components/schemas/AnyOfNoDefault'
+        zero:
+          $ref: '#/components/schemas/AnyOfZeroDefault'
+        disabled:
+          $ref: '#/components/schemas/AnyOfFalseDefault'

--- a/packages/tonik_core/lib/src/model/effective_default.dart
+++ b/packages/tonik_core/lib/src/model/effective_default.dart
@@ -1,10 +1,13 @@
 import 'package:tonik_core/src/model/model.dart';
 
 /// Returns [localDefault] when set; otherwise falls back to [model]'s
-/// default if [model] is an [AliasModel] (which itself walks the alias
-/// chain with cycle protection). The alias default never overrides a
-/// property/parameter's own local default.
+/// enclosing schema default, following alias chains with cycle protection.
+/// Defaults on individual composition members are not inherited.
 Object? effectiveDefault(Object? localDefault, Model model) {
   if (localDefault != null) return localDefault;
-  return model is AliasModel ? model.defaultValue : null;
+  return switch (model) {
+    AliasModel(:final defaultValue) ||
+    CompositeModel(:final defaultValue) => defaultValue,
+    _ => null,
+  };
 }

--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -69,6 +69,9 @@ mixin NamedModel on Model {
 mixin CompositeModel on Model {
   List<Model> get containedModels;
 
+  /// The enclosing schema's default; defaults on members are not inherited.
+  Object? get defaultValue;
+
   @override
   EncodingShape get encodingShape {
     final shapes = containedModels.map((m) => m.encodingShape).toSet();
@@ -171,7 +174,7 @@ class AliasModel._({
        );
 
   /// The locally declared default if set, otherwise the first one found
-  /// while walking nested [AliasModel]s.
+  /// while walking nested [AliasModel]s and their terminal model.
   Object? get defaultValue => _resolveDefault(this, <AliasModel>{});
 
   static Object? _resolveDefault(AliasModel alias, Set<AliasModel> visited) {
@@ -185,7 +188,7 @@ class AliasModel._({
     if (alias._localDefault != null) return alias._localDefault;
     final inner = alias.model;
     if (inner is AliasModel) return _resolveDefault(inner, visited);
-    return null;
+    return effectiveDefault(null, inner);
   }
 
   @override
@@ -333,6 +336,7 @@ class AllOfModel({
   var bool isNullable = false,
   var bool isReadOnly = false,
   var bool isWriteOnly = false,
+  @override var Object? defaultValue,
 }) extends Model with NamedModel, CompositeModel {
   this {
     this.additionalPropertiesPolicy =
@@ -370,6 +374,7 @@ class OneOfModel({
   var bool isNullable = false,
   var bool isReadOnly = false,
   var bool isWriteOnly = false,
+  @override var Object? defaultValue,
 }) extends Model with NamedModel, CompositeModel {
   @override
   List<Model> get containedModels => models.map((m) => m.model).toList();
@@ -394,6 +399,7 @@ class AnyOfModel({
   var bool isNullable = false,
   var bool isReadOnly = false,
   var bool isWriteOnly = false,
+  @override var Object? defaultValue,
 }) extends Model with NamedModel, CompositeModel {
   @override
   List<Model> get containedModels => models.map((m) => m.model).toList();
@@ -497,7 +503,7 @@ class Property({
   var String? description,
 }) {
   /// The property's own [defaultValue] when set, otherwise the default
-  /// carried by its [model] when that model is an [AliasModel] chain.
+  /// carried by its [model], following aliases to an enclosing schema default.
   Object? get effectiveDefaultValue => effectiveDefault(defaultValue, model);
 
   @override

--- a/packages/tonik_core/lib/src/transformer/allof_normalizer.dart
+++ b/packages/tonik_core/lib/src/transformer/allof_normalizer.dart
@@ -101,7 +101,7 @@ class const AllOfNormalizer() {
         isDeprecated: model.isDeprecated,
         isNullable: model.isNullable,
         nameOverride: model.nameOverride,
-        defaultValue: null,
+        defaultValue: model.defaultValue,
         examples: model.examples,
       );
     } else if (model is AllOfModel) {

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -45,5 +45,89 @@ void main() {
         'k': 'v',
       });
     });
+
+    final factories = <String, CompositeModel Function(Object?, Model)>{
+      'allOf': (value, member) => AllOfModel(
+        models: [member],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: value,
+      ),
+      'oneOf': (value, member) => OneOfModel(
+        models: [(discriminatorValue: null, model: member)],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: value,
+      ),
+      'anyOf': (value, member) => AnyOfModel(
+        models: [(discriminatorValue: null, model: member)],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: value,
+      ),
+    };
+
+    for (final MapEntry(key: kind, value: create) in factories.entries) {
+      group(kind, () {
+        test(
+          'preserves enclosing defaults directly and through alias chains',
+          () {
+            for (final value in <Object>[
+              3,
+              0,
+              false,
+              {'key': 'value'},
+              <int>[],
+            ]) {
+              final compound = create(value, aliasWith('member-default'));
+              final inner = AliasModel(
+                model: compound,
+                context: context,
+                examples: const [],
+                defaultValue: null,
+              );
+              final outer = AliasModel(
+                model: inner,
+                context: context,
+                examples: const [],
+                defaultValue: null,
+              );
+
+              expect(effectiveDefault(null, compound), value);
+              expect(effectiveDefault(null, outer), value);
+              expect(outer.defaultValue, value);
+            }
+          },
+        );
+
+        test('local and nearest alias defaults take precedence', () {
+          final compound = create(3, aliasWith(1));
+          final alias = AliasModel(
+            model: compound,
+            context: context,
+            examples: const [],
+            defaultValue: 2,
+          );
+          expect(effectiveDefault(0, compound), 0);
+          expect(effectiveDefault(null, alias), 2);
+          expect(effectiveDefault(false, alias), isFalse);
+        });
+
+        test('a null enclosing default does not inherit member defaults', () {
+          final compound = create(null, aliasWith('member-default'));
+          final alias = AliasModel(
+            model: compound,
+            context: context,
+            examples: const [],
+            defaultValue: null,
+          );
+          expect(effectiveDefault(null, compound), isNull);
+          expect(alias.defaultValue, isNull);
+        });
+      });
+    }
   });
 }

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -46,88 +46,128 @@ void main() {
       });
     });
 
-    final factories = <String, CompositeModel Function(Object?, Model)>{
-      'allOf': (value, member) => AllOfModel(
+    test('returns the enclosing allOf default, including zero', () {
+      final model = AllOfModel(
+        models: [IntegerModel(context: context)],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: 0,
+      );
+
+      expect(effectiveDefault(null, model), 0);
+    });
+
+    test('returns the enclosing oneOf default, including false', () {
+      final model = OneOfModel(
+        models: [
+          (discriminatorValue: null, model: BooleanModel(context: context)),
+        ],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: false,
+      );
+
+      expect(effectiveDefault(null, model), isFalse);
+    });
+
+    test('returns the enclosing anyOf object default unchanged', () {
+      final model = AnyOfModel(
+        models: [(discriminatorValue: null, model: AnyModel(context: context))],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: const {'key': 'value'},
+      );
+
+      expect(effectiveDefault(null, model), {'key': 'value'});
+    });
+
+    test('follows aliases to the enclosing compound default', () {
+      final compound = AllOfModel(
+        models: [IntegerModel(context: context)],
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+        defaultValue: 3,
+      );
+      final inner = AliasModel(
+        model: compound,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final outer = AliasModel(
+        model: inner,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      expect(effectiveDefault(null, outer), 3);
+      expect(outer.defaultValue, 3);
+    });
+
+    test(
+      'local and alias defaults override the enclosing compound default',
+      () {
+        final compound = AllOfModel(
+          models: [IntegerModel(context: context)],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: 3,
+        );
+        final alias = AliasModel(
+          model: compound,
+          context: context,
+          examples: const [],
+          defaultValue: 2,
+        );
+
+        expect(effectiveDefault(0, compound), 0);
+        expect(effectiveDefault(null, alias), 2);
+        expect(effectiveDefault(0, alias), 0);
+      },
+    );
+
+    test('compounds do not inherit defaults from their members', () {
+      final member = AliasModel(
+        model: IntegerModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: 7,
+      );
+      final allOf = AllOfModel(
         models: [member],
         context: context,
         isDeprecated: false,
         examples: const [],
-        defaultValue: value,
-      ),
-      'oneOf': (value, member) => OneOfModel(
+      );
+      final oneOf = OneOfModel(
         models: [(discriminatorValue: null, model: member)],
         context: context,
         isDeprecated: false,
         examples: const [],
-        defaultValue: value,
-      ),
-      'anyOf': (value, member) => AnyOfModel(
+      );
+      final anyOf = AnyOfModel(
         models: [(discriminatorValue: null, model: member)],
         context: context,
         isDeprecated: false,
         examples: const [],
-        defaultValue: value,
-      ),
-    };
+      );
+      final alias = AliasModel(
+        model: allOf,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
 
-    for (final MapEntry(key: kind, value: create) in factories.entries) {
-      group(kind, () {
-        test(
-          'preserves enclosing defaults directly and through alias chains',
-          () {
-            for (final value in <Object>[
-              3,
-              0,
-              false,
-              {'key': 'value'},
-              <int>[],
-            ]) {
-              final compound = create(value, aliasWith('member-default'));
-              final inner = AliasModel(
-                model: compound,
-                context: context,
-                examples: const [],
-                defaultValue: null,
-              );
-              final outer = AliasModel(
-                model: inner,
-                context: context,
-                examples: const [],
-                defaultValue: null,
-              );
-
-              expect(effectiveDefault(null, compound), value);
-              expect(effectiveDefault(null, outer), value);
-              expect(outer.defaultValue, value);
-            }
-          },
-        );
-
-        test('local and nearest alias defaults take precedence', () {
-          final compound = create(3, aliasWith(1));
-          final alias = AliasModel(
-            model: compound,
-            context: context,
-            examples: const [],
-            defaultValue: 2,
-          );
-          expect(effectiveDefault(0, compound), 0);
-          expect(effectiveDefault(null, alias), 2);
-          expect(effectiveDefault(false, alias), isFalse);
-        });
-
-        test('a null enclosing default does not inherit member defaults', () {
-          final compound = create(null, aliasWith('member-default'));
-          final alias = AliasModel(
-            model: compound,
-            context: context,
-            examples: const [],
-            defaultValue: null,
-          );
-          expect(effectiveDefault(null, compound), isNull);
-          expect(alias.defaultValue, isNull);
-        });
-      });
-    }
+      expect(effectiveDefault(null, allOf), isNull);
+      expect(effectiveDefault(null, oneOf), isNull);
+      expect(effectiveDefault(null, anyOf), isNull);
+      expect(alias.defaultValue, isNull);
+    });
   });
 }

--- a/packages/tonik_core/test/src/transformer/allof_normalizer_test.dart
+++ b/packages/tonik_core/test/src/transformer/allof_normalizer_test.dart
@@ -59,6 +59,40 @@ void main() {
         expect(alias.isDeprecated, isFalse);
       });
 
+      test('preserves the enclosing default over the member default', () {
+        final inner = AliasModel(
+          model: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+          defaultValue: 7,
+        );
+        final compound = AllOfModel(
+          name: 'RetryCount',
+          models: [inner],
+          context: context,
+          isDeprecated: false,
+          examples: const [],
+          defaultValue: 0,
+        );
+        final document = ApiDocument(
+          title: 'Test API',
+          version: '1.0.0',
+          models: {compound},
+          responseHeaders: const {},
+          requestHeaders: const {},
+          servers: const {},
+          operations: const {},
+          responses: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          requestBodies: const {},
+        );
+
+        final alias = normalizer.apply(document).models.single as AliasModel;
+        expect(alias.defaultValue, 0);
+      });
+
       test('preserves deprecated flag from AllOfModel', () {
         final baseModel = StringModel(context: context);
 

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -166,6 +166,7 @@ class ModelImporter._(
     if (schema.allOf != null) {
       final modelContext = context.push(name);
       final allOfModel = AllOfModel(
+        defaultValue: schema.rawDefault,
         isDeprecated: schema.isDeprecated ?? false,
         models: <Model>[],
         context: modelContext,
@@ -183,6 +184,7 @@ class ModelImporter._(
 
     if (schema.oneOf != null) {
       final oneOfModel = OneOfModel(
+        defaultValue: schema.rawDefault,
         isDeprecated: schema.isDeprecated ?? false,
         models: <DiscriminatedModel>[],
         context: context,
@@ -200,6 +202,7 @@ class ModelImporter._(
 
     if (schema.anyOf != null) {
       final anyOfModel = AnyOfModel(
+        defaultValue: schema.rawDefault,
         isDeprecated: schema.isDeprecated ?? false,
         models: <DiscriminatedModel>[],
         context: context,
@@ -236,6 +239,7 @@ class ModelImporter._(
     if (types.length > 1) {
       // Multi-type becomes OneOfModel — create shell.
       final oneOfModel = OneOfModel(
+        defaultValue: schema.rawDefault,
         isDeprecated: schema.isDeprecated ?? false,
         models: <DiscriminatedModel>[],
         context: context,
@@ -1085,6 +1089,7 @@ class ModelImporter._(
     }
 
     final allOfModel = AllOfModel(
+      defaultValue: schema.rawDefault,
       models: modelsToMerge,
       context: modelContext,
       isDeprecated: false,
@@ -1388,6 +1393,7 @@ class ModelImporter._(
     }
 
     final allOfModel = AllOfModel(
+      defaultValue: schema.rawDefault,
       name: name,
       models: modelsToMerge,
       context: modelContext,
@@ -1603,6 +1609,7 @@ class ModelImporter._(
     });
 
     final oneOfModel = OneOfModel(
+      defaultValue: schema.rawDefault,
       models: models.toList(),
       name: name,
       context: context,
@@ -1659,6 +1666,7 @@ class ModelImporter._(
     // Register the model early (with an empty member list) so that
     // circular references can find it during member resolution.
     final allOfModel = AllOfModel(
+      defaultValue: schema.rawDefault,
       isDeprecated: schema.isDeprecated ?? false,
       models: <Model>[],
       context: modelContext,
@@ -1713,6 +1721,7 @@ class ModelImporter._(
     // Register the model early (with an empty member list) so that
     // circular references can find it during member resolution.
     final oneOfModel = OneOfModel(
+      defaultValue: schema.rawDefault,
       isDeprecated: schema.isDeprecated ?? false,
       models: <DiscriminatedModel>[],
       context: context,
@@ -1765,6 +1774,7 @@ class ModelImporter._(
     // Register the model early (with an empty member list) so that
     // circular references can find it during member resolution.
     final anyOfModel = AnyOfModel(
+      defaultValue: schema.rawDefault,
       isDeprecated: schema.isDeprecated ?? false,
       models: <DiscriminatedModel>[],
       context: context,

--- a/packages/tonik_parse/test/model/compound_default_value_test.dart
+++ b/packages/tonik_parse/test/model/compound_default_value_test.dart
@@ -2,225 +2,404 @@ import 'package:test/test.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_parse/tonik_parse.dart';
 
-ApiDocument _import(Map<String, Object?> schemas) => Importer().import({
-  'openapi': '3.1.0',
-  'info': {'title': 'Test API', 'version': '1.0.0'},
-  'paths': <String, Object?>{},
-  'components': {'schemas': schemas},
-});
-
-Model _named(ApiDocument api, String name) =>
-    api.models.firstWhere((m) => m is NamedModel && m.name == name);
-
-Map<String, Object?> _ref(String name) => {
-  r'$ref': '#/components/schemas/$name',
-};
-
 void main() {
-  for (final kind in ['allOf', 'oneOf', 'anyOf']) {
-    group('$kind defaults', () {
-      for (final members in [1, 2]) {
-        test(
-          '$members members preserve enclosing defaults through references',
-          () {
-            final api = _import({
-              // Resolve forward references as well as an extra alias hop.
-              'Outer': _ref('Alias'),
-              'Alias': _ref('Value'),
-              'Override': {..._ref('Value'), 'default': 2},
-              'Value': {
-                kind: [
-                  {'type': 'integer'},
-                  if (members == 2)
-                    {'type': kind == 'allOf' ? 'number' : 'string'},
-                ],
-                'default': 3,
-              },
-              'Holder': {
-                'type': 'object',
-                'properties': {
-                  'direct': _ref('Value'),
-                  'aliased': _ref('Outer'),
-                  'aliasOverride': _ref('Override'),
-                  'localOverride': {..._ref('Outer'), 'default': 0},
-                  'nullLocal': {..._ref('Value'), 'default': null},
+  test('referenced compound schemas retain their enclosing defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'RetryCount': {
+            'type': 'integer',
+            'allOf': [
+              {'type': 'integer'},
+            ],
+            'default': 3,
+          },
+          'Choice': {
+            'oneOf': [
+              {'type': 'integer'},
+              {'type': 'string'},
+            ],
+            'default': 0,
+          },
+          'Enabled': {
+            'anyOf': [
+              {'type': 'boolean'},
+              {'type': 'string'},
+            ],
+            'default': false,
+          },
+          'Config': {
+            'type': 'object',
+            'properties': {
+              'retries': {r'$ref': '#/components/schemas/RetryCount'},
+              'choice': {r'$ref': '#/components/schemas/Choice'},
+              'enabled': {r'$ref': '#/components/schemas/Enabled'},
+            },
+          },
+        },
+      },
+    });
+    final retries = api.models.whereType<AllOfModel>().single;
+    final choice = api.models.whereType<OneOfModel>().single;
+    final enabled = api.models.whereType<AnyOfModel>().single;
+    final config = api.models.whereType<ClassModel>().single;
+    final retriesProperty = config.properties.firstWhere(
+      (p) => p.name == 'retries',
+    );
+    final choiceProperty = config.properties.firstWhere(
+      (p) => p.name == 'choice',
+    );
+    final enabledProperty = config.properties.firstWhere(
+      (p) => p.name == 'enabled',
+    );
+
+    expect(retries.defaultValue, 3);
+    expect(choice.defaultValue, 0);
+    expect(enabled.defaultValue, isFalse);
+    expect(retriesProperty.effectiveDefaultValue, 3);
+    expect(choiceProperty.effectiveDefaultValue, 0);
+    expect(enabledProperty.effectiveDefaultValue, isFalse);
+  });
+
+  test(
+    'alias and property defaults take precedence over compound defaults',
+    () {
+      final api = Importer().import({
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, Object?>{},
+        'components': {
+          'schemas': {
+            'Outer': {r'$ref': '#/components/schemas/Alias'},
+            'Alias': {r'$ref': '#/components/schemas/RetryCount'},
+            'Override': {
+              r'$ref': '#/components/schemas/RetryCount',
+              'default': 2,
+            },
+            'RetryCount': {
+              'allOf': [
+                {'type': 'integer'},
+              ],
+              'default': 3,
+            },
+            'Config': {
+              'type': 'object',
+              'properties': {
+                'aliased': {r'$ref': '#/components/schemas/Outer'},
+                'aliasOverride': {r'$ref': '#/components/schemas/Override'},
+                'localOverride': {
+                  r'$ref': '#/components/schemas/Outer',
+                  'default': 0,
+                },
+                'nullLocal': {
+                  r'$ref': '#/components/schemas/RetryCount',
+                  'default': null,
                 },
               },
-            });
-            final value = _named(api, 'Value') as CompositeModel;
-            expect(value.defaultValue, 3);
-            expect((_named(api, 'Outer') as AliasModel).defaultValue, 3);
-            final holder = _named(api, 'Holder') as ClassModel;
-            expect(
-              {
-                for (final p in holder.properties)
-                  p.name: p.effectiveDefaultValue,
-              },
-              {
-                'direct': 3,
-                'aliased': 3,
-                'aliasOverride': 2,
-                'localOverride': 0,
-                // Explicit schema default:null retains the existing fallback.
-                'nullLocal': 3,
-              },
-            );
+            },
           },
-        );
-      }
+        },
+      });
+      final outer = api.models.whereType<AliasModel>().firstWhere(
+        (m) => m.name == 'Outer',
+      );
+      final config = api.models.whereType<ClassModel>().single;
+      final aliased = config.properties.firstWhere((p) => p.name == 'aliased');
+      final aliasOverride = config.properties.firstWhere(
+        (p) => p.name == 'aliasOverride',
+      );
+      final localOverride = config.properties.firstWhere(
+        (p) => p.name == 'localOverride',
+      );
+      final nullLocal = config.properties.firstWhere(
+        (p) => p.name == 'nullLocal',
+      );
 
-      test(
-        'inline and defs models retain defaults without a Property carrier',
-        () {
-          final schema = {
-            kind: [
+      expect(outer.defaultValue, 3);
+      expect(aliased.effectiveDefaultValue, 3);
+      expect(aliasOverride.effectiveDefaultValue, 2);
+      expect(localOverride.effectiveDefaultValue, 0);
+      // A schema default:null retains the existing fallback to the target.
+      expect(nullLocal.effectiveDefaultValue, 3);
+    },
+  );
+
+  test('inline compound array items retain their enclosing defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'Retries': {
+            'type': 'array',
+            'items': {
+              'allOf': [
+                {'type': 'integer'},
+              ],
+              'default': 3,
+            },
+          },
+          'Choices': {
+            'type': 'array',
+            'items': {
+              'oneOf': [
+                {'type': 'integer'},
+              ],
+              'default': 0,
+            },
+          },
+          'Flags': {
+            'type': 'array',
+            'items': {
+              'anyOf': [
+                {'type': 'boolean'},
+              ],
+              'default': false,
+            },
+          },
+        },
+      },
+    });
+    final retries = api.models.whereType<ListModel>().firstWhere(
+      (m) => m.name == 'Retries',
+    );
+    final choices = api.models.whereType<ListModel>().firstWhere(
+      (m) => m.name == 'Choices',
+    );
+    final flags = api.models.whereType<ListModel>().firstWhere(
+      (m) => m.name == 'Flags',
+    );
+
+    expect((retries.content as AllOfModel).defaultValue, 3);
+    expect((choices.content as OneOfModel).defaultValue, 0);
+    expect((flags.content as AnyOfModel).defaultValue, isFalse);
+  });
+
+  test('a defs reference preserves the compound default', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'Config': {
+            'type': 'object',
+            r'$defs': {
+              'Enabled': {
+                'anyOf': [
+                  {'type': 'boolean'},
+                ],
+                'default': false,
+              },
+            },
+            'properties': {
+              'enabled': {
+                r'$ref': r'#/components/schemas/Config/$defs/Enabled',
+              },
+            },
+          },
+        },
+      },
+    });
+    final config = api.models.whereType<ClassModel>().single;
+
+    expect(config.properties.single.effectiveDefaultValue, isFalse);
+  });
+
+  test('absent and null compound defaults do not inherit branch defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'Branch': {'type': 'integer', 'default': 7},
+          'Absent': {
+            'oneOf': [
+              {r'$ref': '#/components/schemas/Branch'},
+            ],
+          },
+          'ExplicitNull': {
+            'anyOf': [
+              {r'$ref': '#/components/schemas/Branch'},
+            ],
+            'default': null,
+          },
+          'Config': {
+            'type': 'object',
+            'properties': {
+              'absent': {r'$ref': '#/components/schemas/Absent'},
+              'explicitNull': {r'$ref': '#/components/schemas/ExplicitNull'},
+            },
+          },
+        },
+      },
+    });
+    final absent = api.models.whereType<OneOfModel>().single;
+    final explicitNull = api.models.whereType<AnyOfModel>().single;
+    final config = api.models.whereType<ClassModel>().single;
+    final absentProperty = config.properties.firstWhere(
+      (p) => p.name == 'absent',
+    );
+    final nullProperty = config.properties.firstWhere(
+      (p) => p.name == 'explicitNull',
+    );
+
+    expect(absent.defaultValue, isNull);
+    expect(explicitNull.defaultValue, isNull);
+    expect(absentProperty.effectiveDefaultValue, isNull);
+    expect(nullProperty.effectiveDefaultValue, isNull);
+  });
+
+  test('named and inline type arrays preserve defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'Value': {
+            'type': ['integer', 'string'],
+            'default': 0,
+          },
+          'Values': {
+            'type': 'array',
+            'items': {
+              'type': ['integer', 'string'],
+              'default': 0,
+            },
+          },
+          'Config': {
+            'type': 'object',
+            'properties': {
+              'value': {r'$ref': '#/components/schemas/Value'},
+            },
+          },
+        },
+      },
+    });
+    final value = api.models.whereType<OneOfModel>().firstWhere(
+      (m) => m.name == 'Value',
+    );
+    final values = api.models.whereType<ListModel>().single;
+    final config = api.models.whereType<ClassModel>().single;
+
+    expect(value.defaultValue, 0);
+    expect((values.content as OneOfModel).defaultValue, 0);
+    expect(config.properties.single.effectiveDefaultValue, 0);
+  });
+
+  test('named and property structural ref wrappers preserve defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, Object?>{},
+      'components': {
+        'schemas': {
+          'Base': {'type': 'object'},
+          'Named': {
+            r'$ref': '#/components/schemas/Base',
+            'properties': {
+              'count': {'type': 'integer'},
+            },
+            'default': {'count': 3},
+          },
+          'Config': {
+            'type': 'object',
+            'properties': {
+              'value': {
+                r'$ref': '#/components/schemas/Base',
+                'properties': {
+                  'count': {'type': 'integer'},
+                },
+                'default': {'count': 3},
+              },
+            },
+          },
+        },
+      },
+    });
+    final named = api.models.whereType<AllOfModel>().firstWhere(
+      (m) => m.name == 'Named',
+    );
+    final config = api.models.whereType<ClassModel>().firstWhere(
+      (m) => m.name == 'Config',
+    );
+    final propertyModel = config.properties.single.model as AllOfModel;
+
+    expect(named.defaultValue, {'count': 3});
+    expect(propertyModel.defaultValue, {'count': 3});
+  });
+
+  test('parameters in every location can use referenced compound defaults', () {
+    final api = Importer().import({
+      'openapi': '3.1.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': {
+        '/items/{retries}': {
+          'get': {
+            'operationId': 'getItem',
+            'parameters': [
+              {
+                'name': 'retries',
+                'in': 'path',
+                'required': true,
+                'schema': {r'$ref': '#/components/schemas/RetryAlias'},
+              },
+              {
+                'name': 'choice',
+                'in': 'query',
+                'schema': {r'$ref': '#/components/schemas/Choice'},
+              },
+              {
+                'name': 'enabled',
+                'in': 'header',
+                'schema': {r'$ref': '#/components/schemas/Enabled'},
+              },
+              {
+                'name': 'attempts',
+                'in': 'cookie',
+                'schema': {r'$ref': '#/components/schemas/RetryAlias'},
+              },
+            ],
+            'responses': {
+              '200': {'description': 'OK'},
+            },
+          },
+        },
+      },
+      'components': {
+        'schemas': {
+          'RetryAlias': {r'$ref': '#/components/schemas/RetryCount'},
+          'RetryCount': {
+            'allOf': [
+              {'type': 'integer'},
+            ],
+            'default': 3,
+          },
+          'Choice': {
+            'oneOf': [
+              {'type': 'integer'},
+            ],
+            'default': 0,
+          },
+          'Enabled': {
+            'anyOf': [
               {'type': 'boolean'},
             ],
             'default': false,
-          };
-          final api = _import({
-            'Values': {'type': 'array', 'items': schema},
-            'Holder': {
-              'type': 'object',
-              r'$defs': {'Value': schema},
-              'properties': {
-                'value': {r'$ref': r'#/components/schemas/Holder/$defs/Value'},
-              },
-            },
-          });
-          final list = _named(api, 'Values') as ListModel;
-          expect((list.content as CompositeModel).defaultValue, isFalse);
-          final holder = _named(api, 'Holder') as ClassModel;
-          expect(holder.properties.single.effectiveDefaultValue, isFalse);
+          },
         },
-      );
-
-      test(
-        'absent and null enclosing defaults do not inherit branch defaults',
-        () {
-          final api = _import({
-            'Branch': {'type': 'integer', 'default': 7},
-            'Absent': {
-              kind: [_ref('Branch')],
-            },
-            'ExplicitNull': {
-              kind: [_ref('Branch')],
-              'nullable': true,
-              'default': null,
-            },
-            'Holder': {
-              'type': 'object',
-              'properties': {
-                'absent': _ref('Absent'),
-                'explicitNull': _ref('ExplicitNull'),
-              },
-            },
-          });
-          final holder = _named(api, 'Holder') as ClassModel;
-          for (final property in holder.properties) {
-            expect(property.effectiveDefaultValue, isNull);
-            expect((property.model as CompositeModel).defaultValue, isNull);
-          }
-        },
-      );
+      },
     });
-  }
 
-  test(
-    'type-array defaults survive named and recursive OneOf construction',
-    () {
-      const schema = {
-        'type': ['integer', 'string'],
-        'default': 0,
-      };
-      final api = _import({
-        'Value': schema,
-        'Values': {'type': 'array', 'items': schema},
-        'Holder': {
-          'type': 'object',
-          'properties': {'value': _ref('Value')},
-        },
-      });
-      expect((_named(api, 'Value') as OneOfModel).defaultValue, 0);
-      final values = _named(api, 'Values') as ListModel;
-      expect((values.content as OneOfModel).defaultValue, 0);
-      final holder = _named(api, 'Holder') as ClassModel;
-      expect(holder.properties.single.effectiveDefaultValue, 0);
-    },
-  );
-
-  test(
-    'structural ref wrappers preserve defaults in named and property paths',
-    () {
-      final schema = {
-        ..._ref('Base'),
-        'properties': {
-          'count': {'type': 'integer'},
-        },
-        'default': {'count': 3},
-      };
-      final api = _import({
-        'Base': {'type': 'object'},
-        'Named': schema,
-        'Holder': {
-          'type': 'object',
-          'properties': {'value': schema},
-        },
-      });
-      expect((_named(api, 'Named') as AllOfModel).defaultValue, {'count': 3});
-      final holder = _named(api, 'Holder') as ClassModel;
-      expect((holder.properties.single.model as AllOfModel).defaultValue, {
-        'count': 3,
-      });
-    },
-  );
-
-  for (final kind in ['allOf', 'oneOf', 'anyOf']) {
-    for (final location in ['path', 'query', 'header', 'cookie']) {
-      test('$location parameter reads $kind defaults through an alias', () {
-        final api = Importer().import({
-          'openapi': '3.1.0',
-          'info': {'title': 'Test API', 'version': '1.0.0'},
-          'paths': {
-            '/items/{value}': {
-              'get': {
-                'operationId': 'getItem',
-                'parameters': [
-                  {
-                    'name': 'value',
-                    'in': location,
-                    'required': location == 'path',
-                    'schema': _ref('Alias'),
-                  },
-                ],
-                'responses': {
-                  '200': {'description': 'OK'},
-                },
-              },
-            },
-          },
-          'components': {
-            'schemas': {
-              'Alias': _ref('Value'),
-              'Value': {
-                kind: [
-                  {'type': 'integer'},
-                ],
-                'default': 3,
-              },
-            },
-          },
-        });
-        final value = switch (location) {
-          'path' => api.pathParameters.single.resolve().effectiveDefaultValue,
-          'query' => api.queryParameters.single.resolve().effectiveDefaultValue,
-          'header' => api.requestHeaders.single.resolve().effectiveDefaultValue,
-          'cookie' =>
-            api.cookieParameters.single.resolve().effectiveDefaultValue,
-          _ => throw StateError('Unexpected parameter location'),
-        };
-        expect(value, 3);
-      });
-    }
-  }
+    expect(api.pathParameters.single.resolve().effectiveDefaultValue, 3);
+    expect(api.queryParameters.single.resolve().effectiveDefaultValue, 0);
+    expect(api.requestHeaders.single.resolve().effectiveDefaultValue, isFalse);
+    expect(api.cookieParameters.single.resolve().effectiveDefaultValue, 3);
+  });
 }

--- a/packages/tonik_parse/test/model/compound_default_value_test.dart
+++ b/packages/tonik_parse/test/model/compound_default_value_test.dart
@@ -1,0 +1,226 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+ApiDocument _import(Map<String, Object?> schemas) => Importer().import({
+  'openapi': '3.1.0',
+  'info': {'title': 'Test API', 'version': '1.0.0'},
+  'paths': <String, Object?>{},
+  'components': {'schemas': schemas},
+});
+
+Model _named(ApiDocument api, String name) =>
+    api.models.firstWhere((m) => m is NamedModel && m.name == name);
+
+Map<String, Object?> _ref(String name) => {
+  r'$ref': '#/components/schemas/$name',
+};
+
+void main() {
+  for (final kind in ['allOf', 'oneOf', 'anyOf']) {
+    group('$kind defaults', () {
+      for (final members in [1, 2]) {
+        test(
+          '$members members preserve enclosing defaults through references',
+          () {
+            final api = _import({
+              // Resolve forward references as well as an extra alias hop.
+              'Outer': _ref('Alias'),
+              'Alias': _ref('Value'),
+              'Override': {..._ref('Value'), 'default': 2},
+              'Value': {
+                kind: [
+                  {'type': 'integer'},
+                  if (members == 2)
+                    {'type': kind == 'allOf' ? 'number' : 'string'},
+                ],
+                'default': 3,
+              },
+              'Holder': {
+                'type': 'object',
+                'properties': {
+                  'direct': _ref('Value'),
+                  'aliased': _ref('Outer'),
+                  'aliasOverride': _ref('Override'),
+                  'localOverride': {..._ref('Outer'), 'default': 0},
+                  'nullLocal': {..._ref('Value'), 'default': null},
+                },
+              },
+            });
+            final value = _named(api, 'Value') as CompositeModel;
+            expect(value.defaultValue, 3);
+            expect((_named(api, 'Outer') as AliasModel).defaultValue, 3);
+            final holder = _named(api, 'Holder') as ClassModel;
+            expect(
+              {
+                for (final p in holder.properties)
+                  p.name: p.effectiveDefaultValue,
+              },
+              {
+                'direct': 3,
+                'aliased': 3,
+                'aliasOverride': 2,
+                'localOverride': 0,
+                // Explicit schema default:null retains the existing fallback.
+                'nullLocal': 3,
+              },
+            );
+          },
+        );
+      }
+
+      test(
+        'inline and defs models retain defaults without a Property carrier',
+        () {
+          final schema = {
+            kind: [
+              {'type': 'boolean'},
+            ],
+            'default': false,
+          };
+          final api = _import({
+            'Values': {'type': 'array', 'items': schema},
+            'Holder': {
+              'type': 'object',
+              r'$defs': {'Value': schema},
+              'properties': {
+                'value': {r'$ref': r'#/components/schemas/Holder/$defs/Value'},
+              },
+            },
+          });
+          final list = _named(api, 'Values') as ListModel;
+          expect((list.content as CompositeModel).defaultValue, isFalse);
+          final holder = _named(api, 'Holder') as ClassModel;
+          expect(holder.properties.single.effectiveDefaultValue, isFalse);
+        },
+      );
+
+      test(
+        'absent and null enclosing defaults do not inherit branch defaults',
+        () {
+          final api = _import({
+            'Branch': {'type': 'integer', 'default': 7},
+            'Absent': {
+              kind: [_ref('Branch')],
+            },
+            'ExplicitNull': {
+              kind: [_ref('Branch')],
+              'nullable': true,
+              'default': null,
+            },
+            'Holder': {
+              'type': 'object',
+              'properties': {
+                'absent': _ref('Absent'),
+                'explicitNull': _ref('ExplicitNull'),
+              },
+            },
+          });
+          final holder = _named(api, 'Holder') as ClassModel;
+          for (final property in holder.properties) {
+            expect(property.effectiveDefaultValue, isNull);
+            expect((property.model as CompositeModel).defaultValue, isNull);
+          }
+        },
+      );
+    });
+  }
+
+  test(
+    'type-array defaults survive named and recursive OneOf construction',
+    () {
+      const schema = {
+        'type': ['integer', 'string'],
+        'default': 0,
+      };
+      final api = _import({
+        'Value': schema,
+        'Values': {'type': 'array', 'items': schema},
+        'Holder': {
+          'type': 'object',
+          'properties': {'value': _ref('Value')},
+        },
+      });
+      expect((_named(api, 'Value') as OneOfModel).defaultValue, 0);
+      final values = _named(api, 'Values') as ListModel;
+      expect((values.content as OneOfModel).defaultValue, 0);
+      final holder = _named(api, 'Holder') as ClassModel;
+      expect(holder.properties.single.effectiveDefaultValue, 0);
+    },
+  );
+
+  test(
+    'structural ref wrappers preserve defaults in named and property paths',
+    () {
+      final schema = {
+        ..._ref('Base'),
+        'properties': {
+          'count': {'type': 'integer'},
+        },
+        'default': {'count': 3},
+      };
+      final api = _import({
+        'Base': {'type': 'object'},
+        'Named': schema,
+        'Holder': {
+          'type': 'object',
+          'properties': {'value': schema},
+        },
+      });
+      expect((_named(api, 'Named') as AllOfModel).defaultValue, {'count': 3});
+      final holder = _named(api, 'Holder') as ClassModel;
+      expect((holder.properties.single.model as AllOfModel).defaultValue, {
+        'count': 3,
+      });
+    },
+  );
+
+  for (final kind in ['allOf', 'oneOf', 'anyOf']) {
+    for (final location in ['path', 'query', 'header', 'cookie']) {
+      test('$location parameter reads $kind defaults through an alias', () {
+        final api = Importer().import({
+          'openapi': '3.1.0',
+          'info': {'title': 'Test API', 'version': '1.0.0'},
+          'paths': {
+            '/items/{value}': {
+              'get': {
+                'operationId': 'getItem',
+                'parameters': [
+                  {
+                    'name': 'value',
+                    'in': location,
+                    'required': location == 'path',
+                    'schema': _ref('Alias'),
+                  },
+                ],
+                'responses': {
+                  '200': {'description': 'OK'},
+                },
+              },
+            },
+          },
+          'components': {
+            'schemas': {
+              'Alias': _ref('Value'),
+              'Value': {
+                kind: [
+                  {'type': 'integer'},
+                ],
+                'default': 3,
+              },
+            },
+          },
+        });
+        final value = switch (location) {
+          'path' => api.pathParameters.single.resolve().effectiveDefaultValue,
+          'query' => api.queryParameters.single.resolve().effectiveDefaultValue,
+          'header' => api.requestHeaders.single.resolve().effectiveDefaultValue,
+          'cookie' =>
+            api.cookieParameters.single.resolve().effectiveDefaultValue,
+          _ => throw StateError('Unexpected parameter location'),
+        };
+        expect(value, 3);
+      });
+    }
+  }
+}


### PR DESCRIPTION
When a property references an `allOf`, `oneOf`, or `anyOf` schema with an enclosing default, generated clients lose that default. For example, decoding `{}` for a property referencing an integer composition with `default: 3` produces `null` instead of `3`.

Preserve enclosing defaults during schema import and resolve them through references and alias chains for model properties and operation parameters. Retain local override precedence, cycle protection, and existing null handling; preserve the metadata when normalizing a single-member `allOf` to an alias. Add explicit regression tests with concrete schemas and direct assertions, and document the supported behavior.

Validation:
- Core/parser regression tests and generator/CLI unit suites passed.
- Generated-client regression tests passed for both Dio and HTTP.
- Package analysis and generated-client analysis passed for both backends.
- Formatting and diff whitespace checks passed; independent code and scope reviews found no blockers.
