### PR TITLE
fix: preserve raw bytes in Dio binary requests

### DIFF
--- a/integration_test/binary_models/binary_models_test/test/binary_request_wire_test.dart
+++ b/integration_test/binary_models/binary_models_test/test/binary_request_wire_test.dart
@@ -1,0 +1,78 @@
+import 'dart:convert';
+
+import 'package:binary_models_api/binary_models_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('required binary body sends ordinary List<int> as raw octets', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 201,
+      responseHeaders: {'content-type': 'application/json'},
+      responseBody: utf8.encode('{"id":"uploaded","size":6}'),
+    );
+    final api = FilesApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.uploadFile(
+      id: 'raw-file',
+      body: const TonikFileBytes([0, 255, 128, 65, 195, 40]),
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.method, 'POST');
+    expect(request.uri.path, '/files/raw-file');
+    expect(request.header('content-type'), 'application/octet-stream');
+    expect(request.bodyBytes, [0, 255, 128, 65, 195, 40]);
+  });
+
+  test('optional binary body sends ordinary List<int> as raw octets', () async {
+    final server = await RawRequestServer.start();
+    final api = FilesApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.uploadOptionalFile(
+      body: const TonikFileBytes([0, 255, 128, 65, 195, 40]),
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.header('content-type'), 'application/octet-stream');
+    expect(request.bodyBytes, [0, 255, 128, 65, 195, 40]);
+  });
+
+  test('optional binary body can be omitted', () async {
+    final server = await RawRequestServer.start();
+    final api = FilesApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.uploadOptionalFile();
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.bodyBytes, isEmpty);
+  });
+
+  test('multi-content binary variant sends raw octets', () async {
+    final server = await RawRequestServer.start();
+    final api = FilesApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.uploadMultiContentFile(
+      body: const FilesMultiContentPostBodyRequestBodyOctetStream(
+        TonikFileBytes([0, 255, 128, 65, 195, 40]),
+      ),
+    );
+
+    expect(result, isTonikSuccess);
+    final request = await server.takeRequest();
+    expect(request.header('content-type'), 'application/octet-stream');
+    expect(request.bodyBytes, [0, 255, 128, 65, 195, 40]);
+  });
+}

--- a/integration_test/binary_models/openapi.yaml
+++ b/integration_test/binary_models/openapi.yaml
@@ -80,6 +80,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+  /files/optional:
+    post:
+      tags:
+        - files
+      summary: Upload an optional binary file
+      operationId: uploadOptionalFile
+      requestBody:
+        required: false
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+      responses:
+        '204':
+          description: File accepted
+  /files/multi-content:
+    post:
+      tags:
+        - files
+      summary: Upload a binary file or JSON metadata
+      operationId: uploadMultiContentFile
+      requestBody:
+        required: true
+        content:
+          application/octet-stream:
+            schema:
+              type: string
+              format: binary
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FileInfo'
+      responses:
+        '204':
+          description: File accepted
   /images/{id}:
     get:
       tags:

--- a/packages/tonik_generate/lib/src/transport/dio/dio_data_generator.dart
+++ b/packages/tonik_generate/lib/src/transport/dio/dio_data_generator.dart
@@ -138,6 +138,7 @@ class const DioDataGenerator({
         switch (item.contentType) {
           ContentType.text || ContentType.form => true,
           ContentType.json => _encodesJsonRoot(item.model),
+          ContentType.bytes => item.model is BinaryModel,
           _ => false,
         };
     final built = _bodyExpression(
@@ -201,11 +202,11 @@ class const DioDataGenerator({
         );
       case ContentType.bytes:
         return BuiltExpression.simple(switch (content.model) {
-          BinaryModel() =>
-            (isRequired
-                    ? value.property('toBytes')
-                    : value.nullSafeProperty('toBytes'))
-                .call([]),
+          // Dio transforms ordinary byte lists; Uint8List is sent as raw bytes.
+          BinaryModel() => refer(
+            'Uint8List',
+            'dart:typed_data',
+          ).property('fromList').call([value.property('toBytes').call([])]),
           PrimitiveModel() => value,
           _ => generateEncodingExceptionExpression(
             'Unsupported model for bytes content type.',

--- a/packages/tonik_generate/test/src/operation/data_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/data_generator_test.dart
@@ -902,7 +902,7 @@ void main() {
 
       const expectedMethod = '''
         Object? _data({required TonikFile body}) {
-          return body.toBytes();
+          return Uint8List.fromList(body.toBytes());
         }
       ''';
 
@@ -948,7 +948,8 @@ void main() {
 
         const expectedMethod = '''
         Object? _data({TonikFile? body}) {
-          return body?.toBytes();
+          if (body == null) return null;
+          return Uint8List.fromList(body.toBytes());
         }
       ''';
 
@@ -1127,7 +1128,7 @@ void main() {
         Object? _data({required Test body}) {
           return switch (body) {
             final TestJson value => value.value.toJson(),
-            final TestOctetStream value => value.value.toBytes(),
+            final TestOctetStream value => Uint8List.fromList(value.value.toBytes()),
           };
         }
       ''';


### PR DESCRIPTION
Dio binary uploads backed by an ordinary `List<int>` were transmitted as JSON-array text. Convert binary request data to `Uint8List` so Dio sends the original octets, while preserving optional-body omission.

Add wire regression coverage for required bodies, optional bodies present and omitted, and binary variants in multi-content requests. The same tests pass with both Dio and HTTP.

Validation:
- All 3,239 generator tests passed.
- Four wire tests passed on each backend; the three byte-preservation cases failed before the fix.
- Generator, generated clients, and integration test packages analyze cleanly.
- Formatting and `git diff --check` passed.
