### PR TITLE
fix: preserve multipart binary content types

### DIFF
--- a/integration_test/multipart/multipart_test/test/binary_content_type_test.dart
+++ b/integration_test/multipart/multipart_test/test/binary_content_type_test.dart
@@ -1,0 +1,121 @@
+import 'dart:io';
+
+import 'package:multipart_api/multipart_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+import 'multipart_wire.dart';
+
+void main() {
+  test(
+    'binary bytes with a text filename keep the schema content type',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(CustomServer(baseUrl: server.baseUrl));
+
+      await api.postBinaryUpload(
+        body: const BinaryUpload(
+          file: TonikFileBytes([72, 105], fileName: 'report.txt'),
+          description: 'A report',
+        ),
+      );
+
+      final file = MultipartWire(await server.takeRequest()).single('file');
+      expect(file.filename, 'report.txt');
+      expect(file.contentType, 'application/octet-stream');
+      expect(file.bodyBytes, [72, 105]);
+    },
+  );
+
+  test(
+    'binary file path with an image filename keeps the schema content type',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'multipart-type-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = File('${directory.path}/image.png');
+      await source.writeAsBytes([1, 2, 3]);
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(CustomServer(baseUrl: server.baseUrl));
+
+      await api.postBinaryUpload(
+        body: BinaryUpload(
+          file: TonikFilePath(source.path, fileName: 'image.png'),
+          description: 'An image',
+        ),
+      );
+
+      final file = MultipartWire(await server.takeRequest()).single('file');
+      expect(file.filename, 'image.png');
+      expect(file.contentType, 'application/octet-stream');
+      expect(file.bodyBytes, [1, 2, 3]);
+    },
+  );
+
+  test(
+    'binary array byte and path items keep the schema content type',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'multipart-type-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = File('${directory.path}/image.png');
+      await source.writeAsBytes([1, 2, 3]);
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(CustomServer(baseUrl: server.baseUrl));
+
+      await api.postMultipleFiles(
+        body: MultipleFilesForm(
+          files: [
+            const TonikFileBytes([72, 105], fileName: 'report.txt'),
+            TonikFilePath(source.path, fileName: 'image.png'),
+          ],
+        ),
+      );
+
+      final files = MultipartWire(await server.takeRequest()).named('files');
+      expect(files, hasLength(2));
+      expect(files[0].filename, 'report.txt');
+      expect(files[0].contentType, 'application/octet-stream');
+      expect(files[0].bodyBytes, [72, 105]);
+      expect(files[1].filename, 'image.png');
+      expect(files[1].contentType, 'application/octet-stream');
+      expect(files[1].bodyBytes, [1, 2, 3]);
+    },
+  );
+
+  test(
+    'binary array byte and path items honor the content-type override',
+    () async {
+      final directory = await Directory.systemTemp.createTemp(
+        'multipart-type-',
+      );
+      addTearDown(() => directory.delete(recursive: true));
+      final source = File('${directory.path}/report.txt');
+      await source.writeAsBytes([1, 2, 3]);
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(CustomServer(baseUrl: server.baseUrl));
+
+      final response = await api.postMultipleFilesOverride(
+        body: MultipleFilesForm(
+          files: [
+            const TonikFileBytes([72, 105], fileName: 'first.txt'),
+            TonikFilePath(source.path, fileName: 'second.txt'),
+          ],
+        ),
+      );
+
+      expect(response, isTonikSuccess);
+      final files = MultipartWire(await server.takeRequest()).named('files');
+      expect(files, hasLength(2));
+      expect(files[0].filename, 'first.txt');
+      expect(files[0].contentType, 'image/png');
+      expect(files[0].bodyBytes, [72, 105]);
+      expect(files[1].filename, 'second.txt');
+      expect(files[1].contentType, 'image/png');
+      expect(files[1].bodyBytes, [1, 2, 3]);
+    },
+  );
+}

--- a/integration_test/multipart/openapi.yaml
+++ b/integration_test/multipart/openapi.yaml
@@ -259,6 +259,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/FilesResponse'
 
+  /multipart/multiple-files-override:
+    post:
+      operationId: postMultipleFilesOverride
+      tags: [multipart]
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/MultipleFilesForm'
+            encoding:
+              files:
+                contentType: image/png
+      responses:
+        '204':
+          description: Uploaded
+
   /multipart/byte:
     post:
       operationId: postByteField

--- a/packages/tonik_generate/lib/src/transport/multipart_body_planner.dart
+++ b/packages/tonik_generate/lib/src/transport/multipart_body_planner.dart
@@ -266,8 +266,9 @@ class const MultipartBodyPlanner({
     );
   }
 
-  List<MultipartEmission> _file(_Part part, {bool listItem = false}) {
-    final declared = part.encoding.wireContentType;
+  List<MultipartEmission> _file(_Part part) {
+    final contentType =
+        part.encoding.wireContentType ?? 'application/octet-stream';
     if (!_dio) {
       return [
         MultipartAppend(
@@ -277,14 +278,11 @@ class const MultipartBodyPlanner({
           filename: part.value
               .property('fileName')
               .ifNullThen(specLiteralString(part.name)),
-          contentType: declared ?? 'application/octet-stream',
+          contentType: contentType,
           headers: part.headers,
         ),
       ];
     }
-    final contentType = listItem || declared == 'application/octet-stream'
-        ? null
-        : declared;
     final filename = refer('fileName').ifNullThen(specLiteralString(part.name));
     return [
       MultipartCode(
@@ -350,7 +348,7 @@ class const MultipartBodyPlanner({
     }
     final itemPart = _withValue(part, refer('item'));
     if (item is BinaryModel || item is Base64Model) {
-      return _loop('item', part.value, _file(itemPart, listItem: true));
+      return _loop('item', part.value, _file(itemPart));
     }
     if (contentBased) {
       if (encoding.contentType != ContentType.json &&

--- a/packages/tonik_generate/test/src/transport/multipart_body_planner_test.dart
+++ b/packages/tonik_generate/test/src/transport/multipart_body_planner_test.dart
@@ -83,6 +83,40 @@ Object? test() {
   });
 
   group('single-value parts', () {
+    test(
+      'Dio retains a binary array content-type override for both sources',
+      () {
+        final content = multipartContentFixture(context, [
+          multipartPartFixture(
+            name: 'files',
+            model: ListModel(
+              content: BinaryModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            encoding: const PartEncoding(
+              contentType: ContentType.bytes,
+              rawContentType: 'image/png',
+              headers: null,
+              style: null,
+              explode: null,
+              allowReserved: null,
+            ),
+          ),
+        ]);
+
+        final plan = const MultipartBodyPlanner(backend: TransportBackend.dio)
+            .plan(content, bodyAccessor: 'body', isRequired: true);
+        final parts = plan.emissions.whereType<MultipartAppend>().toList();
+
+        expect(parts, hasLength(2));
+        expect(parts[0].source, MultipartValueSource.bytes);
+        expect(parts[0].contentType, 'image/png');
+        expect(parts[1].source, MultipartValueSource.path);
+        expect(parts[1].contentType, 'image/png');
+      },
+    );
+
     test('retains file bytes and the existing filename fallback', () {
       for (final model in [
         BinaryModel(context: context),

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -1730,12 +1730,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'avatar',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'avatar'),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'avatar', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'avatar',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'avatar'),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'avatar', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
             }
             return _$formData;
@@ -1779,12 +1779,12 @@ $expectedPartCode
                 case TonikFileBytes(:final bytes, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'document',
-                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'document'),
+                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'document', contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
                 case TonikFilePath(:final path, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'document',
-                    await MultipartFile.fromFile(path, filename: fileName ?? r'document'),
+                    await MultipartFile.fromFile(path, filename: fileName ?? r'document', contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
               }
             }
@@ -1832,12 +1832,12 @@ $expectedPartCode
                 case TonikFileBytes(:final bytes, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'photo',
-                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'photo'),
+                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'photo', contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
                 case TonikFilePath(:final path, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'photo',
-                    await MultipartFile.fromFile(path, filename: fileName ?? r'photo'),
+                    await MultipartFile.fromFile(path, filename: fileName ?? r'photo', contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
               }
             }
@@ -1935,12 +1935,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file'),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file'),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
             }
             return _$formData;
@@ -1984,12 +1984,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'avatar',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'avatar'),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'avatar', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'avatar',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'avatar'),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'avatar', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
             }
             return _$formData;
@@ -4760,9 +4760,9 @@ $expectedPartCode
             for (final item in body.files) {
               switch (item) {
                 case TonikFileBytes(:final bytes, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files')));
+                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
                 case TonikFilePath(:final path, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files')));
+                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
               }
             }
             return _$formData;
@@ -4807,9 +4807,9 @@ $expectedPartCode
             for (final item in body.files) {
               switch (item) {
                 case TonikFileBytes(:final bytes, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files')));
+                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
                 case TonikFilePath(:final path, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files')));
+                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
               }
             }
             return _$formData;
@@ -5587,9 +5587,9 @@ $expectedPartCode
                 for (final item in body.files) {
                   switch (item) {
                     case TonikFileBytes(:final bytes, :final fileName):
-                      _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files')));
+                      _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
                     case TonikFilePath(:final path, :final fileName):
-                      _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files')));
+                      _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'))));
                   }
                 }
                 return _$formData;
@@ -5869,12 +5869,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
             }
             return _$formData;
@@ -5932,12 +5932,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
             }
             return _$formData;
@@ -6231,12 +6231,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file'),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file'),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
             }
             return _$formData;
@@ -6306,12 +6306,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', headers: _$fileHeaders),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                 ));
             }
             return _$formData;
@@ -6353,12 +6353,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file'),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'file',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'file'),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream')),
                 ));
             }
             return _$formData;
@@ -6661,9 +6661,9 @@ $expectedPartCode
             for (final item in body.files) {
               switch (item) {
                 case TonikFileBytes(:final bytes, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files', headers: _$filesHeaders)));
+                  _$formData.files.add(MapEntry(r'files', MultipartFile.fromBytes(bytes, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$filesHeaders)));
                 case TonikFilePath(:final path, :final fileName):
-                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files', headers: _$filesHeaders)));
+                  _$formData.files.add(MapEntry(r'files', await MultipartFile.fromFile(path, filename: fileName ?? r'files', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$filesHeaders)));
               }
             }
             return _$formData;
@@ -6788,12 +6788,12 @@ $expectedPartCode
                 case TonikFileBytes(:final bytes, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'file',
-                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', headers: _$fileHeaders),
+                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                   ));
                 case TonikFilePath(:final path, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'file',
-                    await MultipartFile.fromFile(path, filename: fileName ?? r'file', headers: _$fileHeaders),
+                    await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                   ));
               }
             }
@@ -6857,12 +6857,12 @@ $expectedPartCode
                 case TonikFileBytes(:final bytes, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'file',
-                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', headers: _$fileHeaders),
+                    MultipartFile.fromBytes(bytes, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                   ));
                 case TonikFilePath(:final path, :final fileName):
                   _$formData.files.add(MapEntry(
                     r'file',
-                    await MultipartFile.fromFile(path, filename: fileName ?? r'file', headers: _$fileHeaders),
+                    await MultipartFile.fromFile(path, filename: fileName ?? r'file', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$fileHeaders),
                   ));
               }
             }
@@ -7169,12 +7169,12 @@ $expectedPartCode
               case TonikFileBytes(:final bytes, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'document',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'document', headers: _$documentHeaders),
+                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'document', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$documentHeaders),
                 ));
               case TonikFilePath(:final path, :final fileName):
                 _$formData.files.add(MapEntry(
                   r'document',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'document', headers: _$documentHeaders),
+                  await MultipartFile.fromFile(path, filename: fileName ?? r'document', contentType: DioMediaType.parse(r'application/octet-stream'), headers: _$documentHeaders),
                 ));
             }
             return _$formData;
@@ -7254,12 +7254,12 @@ $expectedPartCode
                 case TonikFileBytes(:final bytes, :final fileName):
                   _$formData.files.add(MapEntry(
                     r"it's-field",
-                    MultipartFile.fromBytes(bytes, filename: fileName ?? r"it's-field"),
+                    MultipartFile.fromBytes(bytes, filename: fileName ?? r"it's-field", contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
                 case TonikFilePath(:final path, :final fileName):
                   _$formData.files.add(MapEntry(
                     r"it's-field",
-                    await MultipartFile.fromFile(path, filename: fileName ?? r"it's-field"),
+                    await MultipartFile.fromFile(path, filename: fileName ?? r"it's-field", contentType: DioMediaType.parse(r'application/octet-stream')),
                   ));
               }
               return _$formData;


### PR DESCRIPTION
Dio inferred a binary multipart part's media type from its filename, turning the schema default into text/plain for report.txt. Explicitly pass the resolved content type for byte and path sources, including arrays, so application/octet-stream defaults and declared overrides survive unchanged.

Validation on the final commit:

- All 6,060 unit tests passed across all five packages.
- Full integration suites passed on both Dio and HTTP: 4,178 tests across all 40 packages per backend, including all 67 multipart tests.
- Regenerated all 44 APIs for each backend through scripts/setup_integration_tests.sh.
- Strict source analysis passed, along with all 85 generated API, test, and helper package analyses for each backend.
- Independent code and scope reviews found no blockers. The branch merges cleanly with current main.
