### PR TITLE
fix: enforce required nullable property presence

### DIFF
--- a/integration_test/nullable_bodies/nullable_bodies_test/test/required_nullable_property_test.dart
+++ b/integration_test/nullable_bodies/nullable_bodies_test/test/required_nullable_property_test.dart
@@ -1,0 +1,101 @@
+import 'dart:convert';
+
+import 'package:nullable_bodies_api/nullable_bodies_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test('rejects an omitted required nullable property', () {
+    expect(
+      () => Profile.fromJson(const <String, Object?>{}),
+      throwsA(
+        isA<JsonDecodingException>().having(
+          (error) => error.message,
+          'message',
+          'Missing required property Profile.nickname.',
+        ),
+      ),
+    );
+  });
+
+  test('preserves explicit null while omitting absent optional properties', () {
+    final profile = Profile.fromJson(const {'nickname': null});
+
+    expect(profile.nickname, isNull);
+    expect(profile.bio, isNull);
+    expect(profile.toJson(), {'nickname': null});
+  });
+
+  test('accepts nonnull values for required and optional properties', () {
+    final profile = Profile.fromJson(const {
+      'nickname': 'daily',
+      'bio': 'Reports',
+    });
+
+    expect(profile.nickname, 'daily');
+    expect(profile.bio, 'Reports');
+    expect(profile.toJson(), {'nickname': 'daily', 'bio': 'Reports'});
+  });
+
+  test('requires a property whose nullable schema is referenced', () {
+    expect(
+      () => AliasProfile.fromJson(const <String, Object?>{}),
+      throwsA(isA<JsonDecodingException>()),
+    );
+    expect(AliasProfile.fromJson(const {'nickname': null}).nickname, isNull);
+  });
+
+  test('requires read-only properties in responses', () {
+    expect(
+      () => DirectionalProfile.fromJson(const <String, Object?>{}),
+      throwsA(isA<JsonDecodingException>()),
+    );
+  });
+
+  test('accepts absent required write-only properties in responses', () {
+    final profile = DirectionalProfile.fromJson(const {'nickname': null});
+
+    expect(profile.nickname, isNull);
+    expect(profile.credential, isNull);
+  });
+
+  test('retains existing default fallback and explicit null behavior', () {
+    final omitted = DefaultProfile.fromJson(const <String, Object?>{});
+    final explicitNull = DefaultProfile.fromJson(const {'nickname': null});
+
+    expect(omitted.nickname, 'guest');
+    expect(explicitNull.nickname, isNull);
+  });
+
+  test(
+    'operation reports a missing required nullable property as an error',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {'Content-Type': 'application/json'},
+        responseBody: utf8.encode('{}'),
+      );
+      final api = NullableBodiesApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.getProfile();
+
+      final error = requireError(response);
+      expect(error.type, TonikErrorType.decoding);
+    },
+  );
+
+  test('operation accepts an explicit null required property', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'Content-Type': 'application/json'},
+      responseBody: utf8.encode('{"nickname":null}'),
+    );
+    final api = NullableBodiesApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.getProfile();
+
+    final success = requireSuccess(response);
+    expect(success.value.toJson(), {'nickname': null});
+  });
+}

--- a/integration_test/nullable_bodies/openapi.yaml
+++ b/integration_test/nullable_bodies/openapi.yaml
@@ -19,6 +19,19 @@ tags:
     description: Operations returning nullable primitive bodies
 
 paths:
+  /profile:
+    get:
+      operationId: getProfile
+      tags:
+        - nullable-bodies
+      responses:
+        '200':
+          description: A profile with a required nullable nickname
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Profile'
+
   /winner/inline:
     get:
       operationId: getWinnerInline
@@ -50,6 +63,45 @@ paths:
 
 components:
   schemas:
+    Profile:
+      type: object
+      required: [nickname]
+      properties:
+        nickname:
+          type: string
+          nullable: true
+        bio:
+          type: string
+
+    AliasProfile:
+      type: object
+      required: [nickname]
+      properties:
+        nickname:
+          $ref: '#/components/schemas/WinnerName'
+
+    DirectionalProfile:
+      type: object
+      required: [nickname, credential]
+      properties:
+        nickname:
+          type: string
+          nullable: true
+          readOnly: true
+        credential:
+          type: string
+          nullable: true
+          writeOnly: true
+
+    DefaultProfile:
+      type: object
+      required: [nickname]
+      properties:
+        nickname:
+          type: string
+          nullable: true
+          default: guest
+
     WinnerName:
       type: string
       nullable: true

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -721,6 +721,23 @@ class const ClassGenerator({
                 !requiredInResponse ||
                 property.model.isEffectivelyNullable;
 
+      if (requiredInResponse && defaulted == null && decodeIsNullable) {
+        codes
+          ..add(
+            Code(
+              r'if (!_$map.containsKey('
+              '${specLiteralStringCode(jsonKey)})) {',
+            ),
+          )
+          ..add(
+            generateJsonDecodingExceptionExpression(
+              'Missing required property $className.$jsonKey.',
+              raw: true,
+            ).statement,
+          )
+          ..add(const Code('}'));
+      }
+
       final valueBuilt = buildFromJsonValueExpression(
         '_\$map[${specLiteralStringCode(jsonKey)}]',
         model: property.model,

--- a/packages/tonik_generate/test/src/model/class_json_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_json_generator_test.dart
@@ -910,8 +910,65 @@ void main() {
       const expectedMethod = r'''
   factory User.fromJson(Object? json) {
     final _$map = json.decodeMap(context: r'User');
+    if (!_$map.containsKey(r'name')) {
+      throw JsonDecodingException(r'Missing required property User.name.');
+    }
     return User(
       name: _$map[r'name'].decodeJsonNullableString(context: r'User.name'),
+    );
+  }''';
+
+      final generatedClass = generator.generateClass(model);
+      expect(
+        collapseWhitespace(format(generatedClass.accept(emitter).toString())),
+        contains(collapseWhitespace(expectedMethod)),
+      );
+    });
+
+    test('checks presence through a nullable alias chain', () {
+      final model = ClassModel(
+        isDeprecated: false,
+        context: context,
+        name: 'Profile',
+        properties: [
+          Property(
+            name: 'display-name',
+            model: AliasModel(
+              name: 'DisplayName',
+              model: AliasModel(
+                name: 'NullableName',
+                model: StringModel(context: context),
+                isNullable: true,
+                context: context,
+                examples: const [],
+                defaultValue: null,
+              ),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        examples: const [],
+      );
+
+      const expectedMethod = r'''
+  factory Profile.fromJson(Object? json) {
+    final _$map = json.decodeMap(context: r'Profile');
+    if (!_$map.containsKey(r'display-name')) {
+      throw JsonDecodingException(
+        r'Missing required property Profile.display-name.',
+      );
+    }
+    return Profile(
+      displayName: _$map[r'display-name'].decodeJsonNullableString(
+        context: r'Profile.display-name',
+      ),
     );
   }''';
 
@@ -1077,6 +1134,9 @@ void main() {
       const expectedMethod = r'''
   factory Repo.fromJson(Object? json) {
     final _$map = json.decodeMap(context: r'Repo');
+    if (!_$map.containsKey(r'license')) {
+      throw JsonDecodingException(r'Missing required property Repo.license.');
+    }
     return Repo(
       license: _$map[r'license'] == null
           ? null
@@ -1124,6 +1184,11 @@ void main() {
       const expectedMethod = r'''
   factory Item.fromJson(Object? json) {
     final _$map = json.decodeMap(context: r'Item');
+    if (!_$map.containsKey(r'description')) {
+      throw JsonDecodingException(
+        r'Missing required property Item.description.',
+      );
+    }
     return Item(
       description: _$map[r'description'].decodeJsonNullableString(
         context: r'Item.description',

--- a/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
+++ b/packages/tonik_generate/test/src/model/class_read_only_write_only_test.dart
@@ -173,6 +173,9 @@ void main() {
       const expectedMethod = r'''
         factory User.fromJson(Object? json) {
           final _$map = json.decodeMap(context: r'User');
+          if (!_$map.containsKey(r'createdAt')) {
+            throw JsonDecodingException(r'Missing required property User.createdAt.');
+          }
           return User(
             id: _$map[r'id'].decodeJsonInt(context: r'User.id'),
             name: _$map[r'name'].decodeJsonString(context: r'User.name'),


### PR DESCRIPTION
A missing required nullable response property was accepted and silently re-encoded as an explicit null. Generated object decoders now check key presence before nullable decoding, so `{}` is rejected while `{'nickname': null}` remains valid.

Cover nullable references, optional fields, read-only/write-only directions, and the existing default fallback behavior.

Validation: all 3,248 generator unit tests passed; nine model and operation regressions passed on each of Dio and HTTP; generator and generated API/test analyzers passed. Independent code and scope reviews found no blockers.

