### PR TITLE
fix: encode form query names independently of allowReserved

### DIFF
--- a/integration_test/allow_reserved/allow_reserved_test/test/form_name_test.dart
+++ b/integration_test/allow_reserved/allow_reserved_test/test/form_name_test.dart
@@ -1,0 +1,112 @@
+import 'package:allow_reserved_api/allow_reserved_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test(
+    'escapes the declared name while allowing reserved value chars',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testFormReservedNames(
+        filterSlashName: 'a/b?c:d@e',
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'filter%2Fname=a/b?c:d@e');
+    },
+  );
+
+  test('escapes the declared name and value without allowReserved', () async {
+    final server = await RawRequestServer.start();
+    final api = QueryApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.testFormReservedNames(
+      defaultSlashName: 'a/b?c:d@e',
+    );
+
+    requireSuccess(response);
+    final request = await server.takeRequest();
+    expect(request.uri.query, 'default%2Fname=a%2Fb%3Fc%3Ad%40e');
+  });
+
+  test(
+    'escapes each repeated array name while retaining value slashes',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testFormReservedNames(
+        repeatedSlashName: const ['a/b', 'c/d'],
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'repeated%2Fname=a/b&repeated%2Fname=c/d');
+    },
+  );
+
+  test(
+    'escapes a collapsed object name while retaining value slashes',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testFormReservedNames(
+        objectSlashName: const ReservedListObject(tags: ['a/b', 'c/d']),
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'object%2Fname=tags,a/b,c/d');
+    },
+  );
+
+  test(
+    'escapes a collapsed object name and value without allowReserved',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testFormReservedNames(
+        defaultObjectSlashName: const ReservedListObject(tags: ['a/b', 'c/d']),
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'defaultObject%2Fname=tags,a%2Fb,c%2Fd');
+    },
+  );
+
+  test(
+    'escapes Date and enum names while retaining reserved enum chars',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testFormReservedNames(
+        dateSlashName: Date(2024, 3, 15),
+        enumSlashName: ReservedChoice.aSlashBc,
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'date%2Fname=2024-03-15&enum%2Fname=a/b:c');
+    },
+  );
+}

--- a/integration_test/allow_reserved/openapi.yaml
+++ b/integration_test/allow_reserved/openapi.yaml
@@ -249,6 +249,64 @@ paths:
         '204':
           description: No Content
 
+  /form-reserved-names:
+    get:
+      operationId: testFormReservedNames
+      tags:
+        - query
+      summary: Test reserved characters in declared form query names
+      parameters:
+        - name: filter/name
+          in: query
+          style: form
+          allowReserved: true
+          schema:
+            type: string
+        - name: default/name
+          in: query
+          style: form
+          allowReserved: false
+          schema:
+            type: string
+        - name: repeated/name
+          in: query
+          style: form
+          explode: true
+          allowReserved: true
+          schema:
+            type: array
+            items:
+              type: string
+        - name: object/name
+          in: query
+          style: form
+          explode: false
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/ReservedListObject'
+        - name: defaultObject/name
+          in: query
+          style: form
+          explode: false
+          schema:
+            $ref: '#/components/schemas/ReservedListObject'
+        - name: date/name
+          in: query
+          style: form
+          allowReserved: true
+          schema:
+            type: string
+            format: date
+        - name: enum/name
+          in: query
+          style: form
+          allowReserved: true
+          schema:
+            $ref: '#/components/schemas/ReservedChoice'
+      responses:
+        '204':
+          description: No Content
+
 components:
   schemas:
     ReservedChoice:

--- a/packages/tonik_util/lib/src/date.dart
+++ b/packages/tonik_util/lib/src/date.dart
@@ -102,7 +102,6 @@ class Date(
       name: paramName.uriEncode(
         allowEmpty: true,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(

--- a/packages/tonik_util/lib/src/encoding/any_encoding.dart
+++ b/packages/tonik_util/lib/src/encoding/any_encoding.dart
@@ -419,7 +419,11 @@ List<ParameterEntry> encodeAnyToFormEntries(
   }
   return [
     (
-      name: name,
+      name: name.uriEncode(
+        allowEmpty: true,
+        useQueryComponent: useQueryComponent,
+        textEncoding: textEncoding,
+      ),
       value: encodeAnyToForm(
         value,
         explode: explode,

--- a/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/form_encoder_extensions.dart
@@ -9,6 +9,8 @@ import 'package:tonik_util/src/encoding/uri_encoder_extensions.dart';
 /// Form encoding produces a list of [ParameterEntry] (`name=value` pairs) that
 /// callers join with the separator for their context — `&` for query strings
 /// and urlencoded bodies, `; ` for cookies.
+/// Declared parameter names are always percent-encoded; `allowReserved` applies
+/// to values, including object member names serialized as part of an object.
 
 // Items, keys, and values may be empty strings; encode to '' rather than throw.
 String _encodeValue(
@@ -38,7 +40,6 @@ extension FormUriEncoder on Uri {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -66,7 +67,6 @@ extension FormStringEncoder on String {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -94,7 +94,6 @@ extension FormIntEncoder on int {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -122,7 +121,6 @@ extension FormDoubleEncoder on double {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -150,7 +148,6 @@ extension FormNumEncoder on num {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -178,7 +175,6 @@ extension FormBoolEncoder on bool {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -206,7 +202,6 @@ extension FormDateTimeEncoder on DateTime {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -234,7 +229,6 @@ extension FormBigDecimalEncoder on BigDecimal {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(
@@ -274,7 +268,6 @@ extension FormStringListEncoder on List<String> {
           name: _encodeValue(
             paramName,
             useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved,
             textEncoding: textEncoding,
           ),
           value: uriEncode(
@@ -294,7 +287,6 @@ extension FormStringListEncoder on List<String> {
           name: _encodeValue(
             paramName,
             useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved,
             textEncoding: textEncoding,
           ),
           value: alreadyEncoded
@@ -338,7 +330,6 @@ extension FormStringMapEncoder on Map<String, String> {
           name: _encodeValue(
             paramName,
             useQueryComponent: useQueryComponent,
-            allowReserved: allowReserved,
             textEncoding: textEncoding,
           ),
           value: uriEncode(
@@ -391,7 +382,6 @@ extension FormBinaryEncoder on List<int> {
       name: _encodeValue(
         paramName,
         useQueryComponent: useQueryComponent,
-        allowReserved: allowReserved,
         textEncoding: textEncoding,
       ),
       value: uriEncode(

--- a/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_form_encoder.dart
@@ -182,6 +182,16 @@ extension PropertyValueFormEncoder on Map<String, PropertyValue> {
           ),
         });
     }
-    return [(name: paramName, value: parts.join(','))];
+    return [
+      (
+        name: _encode(
+          paramName,
+          useQueryComponent: useQueryComponent,
+          allowReserved: false,
+          textEncoding: textEncoding,
+        ),
+        value: parts.join(','),
+      ),
+    ];
   }
 }

--- a/packages/tonik_util/test/src/date_test.dart
+++ b/packages/tonik_util/test/src/date_test.dart
@@ -176,6 +176,33 @@ void main() {
     });
 
     group('form encoding', () {
+      test('toForm escapes reserved name chars with allowReserved', () {
+        expect(
+          Date(2024, 3, 15).toForm(
+            'filter/name',
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+            textEncoding: utf8,
+          ),
+          const [(name: 'filter%2Fname', value: '2024-03-15')],
+        );
+      });
+
+      test('toForm retains name charset and query-component encoding', () {
+        expect(
+          Date(2024, 3, 15).toForm(
+            'clé/a b',
+            explode: false,
+            allowEmpty: true,
+            allowReserved: true,
+            useQueryComponent: true,
+            textEncoding: latin1,
+          ),
+          const [(name: 'cl%E9%2Fa+b', value: '2024-03-15')],
+        );
+      });
+
       test('toForm returns URL-encoded ISO date string', () {
         final date = Date(2024, 3, 15);
         final encoded = date

--- a/packages/tonik_util/test/src/encoding/any_encoding_test.dart
+++ b/packages/tonik_util/test/src/encoding/any_encoding_test.dart
@@ -2062,6 +2062,48 @@ void main() {
   });
 
   group('encodeAnyToFormEntries', () {
+    test('escapes the declared name while retaining reserved value chars', () {
+      expect(
+        encodeAnyToFormEntries(
+          'a/b?c:d@e',
+          name: 'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const [(name: 'filter%2Fname', value: 'a/b?c:d@e')],
+      );
+    });
+
+    test('escapes declared name and value chars without allowReserved', () {
+      expect(
+        encodeAnyToFormEntries(
+          'a/b?c:d@e',
+          name: 'filter/name',
+          explode: false,
+          allowEmpty: true,
+          textEncoding: utf8,
+        ),
+        const [(name: 'filter%2Fname', value: 'a%2Fb%3Fc%3Ad%40e')],
+      );
+    });
+
+    test('retains declared name charset and query-component encoding', () {
+      expect(
+        encodeAnyToFormEntries(
+          'café/a b',
+          name: 'clé/a b',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          useQueryComponent: true,
+          textEncoding: latin1,
+        ),
+        const [(name: 'cl%E9%2Fa+b', value: 'caf%E9/a+b')],
+      );
+    });
+
     test('empty list value yields no entries', () {
       expect(
         encodeAnyToFormEntries(

--- a/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/form_encoder_extensions_test.dart
@@ -1095,42 +1095,185 @@ void main() {
       );
     });
 
-    test('int encoder escapes & in the parameter name', () {
+    test('int encoder escapes reserved characters in the parameter name', () {
       expect(
-        42.toForm('q&a', explode: false, allowEmpty: true, textEncoding: utf8),
-        const <ParameterEntry>[(name: 'q%26a', value: '42')],
+        42.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: '42')],
       );
     });
 
-    test('list explode=false escapes the parameter name', () {
+    test('URI encoder escapes the name and preserves reserved value chars', () {
       expect(
-        [
-          'a',
-          'b',
-        ].toForm('q&a', explode: false, allowEmpty: true, textEncoding: utf8),
-        const <ParameterEntry>[(name: 'q%26a', value: 'a,b')],
-      );
-    });
-
-    test('list explode=true escapes the parameter name on every entry', () {
-      expect(
-        [
-          'a',
-          'b',
-        ].toForm('q&a', explode: true, allowEmpty: true, textEncoding: utf8),
+        Uri.parse('https://example.com/a').toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
         const <ParameterEntry>[
-          (name: 'q%26a', value: 'a'),
-          (name: 'q%26a', value: 'b'),
+          (name: 'filter%2Fname', value: 'https://example.com/a'),
         ],
       );
     });
 
-    test('map explode=false escapes the parameter name', () {
+    test('double encoder escapes reserved characters in the name', () {
       expect(
-        {
-          'k': 'v',
-        }.toForm('q&a', explode: false, allowEmpty: true, textEncoding: utf8),
-        const <ParameterEntry>[(name: 'q%26a', value: 'k,v')],
+        3.14.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: '3.14')],
+      );
+    });
+
+    test('num encoder escapes reserved characters in the name', () {
+      const num value = 2;
+      expect(
+        value.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: '2')],
+      );
+    });
+
+    test('bool encoder escapes reserved characters in the name', () {
+      expect(
+        true.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'true')],
+      );
+    });
+
+    test('DateTime encoder escapes the name and preserves value colons', () {
+      expect(
+        DateTime.utc(2024, 3, 15, 12, 30).toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[
+          (name: 'filter%2Fname', value: '2024-03-15T12:30:00.000Z'),
+        ],
+      );
+    });
+
+    test('BigDecimal encoder escapes reserved characters in the name', () {
+      expect(
+        BigDecimal.parse('3.14').toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: '3.14')],
+      );
+    });
+
+    test('binary encoder escapes the name and preserves value slashes', () {
+      expect(
+        [97, 47, 98].toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'a/b')],
+      );
+    });
+
+    test('list explode=false escapes the name and preserves value slashes', () {
+      expect(
+        ['a/b', 'c/d'].toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'a/b,c/d')],
+      );
+    });
+
+    test('list explode=true escapes the name on every entry', () {
+      expect(
+        ['a/b', 'c/d'].toForm(
+          'filter/name',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[
+          (name: 'filter%2Fname', value: 'a/b'),
+          (name: 'filter%2Fname', value: 'c/d'),
+        ],
+      );
+    });
+
+    test('list escapes the name without re-encoding encoded values', () {
+      expect(
+        ['a%2Fb', 'c%3Ad'].toForm(
+          'filter/name',
+          explode: true,
+          allowEmpty: true,
+          allowReserved: true,
+          alreadyEncoded: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[
+          (name: 'filter%2Fname', value: 'a%2Fb'),
+          (name: 'filter%2Fname', value: 'c%3Ad'),
+        ],
+      );
+    });
+
+    test('map explode=false escapes the name and preserves member slashes', () {
+      expect(
+        {'k/1': 'a/b'}.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'k/1,a/b')],
+      );
+    });
+
+    test('map escapes the name without re-encoding encoded values', () {
+      expect(
+        {'k/1': 'a%2Fb'}.toForm(
+          'filter/name',
+          explode: false,
+          allowEmpty: true,
+          allowReserved: true,
+          alreadyEncoded: true,
+          textEncoding: utf8,
+        ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'k/1,a%2Fb')],
       );
     });
 
@@ -1160,30 +1303,47 @@ void main() {
       );
     });
 
-    test('parameter name keeps other reserved chars literal under '
-        'allowReserved', () {
+    test('parameter name escapes reserved chars with allowReserved', () {
       expect(
-        'v'.toForm(
-          'a:b',
+        'a/b?c:d@e'.toForm(
+          'filter/name',
           explode: false,
           allowEmpty: true,
           allowReserved: true,
           textEncoding: utf8,
         ),
-        const <ParameterEntry>[(name: 'a:b', value: 'v')],
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'a/b?c:d@e')],
       );
     });
 
+    test(
+      'parameter name and value escape reserved chars without allowReserved',
+      () {
+        expect(
+          'a/b?c:d@e'.toForm(
+            'filter/name',
+            explode: false,
+            allowEmpty: true,
+            textEncoding: utf8,
+          ),
+          const <ParameterEntry>[
+            (name: 'filter%2Fname', value: 'a%2Fb%3Fc%3Ad%40e'),
+          ],
+        );
+      },
+    );
+
     test('encodes raw names and values directly with Latin-1', () {
       expect(
-        'café'.toForm(
-          'clé',
+        'café/a b'.toForm(
+          'clé/a b',
           explode: false,
           allowEmpty: true,
+          allowReserved: true,
           useQueryComponent: true,
           textEncoding: latin1,
         ),
-        const <ParameterEntry>[(name: 'cl%E9', value: 'caf%E9')],
+        const <ParameterEntry>[(name: 'cl%E9%2Fa+b', value: 'caf%E9/a+b')],
       );
     });
   });

--- a/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_form_encoder_test.dart
@@ -190,6 +190,54 @@ void main() {
   });
 
   group('object-level explode=false collapse', () {
+    test('escapes the declared name while retaining reserved member chars', () {
+      expect(
+        <String, PropertyValue>{'k/1': const PropertyValue.scalar('a/b?c:d@e')}
+            .toForm(
+              'filter/name',
+              explode: false,
+              allowEmpty: true,
+              allowReserved: true,
+              textEncoding: utf8,
+            ),
+        const <ParameterEntry>[(name: 'filter%2Fname', value: 'k/1,a/b?c:d@e')],
+      );
+    });
+
+    test(
+      'escapes the declared name and member chars without allowReserved',
+      () {
+        expect(
+          <String, PropertyValue>{
+            'k/1': const PropertyValue.scalar('a/b?c:d@e'),
+          }.toForm(
+            'filter/name',
+            explode: false,
+            allowEmpty: true,
+            textEncoding: utf8,
+          ),
+          const <ParameterEntry>[
+            (name: 'filter%2Fname', value: 'k%2F1,a%2Fb%3Fc%3Ad%40e'),
+          ],
+        );
+      },
+    );
+
+    test('retains declared name charset and query-component encoding', () {
+      expect(
+        <String, PropertyValue>{'k/1': const PropertyValue.scalar('café/a b')}
+            .toForm(
+              'clé/a b',
+              explode: false,
+              allowEmpty: true,
+              allowReserved: true,
+              useQueryComponent: true,
+              textEncoding: latin1,
+            ),
+        const <ParameterEntry>[(name: 'cl%E9%2Fa+b', value: 'k/1,caf%E9/a+b')],
+      );
+    });
+
     test('collapses scalars and an array into a single comma-joined entry', () {
       expect(
         <String, PropertyValue>{


### PR DESCRIPTION
With `allowReserved: true`, a form query parameter named `filter/name` was sent as `filter/name=a/b?c:d@e`. This change emits `filter%2Fname=a/b?c:d@e`, encoding the declared name independently while retaining reserved expansion of the value.

Apply the same rule across scalar encoders, Date, arrays, collapsed maps and typed objects, and top-level AnyModel entries. Preserve exploded object-member keys, charset and query-component options, and already-encoded values. Add direct regressions and six generated-request tests with literal query expectations.

Validation:

- All 1,614 utility tests and 93 focused generator tests passed.
- Dio and HTTP each passed all 23 allow-reserved tests and 49 form-urlencoded tests.
- Runtime and affected generated/test package analysis, formatting, and diff checks passed.
- Independent code and scope reviews found no issues.
