### PR TITLE
fix: decode simple map response headers

### DIFF
--- a/integration_test/simple_encoding/openapi.yaml
+++ b/integration_test/simple_encoding/openapi.yaml
@@ -16,6 +16,42 @@ tags:
     description: Operations demonstrating simple encoding
 
 paths:
+  /response-header-maps:
+    get:
+      operationId: testResponseHeaderMaps
+      tags:
+        - simple-encoding
+      responses:
+        '204':
+          description: Flat maps encoded in response headers
+          headers:
+            X-Meta:
+              style: simple
+              explode: true
+              schema:
+                type: object
+                additionalProperties:
+                  type: string
+            X-Counts:
+              style: simple
+              explode: false
+              schema:
+                $ref: '#/components/schemas/HeaderCountsAlias'
+            X-Flags:
+              style: simple
+              explode: true
+              schema:
+                type: object
+                additionalProperties:
+                  type: boolean
+            X-Status:
+              style: simple
+              explode: true
+              schema:
+                type: object
+                additionalProperties:
+                  $ref: '#/components/schemas/StatusEnum'
+
   /anyof/{flexibleValue}:
     get:
       operationId: testAnyOfInPath
@@ -1249,6 +1285,17 @@ paths:
 
 components:
   schemas:
+    HeaderCounts:
+      type: object
+      additionalProperties:
+        $ref: '#/components/schemas/HeaderCount'
+
+    HeaderCountsAlias:
+      $ref: '#/components/schemas/HeaderCounts'
+
+    HeaderCount:
+      type: integer
+
     StatusEnum:
       type: string
       enum:

--- a/integration_test/simple_encoding/simple_encoding_test/test/response_header_maps_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/response_header_maps_test.dart
@@ -1,0 +1,116 @@
+import 'package:simple_encoding_api/simple_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('204 exploded object response header decodes successfully', () async {
+    final server = await RawRequestServer.start(
+      responseHeaders: {'X-Meta': 'role=admin,firstName=Alex'},
+    );
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final success = requireSuccess(result);
+
+    expect(success.response.statusCode, 204);
+    expect(success.value.xMeta, {'role': 'admin', 'firstName': 'Alex'});
+    expect(success.value.xCounts, isNull);
+  });
+
+  test('non-exploded alias map decodes integer values', () async {
+    final server = await RawRequestServer.start(
+      responseHeaders: {'X-Counts': 'count,42,remaining,7'},
+    );
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final success = requireSuccess(result);
+
+    expect(success.value.xCounts, {'count': 42, 'remaining': 7});
+    expect(success.value.xMeta, isNull);
+  });
+
+  test('exploded maps decode boolean and enum values', () async {
+    final server = await RawRequestServer.start(
+      responseHeaders: {
+        'X-Flags': 'enabled=true,archived=false',
+        'X-Status': 'primary=active,secondary=pending',
+      },
+    );
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final success = requireSuccess(result);
+
+    expect(success.value.xFlags, {'enabled': true, 'archived': false});
+    expect(success.value.xStatus, {
+      'primary': StatusEnum.active,
+      'secondary': StatusEnum.pending,
+    });
+  });
+
+  test('all absent optional map headers decode as null', () async {
+    final server = await RawRequestServer.start();
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final success = requireSuccess(result);
+
+    expect(success.value.xMeta, isNull);
+    expect(success.value.xCounts, isNull);
+    expect(success.value.xFlags, isNull);
+    expect(success.value.xStatus, isNull);
+  });
+
+  test('malformed non-exploded map produces a contextual error', () async {
+    final server = await RawRequestServer.start(
+      responseHeaders: {'X-Counts': 'count,42,remaining'},
+    );
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final error = requireError(result);
+
+    expect(error.type, TonikErrorType.decoding);
+    expect(error.response?.statusCode, 204);
+    expect(
+      error.error,
+      isA<InvalidFormatException>().having(
+        (error) => error.format,
+        'format',
+        'alternating key-value pairs in X-Counts',
+      ),
+    );
+  });
+
+  test('invalid typed map value produces a contextual error', () async {
+    final server = await RawRequestServer.start(
+      responseHeaders: {'X-Counts': 'count,oops'},
+    );
+    final api = SimpleEncodingApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final result = await api.testResponseHeaderMaps();
+    final error = requireError(result);
+
+    expect(error.type, TonikErrorType.decoding);
+    expect(
+      error.error,
+      isA<InvalidTypeException>()
+          .having((error) => error.context, 'context', 'X-Counts')
+          .having((error) => error.value, 'value', 'oops'),
+    );
+  });
+}

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -1074,6 +1074,7 @@ class const AllOfGenerator({
               contextClass: className,
               contextProperty: name,
               explode: refer('explode'),
+              useImmutableCollections: useImmutableCollections,
             );
 
       constructorArgs[name] = expression.expression;

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -1522,6 +1522,7 @@ class const AnyOfGenerator({
                         package: package,
                         contextClass: className,
                         explode: refer('explode'),
+                        useImmutableCollections: useImmutableCollections,
                       ))
                 .expression,
         };

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -688,6 +688,7 @@ class const ParseGenerator({
         package: package,
         contextProperty: rawHeaderName,
         explode: literalBool(resolvedHeader.explode),
+        useImmutableCollections: useImmutableCollections,
       );
       supported[normalizedName] = decode.expression;
     }

--- a/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/from_simple_value_expression_generator.dart
@@ -5,6 +5,7 @@ import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/exception_code_generator.dart';
 import 'package:tonik_generate/src/util/source_file_url.dart';
 import 'package:tonik_generate/src/util/spec_literal_string.dart';
+import 'package:tonik_util/tonik_util.dart';
 
 /// Returns the reason why simple decoding is not supported for the given model,
 /// or `null` if simple decoding is supported.
@@ -30,9 +31,20 @@ String? getSimpleDecodingUnsupportedReason(Model model) {
     NeverModel() => 'NeverModel does not permit any value',
     ListModel(:final content) => _getListContentUnsupportedReason(content),
     AliasModel(:final model) => getSimpleDecodingUnsupportedReason(model),
-    MapModel() => 'Map types cannot be simple-decoded',
+    MapModel(:final valueModel) => _getMapValueUnsupportedReason(valueModel),
     NamedModel() || CompositeModel() => 'Unsupported model type: $model',
   };
+}
+
+String? _getMapValueUnsupportedReason(Model model) {
+  if (model is AliasModel) {
+    return _getMapValueUnsupportedReason(model.model);
+  }
+  if (model is AnyModel) return null;
+  if (model.encodingShape != EncodingShape.simple) {
+    return 'Map values must be scalar in simple encoding';
+  }
+  return getSimpleDecodingUnsupportedReason(model);
 }
 
 String? _getListContentUnsupportedReason(Model content) {
@@ -70,6 +82,7 @@ BuiltExpression buildSimpleValueExpression(
   String? package,
   String? contextClass,
   String? contextProperty,
+  bool useImmutableCollections = false,
 }) {
   return BuiltExpression.simple(
     _buildSimpleValueExpression(
@@ -81,6 +94,7 @@ BuiltExpression buildSimpleValueExpression(
       package: package,
       contextClass: contextClass,
       contextProperty: contextProperty,
+      useImmutableCollections: useImmutableCollections,
     ),
   );
 }
@@ -94,6 +108,7 @@ Expression _buildSimpleValueExpression(
   String? package,
   String? contextClass,
   String? contextProperty,
+  bool useImmutableCollections = false,
 }) {
   final contextParam = (contextClass != null || contextProperty != null)
       ? {
@@ -188,18 +203,76 @@ Expression _buildSimpleValueExpression(
       package: package,
       contextClass: contextClass,
       contextProperty: contextProperty,
+      useImmutableCollections: useImmutableCollections,
       explode: explode,
     ),
     NeverModel() => _buildNeverModelExpression(value, isRequired),
     AnyModel() => value,
-    MapModel() => generateSimpleDecodingExceptionExpression(
-      'Map types cannot be simple-decoded.',
+    final MapModel mapModel => _buildMapFromSimpleExpression(
+      value,
+      mapModel,
+      isRequired,
+      nameManager,
+      package: package,
+      contextClass: contextClass,
+      contextProperty: contextProperty,
+      explode: explode,
+      contextParam: contextParam,
+      useImmutableCollections: useImmutableCollections,
     ),
     NamedModel() ||
     CompositeModel() => generateSimpleDecodingExceptionExpression(
       'Unsupported model type for simple decoding.',
     ),
   };
+}
+
+Expression _buildMapFromSimpleExpression(
+  Expression value,
+  MapModel model,
+  bool isRequired,
+  NameManager nameManager, {
+  required Expression explode,
+  required Map<String, Expression> contextParam,
+  String? package,
+  String? contextClass,
+  String? contextProperty,
+  bool useImmutableCollections = false,
+}) {
+  final unsupportedReason = _getMapValueUnsupportedReason(model.valueModel);
+  if (unsupportedReason != null) {
+    return generateSimpleDecodingExceptionExpression('$unsupportedReason.');
+  }
+
+  final decodeValue = _buildSimpleValueExpression(
+    refer('v'),
+    model: model.valueModel,
+    isRequired:
+        !model.isValueNullable && !model.valueModel.isEffectivelyNullable,
+    nameManager: nameManager,
+    explode: explode,
+    package: package,
+    contextClass: contextClass,
+    contextProperty: contextProperty,
+    useImmutableCollections: useImmutableCollections,
+  );
+  final decoder = Method(
+    (b) => b
+      ..requiredParameters.add(Parameter((p) => p..name = 'v'))
+      ..body = decodeValue.code,
+  ).closure;
+  final result = value
+      .property(isRequired ? 'decodeSimpleMap' : 'decodeSimpleNullableMap')
+      .call([decoder], {'explode': explode, ...contextParam});
+  if (!useImmutableCollections) return result;
+
+  final immutableMap = refer(
+    'IMap',
+    'package:fast_immutable_collections/fast_immutable_collections.dart',
+  ).call([result]);
+  return isRequired
+      ? immutableMap
+      : value.equalTo(literalNull).conditional(literalNull, immutableMap);
 }
 
 Expression _buildNeverModelExpression(Expression value, bool isRequired) {

--- a/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/all_of_simple_generator_test.dart
@@ -32,6 +32,52 @@ void main() {
     emitter = DartEmitter(useNullSafetySyntax: true);
   });
 
+  test('generates immutable map decoding for an allOf map component', () {
+    final model = AllOfModel(
+      isDeprecated: false,
+      name: 'MapComponent',
+      models: [
+        MapModel(
+          name: 'Metadata',
+          valueModel: StringModel(context: context),
+          context: context,
+          examples: const [],
+        ),
+      ],
+      context: context,
+      examples: const [],
+    );
+    final immutableGenerator = AllOfGenerator(
+      nameManager: nameManager,
+      package: 'example',
+      stableModelSorter: StableModelSorter(),
+      useImmutableCollections: true,
+    );
+
+    final generated = format(
+      immutableGenerator.generateClass(model).accept(emitter).toString(),
+    );
+
+    expect(
+      collapseWhitespace(generated),
+      contains(
+        collapseWhitespace('''
+          factory MapComponent.fromSimple(String? value, {required bool explode}) {
+            return MapComponent(
+              metadata: IMap(
+                value.decodeSimpleMap(
+                  (v) => v.decodeSimpleString(context: r'MapComponent.metadata'),
+                  explode: explode,
+                  context: r'MapComponent.metadata',
+                ),
+              ),
+            );
+          }
+        '''),
+      ),
+    );
+  });
+
   test('generates toSimple for allOf with list of DateTime', () {
     final model = AllOfModel(
       isDeprecated: false,

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -47,6 +47,117 @@ void main() {
       );
     });
 
+    test(
+      'wraps required and optional aliased map headers as immutable maps',
+      () {
+        final mapModel = MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+          examples: const [],
+        );
+        final operation = Operation(
+          operationId: 'mapHeaders',
+          context: context,
+          summary: '',
+          description: '',
+          tags: const {},
+          isDeprecated: false,
+          path: '/maps',
+          method: HttpMethod.get,
+          headers: const {},
+          queryParameters: const {},
+          pathParameters: const {},
+          cookieParameters: const {},
+          securitySchemes: const {},
+          responses: {
+            const ExplicitResponseStatus(statusCode: 204): ResponseObject(
+              name: 'MapHeadersResponse',
+              context: context,
+              description: '',
+              bodies: const {},
+              headers: {
+                'X-Meta': ResponseHeaderObject(
+                  name: 'X-Meta',
+                  context: context,
+                  description: '',
+                  isRequired: true,
+                  isDeprecated: false,
+                  model: mapModel,
+                  explode: true,
+                  encoding: ResponseHeaderEncoding.simple,
+                  examples: const [],
+                ),
+                'X-Optional': ResponseHeaderObject(
+                  name: 'X-Optional',
+                  context: context,
+                  description: '',
+                  isRequired: false,
+                  isDeprecated: false,
+                  model: AliasModel(
+                    name: 'MetaAlias',
+                    model: mapModel,
+                    context: context,
+                    examples: const [],
+                    defaultValue: null,
+                  ),
+                  explode: false,
+                  encoding: ResponseHeaderEncoding.simple,
+                  examples: const [],
+                ),
+              },
+            ),
+          },
+        );
+        final immutableGenerator = ParseGenerator(
+          nameManager: nameManager,
+          package: package,
+          backendGenerator: const DioBackendGenerator(),
+          useImmutableCollections: true,
+        );
+
+        final code = collapseWhitespace(
+          format(
+            immutableGenerator
+                .generateParseResponseMethod(operation)
+                .accept(emitter)
+                .toString(),
+          ),
+        );
+
+        expect(
+          code,
+          contains(
+            collapseWhitespace('''
+            xMeta: IMap(
+              (response.headers[r'X-Meta']?.join(',')).decodeSimpleMap(
+                (v) => v.decodeSimpleString(context: r'X-Meta'),
+                explode: true,
+                context: r'X-Meta',
+              ),
+            ),
+          '''),
+          ),
+        );
+        expect(
+          code,
+          contains(
+            collapseWhitespace('''
+            xOptional: (response.headers[r'X-Optional']?.join(',')) == null
+              ? null
+              : IMap(
+                  (response.headers[r'X-Optional']?.join(','))
+                    .decodeSimpleNullableMap(
+                      (v) => v.decodeSimpleString(context: r'X-Optional'),
+                      explode: false,
+                      context: r'X-Optional',
+                    ),
+                ),
+          '''),
+          ),
+        );
+      },
+    );
+
     test('generates for primitive response', () {
       final operation = Operation(
         operationId: 'primitiveOp',

--- a/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/from_simple_value_expression_generator_test.dart
@@ -607,6 +607,147 @@ void main() {
       });
     });
 
+    group('MapModel', () {
+      test('generates required exploded string map decoding', () {
+        final model = MapModel(
+          valueModel: StringModel(context: context),
+          context: context,
+          examples: const [],
+        );
+
+        expect(getSimpleDecodingUnsupportedReason(model), isNull);
+        expect(
+          buildSimpleValueExpression(
+            refer('value'),
+            model: model,
+            isRequired: true,
+            nameManager: nameManager,
+            explode: literalBool(true),
+          ).accept(emitter).toString(),
+          'value.decodeSimpleMap((v) => v.decodeSimpleString(), '
+          'explode: true, )',
+        );
+      });
+
+      test('generates optional non-exploded typed maps with context', () {
+        final model = MapModel(
+          valueModel: IntegerModel(context: context),
+          context: context,
+          examples: const [],
+        );
+
+        expect(
+          buildSimpleValueExpression(
+            refer('value'),
+            model: model,
+            isRequired: false,
+            nameManager: nameManager,
+            contextProperty: 'X-Counts',
+            explode: literalBool(false),
+          ).accept(emitter).toString(),
+          'value.decodeSimpleNullableMap((v) => '
+          "v.decodeSimpleInt(context: r'X-Counts'), "
+          "explode: false, context: r'X-Counts', )",
+        );
+      });
+
+      test('unwraps aliases for the map and its values', () {
+        final model = AliasModel(
+          model: MapModel(
+            valueModel: AliasModel(
+              model: BooleanModel(context: context),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+            context: context,
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+          defaultValue: null,
+        );
+
+        expect(getSimpleDecodingUnsupportedReason(model), isNull);
+        expect(
+          buildSimpleValueExpression(
+            refer('value'),
+            model: model,
+            isRequired: true,
+            nameManager: nameManager,
+            explode: literalBool(true),
+          ).accept(emitter).toString(),
+          'value.decodeSimpleMap((v) => v.decodeSimpleBool(), explode: true, )',
+        );
+      });
+
+      test('honors nullable map values', () {
+        final model = MapModel(
+          valueModel: IntegerModel(context: context),
+          isValueNullable: true,
+          context: context,
+          examples: const [],
+        );
+
+        expect(
+          buildSimpleValueExpression(
+            refer('value'),
+            model: model,
+            isRequired: true,
+            nameManager: nameManager,
+            explode: literalBool(false),
+          ).accept(emitter).toString(),
+          'value.decodeSimpleMap((v) => v.decodeSimpleNullableInt(), '
+          'explode: false, )',
+        );
+      });
+
+      test('rejects nested maps before recursively generating decoders', () {
+        final model = MapModel(
+          valueModel: MapModel(
+            valueModel: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+        );
+
+        expect(
+          getSimpleDecodingUnsupportedReason(model),
+          'Map values must be scalar in simple encoding',
+        );
+        expect(
+          buildSimpleValueExpression(
+            refer('value'),
+            model: model,
+            isRequired: true,
+            nameManager: nameManager,
+            explode: literalBool(true),
+          ).accept(emitter).toString(),
+          "throw  SimpleDecodingException('Map values must be scalar "
+          "in simple encoding.')",
+        );
+      });
+
+      test('rejects list values', () {
+        final model = MapModel(
+          valueModel: ListModel(
+            content: StringModel(context: context),
+            context: context,
+            examples: const [],
+          ),
+          context: context,
+          examples: const [],
+        );
+
+        expect(
+          getSimpleDecodingUnsupportedReason(model),
+          'Map values must be scalar in simple encoding',
+        );
+      });
+    });
+
     group('BinaryModel', () {
       test('generates TonikFileBytes wrapping for required BinaryModel', () {
         final value = refer('value');

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -315,6 +315,72 @@ extension SimpleDecoder on String? {
     return decodeSimpleStringNullableList(context: context);
   }
 
+  /// Decodes a flat simple-style object, converting values with [decodeValue].
+  ///
+  /// Exploded objects use `key=value,key=value`; non-exploded objects use
+  /// `key,value,key,value`. A bare exploded key has an empty value.
+  /// Keys and values retain literal percent sequences.
+  /// An empty string represents an empty map. Throws [InvalidTypeException]
+  /// for null and [InvalidFormatException] for malformed or duplicate pairs.
+  Map<String, T> decodeSimpleMap<T>(
+    T Function(String) decodeValue, {
+    required bool explode,
+    String? context,
+  }) {
+    final value = this;
+    if (value == null) {
+      throw InvalidTypeException(
+        value: 'null',
+        targetType: Map<String, T>,
+        context: context,
+      );
+    }
+    if (value.isEmpty) return {};
+
+    final parts = value.split(',');
+    final result = <String, T>{};
+    final location = context == null ? '' : ' in $context';
+    if (!explode && parts.length.isOdd) {
+      throw InvalidFormatException(
+        value: value,
+        format: 'alternating key-value pairs$location',
+      );
+    }
+    for (var i = 0; i < parts.length; i += explode ? 1 : 2) {
+      final String key;
+      final String rawValue;
+      if (explode) {
+        final separator = parts[i].indexOf('=');
+        key = separator == -1 ? parts[i] : parts[i].substring(0, separator);
+        rawValue = separator == -1 ? '' : parts[i].substring(separator + 1);
+      } else {
+        key = parts[i];
+        rawValue = parts[i + 1];
+      }
+      if (result.containsKey(key)) {
+        throw InvalidFormatException(
+          value: key,
+          format: 'single occurrence per key$location',
+        );
+      }
+      result[key] = decodeValue(rawValue);
+    }
+    return result;
+  }
+
+  /// Decodes a nullable flat simple-style object.
+  ///
+  /// Returns null only when the field is absent.
+  /// An empty field is an empty map.
+  Map<String, T>? decodeSimpleNullableMap<T>(
+    T Function(String) decodeValue, {
+    required bool explode,
+    String? context,
+  }) {
+    if (this == null) return null;
+    return decodeSimpleMap(decodeValue, explode: explode, context: context);
+  }
+
   /// Decodes a string to a Date.
   ///
   /// The string must be in ISO 8601 format (YYYY-MM-DD).

--- a/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
@@ -323,6 +323,144 @@ void main() {
       });
     });
 
+    group('Maps', () {
+      test('decodes exploded string pairs', () {
+        expect(
+          'role=admin,firstName=Alex'.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: true,
+          ),
+          {'role': 'admin', 'firstName': 'Alex'},
+        );
+      });
+
+      test('decodes alternating keys and typed values', () {
+        expect(
+          'count,42,remaining,7'.decodeSimpleMap(
+            (value) => value.decodeSimpleInt(),
+            explode: false,
+          ),
+          {'count': 42, 'remaining': 7},
+        );
+      });
+
+      test('preserves percent sequences, equals signs and empty values', () {
+        expect(
+          '50%=a%20b,payload=SGVsbG8=,empty='.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: true,
+          ),
+          {'50%': 'a%20b', 'payload': 'SGVsbG8=', 'empty': ''},
+        );
+      });
+
+      test('returns empty maps for present empty fields', () {
+        expect(
+          ''.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: true,
+          ),
+          <String, String>{},
+        );
+        expect(
+          ''.decodeSimpleNullableMap(
+            (value) => value.decodeSimpleString(),
+            explode: false,
+          ),
+          <String, String>{},
+        );
+      });
+
+      test('returns null for an absent optional field', () {
+        expect(
+          null.decodeSimpleNullableMap(
+            (value) => value.decodeSimpleInt(),
+            explode: true,
+          ),
+          isNull,
+        );
+      });
+
+      test('rejects an absent required field with context', () {
+        expect(
+          () => null.decodeSimpleMap(
+            (value) => value.decodeSimpleInt(),
+            explode: true,
+            context: 'X-Counts',
+          ),
+          throwsA(
+            isA<InvalidTypeException>().having(
+              (error) => error.context,
+              'context',
+              'X-Counts',
+            ),
+          ),
+        );
+      });
+
+      test('decodes a bare exploded key as an empty string', () {
+        expect(
+          'role=admin,firstName'.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: true,
+          ),
+          {'role': 'admin', 'firstName': ''},
+        );
+      });
+
+      test('rejects an unmatched alternating key with context', () {
+        expect(
+          () => 'count,42,remaining'.decodeSimpleMap(
+            (value) => value.decodeSimpleInt(),
+            explode: false,
+            context: 'X-Counts',
+          ),
+          throwsA(
+            isA<InvalidFormatException>().having(
+              (error) => error.format,
+              'format',
+              'alternating key-value pairs in X-Counts',
+            ),
+          ),
+        );
+      });
+
+      test('rejects duplicate exploded keys', () {
+        expect(
+          () => 'role=admin,role=user'.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: true,
+          ),
+          throwsA(isA<InvalidFormatException>()),
+        );
+      });
+
+      test('rejects duplicate non-exploded keys', () {
+        expect(
+          () => 'role,admin,role,user'.decodeSimpleMap(
+            (value) => value.decodeSimpleString(),
+            explode: false,
+          ),
+          throwsA(isA<InvalidFormatException>()),
+        );
+      });
+
+      test('propagates a typed value error with context', () {
+        expect(
+          () => 'count=oops'.decodeSimpleMap(
+            (value) => value.decodeSimpleInt(context: 'X-Counts'),
+            explode: true,
+            context: 'X-Counts',
+          ),
+          throwsA(
+            isA<InvalidTypeException>()
+                .having((error) => error.value, 'value', 'oops')
+                .having((error) => error.context, 'context', 'X-Counts'),
+          ),
+        );
+      });
+    });
+
     group('Literal percent handling', () {
       test('decodeSimpleString returns percent signs literally', () {
         expect('50%'.decodeSimpleString(), '50%');


### PR DESCRIPTION
Object response headers using simple serialization currently fail before their values are read. This change decodes headers such as `X-Meta: role=admin,firstName=Alex` into the declared map with both Dio and package:http.

Supports both explode modes, typed and nullable values, aliases, absent optional headers, and literal header text. Malformed input produces contextual decoding errors, nested collection values remain guarded, and immutable map conversion is preserved across response headers and shared model decoders.

Validation:

- 1,625 runtime tests and 3,247 generator tests passed.
- Six public-operation regression tests passed on each backend; both generated clients passed analysis.
- Existing immutable collections and a generated immutable header client passed analysis.
- Changed package analysis, formatting, and independent review passed.
