### PR TITLE
fix: preserve empty string response headers

### DIFF
--- a/integration_test/simple_encoding/simple_encoding_test/test/empty_string_response_header_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/empty_string_response_header_test.dart
@@ -1,0 +1,57 @@
+import 'package:simple_encoding_api/simple_encoding_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+
+void main() {
+  test('present empty optional string response header stays empty', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'X-String': ''},
+    );
+    final api = SimpleEncodingApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.testHeaderRoundtripPrimitives();
+
+    final success = requireSuccess(response);
+    expect(success.value.xString, '');
+  });
+
+  test('absent optional string response header remains null', () async {
+    final server = await RawRequestServer.start(responseStatusCode: 200);
+    final api = SimpleEncodingApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.testHeaderRoundtripPrimitives();
+
+    final success = requireSuccess(response);
+    expect(success.value.xString, isNull);
+  });
+
+  test('nonempty optional string response header keeps its value', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'X-String': 'daily'},
+    );
+    final api = SimpleEncodingApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.testHeaderRoundtripPrimitives();
+
+    final success = requireSuccess(response);
+    expect(success.value.xString, 'daily');
+  });
+
+  test(
+    'optional string response header preserves literal percent text',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {'X-String': '50% ready%2Fdone'},
+      );
+      final api = SimpleEncodingApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.testHeaderRoundtripPrimitives();
+
+      final success = requireSuccess(response);
+      expect(success.value.xString, '50% ready%2Fdone');
+    },
+  );
+}

--- a/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
+++ b/integration_test/simple_encoding/simple_encoding_test/test/header_roundtrip_aliases_test.dart
@@ -82,22 +82,17 @@ void main() {
         expect(success.value.xUserName, userName);
       });
 
-      test(
-        'sends empty string as an empty header, decoded back as null',
-        () async {
-          const userName = '';
+      test('round-trips an empty string as an empty header', () async {
+        const userName = '';
 
-          final result = await api.testHeaderRoundtripAliases(
-            userName: userName,
-          );
+        final result = await api.testHeaderRoundtripAliases(userName: userName);
 
-          expect(result, isTonikSuccess);
-          final success = requireSuccess(result);
-          final recordedRequest = await imposterServer.takeRequest();
-          expect(recordedRequest.headers['x-user-name'], '');
-          expect(success.value.xUserName, isNull);
-        },
-      );
+        expect(result, isTonikSuccess);
+        final success = requireSuccess(result);
+        final recordedRequest = await imposterServer.takeRequest();
+        expect(recordedRequest.headers['x-user-name'], '');
+        expect(success.value.xUserName, '');
+      });
 
       test('roundtrips UserName with special characters', () async {
         const userName = 'user@example.com';

--- a/packages/tonik_util/lib/src/decoding/simple_decoder.dart
+++ b/packages/tonik_util/lib/src/decoding/simple_decoder.dart
@@ -28,11 +28,9 @@ extension SimpleDecoder on String? {
 
   /// Decodes a string to a nullable string.
   ///
-  /// Returns null if the string is empty or null.
-  String? decodeSimpleNullableString({String? context}) {
-    if (this?.isEmpty ?? true) return null;
-    return this!;
-  }
+  /// Returns the string value as is, including an empty string.
+  /// Returns null only when the value is absent.
+  String? decodeSimpleNullableString({String? context}) => this;
 
   /// Decodes a string to an integer.
   ///
@@ -300,10 +298,7 @@ extension SimpleDecoder on String? {
       );
     }
     if (this!.isEmpty) return [];
-    return this!
-        .split(',')
-        .map((s) => s.decodeSimpleNullableString(context: context))
-        .toList();
+    return this!.split(',').map((s) => s.isEmpty ? null : s).toList();
   }
 
   /// Decodes a string to a nullable list of nullable strings.

--- a/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
+++ b/packages/tonik_util/test/src/decoding/simple_decoder_test.dart
@@ -297,7 +297,10 @@ void main() {
       test('decodes nullable string values', () {
         expect('test'.decodeSimpleNullableString(), 'test');
         expect(null.decodeSimpleNullableString(), isNull);
-        expect(''.decodeSimpleNullableString(), isNull);
+      });
+
+      test('preserves a present empty nullable string', () {
+        expect(''.decodeSimpleNullableString(), '');
       });
 
       test('decodes integer values', () {
@@ -475,7 +478,7 @@ void main() {
         expect('50%'.decodeSimpleNullableString(), '50%');
         expect('foo%2Cbar'.decodeSimpleNullableString(), 'foo%2Cbar');
         expect('%ZZ'.decodeSimpleNullableString(), '%ZZ');
-        expect(''.decodeSimpleNullableString(), isNull);
+        expect(''.decodeSimpleNullableString(), '');
         expect((null as String?).decodeSimpleNullableString(), isNull);
       });
 


### PR DESCRIPTION
A present empty optional string response header was decoded as null. Preserve the scalar string value, including `''`, while keeping missing headers null and retaining the existing nullable-list element behavior. Update the existing alias round-trip expectation to preserve an empty header too.

Validation: all 1,626 utility and 3,247 generator unit tests passed. The full 313-test simple-encoding integration suite passed on each of Dio and HTTP, including four raw-server response-header regressions. Utility and generated API/test analyzers passed. Independent code and scope reviews found no blockers.
