### PR TITLE
fix: dispatch parameterized response media types

### DIFF
--- a/integration_test/structured_syntax_suffix/openapi.yaml
+++ b/integration_test/structured_syntax_suffix/openapi.yaml
@@ -12,6 +12,37 @@ tags:
   - name: widgets
     description: Widget operations
 paths:
+  /document:
+    get:
+      tags: [widgets]
+      operationId: getDocument
+      responses:
+        '200':
+          description: Document representations selected by media parameters
+          content:
+            application/vnd.example.document+json:
+              schema:
+                type: integer
+            application/vnd.example.document+json;version=2:
+              schema:
+                type: string
+            'application/vnd.example.document+json;version=2;profile="Full;V2"':
+              schema:
+                type: boolean
+  /document/reversed:
+    get:
+      tags: [widgets]
+      operationId: getDocumentReversed
+      responses:
+        '200':
+          description: Parameterized representation declared first
+          content:
+            application/vnd.example.document+json;version=2:
+              schema:
+                type: string
+            application/vnd.example.document+json:
+              schema:
+                type: integer
   /widget:
     get:
       tags:

--- a/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/parameterized_response_test.dart
+++ b/integration_test/structured_syntax_suffix/structured_syntax_suffix_test/test/parameterized_response_test.dart
@@ -1,0 +1,153 @@
+import 'dart:convert';
+
+import 'package:structured_syntax_suffix_api/structured_syntax_suffix_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+
+void main() {
+  test('selects the versioned string representation', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {
+        'Content-Type': 'application/vnd.example.document+json;version=2',
+      },
+      responseBody: utf8.encode('"doc-42"'),
+    );
+    final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.getDocument();
+
+    expect(
+      requireSuccess(response).value,
+      const DocumentGet200ResponseVndExampleDocumentJsonVersion2(
+        body: 'doc-42',
+      ),
+    );
+  });
+
+  test('selects the unparameterized integer representation', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {
+        'Content-Type': 'application/vnd.example.document+json',
+      },
+      responseBody: utf8.encode('42'),
+    );
+    final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.getDocument();
+
+    expect(
+      requireSuccess(response).value,
+      const DocumentGet200ResponseVndExampleDocumentJson(body: 42),
+    );
+  });
+
+  test(
+    'falls back to the bare representation for an undeclared version',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {
+          'Content-Type': 'application/vnd.example.document+json;version=3',
+        },
+        responseBody: utf8.encode('42'),
+      );
+      final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.getDocument();
+
+      expect(
+        requireSuccess(response).value,
+        const DocumentGet200ResponseVndExampleDocumentJson(body: 42),
+      );
+    },
+  );
+
+  test('matches mixed case names and permits extra charset', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {
+        'Content-Type':
+            'Application/Vnd.Example.Document+JSON; CHARSET=UTF-8; VERSION="2"',
+      },
+      responseBody: utf8.encode('"doc-42"'),
+    );
+    final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.getDocument();
+
+    expect(
+      requireSuccess(response).value,
+      const DocumentGet200ResponseVndExampleDocumentJsonVersion2(
+        body: 'doc-42',
+      ),
+    );
+  });
+
+  test(
+    'prefers the most specific declared parameters regardless of order',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {
+          'Content-Type': 'application/vnd.example.document+json; profile="Full;V2"; version=2',
+        },
+        responseBody: utf8.encode('true'),
+      );
+      final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.getDocument();
+
+      expect(
+        requireSuccess(response).value,
+        const DocumentGet200ResponseVndExampleDocumentJsonVersion2ProfileFullV2(
+          body: true,
+        ),
+      );
+    },
+  );
+
+  test('preserves case when comparing profile parameter values', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {
+        'Content-Type': 'application/vnd.example.document+json; profile="full;v2"; version=2',
+      },
+      responseBody: utf8.encode('"doc-42"'),
+    );
+    final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+    final response = await api.getDocument();
+
+    expect(
+      requireSuccess(response).value,
+      const DocumentGet200ResponseVndExampleDocumentJsonVersion2(
+        body: 'doc-42',
+      ),
+    );
+  });
+
+  test(
+    'also selects the versioned representation when declared first',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {
+          'Content-Type': 'application/vnd.example.document+json;version=2',
+        },
+        responseBody: utf8.encode('"doc-42"'),
+      );
+      final api = WidgetsApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.getDocumentReversed();
+
+      expect(
+        requireSuccess(response).value,
+        const DocumentReversedGet200ResponseVndExampleDocumentJsonVersion2(
+          body: 'doc-42',
+        ),
+      );
+    },
+  );
+}

--- a/packages/tonik_generate/lib/src/operation/parse_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/parse_generator.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:code_builder/code_builder.dart';
 import 'package:logging/logging.dart';
 import 'package:tonik_core/tonik_core.dart';
@@ -147,21 +149,36 @@ class const ParseGenerator({
     final mediaTypeGuard = isMediaRange
         ? _mediaTypeRangeGuard(normalized)
         : null;
+    final parameters = tonik_util.parseMediaTypeParameters(contentType);
+    final parameterGuard = parameters != null && parameters.isNotEmpty
+        ? refer(
+            'matchesMediaTypeParameters',
+            'package:tonik_util/tonik_util.dart',
+          ).call([
+            backendGenerator.responseContentType(refer('response')),
+            literalMap({
+              for (final entry in parameters.entries)
+                specLiteralString(entry.key): specLiteralString(entry.value),
+            }),
+          ]).code
+        : null;
 
     switch (status) {
       case ExplicitResponseStatus():
         return _caseWithGuards(
           'case (${status.statusCode}, $contentTypePattern)',
-          [?mediaTypeGuard],
+          [?mediaTypeGuard, ?parameterGuard],
         );
       case RangeResponseStatus():
         return _caseWithGuards('case (var status, $contentTypePattern)', [
           backendGenerator.responseStatusCodeRangeGuard(status),
           ?mediaTypeGuard,
+          ?parameterGuard,
         ]);
       case DefaultResponseStatus():
         return _caseWithGuards('case (_, $contentTypePattern)', [
           ?mediaTypeGuard,
+          ?parameterGuard,
         ]);
     }
   }
@@ -707,7 +724,7 @@ class const ParseGenerator({
 
     for (final body in resolvedResponse.bodies) {
       final raw = body.rawContentType;
-      final normalized = tonik_util.extractMediaType(raw);
+      final normalized = _contentTypeKey(raw);
       if (normalized == null) {
         contentTypes.add(raw);
         continue;
@@ -758,7 +775,15 @@ class const ParseGenerator({
     final catchAllRanges = <String?>[];
     final catchAllPatterns = <String?>[];
 
-    for (final contentType in contentTypes) {
+    final byParameterCount = contentTypes.indexed.toList()
+      ..sort((a, b) {
+        final aCount = tonik_util.parseMediaTypeParameters(a.$2)?.length ?? 0;
+        final bCount = tonik_util.parseMediaTypeParameters(b.$2)?.length ?? 0;
+        final countOrder = bCount.compareTo(aCount);
+        return countOrder != 0 ? countOrder : a.$1.compareTo(b.$1);
+      });
+
+    for (final (_, contentType) in byParameterCount) {
       switch (_contentTypeSpecificity(contentType)) {
         case 0:
           exact.add(contentType);
@@ -772,6 +797,18 @@ class const ParseGenerator({
     }
 
     return {...exact, ...typeRanges, ...catchAllRanges, ...catchAllPatterns};
+  }
+
+  String? _contentTypeKey(String contentType) {
+    final normalized = tonik_util.extractMediaType(contentType);
+    if (normalized == null) return null;
+    final parameters = tonik_util.parseMediaTypeParameters(contentType);
+    if (parameters == null || parameters.isEmpty) return normalized;
+    final names = parameters.keys.toList()..sort();
+    final normalizedParameters = names
+        .map((name) => '; $name=${jsonEncode(parameters[name])}')
+        .join();
+    return '$normalized$normalizedParameters';
   }
 
   int _contentTypeSpecificity(String? contentType) {

--- a/packages/tonik_generate/test/src/operation/parse_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/parse_generator_test.dart
@@ -4403,7 +4403,7 @@ String _parseResponse(Response<List<int>> response) {
         );
       });
 
-      test('strips parameters from spec key in case pattern', () {
+      test('matches parameters from spec key with a guard', () {
         final operation = Operation(
           operationId: 'paramContentTypeOp',
           context: context,
@@ -4440,7 +4440,7 @@ String _parseResponse(Response<List<int>> response) {
 String _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
   switch ((response.statusCode, _$mediaType)) {
-    case (200, r'application/json'):
+    case (200, r'application/json') when matchesMediaTypeParameters(response.headers.value('content-type'), {r'charset': r'utf-8'}):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = _$json.decodeJsonString();
       return _$body;
@@ -4550,7 +4550,7 @@ String _parseResponse(Response<List<int>> response) {
 String _parseResponse(Response<List<int>> response) {
   final _$mediaType = extractMediaType(response.headers.value('content-type'));
   switch ((response.statusCode, _$mediaType)) {
-    case (_, r'application/vnd.foo+json'):
+    case (_, r'application/vnd.foo+json') when matchesMediaTypeParameters(response.headers.value('content-type'), {r'version': r'1'}):
       final _$json = decodeResponseJson<Object?>(response.data);
       final _$body = _$json.decodeJsonString();
       return _$body;
@@ -4657,7 +4657,7 @@ String _parseResponse(Response<List<int>> response) {
                   ),
                   ResponseBody(
                     model: IntegerModel(context: context),
-                    rawContentType: 'application/json; charset=utf-8',
+                    rawContentType: 'application/JSON',
                     contentType: ContentType.json,
                     examples: const [],
                   ),
@@ -4699,11 +4699,93 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
               .map((r) => r.message)
               .toList();
           expect(warnings, hasLength(1));
-          expect(warnings.single, contains('application/json; charset=utf-8'));
+          expect(warnings.single, contains('application/JSON'));
           expect(warnings.single, contains('Application/JSON'));
           expect(warnings.single, contains('kept model: StringModel'));
           expect(warnings.single, contains('dropped models:'));
           expect(warnings.single, contains('IntegerModel'));
+        },
+      );
+
+      test(
+        'keeps distinct parameters and dedupes equivalent quoted parameters',
+        () {
+          final previousRootLevel = Logger.root.level;
+          Logger.root.level = Level.ALL;
+          addTearDown(() => Logger.root.level = previousRootLevel);
+          final logs = <LogRecord>[];
+          final sub = Logger('ParseGenerator').onRecord.listen(logs.add);
+          addTearDown(sub.cancel);
+
+          final operation = Operation(
+            operationId: 'parameterVariants',
+            context: context,
+            summary: '',
+            description: '',
+            tags: const {},
+            isDeprecated: false,
+            path: '/parameter-variants',
+            method: HttpMethod.get,
+            headers: const {},
+            queryParameters: const {},
+            pathParameters: const {},
+            cookieParameters: const {},
+            responses: {
+              const ExplicitResponseStatus(statusCode: 200): ResponseObject(
+                name: null,
+                context: context,
+                headers: const {},
+                description: '',
+                bodies: {
+                  ResponseBody(
+                    model: IntegerModel(context: context),
+                    rawContentType: 'application/json',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: StringModel(context: context),
+                    rawContentType: 'application/json; version=2',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: BooleanModel(context: context),
+                    rawContentType:
+                        'application/json; version=2; charset=UTF-8',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                  ResponseBody(
+                    model: DoubleModel(context: context),
+                    rawContentType:
+                        'Application/JSON; CHARSET="utf-8"; VERSION="2"',
+                    contentType: ContentType.json,
+                    examples: const [],
+                  ),
+                },
+              ),
+            },
+            securitySchemes: const {},
+          );
+
+          final generated = generator
+              .generateParseResponseMethod(operation)
+              .accept(emitter)
+              .toString();
+
+          expect(generated, contains('decodeJsonInt()'));
+          expect(generated, contains('decodeJsonString()'));
+          expect(generated, contains('decodeJsonBool()'));
+          expect(generated, isNot(contains('decodeJsonDouble()')));
+          final warnings = logs.where(
+            (record) => record.level == Level.WARNING,
+          );
+          expect(warnings, hasLength(1));
+          expect(
+            warnings.single.message,
+            contains('dropped models: DoubleModel'),
+          );
         },
       );
 
@@ -4745,7 +4827,7 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
                 ),
                 ResponseBody(
                   model: StringModel(context: context),
-                  rawContentType: 'application/json; charset=utf-8',
+                  rawContentType: 'Application/JSON',
                   contentType: ContentType.json,
                   examples: const [],
                 ),
@@ -4757,7 +4839,7 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
                 ),
                 ResponseBody(
                   model: StringModel(context: context),
-                  rawContentType: 'application/xml; charset=utf-8',
+                  rawContentType: 'Application/XML',
                   contentType: ContentType.json,
                   examples: const [],
                 ),
@@ -4800,13 +4882,13 @@ AnonymousResponse _parseResponse(Response<List<int>> response) {
         final jsonWarning = warnings.firstWhere(
           (w) => w.contains('"application/json"'),
         );
-        expect(jsonWarning, contains('application/json; charset=utf-8'));
+        expect(jsonWarning, contains('Application/JSON'));
         expect(jsonWarning, isNot(contains('kept model:')));
         expect(jsonWarning, isNot(contains('dropped models:')));
         final xmlWarning = warnings.firstWhere(
           (w) => w.contains('"application/xml"'),
         );
-        expect(xmlWarning, contains('application/xml; charset=utf-8'));
+        expect(xmlWarning, contains('Application/XML'));
         expect(xmlWarning, isNot(contains('kept model:')));
         expect(xmlWarning, isNot(contains('dropped models:')));
       });

--- a/packages/tonik_util/lib/src/decoding/media_type.dart
+++ b/packages/tonik_util/lib/src/decoding/media_type.dart
@@ -1,3 +1,38 @@
+import 'package:http_parser/http_parser.dart';
+
+/// Parses media type parameters, returning null for missing or invalid input.
+///
+/// Parameter names and charset values are normalized to lowercase. Other
+/// values retain their case, with quoted-string escapes decoded.
+Map<String, String>? parseMediaTypeParameters(String? header) {
+  if (header == null) return null;
+  try {
+    final parsed = MediaType.parse(header);
+    return {
+      for (final entry in parsed.parameters.entries)
+        entry.key.toLowerCase(): entry.key.toLowerCase() == 'charset'
+            ? entry.value.toLowerCase()
+            : entry.value,
+    };
+  } on FormatException {
+    return null;
+  }
+}
+
+/// Returns whether [actual] contains every declared media type parameter.
+///
+/// Extra parameters are allowed. Parameter names and charset values match
+/// without regard to case; other parameter values match exactly.
+bool matchesMediaTypeParameters(String? actual, Map<String, String> declared) {
+  final parameters = parseMediaTypeParameters(actual);
+  if (parameters == null) return false;
+  return declared.entries.every((entry) {
+    final name = entry.key.toLowerCase();
+    final value = name == 'charset' ? entry.value.toLowerCase() : entry.value;
+    return parameters[name] == value;
+  });
+}
+
 /// Extracts the bare `type/subtype` portion of an HTTP `Content-Type` header.
 ///
 /// Servers commonly append `charset=utf-8`; ignoring parameters is required to

--- a/packages/tonik_util/test/src/decoding/media_type_test.dart
+++ b/packages/tonik_util/test/src/decoding/media_type_test.dart
@@ -2,6 +2,79 @@ import 'package:test/test.dart';
 import 'package:tonik_util/tonik_util.dart';
 
 void main() {
+  group('media type parameters', () {
+    test('normalizes names and charset while preserving other value case', () {
+      expect(
+        parseMediaTypeParameters(
+          'Application/JSON; VERSION=Beta; Charset=UTF-8',
+        ),
+        {'version': 'Beta', 'charset': 'utf-8'},
+      );
+    });
+
+    test('parses quoted parameter values and escaped quotes', () {
+      expect(parseMediaTypeParameters(r'application/json; profile="a;b\"c"'), {
+        'profile': 'a;b"c',
+      });
+    });
+
+    test('matches a declared subset with extra parameters', () {
+      expect(
+        matchesMediaTypeParameters(
+          'application/json; charset=utf-8; version=2',
+          {'version': '2'},
+        ),
+        isTrue,
+      );
+    });
+
+    test('matches names and charset without regard to case', () {
+      expect(
+        matchesMediaTypeParameters('application/json; CHARSET=UTF-8', {
+          'Charset': 'utf-8',
+        }),
+        isTrue,
+      );
+    });
+
+    test('requires other parameter values to match case', () {
+      expect(
+        matchesMediaTypeParameters('application/json; profile=Beta', {
+          'profile': 'beta',
+        }),
+        isFalse,
+      );
+    });
+
+    test('rejects a missing declared parameter', () {
+      expect(
+        matchesMediaTypeParameters('application/json; charset=utf-8', {
+          'version': '2',
+        }),
+        isFalse,
+      );
+    });
+
+    test('rejects a different parameter value', () {
+      expect(
+        matchesMediaTypeParameters('application/json; version=3', {
+          'version': '2',
+        }),
+        isFalse,
+      );
+    });
+
+    test('rejects missing and malformed headers', () {
+      expect(matchesMediaTypeParameters(null, {'version': '2'}), isFalse);
+      expect(
+        matchesMediaTypeParameters('application/json; version="2', {
+          'version': '2',
+        }),
+        isFalse,
+      );
+    });
+  });
+
   group('extractMediaType', () {
     test('returns null for null header', () {
       expect(extractMediaType(null), isNull);


### PR DESCRIPTION
Response content entries that differed only by parameters were collapsed, so a versioned string response could be decoded using the generic integer schema. Retain distinct parameter sets and dispatch to the most specific matching entry, allowing extra response parameters and correctly handling quoted values and case rules.

Equivalent declarations still deduplicate. Existing status-code and exact/type-wildcard/catchall precedence is preserved.

Validation: all 3,248 generator and 1,633 utility unit tests passed; 11 structured-syntax and media-dispatch integration tests passed on each of Dio and HTTP; source and generated API/test analyzers passed. Independent code and scope reviews found no blockers.
