### PR TITLE
fix: preserve date-time enum wire values

### DIFF
--- a/docs/data_types.md
+++ b/docs/data_types.md
@@ -60,13 +60,17 @@ If a class also contains nested objects, `fromSimple`/`fromForm` throw because t
 
 Tonik provides timezone-aware parsing for `date-time` format strings using the `OffsetDateTime` class. The parsing behavior depends on the timezone information present in the input:
 
-All generated code will always expose Dart `DateTime` objects in the generated code. However, internally Tonik uses `OffsetDateTime.parse()` to provide consistent timezone handling. The `OffsetDateTime` class extends Dart's `DateTime` interface while preserving timezone offset information:
+Regular date-time fields expose Dart `DateTime` objects. Internally Tonik uses `OffsetDateTime.parse()` to provide consistent timezone handling. The `OffsetDateTime` class extends Dart's `DateTime` interface while preserving timezone offset information:
 
 | Input Format | Return Type | Example | Description |
 |--------------|-------------|---------|-------------|
 | UTC (with Z) | `OffsetDateTime` (UTC) | `2023-12-25T15:30:45Z` | OffsetDateTime with zero offset (UTC) |
 | Local (no timezone) | `OffsetDateTime` (system timezone) | `2023-12-25T15:30:45` | OffsetDateTime with system timezone offset |
 | Timezone offset | `OffsetDateTime` (specified offset) | `2023-12-25T15:30:45+05:00` | OffsetDateTime with the specified offset |
+
+Date-time schemas with `enum` generate string-backed Dart enums. Each declared string is a distinct member and serializes exactly as written in the schema, even when two strings represent the same instant. For example, `2026-09-06T12:00:00.1000+02:00` remains distinct from `2026-09-06T12:00:00.100+02:00`.
+
+Call `value.toDateTime()` when you need a `DateTime`. This uses the same offset-preserving parser as regular date-time fields, with Dart's normalization and microsecond precision; it leaves enum identity and serialization unchanged. Conversion throws `DecodingException` for literals the parser cannot handle, or `StateError` for a configured unknown fallback member. Unknown wire strings are rejected unless an enum fallback is configured.
 
 ### Binary and Text Bodies
 

--- a/docs/defaults.md
+++ b/docs/defaults.md
@@ -11,6 +11,8 @@ Defaults are supported on:
 - model class properties (`components.schemas.*.properties.*.default`),
 - operation parameters (the parameter's `schema.default`) for path, query,
   header, and cookie locations,
+- referenced string and integer enum schemas, including date-time enums
+  and references through aliases,
 - referenced `allOf`, `oneOf`, and `anyOf` schemas with an enclosing
   `default`, including references through aliases,
 - `$ref` siblings — a property `$ref`-ing another schema can carry a
@@ -19,6 +21,9 @@ Defaults are supported on:
 Defaults declared on individual composition branches are not inherited by the
 composition. A local property or parameter default takes precedence over the
 referenced schema's default.
+
+Enum defaults select the member with the exact declared wire value. Date-time
+enum defaults are enum constants and retain the original timestamp spelling.
 
 ## Behaviour
 

--- a/integration_test/adversarial_strings/adversarial_strings_test/test/date_time_enum_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/date_time_enum_test.dart
@@ -160,6 +160,14 @@ void main() {
     });
   });
 
+  test('ordinary string and integer enums inherit component defaults', () {
+    final value = PlainEnumDefaultEnvelope.fromJson(const <String, Object?>{});
+
+    expect(value.status, DefaultedStringChoice.active);
+    expect(value.priority, DefaultedIntegerChoice.two);
+    expect(value.toJson(), {'status': 'active', 'priority': 2});
+  });
+
   test('unknown fallback cannot be converted or serialized', () {
     final value = EmptyDateTimeChoice.fromJson('2026-09-06T12:00:00Z');
 

--- a/integration_test/adversarial_strings/adversarial_strings_test/test/date_time_enum_test.dart
+++ b/integration_test/adversarial_strings/adversarial_strings_test/test/date_time_enum_test.dart
@@ -1,0 +1,177 @@
+import 'dart:convert';
+
+import 'package:adversarial_strings_api/adversarial_strings_api.dart';
+import 'package:test/test.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('equivalent timestamp strings remain distinct enum members', () {
+    final precise = DateTimeChoice.fromJson('2026-09-06T12:00:00.1000+02:00');
+    final short = DateTimeChoice.fromJson('2026-09-06T12:00:00.100+02:00');
+
+    expect(precise, DateTimeChoice.$toDateTime);
+    expect(short, DateTimeChoice.$toDateTime2);
+    expect(precise, isNot(short));
+    expect(precise.toJson(), '2026-09-06T12:00:00.1000+02:00');
+    expect(short.toJson(), '2026-09-06T12:00:00.100+02:00');
+    expect(jsonEncode(precise), '"2026-09-06T12:00:00.1000+02:00"');
+  });
+
+  test('undeclared timestamp spellings are rejected', () {
+    expect(
+      () => DateTimeChoice.fromJson('2026-09-06T10:00:00.100Z'),
+      throwsA(isA<DecodingException>()),
+    );
+    expect(
+      () => DateTimeChoice.fromSimple(
+        '2026-09-06T12:00:00.10000+02:00',
+        explode: false,
+      ),
+      throwsA(isA<DecodingException>()),
+    );
+    expect(
+      () => DateTimeChoice.fromForm(
+        '2026-09-06T10%3A00%3A00.100Z',
+        explode: false,
+      ),
+      throwsA(isA<DecodingException>()),
+    );
+  });
+
+  test('toDateTime preserves the offset without changing serialization', () {
+    final precise = DateTimeChoice.$toDateTime.toDateTime();
+    final short = DateTimeChoice.$toDateTime2.toDateTime();
+
+    expect(precise, isA<DateTime>());
+    expect(precise.timeZoneOffset, const Duration(hours: 2));
+    expect(precise.hour, 12);
+    expect(
+      precise.isAtSameMomentAs(DateTime.utc(2026, 9, 6, 10, 0, 0, 100)),
+      isTrue,
+    );
+    expect(precise.isAtSameMomentAs(short), isTrue);
+    expect(
+      DateTimeChoice.$toDateTime.toJson(),
+      '2026-09-06T12:00:00.1000+02:00',
+    );
+  });
+
+  test('date-time precision loss does not affect the enum wire value', () {
+    final value = DateTimeChoice.nanoseconds.toDateTime();
+
+    expect(value.millisecond, 123);
+    expect(value.microsecond, 456);
+    expect(
+      DateTimeChoice.nanoseconds.toJson(),
+      '2026-09-06T12:00:00.123456789+02:00',
+    );
+  });
+
+  test('simple and form decoding preserve exact enum membership', () {
+    expect(
+      DateTimeChoice.fromSimple(
+        '2026-09-06T12:00:00.1000+02:00',
+        explode: false,
+      ),
+      DateTimeChoice.$toDateTime,
+    );
+    expect(
+      DateTimeChoice.fromForm(
+        '2026-09-06T12%3A00%3A00.1000%2B02%3A00',
+        explode: false,
+      ),
+      DateTimeChoice.$toDateTime,
+    );
+  });
+
+  test('parameter encoders retain the literal timestamp', () {
+    const value = DateTimeChoice.$toDateTime;
+
+    expect(
+      value.toSimple(explode: false, allowEmpty: true, literal: true),
+      '2026-09-06T12:00:00.1000+02:00',
+    );
+    expect(
+      value.toForm(
+        'timestamp',
+        explode: false,
+        allowEmpty: true,
+        useQueryComponent: true,
+        textEncoding: utf8,
+      ),
+      [(name: 'timestamp', value: '2026-09-06T12%3A00%3A00.1000%2B02%3A00')],
+    );
+    expect(
+      value.toLabel(explode: false, allowEmpty: true),
+      '.2026-09-06T12%3A00%3A00.1000%2B02%3A00',
+    );
+    expect(
+      value.toMatrix('timestamp', explode: false, allowEmpty: true),
+      ';timestamp=2026-09-06T12%3A00%3A00.1000%2B02%3A00',
+    );
+    expect(
+      value.uriEncode(allowEmpty: true, textEncoding: utf8),
+      '2026-09-06T12%3A00%3A00.1000%2B02%3A00',
+    );
+  });
+
+  test('references, inline nullable enums and defaults retain literals', () {
+    final value = DateTimeEnvelope.fromJson(const {
+      'timestamp': '2026-09-06T12:00:00.1000+02:00',
+      'optional': '2026-09-06t10:00:00.1000z',
+    });
+
+    expect(value.timestamp, DateTimeChoice.$toDateTime);
+    expect(value.defaulted?.toJson(), '2026-09-06T12:00:00.1000+02:00');
+    expect(
+      value.defaulted?.toDateTime().timeZoneOffset,
+      const Duration(hours: 2),
+    );
+    expect(value.optional?.toDateTime().isUtc, isTrue);
+    expect(value.toJson(), {
+      'timestamp': '2026-09-06T12:00:00.1000+02:00',
+      'defaulted': '2026-09-06T12:00:00.1000+02:00',
+      'optional': '2026-09-06t10:00:00.1000z',
+    });
+  });
+
+  test('nullable date-time enum accepts null', () {
+    final value = DateTimeEnvelope.fromJson(const {
+      'timestamp': '2026-09-06T12:00:00.100+02:00',
+      'optional': null,
+    });
+
+    expect(value.optional, isNull);
+    expect(value.toJson(), {
+      'timestamp': '2026-09-06T12:00:00.100+02:00',
+      'defaulted': '2026-09-06T12:00:00.1000+02:00',
+      'optional': null,
+    });
+  });
+
+  test('component defaults are inherited through references and aliases', () {
+    final value = DateTimeDefaultEnvelope.fromJson(const <String, Object?>{});
+
+    expect(value.timestamp, DateTimeChoice.$toDateTime);
+    expect(value.aliased, DateTimeChoice.$toDateTime);
+    expect(value.toJson(), {
+      'timestamp': '2026-09-06T12:00:00.1000+02:00',
+      'aliased': '2026-09-06T12:00:00.1000+02:00',
+    });
+  });
+
+  test('unknown fallback cannot be converted or serialized', () {
+    final value = EmptyDateTimeChoice.fromJson('2026-09-06T12:00:00Z');
+
+    expect(value, EmptyDateTimeChoice.unknown);
+    expect(value.toDateTime, throwsStateError);
+    expect(value.toJson, throwsA(isA<EncodingException>()));
+  });
+
+  test('unparseable literal only fails when converted to DateTime', () {
+    final value = InvalidDateTimeChoice.fromJson('not-a-date');
+
+    expect(value.toDateTime, throwsA(isA<DecodingException>()));
+    expect(value.toJson(), 'not-a-date');
+  });
+}

--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -411,3 +411,69 @@ components:
         mapping:
           person: '#/components/schemas/PersonModel'
           company: '#/components/schemas/CompanyModel'
+
+    DateTimeChoice:
+      type: string
+      format: date-time
+      default: '2026-09-06T12:00:00.1000+02:00'
+      enum:
+        - '2026-09-06T12:00:00.1000+02:00'
+        - '2026-09-06T12:00:00.100+02:00'
+        - '2026-09-06T12:00:00.123456789+02:00'
+      x-dart-enum:
+        - toDateTime
+        - $toDateTime
+        - nanoseconds
+
+    DateTimeChoiceAlias:
+      $ref: '#/components/schemas/DateTimeChoice'
+
+    DateTimeChoiceAliasChain:
+      $ref: '#/components/schemas/DateTimeChoiceAlias'
+
+    DateTimeDefaultEnvelope:
+      type: object
+      required:
+        - timestamp
+        - aliased
+      properties:
+        timestamp:
+          $ref: '#/components/schemas/DateTimeChoice'
+        aliased:
+          $ref: '#/components/schemas/DateTimeChoiceAliasChain'
+
+    DateTimeEnvelope:
+      type: object
+      required:
+        - timestamp
+      properties:
+        timestamp:
+          $ref: '#/components/schemas/DateTimeChoice'
+        defaulted:
+          type: string
+          format: date-time
+          enum:
+            - '2026-09-06T12:00:00.1000+02:00'
+          x-dart-enum:
+            - toDateTime
+          default: '2026-09-06T12:00:00.1000+02:00'
+        optional:
+          type: string
+          format: date-time
+          nullable: true
+          enum:
+            - '2026-09-06t10:00:00.1000z'
+            - null
+          x-dart-enum:
+            - lowercase
+
+    EmptyDateTimeChoice:
+      type: string
+      format: date-time
+      enum: []
+
+    InvalidDateTimeChoice:
+      type: string
+      format: date-time
+      enum:
+        - not-a-date

--- a/integration_test/adversarial_strings/openapi.yaml
+++ b/integration_test/adversarial_strings/openapi.yaml
@@ -425,6 +425,27 @@ components:
         - $toDateTime
         - nanoseconds
 
+    DefaultedStringChoice:
+      type: string
+      enum: [active, inactive]
+      default: active
+
+    DefaultedIntegerChoice:
+      type: integer
+      enum: [1, 2]
+      default: 2
+
+    PlainEnumDefaultEnvelope:
+      type: object
+      required:
+        - status
+        - priority
+      properties:
+        status:
+          $ref: '#/components/schemas/DefaultedStringChoice'
+        priority:
+          $ref: '#/components/schemas/DefaultedIntegerChoice'
+
     DateTimeChoiceAlias:
       $ref: '#/components/schemas/DateTimeChoice'
 

--- a/packages/tonik_core/lib/src/model/effective_default.dart
+++ b/packages/tonik_core/lib/src/model/effective_default.dart
@@ -7,6 +7,7 @@ Object? effectiveDefault(Object? localDefault, Model model) {
   if (localDefault != null) return localDefault;
   return switch (model) {
     AliasModel(:final defaultValue) ||
+    EnumModel(:final defaultValue) ||
     CompositeModel(:final defaultValue) => defaultValue,
     _ => null,
   };

--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -308,6 +308,14 @@ class EnumModel<T>({
   @override var String? nameOverride,
   var String? description,
 
+  /// Whether string values have the OpenAPI `date-time` format.
+  ///
+  /// The format enables date-time conversion; values retain string identity.
+  final bool isDateTime = false,
+
+  /// The schema default, retained for date-time enums.
+  final Object? defaultValue,
+
   /// Optional fallback value if no other value matches.
   var EnumEntry<T>? fallbackValue,
   var bool isReadOnly = false,

--- a/packages/tonik_core/lib/src/model/model.dart
+++ b/packages/tonik_core/lib/src/model/model.dart
@@ -39,6 +39,7 @@ sealed class Model({required final Context context}) {
     ListModel(:final name) => 'ListModel($name)',
     MapModel(:final name) => 'MapModel($name)',
     ClassModel(:final name) => 'ClassModel($name)',
+    DateTimeEnumModel(:final name) => 'DateTimeEnumModel($name)',
     EnumModel(:final name) => 'EnumModel($name)',
     AllOfModel(:final name) => 'AllOfModel($name)',
     OneOfModel(:final name) => 'OneOfModel($name)',
@@ -308,12 +309,7 @@ class EnumModel<T>({
   @override var String? nameOverride,
   var String? description,
 
-  /// Whether string values have the OpenAPI `date-time` format.
-  ///
-  /// The format enables date-time conversion; values retain string identity.
-  final bool isDateTime = false,
-
-  /// The schema default, retained for date-time enums.
+  /// The enclosing schema's raw default, validated during generation.
   final Object? defaultValue,
 
   /// Optional fallback value if no other value matches.
@@ -327,6 +323,32 @@ class EnumModel<T>({
   @override
   String toString() =>
       'EnumModel<$T>{name: $name, nameOverride: $nameOverride, '
+      'values: $values, isNullable: $isNullable, description: $description, '
+      'isDeprecated: $isDeprecated, fallbackValue: $fallbackValue, '
+      'examples: $examples}';
+}
+
+/// An enum of exact string literals with date-time conversion support.
+///
+/// Values keep their original spelling for identity and serialization.
+/// Date-time parsing is a separate conversion and never determines membership.
+class DateTimeEnumModel({
+  required super.values,
+  required super.isNullable,
+  required super.context,
+  required super.isDeprecated,
+  required super.examples,
+  super.name,
+  super.nameOverride,
+  super.description,
+  super.defaultValue,
+  super.fallbackValue,
+  super.isReadOnly,
+  super.isWriteOnly,
+}) extends EnumModel<String> {
+  @override
+  String toString() =>
+      'DateTimeEnumModel{name: $name, nameOverride: $nameOverride, '
       'values: $values, isNullable: $isNullable, description: $description, '
       'isDeprecated: $isDeprecated, fallbackValue: $fallbackValue, '
       'examples: $examples}';

--- a/packages/tonik_core/lib/src/util/stable_model_key.dart
+++ b/packages/tonik_core/lib/src/util/stable_model_key.dart
@@ -145,6 +145,7 @@ class StableModelSorter() {
     if (depth > _maxDepth) {
       return switch (model) {
         ClassModel(:final name) => 'ClassModel{$name}',
+        DateTimeEnumModel(:final name) => 'DateTimeEnumModel{$name}',
         EnumModel(:final name) => 'EnumModel{$name}',
         AliasModel(:final name) => 'AliasModel{$name}',
         ListModel(:final name) => 'ListModel{$name}',
@@ -200,6 +201,8 @@ class StableModelSorter() {
           depth,
           preserveCompoundOrder: preserveCompoundOrder,
         ),
+      DateTimeEnumModel(:final name, :final values) =>
+        'DateTimeEnumModel{$name,${_stableSortedEnumValues(values)}}',
       EnumModel(:final name, :final values) =>
         'EnumModel{$name,${_stableSortedEnumValues(values)}}',
       AliasModel(:final name, :final model) => _nestedModelKey(

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -19,9 +19,8 @@ void main() {
 
   group('effectiveDefault', () {
     test('inherits a date-time enum default through an alias chain', () {
-      final model = EnumModel<String>(
+      final model = DateTimeEnumModel(
         values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
-        isDateTime: true,
         defaultValue: '2026-09-06T12:00:00.1000+02:00',
         isNullable: false,
         isDeprecated: false,

--- a/packages/tonik_core/test/src/model/effective_default_test.dart
+++ b/packages/tonik_core/test/src/model/effective_default_test.dart
@@ -18,6 +18,38 @@ void main() {
   );
 
   group('effectiveDefault', () {
+    test('inherits a date-time enum default through an alias chain', () {
+      final model = EnumModel<String>(
+        values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
+        isDateTime: true,
+        defaultValue: '2026-09-06T12:00:00.1000+02:00',
+        isNullable: false,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+      );
+      final inner = AliasModel(
+        model: model,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final outer = AliasModel(
+        model: inner,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      expect(effectiveDefault(null, model), '2026-09-06T12:00:00.1000+02:00');
+      expect(effectiveDefault(null, outer), '2026-09-06T12:00:00.1000+02:00');
+      expect(outer.defaultValue, '2026-09-06T12:00:00.1000+02:00');
+      expect(
+        effectiveDefault('2026-09-06T12:00:00.100+02:00', outer),
+        '2026-09-06T12:00:00.100+02:00',
+      );
+    });
+
     test('returns the local default when set, regardless of model type', () {
       expect(effectiveDefault('local', StringModel(context: context)), 'local');
     });

--- a/packages/tonik_core/test/src/model/model_test.dart
+++ b/packages/tonik_core/test/src/model/model_test.dart
@@ -9,6 +9,38 @@ void main() {
     context = Context.initial();
   });
 
+  test(
+    'date-time enum retains string behavior and identifies its model type',
+    () {
+      final model = DateTimeEnumModel(
+        name: 'Timestamp',
+        values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
+        isNullable: true,
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+      );
+      final alias = AliasModel(
+        model: model,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      expect(model, isA<EnumModel<String>>());
+      expect(model.encodingShape, EncodingShape.simple);
+      expect(model.isEffectivelyNullable, isTrue);
+      expect(
+        model.toString(),
+        startsWith('DateTimeEnumModel{name: Timestamp,'),
+      );
+      expect(
+        alias.toString(),
+        contains('model: DateTimeEnumModel(Timestamp),'),
+      );
+    },
+  );
+
   group('MapModel', () {
     test('has correct name and valueModel', () {
       final mapModel = MapModel(

--- a/packages/tonik_core/test/src/util/stable_model_key_test.dart
+++ b/packages/tonik_core/test/src/util/stable_model_key_test.dart
@@ -392,6 +392,36 @@ void main() {
       expect(key, contains('count:IntegerModel'));
     });
 
+    test('distinguishes date-time enums from ordinary string enums', () {
+      final plain = EnumModel<String>(
+        name: 'Timestamp',
+        values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
+        isNullable: false,
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+      final dateTime = DateTimeEnumModel(
+        name: 'Timestamp',
+        values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
+        isNullable: false,
+        context: context,
+        isDeprecated: false,
+        examples: const [],
+      );
+
+      expect(
+        sorter.stableKeyOf(plain),
+        'EnumModel{Timestamp,2026-09-06T12:00:00.1000+02:00}',
+      );
+      expect(
+        sorter.stableKeyOf(dateTime),
+        'DateTimeEnumModel{Timestamp,2026-09-06T12:00:00.1000+02:00}',
+      );
+      expect(sorter.sortModels([plain, dateTime]), [dateTime, plain]);
+      expect(sorter.sortModels([dateTime, plain]), [dateTime, plain]);
+    });
+
     test('generates stable key for EnumModel with sorted values', () {
       final model1 = EnumModel<String>(
         name: 'Status',

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -171,6 +171,12 @@ class const EnumGenerator({required final NameManager nameManager}) {
           ),
         )
         ..values.addAll(enumValues);
+
+      if (model.isDateTime && T == String) {
+        b.methods.add(
+          _generateToDateTimeMethod(actualEnumName, fallbackNormalizedName),
+        );
+      }
     });
 
     final typedefValue = model.isNullable
@@ -366,6 +372,47 @@ class const EnumGenerator({required final NameManager nameManager}) {
                 ],
                 {'orElse': orElse},
               )
+              .returned
+              .statement,
+        ]),
+    );
+  }
+
+  Method _generateToDateTimeMethod(
+    String actualEnumName,
+    String? fallbackNormalizedName,
+  ) {
+    return Method(
+      (b) => b
+        ..name = 'toDateTime'
+        ..returns = refer('DateTime', 'dart:core')
+        ..docs.addAll([
+          '/// Parses this value as a date-time, preserving its UTC offset.',
+          '///',
+          '/// Conversion uses `OffsetDateTime.parse`, with Dart date-time',
+          '/// normalization and microsecond precision. It does not change the',
+          '/// original string used for enum identity and serialization.',
+          '///',
+          '/// Throws `DecodingException` if the literal cannot be parsed.',
+          if (fallbackNormalizedName != null)
+            '/// Throws `StateError` for the unknown fallback value.',
+        ])
+        ..body = Block.of([
+          if (fallbackNormalizedName != null) ...[
+            Code('if (this == $actualEnumName.$fallbackNormalizedName) {'),
+            refer('StateError', 'dart:core')
+                .call([
+                  literalString(
+                    'Cannot convert unknown enum value to DateTime',
+                  ),
+                ])
+                .thrown
+                .statement,
+            const Code('}'),
+          ],
+          refer('OffsetDateTime', 'package:tonik_util/tonik_util.dart')
+              .property('parse')
+              .call([refer(_rawValueFieldName)])
               .returned
               .statement,
         ]),

--- a/packages/tonik_generate/lib/src/model/enum_generator.dart
+++ b/packages/tonik_generate/lib/src/model/enum_generator.dart
@@ -172,7 +172,7 @@ class const EnumGenerator({required final NameManager nameManager}) {
         )
         ..values.addAll(enumValues);
 
-      if (model.isDateTime && T == String) {
+      if (model is DateTimeEnumModel) {
         b.methods.add(
           _generateToDateTimeMethod(actualEnumName, fallbackNormalizedName),
         );

--- a/packages/tonik_generate/lib/src/naming/name_manager.dart
+++ b/packages/tonik_generate/lib/src/naming/name_manager.dart
@@ -378,7 +378,7 @@ class NameManager({
       ];
       final normalized = normalizeEnumValues(
         inputs,
-        additionalReservedNames: {if (model.isDateTime) 'toDateTime'},
+        additionalReservedNames: {if (model is DateTimeEnumModel) 'toDateTime'},
       );
       final result = (
         valueNames: List<String>.unmodifiable(

--- a/packages/tonik_generate/lib/src/naming/name_manager.dart
+++ b/packages/tonik_generate/lib/src/naming/name_manager.dart
@@ -376,7 +376,10 @@ class NameManager({
           model.fallbackValue!.nameOverride ??
               model.fallbackValue!.value.toString(),
       ];
-      final normalized = normalizeEnumValues(inputs);
+      final normalized = normalizeEnumValues(
+        inputs,
+        additionalReservedNames: {if (model.isDateTime) 'toDateTime'},
+      );
       final result = (
         valueNames: List<String>.unmodifiable(
           normalized.take(values.length).map((n) => n.normalizedName),

--- a/packages/tonik_generate/lib/src/naming/property_name_normalizer.dart
+++ b/packages/tonik_generate/lib/src/naming/property_name_normalizer.dart
@@ -50,16 +50,16 @@ List<({String normalizedName, Property property})> normalizeProperties(
 /// - [123, one_two_three] -> [oneHundredTwentyThree, oneTwoThree]
 /// - [_, __, ___] -> [value, value2, value3]
 List<({String normalizedName, String originalValue})> normalizeEnumValues(
-  List<String> values,
-) {
-  final normalized = values
-      .map(
-        (value) => (
-          normalizedName: normalizeEnumValueName(value),
-          originalValue: value,
-        ),
-      )
-      .toList();
+  List<String> values, {
+  Set<String> additionalReservedNames = const {},
+}) {
+  final normalized = values.map((value) {
+    final name = normalizeEnumValueName(value);
+    return (
+      normalizedName: additionalReservedNames.contains(name) ? '\$$name' : name,
+      originalValue: value,
+    );
+  }).toList();
 
   return ensureUniqueness(normalized);
 }

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -172,6 +172,110 @@ void main() {
       expect(toJson.body?.accept(DartEmitter()).toString(), r'_$rawValue');
     });
 
+    test(
+      'date-time enum keeps literals and reserves the conversion method',
+      () {
+        final model = EnumModel<String>(
+          name: 'Timestamp',
+          values: {
+            const EnumEntry(
+              value: '2026-09-06T12:00:00.1000+02:00',
+              nameOverride: 'toDateTime',
+            ),
+            const EnumEntry(
+              value: '2026-09-06T12:00:00.100+02:00',
+              nameOverride: r'$toDateTime',
+            ),
+          },
+          isDateTime: true,
+          isNullable: false,
+          isDeprecated: false,
+          context: Context.initial(),
+          examples: const [],
+        );
+
+        final generated = generator.generateEnum(model, 'Timestamp').enumValue;
+        final conversion = generated.methods.firstWhere(
+          (method) => method.name == 'toDateTime',
+        );
+
+        expect(generated.values[0].name, r'$toDateTime');
+        expect(generated.values[1].name, r'$toDateTime2');
+        expect(
+          generated.values[0].arguments.single.accept(DartEmitter()).toString(),
+          "r'2026-09-06T12:00:00.1000+02:00'",
+        );
+        expect(conversion.type, isNull);
+        expect(
+          conversion.returns?.accept(DartEmitter()).toString(),
+          'DateTime',
+        );
+        expect(
+          formatMethod(conversion.rebuild((b) => b.docs.clear()), 'Timestamp'),
+          format(r'''
+        class Timestamp {
+          DateTime toDateTime() {
+            return OffsetDateTime.parse(_$rawValue);
+          }
+        }'''),
+        );
+      },
+    );
+
+    test('plain string enum may retain a toDateTime member', () {
+      final model = EnumModel<String>(
+        name: 'Plain',
+        values: {const EnumEntry(value: 'toDateTime')},
+        isNullable: false,
+        isDeprecated: false,
+        context: Context.initial(),
+        examples: const [],
+      );
+
+      final generated = generator.generateEnum(model, 'Plain').enumValue;
+
+      expect(generated.values.single.name, 'toDateTime');
+      expect(generated.methods.any((m) => m.name == 'toDateTime'), isFalse);
+    });
+
+    test(
+      'date-time conversion rejects a synthetic fallback before parsing',
+      () {
+        final model = EnumModel<String>(
+          name: 'Timestamp',
+          values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
+          fallbackValue: const EnumEntry(
+            value: '2026-01-01T00:00:00Z',
+            nameOverride: 'toDateTime',
+          ),
+          isDateTime: true,
+          isNullable: false,
+          isDeprecated: false,
+          context: Context.initial(),
+          examples: const [],
+        );
+
+        final generated = generator.generateEnum(model, 'Timestamp').enumValue;
+        final conversion = generated.methods.firstWhere(
+          (method) => method.name == 'toDateTime',
+        );
+
+        expect(generated.values.last.name, r'$toDateTime');
+        expect(
+          formatMethod(conversion.rebuild((b) => b.docs.clear()), 'Timestamp'),
+          format(r'''
+        class Timestamp {
+          DateTime toDateTime() {
+            if (this == Timestamp.$toDateTime) {
+              throw StateError('Cannot convert unknown enum value to DateTime');
+            }
+            return OffsetDateTime.parse(_$rawValue);
+          }
+        }'''),
+        );
+      },
+    );
+
     test('generates nullable enum code', () {
       final model = EnumModel<String>(
         isDeprecated: false,

--- a/packages/tonik_generate/test/src/model/enum_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/enum_generator_test.dart
@@ -175,7 +175,7 @@ void main() {
     test(
       'date-time enum keeps literals and reserves the conversion method',
       () {
-        final model = EnumModel<String>(
+        final model = DateTimeEnumModel(
           name: 'Timestamp',
           values: {
             const EnumEntry(
@@ -187,7 +187,6 @@ void main() {
               nameOverride: r'$toDateTime',
             ),
           },
-          isDateTime: true,
           isNullable: false,
           isDeprecated: false,
           context: Context.initial(),
@@ -241,14 +240,13 @@ void main() {
     test(
       'date-time conversion rejects a synthetic fallback before parsing',
       () {
-        final model = EnumModel<String>(
+        final model = DateTimeEnumModel(
           name: 'Timestamp',
           values: {const EnumEntry(value: '2026-09-06T12:00:00.1000+02:00')},
           fallbackValue: const EnumEntry(
             value: '2026-01-01T00:00:00Z',
             nameOverride: 'toDateTime',
           ),
-          isDateTime: true,
           isNullable: false,
           isDeprecated: false,
           context: Context.initial(),

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -1474,6 +1474,8 @@ class ModelImporter._(
     }
 
     var model = switch (types.firstOrNull) {
+      'string' when schema.format == 'date-time' && schema.enumerated != null =>
+        _parseStringEnum(name, schema, context),
       'string' when schema.format == 'date-time' => DateTimeModel(
         context: context,
       ),
@@ -1492,18 +1494,10 @@ class ModelImporter._(
         _resolveContentEncodedModel(schema, context),
       'string' when schema.format == 'binary' => BinaryModel(context: context),
       'string' when schema.format == 'byte' => Base64Model(context: context),
-      'string' when schema.enumerated != null => _parseEnum<String>(
+      'string' when schema.enumerated != null => _parseStringEnum(
         name,
-        schema.enumerated!,
-        schema.isNullable ?? hasNullType,
+        schema,
         context,
-        emptyFallbackValue: _unknownEnumCaseName,
-        description: schema.description,
-        isDeprecated: schema.isDeprecated ?? false,
-        isReadOnly: schema.isReadOnly ?? false,
-        isWriteOnly: schema.isWriteOnly ?? false,
-        xDartEnum: schema.xDartEnum,
-        examples: exampleImporter.fromSchema(schema),
       ),
       'string' => StringModel(context: context),
       'number' when schema.format == 'float' || schema.format == 'double' =>
@@ -2041,6 +2035,26 @@ class ModelImporter._(
     return model;
   }
 
+  EnumModel<String> _parseStringEnum(
+    String? name,
+    Schema schema,
+    Context context,
+  ) => _parseEnum<String>(
+    name,
+    schema.enumerated!,
+    schema.isNullable ?? schema.hasNullType,
+    context,
+    emptyFallbackValue: _unknownEnumCaseName,
+    isDateTime: schema.format == 'date-time',
+    defaultValue: schema.format == 'date-time' ? schema.rawDefault : null,
+    description: schema.description,
+    isDeprecated: schema.isDeprecated ?? false,
+    isReadOnly: schema.isReadOnly ?? false,
+    isWriteOnly: schema.isWriteOnly ?? false,
+    xDartEnum: schema.xDartEnum,
+    examples: exampleImporter.fromSchema(schema),
+  );
+
   EnumModel<T> _parseEnum<T>(
     String? name,
     List<dynamic> values,
@@ -2050,6 +2064,8 @@ class ModelImporter._(
     required String? description,
     required bool isDeprecated,
     required List<Example> examples,
+    bool isDateTime = false,
+    Object? defaultValue,
     bool isReadOnly = false,
     bool isWriteOnly = false,
     List<String>? xDartEnum,
@@ -2109,6 +2125,8 @@ class ModelImporter._(
       isWriteOnly: isWriteOnly,
       examples: examples,
       fallbackValue: fallbackValue,
+      isDateTime: isDateTime,
+      defaultValue: defaultValue,
     );
 
     if (name == null || _findNamedModel(name) == null) {

--- a/packages/tonik_parse/lib/src/model_importer.dart
+++ b/packages/tonik_parse/lib/src/model_importer.dart
@@ -1503,18 +1503,10 @@ class ModelImporter._(
       'number' when schema.format == 'float' || schema.format == 'double' =>
         DoubleModel(context: context),
       'number' => NumberModel(context: context),
-      'integer' when schema.enumerated != null => _parseEnum<int>(
+      'integer' when schema.enumerated != null => _parseIntegerEnum(
         name,
-        schema.enumerated!,
-        schema.isNullable ?? hasNullType,
+        schema,
         context,
-        emptyFallbackValue: -1,
-        description: schema.description,
-        isDeprecated: schema.isDeprecated ?? false,
-        isReadOnly: schema.isReadOnly ?? false,
-        isWriteOnly: schema.isWriteOnly ?? false,
-        xDartEnum: schema.xDartEnum,
-        examples: exampleImporter.fromSchema(schema),
       ),
       'integer' => IntegerModel(context: context),
       'boolean' => BooleanModel(context: context),
@@ -1533,6 +1525,11 @@ class ModelImporter._(
         defaultValue: schema.rawDefault,
         examples: exampleImporter.fromSchema(schema),
       );
+      _logModelAdded(model);
+      _registerModel(model);
+    }
+
+    if (model is EnumModel && (name == null || _findNamedModel(name) == null)) {
       _logModelAdded(model);
       _registerModel(model);
     }
@@ -2039,37 +2036,66 @@ class ModelImporter._(
     String? name,
     Schema schema,
     Context context,
-  ) => _parseEnum<String>(
-    name,
-    schema.enumerated!,
-    schema.isNullable ?? schema.hasNullType,
-    context,
-    emptyFallbackValue: _unknownEnumCaseName,
-    isDateTime: schema.format == 'date-time',
-    defaultValue: schema.format == 'date-time' ? schema.rawDefault : null,
-    description: schema.description,
-    isDeprecated: schema.isDeprecated ?? false,
-    isReadOnly: schema.isReadOnly ?? false,
-    isWriteOnly: schema.isWriteOnly ?? false,
-    xDartEnum: schema.xDartEnum,
-    examples: exampleImporter.fromSchema(schema),
-  );
+  ) {
+    final parsed = _parseEnumValues<String>(
+      name,
+      schema,
+      context,
+      emptyFallbackValue: _unknownEnumCaseName,
+    );
+    final createEnum = schema.format == 'date-time'
+        ? DateTimeEnumModel.new
+        : EnumModel<String>.new;
+    return createEnum(
+      name: name,
+      values: parsed.values,
+      isNullable: parsed.isNullable,
+      fallbackValue: parsed.fallbackValue,
+      context: context,
+      defaultValue: schema.rawDefault,
+      description: schema.description,
+      isDeprecated: schema.isDeprecated ?? false,
+      isReadOnly: schema.isReadOnly ?? false,
+      isWriteOnly: schema.isWriteOnly ?? false,
+      examples: exampleImporter.fromSchema(schema),
+    );
+  }
 
-  EnumModel<T> _parseEnum<T>(
+  EnumModel<int> _parseIntegerEnum(
     String? name,
-    List<dynamic> values,
-    bool isNullable,
+    Schema schema,
+    Context context,
+  ) {
+    final parsed = _parseEnumValues<int>(
+      name,
+      schema,
+      context,
+      emptyFallbackValue: -1,
+    );
+    return EnumModel<int>(
+      name: name,
+      values: parsed.values,
+      isNullable: parsed.isNullable,
+      fallbackValue: parsed.fallbackValue,
+      context: context,
+      defaultValue: schema.rawDefault,
+      description: schema.description,
+      isDeprecated: schema.isDeprecated ?? false,
+      isReadOnly: schema.isReadOnly ?? false,
+      isWriteOnly: schema.isWriteOnly ?? false,
+      examples: exampleImporter.fromSchema(schema),
+    );
+  }
+
+  ({Set<EnumEntry<T>> values, bool isNullable, EnumEntry<T>? fallbackValue})
+  _parseEnumValues<T>(
+    String? name,
+    Schema schema,
     Context context, {
     required T emptyFallbackValue,
-    required String? description,
-    required bool isDeprecated,
-    required List<Example> examples,
-    bool isDateTime = false,
-    Object? defaultValue,
-    bool isReadOnly = false,
-    bool isWriteOnly = false,
-    List<String>? xDartEnum,
   }) {
+    final values = schema.enumerated!;
+    final xDartEnum = schema.xDartEnum;
     log.fine('Parsing enum $name<$T> for $context with values $values');
     final location = switch (name) {
       final name? when name.isNotEmpty => context.push(name).toString(),
@@ -2114,27 +2140,11 @@ class ModelImporter._(
       );
     }
 
-    final model = EnumModel<T>(
-      isDeprecated: isDeprecated,
+    return (
       values: enumValues,
-      isNullable: isNullable || hasNull,
-      context: context,
-      name: name,
-      description: description,
-      isReadOnly: isReadOnly,
-      isWriteOnly: isWriteOnly,
-      examples: examples,
+      isNullable: (schema.isNullable ?? schema.hasNullType) || hasNull,
       fallbackValue: fallbackValue,
-      isDateTime: isDateTime,
-      defaultValue: defaultValue,
     );
-
-    if (name == null || _findNamedModel(name) == null) {
-      _logModelAdded(model);
-      _registerModel(model);
-    }
-
-    return model;
   }
 
   void _logModelAdded(Model model) {

--- a/packages/tonik_parse/test/model/model_enum_test.dart
+++ b/packages/tonik_parse/test/model/model_enum_test.dart
@@ -111,6 +111,117 @@ void main() {
     expect((required as EnumModel).isNullable, isFalse);
   });
 
+  group('date-time enums', () {
+    test('retains named literals, nullability and reference defaults', () {
+      final api = Importer().import({
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'Timestamp': {
+              'type': ['string', 'null'],
+              'format': 'date-time',
+              'enum': [
+                '2026-09-06T12:00:00.1000+02:00',
+                '2026-09-06T12:00:00.100+02:00',
+                null,
+              ],
+              'x-dart-enum': ['precise', 'short'],
+              'default': '2026-09-06T12:00:00.1000+02:00',
+            },
+            'TimestampAlias': {r'$ref': '#/components/schemas/Timestamp'},
+            'TimestampAliasChain': {
+              r'$ref': '#/components/schemas/TimestampAlias',
+            },
+            'Event': {
+              'type': 'object',
+              'properties': {
+                'timestamp': {
+                  r'$ref': '#/components/schemas/Timestamp',
+                  'default': '2026-09-06T12:00:00.100+02:00',
+                },
+                'inherited': {r'$ref': '#/components/schemas/Timestamp'},
+                'aliased': {
+                  r'$ref': '#/components/schemas/TimestampAliasChain',
+                },
+              },
+            },
+          },
+        },
+      });
+      final timestamp = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'Timestamp',
+      ) as EnumModel<String>;
+      final event = api.models.firstWhere(
+        (m) => m is NamedModel && m.name == 'Event',
+      ) as ClassModel;
+
+      expect(timestamp.isDateTime, isTrue);
+      expect(timestamp.isNullable, isTrue);
+      expect(timestamp.defaultValue, '2026-09-06T12:00:00.1000+02:00');
+      expect(timestamp.values, {
+        const EnumEntry(
+          value: '2026-09-06T12:00:00.1000+02:00',
+          nameOverride: 'precise',
+        ),
+        const EnumEntry(
+          value: '2026-09-06T12:00:00.100+02:00',
+          nameOverride: 'short',
+        ),
+      });
+      final reference = event.properties.first.model as AliasModel;
+      expect(reference.model, same(timestamp));
+      expect(reference.defaultValue, '2026-09-06T12:00:00.100+02:00');
+      expect(event.properties[1].model, same(timestamp));
+      expect(
+        event.properties[1].effectiveDefaultValue,
+        '2026-09-06T12:00:00.1000+02:00',
+      );
+      expect(event.properties[2].model.resolved, same(timestamp));
+      expect(
+        event.properties[2].effectiveDefaultValue,
+        '2026-09-06T12:00:00.1000+02:00',
+      );
+    });
+
+    test('imports inline date-time enum ahead of content encoding', () {
+      final api = Importer().import({
+        'openapi': '3.1.0',
+        'info': {'title': 'Test API', 'version': '1.0.0'},
+        'paths': <String, dynamic>{},
+        'components': {
+          'schemas': {
+            'Event': {
+              'type': 'object',
+              'properties': {
+                'timestamp': {
+                  'type': 'string',
+                  'format': 'date-time',
+                  'contentEncoding': 'base64',
+                  'enum': ['2026-09-06T12:00:00.1000+02:00'],
+                },
+                'regular': {'type': 'string', 'format': 'date-time'},
+                'uri': {
+                  'type': 'string',
+                  'format': 'uri',
+                  'enum': ['https://example.com'],
+                },
+              },
+            },
+          },
+        },
+      });
+      final event = api.models.whereType<ClassModel>().single;
+      final timestamp = event.properties.first.model as EnumModel<String>;
+
+      expect(timestamp.isDateTime, isTrue);
+      expect(timestamp.values.single.value, '2026-09-06T12:00:00.1000+02:00');
+      expect(event.properties[1].model, isA<DateTimeModel>());
+      expect(event.properties[2].model, isA<UriModel>());
+    });
+  });
+
   group('empty enum', () {
     test('adds typed fallback cases and warns', () {
       final logs = <LogRecord>[];

--- a/packages/tonik_parse/test/model/model_enum_test.dart
+++ b/packages/tonik_parse/test/model/model_enum_test.dart
@@ -111,6 +111,48 @@ void main() {
     expect((required as EnumModel).isNullable, isFalse);
   });
 
+  test('inherits defaults from string and integer enum components', () {
+    final api = Importer().import({
+      'openapi': '3.0.0',
+      'info': {'title': 'Test API', 'version': '1.0.0'},
+      'paths': <String, dynamic>{},
+      'components': {
+        'schemas': {
+          'Status': {
+            'type': 'string',
+            'enum': ['active', 'inactive'],
+            'default': 'active',
+          },
+          'Priority': {
+            'type': 'integer',
+            'enum': [1, 2],
+            'default': 2,
+          },
+          'Event': {
+            'type': 'object',
+            'properties': {
+              'status': {r'$ref': '#/components/schemas/Status'},
+              'priority': {r'$ref': '#/components/schemas/Priority'},
+            },
+          },
+        },
+      },
+    });
+    final status = api.models.firstWhere(
+      (m) => m is NamedModel && m.name == 'Status',
+    ) as EnumModel<String>;
+    final priority = api.models.firstWhere(
+      (m) => m is NamedModel && m.name == 'Priority',
+    ) as EnumModel<int>;
+    final event = api.models.whereType<ClassModel>().single;
+
+    expect(status, isNot(isA<DateTimeEnumModel>()));
+    expect(status.defaultValue, 'active');
+    expect(priority.defaultValue, 2);
+    expect(event.properties[0].effectiveDefaultValue, 'active');
+    expect(event.properties[1].effectiveDefaultValue, 2);
+  });
+
   group('date-time enums', () {
     test('retains named literals, nullability and reference defaults', () {
       final api = Importer().import({
@@ -157,7 +199,7 @@ void main() {
         (m) => m is NamedModel && m.name == 'Event',
       ) as ClassModel;
 
-      expect(timestamp.isDateTime, isTrue);
+      expect(timestamp, isA<DateTimeEnumModel>());
       expect(timestamp.isNullable, isTrue);
       expect(timestamp.defaultValue, '2026-09-06T12:00:00.1000+02:00');
       expect(timestamp.values, {
@@ -215,7 +257,7 @@ void main() {
       final event = api.models.whereType<ClassModel>().single;
       final timestamp = event.properties.first.model as EnumModel<String>;
 
-      expect(timestamp.isDateTime, isTrue);
+      expect(timestamp, isA<DateTimeEnumModel>());
       expect(timestamp.values.single.value, '2026-09-06T12:00:00.1000+02:00');
       expect(event.properties[1].model, isA<DateTimeModel>());
       expect(event.properties[2].model, isA<UriModel>());


### PR DESCRIPTION
Date-time string enums were imported as `DateTime` fields, discarding enum membership and normalizing valid wire values. For example, `2026-09-06T12:00:00.1000+02:00` could serialize as `2026-09-06T12:00:00.100+02:00`, outside the declared enum.

Generate string-backed enums that match and serialize exact literals, with a `toDateTime()` method using the existing offset-preserving parser. Distinct spellings remain distinct members even when they represent the same instant. Conversion does not change serialization.

The core model represents this as `DateTimeEnumModel extends EnumModel<String>`. Shared enum behavior handles values, nullability, fallbacks, and raw schema defaults; the subtype retains its identity in diagnostics and structural sort keys. Referenced string and integer enums inherit schema defaults consistently, including through alias chains.

This changes the generated field type from `DateTime` to an enum for schemas combining `format: date-time` and `enum`. Nullable values, naming overrides, inherited defaults through references and aliases, and unknown fallback errors are covered. Ordinary date-time fields retain their existing behavior.

Validation:

- 4,287 unit tests passed across the core, parser, and generator packages, plus focused core and transport checks.
- All 12 runtime regression tests passed against generated dio and http clients.
- Package analysis, generated http client analysis, and runtime test analysis reported no issues.
- Formatting and diff checks passed; independent review found no remaining blockers.
