### PR TITLE
fix: omit empty matrix objects during path encoding

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -1280,6 +1280,42 @@ paths:
   # MATRIX STYLE - MAP PARAMETERS
   # =============================================================================
 
+  /items/{coordinates}:
+    get:
+      operationId: testMatrixExplodedCoordinates
+      tags: [matrix]
+      summary: An empty exploded object leaves the literal trailing slash
+      parameters:
+        - name: coordinates
+          in: path
+          required: true
+          style: matrix
+          explode: true
+          schema:
+            type: object
+            additionalProperties:
+              type: string
+      responses:
+        '204':
+          description: OK
+
+  /matrix/object/optional/{value}:
+    get:
+      operationId: testMatrixOptionalObject
+      tags: [matrix]
+      summary: An object with all optional properties omitted expands to nothing
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: matrix
+          explode: true
+          schema:
+            $ref: '#/components/schemas/OptionalObject'
+      responses:
+        '204':
+          description: OK
+
   /matrix/map/string/{values}:
     get:
       operationId: testMatrixMapString
@@ -1695,6 +1731,12 @@ components:
         - 1
         - 2
         - 3
+
+    OptionalObject:
+      type: object
+      properties:
+        name:
+          type: string
 
     SimpleObject:
       type: object

--- a/integration_test/path_encoding/path_encoding_test/test/empty_matrix_object_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/empty_matrix_object_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:path_encoding_api/path_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+
+void main() {
+  test('empty exploded map sends the request with a trailing slash', () async {
+    final server = await RawRequestServer.start();
+    final api = MatrixApi(CustomServer(baseUrl: server.baseUrl));
+
+    final result = await api.testMatrixExplodedCoordinates(
+      coordinates: const {},
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.method, 'GET');
+    expect(request.uri.path, '/items/');
+    expect(request.uri.query, '');
+  });
+
+  test('nonempty exploded map keeps its property name and value', () async {
+    final server = await RawRequestServer.start();
+    final api = MatrixApi(CustomServer(baseUrl: server.baseUrl));
+
+    final result = await api.testMatrixExplodedCoordinates(
+      coordinates: const {'x': '1'},
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.uri.path, '/items/;x=1');
+  });
+
+  test('empty collapsed map sends the request with a trailing slash', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'content-type': 'application/json'},
+      responseBody: utf8.encode('{}'),
+    );
+    final api = MatrixApi(CustomServer(baseUrl: server.baseUrl));
+
+    final result = await api.testMatrixMapString(values: const {});
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.uri.path, '/matrix/map/string/');
+  });
+
+  test('model with all properties omitted expands to nothing', () async {
+    final server = await RawRequestServer.start();
+    final api = MatrixApi(CustomServer(baseUrl: server.baseUrl));
+
+    final result = await api.testMatrixOptionalObject(
+      value: const OptionalObject(),
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.uri.path, '/matrix/object/optional/');
+  });
+
+  test('empty scalar string still expands to the parameter name', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'content-type': 'application/json'},
+      responseBody: utf8.encode('{}'),
+    );
+    final api = MatrixApi(CustomServer(baseUrl: server.baseUrl));
+
+    final result = await api.testMatrixPrimitiveString(value: '');
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.uri.path, '/matrix/primitive/string/;value');
+  });
+}

--- a/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
+++ b/packages/tonik_util/lib/src/encoding/matrix_encoder_extensions.dart
@@ -148,9 +148,8 @@ extension MatrixStringMapEncoder on Map<String, String> {
   /// When [explode] is true, produces key=value pairs separated by semicolons.
   /// When false, produces key,value pairs without separators.
   ///
-  /// The [allowEmpty] parameter controls whether empty maps are allowed:
-  /// - When `true`, empty maps are encoded as `;paramName`
-  /// - When `false`, empty maps throw an exception
+  /// Empty maps expand to nothing under RFC 6570 Sections 2.3 and 3.2.1,
+  /// regardless of [allowEmpty].
   ///
   /// The [alreadyEncoded] parameter indicates whether the values are already
   /// URL-encoded. When `true`, values are not re-encoded to prevent double
@@ -161,11 +160,8 @@ extension MatrixStringMapEncoder on Map<String, String> {
     required bool allowEmpty,
     bool alreadyEncoded = false,
   }) {
-    if (isEmpty && !allowEmpty) {
-      throw const EmptyValueException();
-    }
     if (isEmpty) {
-      return ';$paramName';
+      return '';
     }
 
     if (explode) {

--- a/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
+++ b/packages/tonik_util/lib/src/encoding/property_value_style_encoders.dart
@@ -165,14 +165,16 @@ extension PropertyValueStyleEncoders on Map<String, PropertyValue> {
   }
 
   /// Uses property names when exploded and [paramName] when collapsed.
+  ///
+  /// Empty objects expand to nothing under RFC 6570 Sections 2.3 and 3.2.1,
+  /// regardless of [allowEmpty].
   String toMatrix(
     String paramName, {
     required bool explode,
     required bool allowEmpty,
   }) {
-    _guardEmpty(this, allowEmpty: allowEmpty);
     if (isEmpty) {
-      return ';$paramName';
+      return '';
     }
     if (explode) {
       // Matrix is an RFC 6570 named operator: empty values expand to the

--- a/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
+++ b/packages/tonik_util/test/src/encoding/matrix_encoder_extensions_test.dart
@@ -306,28 +306,22 @@ void main() {
 
     test('encodes empty map with explode=false and allowEmpty=true', () {
       final map = <String, String>{};
-      expect(map.toMatrix('point', explode: false, allowEmpty: true), ';point');
+      expect(map.toMatrix('point', explode: false, allowEmpty: true), '');
     });
 
     test('encodes empty map with explode=false and allowEmpty=false', () {
       final map = <String, String>{};
-      expect(
-        () => map.toMatrix('point', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(map.toMatrix('point', explode: false, allowEmpty: false), '');
     });
 
     test('encodes empty map with explode=true and allowEmpty=true', () {
       final map = <String, String>{};
-      expect(map.toMatrix('point', explode: true, allowEmpty: true), ';point');
+      expect(map.toMatrix('point', explode: true, allowEmpty: true), '');
     });
 
     test('encodes empty map with explode=true and allowEmpty=false', () {
       final map = <String, String>{};
-      expect(
-        () => map.toMatrix('point', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(map.toMatrix('point', explode: true, allowEmpty: false), '');
     });
 
     test('encodes map with special characters and explode=true', () {

--- a/packages/tonik_util/test/src/encoding/object_parameter_encodable_test.dart
+++ b/packages/tonik_util/test/src/encoding/object_parameter_encodable_test.dart
@@ -288,10 +288,7 @@ void main() {
     test('empty objects preserve each style response when allowed', () {
       expect(empty.toSimple(explode: true, allowEmpty: true), '');
       expect(empty.toLabel(explode: true, allowEmpty: true), '.');
-      expect(
-        empty.toMatrix('filter', explode: false, allowEmpty: true),
-        ';filter',
-      );
+      expect(empty.toMatrix('filter', explode: false, allowEmpty: true), '');
       expect(
         empty.toForm(
           'filter',
@@ -315,21 +312,57 @@ void main() {
       );
     });
 
-    for (final entry in encoders.entries) {
-      test(
-        '${entry.key} preserves the empty-object policy when disallowed',
-        () {
-          if (entry.key == 'form') {
-            expect(entry.value(empty, allowEmpty: false), <ParameterEntry>[]);
-          } else {
-            expect(
-              () => entry.value(empty, allowEmpty: false),
-              throwsA(isA<EmptyValueException>()),
-            );
-          }
-        },
+    test('simple rejects empty objects when disallowed', () {
+      expect(
+        () => empty.toSimple(explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
       );
-    }
+    });
+
+    test('form omits empty objects when allowEmpty=false', () {
+      expect(
+        empty.toForm(
+          'filter',
+          explode: true,
+          allowEmpty: false,
+          textEncoding: utf8,
+        ),
+        <ParameterEntry>[],
+      );
+    });
+
+    test('label rejects empty objects when disallowed', () {
+      expect(
+        () => empty.toLabel(explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('matrix omits empty objects when allowEmpty=false', () {
+      expect(empty.toMatrix('filter', explode: true, allowEmpty: false), '');
+      expect(empty.toMatrix('filter', explode: false, allowEmpty: false), '');
+    });
+
+    test('deepObject rejects empty objects when disallowed', () {
+      expect(
+        () => empty.toDeepObject('filter', explode: true, allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('pipeDelimited rejects empty objects when disallowed', () {
+      expect(
+        () => empty.toPipeDelimited('filter', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
+
+    test('spaceDelimited rejects empty objects when disallowed', () {
+      expect(
+        () => empty.toSpaceDelimited('filter', allowEmpty: false),
+        throwsA(isA<EmptyValueException>()),
+      );
+    });
 
     test(
       'empty scalar and array properties remain valid for simple styles',

--- a/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
+++ b/packages/tonik_util/test/src/encoding/property_value_style_encoders_test.dart
@@ -438,28 +438,16 @@ void main() {
       },
     );
 
-    test('empty map renders ;paramName with allowEmpty=true', () {
+    test('empty map expands to nothing with allowEmpty=true', () {
       const value = <String, PropertyValue>{};
-      expect(
-        value.toMatrix('point', explode: false, allowEmpty: true),
-        ';point',
-      );
-      expect(
-        value.toMatrix('point', explode: true, allowEmpty: true),
-        ';point',
-      );
+      expect(value.toMatrix('point', explode: false, allowEmpty: true), '');
+      expect(value.toMatrix('point', explode: true, allowEmpty: true), '');
     });
 
-    test('empty map throws with allowEmpty=false', () {
+    test('empty map expands to nothing with allowEmpty=false', () {
       const value = <String, PropertyValue>{};
-      expect(
-        () => value.toMatrix('point', explode: false, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
-      expect(
-        () => value.toMatrix('point', explode: true, allowEmpty: false),
-        throwsA(isA<EmptyValueException>()),
-      );
+      expect(value.toMatrix('point', explode: false, allowEmpty: false), '');
+      expect(value.toMatrix('point', explode: true, allowEmpty: false), '');
     });
 
     test(


### PR DESCRIPTION
Empty matrix objects currently fail encoding when `allowEmpty` is false and emit a name-only parameter when it is true. Both object encoders now expand an empty map to an empty string for either `explode` setting. For `/items/{coordinates}`, passing `{}` sends `/items/` with its trailing slash preserved.

This follows [RFC 6570 §2.3](https://www.rfc-editor.org/rfc/rfc6570.html#section-2.3), which treats zero-member maps as undefined, and [§3.2.1](https://www.rfc-editor.org/rfc/rfc6570.html#section-3.2.1), which gives undefined variables an empty expansion. The OAS maintainers corrected the contradictory matrix examples in [OAI/OpenAPI-Specification#5080](https://github.com/OAI/OpenAPI-Specification/pull/5080). Nonempty objects and empty scalar strings retain their existing encoding.

Validation:
- All 1,596 `tonik_util` tests passed.
- Five regression tests passed for each generated backend (Dio and HTTP), covering empty exploded/collapsed maps, empty generated models, nonempty maps, and empty strings.
- Utility, generated client, and integration test analysis passed; formatting and `git diff --check` are clean.
- Independent code and scope reviews passed.
