### PR TITLE
fix: preserve adjacent path parameter expansions

### DIFF
--- a/integration_test/path_encoding/openapi.yaml
+++ b/integration_test/path_encoding/openapi.yaml
@@ -20,6 +20,121 @@ tags:
     description: Operations testing simple-style path parameters (RFC 6570 Section 3.2.2)
 
 paths:
+  /reports{labels}:
+    get:
+      operationId: testLabelLiteralPrefix
+      tags: [label]
+      parameters:
+        - name: labels
+          in: path
+          required: true
+          style: label
+          explode: false
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /reports/{labels}.json:
+    get:
+      operationId: testLabelLiteralSuffix
+      tags: [label]
+      parameters:
+        - name: labels
+          in: path
+          required: true
+          style: label
+          explode: true
+          schema:
+            type: array
+            items:
+              type: string
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /reports/{name}{labels}{revision}.json/:
+    get:
+      operationId: testAdjacentPathStyles
+      tags: [label]
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: labels
+          in: path
+          required: true
+          style: label
+          schema:
+            type: string
+        - name: revision
+          in: path
+          required: true
+          style: matrix
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /label/binary{value}.json:
+    get:
+      operationId: testLabelBinaryWithSuffix
+      tags: [label]
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: label
+          schema:
+            type: string
+            format: binary
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
+  /matrix/objects{value}.json:
+    get:
+      operationId: testMatrixObjectArrayWithSuffix
+      tags: [matrix]
+      parameters:
+        - name: value
+          in: path
+          required: true
+          style: matrix
+          schema:
+            type: array
+            items:
+              $ref: '#/components/schemas/SimpleObject'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/EchoResponse'
+
   /label/primitive/string/{value}:
     get:
       operationId: testLabelPrimitiveString

--- a/integration_test/path_encoding/path_encoding_test/test/adjacent_parameters_test.dart
+++ b/integration_test/path_encoding/path_encoding_test/test/adjacent_parameters_test.dart
@@ -1,0 +1,95 @@
+import 'package:path_encoding_api/path_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  late ImposterServer imposterServer;
+  late String baseUrl;
+
+  setUpAll(() async {
+    imposterServer = await setupImposterServer();
+    baseUrl = 'http://localhost:${imposterServer.port}/v1';
+  });
+
+  test('label array stays attached to its literal prefix', () async {
+    final api = LabelApi(
+      CustomServer(baseUrl: baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.testLabelLiteralPrefix(labels: ['daily']);
+
+    expect(response, isTonikSuccess);
+    final request = await imposterServer.takeRequest();
+    expect(request.uri.path, '/v1/reports.daily');
+  });
+
+  test(
+    'exploded label array keeps its suffix and escapes values once',
+    () async {
+      final api = LabelApi(
+        CustomServer(baseUrl: baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testLabelLiteralSuffix(
+        labels: ['a/b', 'daily'],
+      );
+
+      expect(response, isTonikSuccess);
+      final request = await imposterServer.takeRequest();
+      expect(request.uri.path, '/v1/reports/.a%2Fb.daily.json');
+    },
+  );
+
+  test('adjacent styles preserve the segment and trailing slash', () async {
+    final api = LabelApi(
+      CustomServer(baseUrl: baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.testAdjacentPathStyles(
+      name: 'sales',
+      labels: 'daily',
+      revision: 2,
+    );
+
+    expect(response, isTonikSuccess);
+    final request = await imposterServer.takeRequest();
+    expect(request.uri.path, '/v1/reports/sales.daily;revision=2.json/');
+  });
+
+  test(
+    'binary label with surrounding literals returns an encoding error',
+    () async {
+      final api = LabelApi(
+        CustomServer(baseUrl: baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testLabelBinaryWithSuffix(
+        value: const TonikFileBytes([1, 2, 3]),
+      );
+
+      expect(response, isTonikError);
+      final error = requireError(response);
+      expect(error.type, TonikErrorType.encoding);
+      expect(error.error, isA<EncodingException>());
+    },
+  );
+
+  test(
+    'matrix object array with surrounding literals returns an encoding error',
+    () async {
+      final api = MatrixApi(
+        CustomServer(baseUrl: baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testMatrixObjectArrayWithSuffix(
+        value: const [SimpleObject(name: 'daily', count: 1)],
+      );
+
+      expect(response, isTonikError);
+      final error = requireError(response);
+      expect(error.type, TonikErrorType.encoding);
+      expect(error.error, isA<EncodingException>());
+    },
+  );
+}

--- a/packages/tonik_generate/lib/src/operation/path_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/path_generator.dart
@@ -125,9 +125,8 @@ class const PathGenerator({
       return;
     }
 
-    // Simple-encoded parameters and adjacent literals are concatenated into a
-    // single list entry. Label and matrix parameters always become their own
-    // list entries because they produce their own prefix (. or ;).
+    // Every expansion belongs to its original slash-delimited segment,
+    // including label and matrix prefixes (. or ;) and adjacent literals.
     final currentConcatParts = <Expression>[];
 
     for (final part in parts.where((p) => p.isNotEmpty)) {
@@ -170,16 +169,12 @@ class const PathGenerator({
           );
           currentConcatParts.add(valueExpression.expression);
         case PathParameterEncoding.label:
-          _flushConcatParts(currentConcatParts, pathPartExpressions);
-
           final valueExpression = buildToLabelPathParameterExpression(
             param.normalizedName,
             param.parameter,
           );
-          pathPartExpressions.add(valueExpression.expression);
+          currentConcatParts.add(valueExpression.expression);
         case PathParameterEncoding.matrix:
-          _flushConcatParts(currentConcatParts, pathPartExpressions);
-
           // `.resolved` is only needed for this pre-flight type test —
           // `isEffectivelyNullable` and `buildMatrixParameterExpression`
           // handle aliases.
@@ -208,7 +203,7 @@ class const PathGenerator({
             explode: literalBool(param.parameter.explode),
             allowEmpty: literalBool(param.parameter.allowEmptyValue),
           );
-          pathPartExpressions.add(matrixExpression.expression);
+          currentConcatParts.add(matrixExpression.expression);
       }
     }
 
@@ -226,7 +221,12 @@ class const PathGenerator({
         if (i > 0) {
           codes.add(const Code(' + '));
         }
-        codes.add(parts[i].code);
+        // Encoders can emit `throw` expressions. Parentheses keep an adjacent
+        // literal from becoming part of the thrown expression.
+        final part = parts[i];
+        codes.add(
+          part is BinaryExpression ? part.parenthesized.code : part.code,
+        );
       }
       target.add(CodeExpression(Block.of(codes)));
     }

--- a/packages/tonik_generate/test/src/operation/path_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/path_generator_test.dart
@@ -234,7 +234,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required List<String> ids}) {
-          return [r'users', ids.toLabel(explode: false, allowEmpty: false, ), ];
+          return [r'users' + ids.toLabel(explode: false, allowEmpty: false, ), ];
         }
       ''';
 
@@ -300,7 +300,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required List<String> ids}) {
-          return [r'users', ids.toMatrix(r'ids', explode: false, allowEmpty: false, ), ];
+          return [r'users' + ids.toMatrix(r'ids', explode: false, allowEmpty: false, ), ];
         }
       ''';
 
@@ -371,7 +371,7 @@ void main() {
 
       const expectedMethod = '''
         List<String> _path({required NullableStatus status}) {
-          return [r'items', status!.toMatrix(r'status', explode: false, allowEmpty: false, ), ];
+          return [r'items' + status!.toMatrix(r'status', explode: false, allowEmpty: false, ), ];
         }
       ''';
 
@@ -601,7 +601,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required String userId, required String type, required List<String> roles, }) {
-          return [r'users', userId.toSimple(explode: false, allowEmpty: false, ), type.toLabel(explode: false, allowEmpty: false, ), roles.toMatrix(r'roles', explode: false, allowEmpty: false, ), ];
+          return [r'users', userId.toSimple(explode: false, allowEmpty: false, ) + type.toLabel(explode: false, allowEmpty: false, ) + roles.toMatrix(r'roles', explode: false, allowEmpty: false, ), ];
         }
       ''';
 
@@ -1100,7 +1100,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required List<String> tags}) {
-          return [r'data', tags.toMatrix(r'tags', explode: false, allowEmpty: false, ), ];
+          return [r'data' + tags.toMatrix(r'tags', explode: false, allowEmpty: false, ), ];
         }
       ''';
 
@@ -1169,7 +1169,7 @@ void main() {
     const expectedMethod = '''
       List<String> _path({required List<int> ids}) {
         return [
-          r'data',
+          r'data' +
           ids
               .map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
               .toList()
@@ -1260,7 +1260,7 @@ void main() {
     const expectedMethod = '''
       List<String> _path({required List<AnonymousModel> statuses}) {
         return [
-          r'data',
+          r'data' +
           statuses
               .map<String>((e) => e.uriEncode(allowEmpty: false, textEncoding: utf8))
               .toList()
@@ -1346,7 +1346,7 @@ void main() {
 
       const expectedMethod = '''
         List<String> _path({required List<AnonymousModel> filters}) {
-          return [r'data', throw EncodingException('Lists with complex content cannot be matrix-encoded'), ];
+          return [r'data' + (throw EncodingException('Lists with complex content cannot be matrix-encoded')), ];
         }
       ''';
 
@@ -1421,7 +1421,7 @@ void main() {
     const expectedMethod = '''
         List<String> _path({required List<List<String>> matrix}) {
           throw EncodingException('Matrix encoding does not support arrays of objects or nested arrays for path parameter matrix');
-          return [r'data'];
+          return [];
         }
       ''';
 
@@ -1913,7 +1913,7 @@ void main() {
     );
   });
 
-  test('label parameter with literal suffix emits separate list entries', () {
+  test('concatenates label parameter and literal suffix', () {
     final typeParam = PathParameterObject(
       name: 'type',
       rawName: 'type',
@@ -1948,7 +1948,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required String type}) {
-          return [r'resources', type.toLabel(explode: false, allowEmpty: false, ), r'.json', ];
+          return [r'resources', type.toLabel(explode: false, allowEmpty: false, ) + r'.json', ];
         }
       ''';
 
@@ -1966,7 +1966,7 @@ void main() {
     );
   });
 
-  test('matrix parameter with literal suffix emits separate list entries', () {
+  test('concatenates matrix parameter and literal suffix', () {
     final rolesParam = PathParameterObject(
       name: 'roles',
       rawName: 'roles',
@@ -2001,7 +2001,7 @@ void main() {
 
     const expectedMethod = '''
         List<String> _path({required String roles}) {
-          return [r'resources', roles.toMatrix(r'roles', explode: false, allowEmpty: false, ), r'.json', ];
+          return [r'resources', roles.toMatrix(r'roles', explode: false, allowEmpty: false, ) + r'.json', ];
         }
       ''';
 


### PR DESCRIPTION
Label-style parameters adjacent to path text introduced an extra slash: `/reports{labels}` with `['daily']` requested `/reports/.daily`. Keep simple, label, and matrix expansions within their original slash-delimited segment, preserving suffixes, escaping, trailing slashes, and encoding errors.

Validation: all 3,247 generator unit tests passed; 68 focused generated-client integration tests passed on each of Dio and HTTP; generator and generated-client analyzers passed. Independent code and scope reviews found no remaining blockers.
