### PR TITLE
fix: base64 encode multipart byte fields

### DIFF
--- a/integration_test/multipart/multipart_test/imposter/response.groovy
+++ b/integration_test/multipart/multipart_test/imposter/response.groovy
@@ -325,7 +325,7 @@ switch (path) {
         break
 
     case '/multipart31/byte':
-        // format:byte fields default to application/octet-stream in OAS 3.1.
+        // Legacy Tonik format:byte compatibility uses application/octet-stream.
         // Binary parts do NOT appear in formParams (unlike text/plain parts).
         respond {
             withStatusCode 200

--- a/integration_test/multipart/multipart_test/test/base64_parts_test.dart
+++ b/integration_test/multipart/multipart_test/test/base64_parts_test.dart
@@ -39,6 +39,113 @@ void main() {
     expect(wire.single('label').header('content-transfer-encoding'), isNull);
   });
 
+  test(
+    'sends a Unicode filename when base64 adds the only custom part header',
+    () async {
+      final server = await RawRequestServer.start(
+        responseStatusCode: 200,
+        responseHeaders: {'content-type': 'application/json'},
+        responseBody: utf8.encode('{"success":true}'),
+      );
+      final api = MultipartApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postByteField(
+        body: const ByteForm(
+          label: 'report',
+          data: TonikFileBytes([0, 255, 128, 65], fileName: '報告.txt'),
+        ),
+      );
+      expect(response, isTonikSuccess);
+
+      final data = MultipartWire(await server.takeRequest()).single('data');
+      expect(latin1.encode(data.filename!), [
+        229,
+        160,
+        177,
+        229,
+        145,
+        138,
+        46,
+        116,
+        120,
+        116,
+      ]);
+      expect(
+        utf8.decode(latin1.encode(data.header('content-disposition')!)),
+        'form-data; name="data"; filename="報告.txt"',
+      );
+      expect(data.bodyBytes, [65, 80, 43, 65, 81, 81, 61, 61]);
+      expect(data.header('content-transfer-encoding'), 'base64');
+      expect(data.contentType, 'application/octet-stream');
+    },
+  );
+
+  test(
+    'preserves Unicode filenames on base64 and sibling binary parts',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postBase64Parts(
+        body: const Base64PartsForm(
+          files: [
+            TonikFileBytes([0, 255, 128, 65], fileName: '報告.txt'),
+          ],
+          binary: TonikFileBytes([0, 255, 128, 65], fileName: '画像.png'),
+        ),
+        filesPartLabel: 'images',
+      );
+      expect(response, isTonikSuccess);
+
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.parts, hasLength(2));
+      final encoded = wire.single('files');
+      expect(latin1.encode(encoded.filename!), [
+        229,
+        160,
+        177,
+        229,
+        145,
+        138,
+        46,
+        116,
+        120,
+        116,
+      ]);
+      expect(
+        utf8.decode(latin1.encode(encoded.header('content-disposition')!)),
+        'form-data; name="files"; filename="報告.txt"',
+      );
+      expect(encoded.bodyBytes, [65, 80, 43, 65, 81, 81, 61, 61]);
+      expect(encoded.header('content-transfer-encoding'), 'base64');
+      expect(encoded.header('x-part-label'), 'images');
+      expect(encoded.contentType, 'image/png');
+      final binary = wire.single('binary');
+      expect(latin1.encode(binary.filename!), [
+        231,
+        148,
+        187,
+        229,
+        131,
+        143,
+        46,
+        112,
+        110,
+        103,
+      ]);
+      expect(
+        utf8.decode(latin1.encode(binary.header('content-disposition')!)),
+        'form-data; name="binary"; filename="画像.png"',
+      );
+      expect(binary.bodyBytes, [0, 255, 128, 65]);
+      expect(binary.header('content-transfer-encoding'), isNull);
+    },
+  );
+
   test('base64 encodes file paths and preserves the filename', () async {
     final directory = await Directory.systemTemp.createTemp('multipart-byte-');
     addTearDown(() => directory.delete(recursive: true));

--- a/integration_test/multipart/multipart_test/test/base64_parts_test.dart
+++ b/integration_test/multipart/multipart_test/test/base64_parts_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:multipart_api/multipart_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+import 'multipart_wire.dart';
+
+void main() {
+  test('sends decoded format byte data as ASCII base64', () async {
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'content-type': 'application/json'},
+      responseBody: utf8.encode('{"success":true}'),
+    );
+    final api = MultipartApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+    final body = ByteForm.fromJson(const {
+      'label': 'encoded',
+      'data': 'AP+AQQ==',
+    });
+    expect(body.data.toBytes(), [0, 255, 128, 65]);
+    expect(body.toJson(), {'label': 'encoded', 'data': 'AP+AQQ=='});
+
+    final response = await api.postByteField(body: body);
+    expect(response, isTonikSuccess);
+
+    final wire = MultipartWire(await server.takeRequest());
+    final data = wire.single('data');
+    expect(data.bodyText, 'AP+AQQ==');
+    expect(data.bodyBytes, [65, 80, 43, 65, 81, 81, 61, 61]);
+    expect(data.contentType, 'application/octet-stream');
+    expect(data.header('content-transfer-encoding'), 'base64');
+    expect(data.filename, 'data');
+    expect(wire.single('label').bodyText, 'encoded');
+    expect(wire.single('label').header('content-transfer-encoding'), isNull);
+  });
+
+  test('base64 encodes file paths and preserves the filename', () async {
+    final directory = await Directory.systemTemp.createTemp('multipart-byte-');
+    addTearDown(() => directory.delete(recursive: true));
+    final file = File('${directory.path}/report.txt');
+    await file.writeAsBytes([0, 255, 128, 65]);
+    final server = await RawRequestServer.start(
+      responseStatusCode: 200,
+      responseHeaders: {'content-type': 'application/json'},
+      responseBody: utf8.encode('{"success":true}'),
+    );
+    final api = MultipartApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.postByteField(
+      body: ByteForm(
+        label: 'path',
+        data: TonikFilePath(file.path, fileName: 'report.txt'),
+      ),
+    );
+
+    expect(response, isTonikSuccess);
+
+    final data = MultipartWire(await server.takeRequest()).single('data');
+    expect(data.bodyText, 'AP+AQQ==');
+    expect(data.contentType, 'application/octet-stream');
+    expect(data.filename, 'report.txt');
+    expect(data.header('content-transfer-encoding'), 'base64');
+  });
+
+  test(
+    'repeats base64 array parts while preserving raw binary and headers',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postBase64Parts(
+        body: const Base64PartsForm(
+          files: [
+            TonikFileBytes([0, 255, 128, 65], fileName: 'first.png'),
+            TonikFileBytes([72, 105], fileName: 'second.png'),
+          ],
+          binary: TonikFileBytes([0, 255, 128, 65], fileName: 'raw.bin'),
+        ),
+        filesPartLabel: 'images',
+        filesCOnTeNtTrAnSfErEnCoDiNg: 'BASE64',
+      );
+      expect(response, isTonikSuccess);
+
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.parts, hasLength(3));
+      final files = wire.named('files');
+      expect(files, hasLength(2));
+      expect(files[0].bodyText, 'AP+AQQ==');
+      expect(files[0].filename, 'first.png');
+      expect(files[0].contentType, 'image/png');
+      expect(files[0].header('content-transfer-encoding'), 'base64');
+      expect(
+        files[0].headers.toLowerCase().split('content-transfer-encoding'),
+        hasLength(2),
+      );
+      expect(files[0].header('x-part-label'), 'images');
+      expect(files[1].bodyText, 'SGk=');
+      expect(files[1].filename, 'second.png');
+      expect(files[1].contentType, 'image/png');
+      expect(files[1].header('content-transfer-encoding'), 'base64');
+      expect(files[1].header('x-part-label'), 'images');
+      expect(wire.single('binary').bodyBytes, [0, 255, 128, 65]);
+      expect(wire.single('binary').header('content-transfer-encoding'), isNull);
+    },
+  );
+
+  test(
+    'generates the transfer header when only a custom header is supplied',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postBase64Parts(
+        body: const Base64PartsForm(
+          files: [
+            TonikFileBytes([72, 105]),
+          ],
+        ),
+        filesPartLabel: 'single',
+      );
+      expect(response, isTonikSuccess);
+
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.parts, hasLength(1));
+      expect(wire.single('files').bodyText, 'SGk=');
+      expect(
+        wire.single('files').header('content-transfer-encoding'),
+        'base64',
+      );
+      expect(wire.single('files').header('x-part-label'), 'single');
+    },
+  );
+
+  test('omits empty base64 arrays and absent optional binary fields', () async {
+    final server = await RawRequestServer.start();
+    final api = MultipartApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.postBase64Parts(
+      body: const Base64PartsForm(files: []),
+      filesPartLabel: 'empty',
+    );
+    expect(response, isTonikSuccess);
+
+    expect(MultipartWire(await server.takeRequest()).parts, isEmpty);
+  });
+
+  test(
+    'rejects a transfer header that disagrees with base64 serialization',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = MultipartApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postBase64Parts(
+        body: const Base64PartsForm(
+          files: [
+            TonikFileBytes([72, 105]),
+          ],
+        ),
+        filesPartLabel: 'conflict',
+        filesCOnTeNtTrAnSfErEnCoDiNg: 'binary',
+      );
+
+      expect(response, isTonikError);
+      final error = requireError(response);
+      expect(error.type, TonikErrorType.encoding);
+      expect(error.error, isA<EncodingException>());
+    },
+  );
+}

--- a/integration_test/multipart/multipart_test/test/content_encoding_base64_test.dart
+++ b/integration_test/multipart/multipart_test/test/content_encoding_base64_test.dart
@@ -1,0 +1,78 @@
+import 'package:multipart_3_1_api/multipart_3_1_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+import 'multipart_wire.dart';
+
+void main() {
+  test(
+    'contentEncoding base64 serializes a scalar with one transfer header',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = Multipart31Api(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postContentEncodedBase64(
+        body: const ContentEncodedBase64Form(
+          data: TonikFileBytes([0, 255, 128, 65], fileName: 'report.bin'),
+        ),
+      );
+      expect(response, isTonikSuccess);
+
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.parts, hasLength(1));
+      final data = wire.single('data');
+      expect(data.filename, 'report.bin');
+      expect(data.bodyText, 'AP+AQQ==');
+      expect(data.bodyBytes, [65, 80, 43, 65, 81, 81, 61, 61]);
+      expect(data.header('content-transfer-encoding'), 'base64');
+      expect(
+        data.headers.toLowerCase().split('content-transfer-encoding'),
+        hasLength(2),
+      );
+    },
+  );
+
+  test(
+    'contentEncoding base64 arrays retain repeated names and image media type',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = Multipart31Api(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.postContentEncodedBase64Array(
+        body: const ContentEncodedBase64ArrayForm(
+          files: [
+            TonikFileBytes([0, 255, 128, 65], fileName: 'first.png'),
+            TonikFileBytes([72, 105], fileName: 'second.png'),
+          ],
+        ),
+      );
+      expect(response, isTonikSuccess);
+
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.parts, hasLength(2));
+      final files = wire.named('files');
+      expect(files, hasLength(2));
+      expect(files[0].filename, 'first.png');
+      expect(files[0].contentType, 'image/png');
+      expect(files[0].bodyBytes, [65, 80, 43, 65, 81, 81, 61, 61]);
+      expect(files[0].header('content-transfer-encoding'), 'base64');
+      expect(
+        files[0].headers.toLowerCase().split('content-transfer-encoding'),
+        hasLength(2),
+      );
+      expect(files[1].filename, 'second.png');
+      expect(files[1].contentType, 'image/png');
+      expect(files[1].bodyBytes, [83, 71, 107, 61]);
+      expect(files[1].header('content-transfer-encoding'), 'base64');
+      expect(
+        files[1].headers.toLowerCase().split('content-transfer-encoding'),
+        hasLength(2),
+      );
+    },
+  );
+}

--- a/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
@@ -260,7 +260,7 @@ void main() {
 
   group('OAS 3.1 format:byte field', () {
     test(
-      'sends format:byte as binary part, not a readable text field',
+      'sends the classified base64 field with its transfer header',
       () async {
         final server = await _jsonServer();
         final fileBytes = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
@@ -274,7 +274,11 @@ void main() {
         expect(wire.single('label').bodyText, 'test-label');
         expect(wire.single('label').contentType, startsWith('text/plain'));
         expect(wire.single('data').contentType, 'application/octet-stream');
-        expect(wire.single('data').bodyBytes, fileBytes);
+        expect(wire.single('data').bodyText, '3q2+7w==');
+        expect(
+          wire.single('data').header('content-transfer-encoding'),
+          'base64',
+        );
       },
     );
   });

--- a/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_3_1_test.dart
@@ -258,29 +258,23 @@ void main() {
     });
   });
 
-  group('OAS 3.1 format:byte field', () {
-    test(
-      'sends the classified base64 field with its transfer header',
-      () async {
-        final server = await _jsonServer();
-        final fileBytes = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
+  group('Legacy Tonik format:byte compatibility in OAS 3.1', () {
+    test('preserves legacy base64 encoding and its transfer header', () async {
+      final server = await _jsonServer();
+      final fileBytes = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
 
-        final response = await _api(server).postByteField31(
-          body: ByteForm(label: 'test-label', data: TonikFileBytes(fileBytes)),
-        );
+      final response = await _api(server).postByteField31(
+        body: ByteForm(label: 'test-label', data: TonikFileBytes(fileBytes)),
+      );
 
-        expect(response, isTonikSuccess);
-        final wire = MultipartWire(await server.takeRequest());
-        expect(wire.single('label').bodyText, 'test-label');
-        expect(wire.single('label').contentType, startsWith('text/plain'));
-        expect(wire.single('data').contentType, 'application/octet-stream');
-        expect(wire.single('data').bodyText, '3q2+7w==');
-        expect(
-          wire.single('data').header('content-transfer-encoding'),
-          'base64',
-        );
-      },
-    );
+      expect(response, isTonikSuccess);
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.single('label').bodyText, 'test-label');
+      expect(wire.single('label').contentType, startsWith('text/plain'));
+      expect(wire.single('data').contentType, 'application/octet-stream');
+      expect(wire.single('data').bodyText, '3q2+7w==');
+      expect(wire.single('data').header('content-transfer-encoding'), 'base64');
+    });
   });
 
   group('OAS 3.1 AnyModel multipart JSON encoding', () {

--- a/integration_test/multipart/multipart_test/test/multipart_test.dart
+++ b/integration_test/multipart/multipart_test/test/multipart_test.dart
@@ -307,23 +307,21 @@ void main() {
   });
 
   group('format:byte field (OAS 3.0)', () {
-    test(
-      'sends format:byte as binary part, not a readable text field',
-      () async {
-        final server = await RawRequestServer.start();
-        final fileBytes = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
+    test('sends format:byte as base64 text with its transfer header', () async {
+      final server = await RawRequestServer.start();
+      final fileBytes = Uint8List.fromList([0xDE, 0xAD, 0xBE, 0xEF]);
 
-        await _rawApi(server).postByteField(
-          body: ByteForm(label: 'test-label', data: TonikFileBytes(fileBytes)),
-        );
+      await _rawApi(server).postByteField(
+        body: ByteForm(label: 'test-label', data: TonikFileBytes(fileBytes)),
+      );
 
-        final wire = MultipartWire(await server.takeRequest());
-        expect(wire.single('label').bodyText, 'test-label');
-        expect(wire.single('label').contentType, startsWith('text/plain'));
-        expect(wire.single('data').contentType, 'application/octet-stream');
-        expect(wire.single('data').bodyBytes, fileBytes);
-      },
-    );
+      final wire = MultipartWire(await server.takeRequest());
+      expect(wire.single('label').bodyText, 'test-label');
+      expect(wire.single('label').contentType, startsWith('text/plain'));
+      expect(wire.single('data').contentType, 'application/octet-stream');
+      expect(wire.single('data').bodyText, '3q2+7w==');
+      expect(wire.single('data').header('content-transfer-encoding'), 'base64');
+    });
   });
 
   group('anyOf model in multipart', () {

--- a/integration_test/multipart/openapi.yaml
+++ b/integration_test/multipart/openapi.yaml
@@ -266,9 +266,8 @@ paths:
         - multipart
       summary: Post a format byte field in multipart
       description: >-
-        Tests that format:byte (Base64Model) is sent as application/octet-stream,
-        not text/plain. Per OAS 3.0.4 §4.7.15, format:byte defaults to
-        application/octet-stream in multipart encoding.
+        Tests that format:byte (Base64Model) is sent as base64 text with
+        Content-Transfer-Encoding: base64 and application/octet-stream.
       requestBody:
         required: true
         content:
@@ -282,6 +281,33 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
+
+  /multipart/base64-parts:
+    post:
+      operationId: postBase64Parts
+      tags:
+        - multipart
+      summary: Post repeated base64 parts with custom headers
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/Base64PartsForm'
+            encoding:
+              files:
+                contentType: image/png
+                headers:
+                  X-Part-Label:
+                    required: true
+                    schema:
+                      type: string
+                  cOnTeNt-TrAnSfEr-EnCoDiNg:
+                    schema:
+                      type: string
+      responses:
+        '204':
+          description: Accepted
 
   /multipart/response:
     get:
@@ -841,6 +867,20 @@ components:
           description: >-
             Base64-encoded binary data. Per OAS 3.0.4 §4.7.15, format:byte
             defaults to application/octet-stream in multipart encoding.
+
+    Base64PartsForm:
+      type: object
+      required:
+        - files
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+            format: byte
+        binary:
+          type: string
+          format: binary
 
     ModelType:
       type: string

--- a/integration_test/multipart/openapi_3_1.yaml
+++ b/integration_test/multipart/openapi_3_1.yaml
@@ -272,16 +272,51 @@ paths:
               schema:
                 $ref: '#/components/schemas/GenericResponse'
 
+  /multipart31/content-encoded-base64:
+    post:
+      operationId: postContentEncodedBase64
+      tags:
+        - multipart31
+      summary: Post a base64 content-encoded scalar
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ContentEncodedBase64Form'
+      responses:
+        '204':
+          description: Accepted
+
+  /multipart31/content-encoded-base64-array:
+    post:
+      operationId: postContentEncodedBase64Array
+      tags:
+        - multipart31
+      summary: Post repeated base64 content-encoded image parts
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              $ref: '#/components/schemas/ContentEncodedBase64ArrayForm'
+            encoding:
+              files:
+                contentType: image/png
+      responses:
+        '204':
+          description: Accepted
+
   /multipart31/byte:
     post:
       operationId: postByteField31
       tags:
         - multipart31
-      summary: Post a format byte field in multipart (OAS 3.1)
+      summary: Preserve legacy Tonik format byte multipart compatibility
       description: >-
-        Tests that format:byte (Base64Model) is sent as application/octet-stream,
-        not text/plain. Per OAS 3.1, format:byte defaults to
-        application/octet-stream in multipart encoding.
+        Preserves Tonik compatibility for legacy format:byte schemas by sending
+        base64 with application/octet-stream. Canonical OAS 3.1 schemas use
+        contentEncoding to specify the encoding.
       requestBody:
         required: true
         content:
@@ -481,6 +516,26 @@ components:
         lastName:
           type: string
 
+    ContentEncodedBase64Form:
+      type: object
+      required:
+        - data
+      properties:
+        data:
+          type: string
+          contentEncoding: base64
+
+    ContentEncodedBase64ArrayForm:
+      type: object
+      required:
+        - files
+      properties:
+        files:
+          type: array
+          items:
+            type: string
+            contentEncoding: base64
+
     ByteForm:
       type: object
       required:
@@ -494,8 +549,8 @@ components:
           type: string
           format: byte
           description: >-
-            Base64-encoded binary data. Per OAS 3.1, format:byte defaults to
-            application/octet-stream in multipart encoding.
+            Legacy format:byte input retained for Tonik compatibility, encoded as
+            base64 with application/octet-stream.
 
     AnyValue: true
 

--- a/packages/tonik_generate/lib/src/transport/multipart_body_planner.dart
+++ b/packages/tonik_generate/lib/src/transport/multipart_body_planner.dart
@@ -185,6 +185,11 @@ class const MultipartBodyPlanner({
         parameters,
         nullable,
         emissions,
+        base64: switch (property.property.model.resolved) {
+          Base64Model() => true,
+          ListModel(:final content) => content.resolved is Base64Model,
+          _ => false,
+        },
       );
       final hasNullAwareAccess =
           accesses.length == 1 &&
@@ -211,13 +216,19 @@ class const MultipartBodyPlanner({
       rawContentType: content.rawContentType,
       isRequired: isRequired,
       emissions: emissions,
-      usesCustomParts: !_dio && parameters.isNotEmpty,
+      usesCustomParts:
+          !_dio &&
+          (parameters.isNotEmpty ||
+              emissions.whereType<MultipartAppend>().any(
+                (part) => part.headers != null,
+              )),
       mergeHelpers: mergeHelpers,
     );
   }
 
   List<MultipartEmission> _part(_Part part, Model model) => switch (model) {
-    BinaryModel() || Base64Model() => _file(part),
+    BinaryModel() => _file(part),
+    Base64Model() => [_base64(part)],
     ListModel() => _list(part, model),
     NeverModel() => _error(
       "Cannot encode NeverModel property '${part.name}' - this type does not "
@@ -323,6 +334,20 @@ class const MultipartBodyPlanner({
     ];
   }
 
+  MultipartAppend _base64(_Part part) => MultipartAppend(
+    name: specLiteralString(part.name),
+    value: refer(
+      'ascii',
+      'dart:convert',
+    ).property('encode').call([part.value.property('toBase64String').call([])]),
+    source: MultipartValueSource.bytes,
+    filename: part.value
+        .property('fileName')
+        .ifNullThen(specLiteralString(part.name)),
+    contentType: part.encoding.wireContentType ?? 'application/octet-stream',
+    headers: part.headers,
+  );
+
   List<MultipartEmission> _list(_Part part, ListModel model) {
     final encoding = part.encoding;
     final item = model.content.resolved;
@@ -349,7 +374,10 @@ class const MultipartBodyPlanner({
       );
     }
     final itemPart = _withValue(part, refer('item'));
-    if (item is BinaryModel || item is Base64Model) {
+    if (item is Base64Model) {
+      return _loop('item', part.value, [_base64(itemPart)]);
+    }
+    if (item is BinaryModel) {
       return _loop('item', part.value, _file(itemPart, listItem: true));
     }
     if (contentBased) {
@@ -676,19 +704,25 @@ class const MultipartBodyPlanner({
     String normalizedName,
     List<MultipartHeaderParamInfo> parameters,
     bool nullable,
-    List<MultipartEmission> emissions,
-  ) {
+    List<MultipartEmission> emissions, {
+    required bool base64,
+  }) {
     final headers = encoding?.headers?.entries
         .where((entry) => entry.key.toLowerCase() != 'content-type')
         .toList();
-    if (headers == null || headers.isEmpty) return null;
+    if (!base64 && (headers == null || headers.isEmpty)) return null;
     final variable = '_\$${normalizedName}Headers';
     emissions.add(
       MultipartCode(
         declareFinal(variable)
             .assign(
               literalMap(
-                {},
+                {
+                  if (base64)
+                    specLiteralString('Content-Transfer-Encoding'): _dio
+                        ? literalList([specLiteralString('base64')])
+                        : specLiteralString('base64'),
+                },
                 refer('String', 'dart:core'),
                 _dio
                     ? TypeReference(
@@ -703,7 +737,7 @@ class const MultipartBodyPlanner({
             .statement,
       ),
     );
-    for (final entry in headers) {
+    for (final entry in headers ?? <MapEntry<String, ResponseHeader>>[]) {
       final header = entry.value.resolve();
       final parameter = parameters.firstWhere(
         (parameter) =>
@@ -719,14 +753,30 @@ class const MultipartBodyPlanner({
         explode: header.explode,
         allowEmpty: true,
       );
-      final assignment = refer(variable)
-          .index(specLiteralString(entry.key))
-          .assign(
-            _dio
-                ? literalList([serialized.expression])
-                : serialized.unsafeRawBody,
-          )
-          .statement;
+      final assignment =
+          base64 && entry.key.toLowerCase() == 'content-transfer-encoding'
+          ? Block.of([
+              const Code('if ('),
+              serialized.unsafeRawBody.parenthesized
+                  .property('toLowerCase')
+                  .call([])
+                  .code,
+              const Code(" != 'base64') {"),
+              generateEncodingExceptionExpression(
+                'Multipart property "$normalizedName" requires '
+                'Content-Transfer-Encoding: base64.',
+                raw: true,
+              ).statement,
+              const Code('}'),
+            ])
+          : refer(variable)
+                .index(specLiteralString(entry.key))
+                .assign(
+                  _dio
+                      ? literalList([serialized.expression])
+                      : serialized.unsafeRawBody,
+                )
+                .statement;
       emissions.add(
         MultipartCode(
           header.isRequired

--- a/packages/tonik_generate/test/src/transport/multipart_body_planner_test.dart
+++ b/packages/tonik_generate/test/src/transport/multipart_body_planner_test.dart
@@ -84,11 +84,7 @@ Object? test() {
 
   group('single-value parts', () {
     test('retains file bytes and the existing filename fallback', () {
-      for (final model in [
-        BinaryModel(context: context),
-        Base64Model(context: context),
-      ]) {
-        expectPropertyCode(model, r'''
+      expectPropertyCode(BinaryModel(context: context), r'''
   _$multipartFiles.add(
     MultipartFile.fromBytes(
       r'value',
@@ -97,7 +93,79 @@ Object? test() {
       contentType: MediaType.parse(r'application/octet-stream'),
     ),
   );''');
-      }
+    });
+
+    test('encodes base64 file content using custom HTTP parts', () {
+      final content = multipartContentFixture(context, [
+        multipartPartFixture(
+          name: 'value',
+          model: Base64Model(context: context),
+        ),
+      ]);
+      const expected = r'''
+Object? test() {
+  final _$multipartParts = <TonikMultipartPart>[];
+  final _$valueHeaders = <String, String>{
+    r'Content-Transfer-Encoding': r'base64',
+  };
+  _$multipartParts.add(TonikMultipartPart(
+    name: r'value',
+    bytes: ascii.encode(body.value.toBase64String()),
+    contentType: r'application/octet-stream',
+    filename: body.value.fileName ?? r'value',
+    headers: _$valueHeaders,
+  ));
+  return TonikMultipartBody(_$multipartParts);
+}
+''';
+      expect(
+        collapseWhitespace(emit(content)),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('encodes aliased base64 array items with their media override', () {
+      final content = multipartContentFixture(context, [
+        multipartPartFixture(
+          name: 'value',
+          model: _list(
+            context,
+            AliasModel(
+              name: 'EncodedBytes',
+              model: Base64Model(context: context),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+          ),
+          encoding: _encoding(
+            contentType: ContentType.bytes,
+            rawContentType: 'image/png',
+          ),
+        ),
+      ]);
+      const expected = r'''
+Object? test() {
+  final _$multipartParts = <TonikMultipartPart>[];
+  final _$valueHeaders = <String, String>{
+    r'Content-Transfer-Encoding': r'base64',
+  };
+  for (final item in body.value) {
+    _$multipartParts.add(TonikMultipartPart(
+      name: r'value',
+      bytes: ascii.encode(item.toBase64String()),
+      contentType: r'image/png',
+      filename: item.fileName ?? r'value',
+      headers: _$valueHeaders,
+    ));
+  }
+  return TonikMultipartBody(_$multipartParts);
+}
+''';
+      expect(
+        collapseWhitespace(emit(content)),
+        collapseWhitespace(format(expected)),
+      );
     });
 
     test('converts date URI decimal and boolean scalar values once', () {

--- a/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/to_multipart_expression_generator_test.dart
@@ -1951,7 +1951,7 @@ $expectedPartCode
     });
 
     test(
-      'generates binary switch for Base64Model property (same as BinaryModel)',
+      'generates base64 bytes and transfer header for Base64Model property',
       () {
         final content = multipartContentFixture(testContext, [
           multipartPartFixture(
@@ -1980,18 +1980,18 @@ $expectedPartCode
             format(r'''
           void test() {
             final _$formData = FormData();
-            switch (body.avatar) {
-              case TonikFileBytes(:final bytes, :final fileName):
-                _$formData.files.add(MapEntry(
-                  r'avatar',
-                  MultipartFile.fromBytes(bytes, filename: fileName ?? r'avatar'),
-                ));
-              case TonikFilePath(:final path, :final fileName):
-                _$formData.files.add(MapEntry(
-                  r'avatar',
-                  await MultipartFile.fromFile(path, filename: fileName ?? r'avatar'),
-                ));
-            }
+            final _$avatarHeaders = <String, List<String>>{
+              r'Content-Transfer-Encoding': [r'base64'],
+            };
+            _$formData.files.add(MapEntry(
+              r'avatar',
+              MultipartFile.fromBytes(
+                ascii.encode(body.avatar.toBase64String()),
+                filename: body.avatar.fileName ?? r'avatar',
+                contentType: DioMediaType.parse(r'application/octet-stream'),
+                headers: _$avatarHeaders,
+              ),
+            ));
             return _$formData;
           }
         '''),

--- a/packages/tonik_util/lib/src/multipart/tonik_multipart_body.dart
+++ b/packages/tonik_util/lib/src/multipart/tonik_multipart_body.dart
@@ -69,7 +69,7 @@ final class TonikMultipartBody._(
       _validatePart(part);
       bytes
         ..add(ascii.encode('--$boundary\r\n'))
-        ..add(latin1.encode(_partHeaders(part)))
+        ..add(utf8.encode(_partHeaders(part)))
         ..add(part.bytes)
         ..add(const [13, 10]);
     }

--- a/packages/tonik_util/test/src/multipart/tonik_multipart_body_test.dart
+++ b/packages/tonik_util/test/src/multipart/tonik_multipart_body_test.dart
@@ -43,6 +43,29 @@ void main() {
     );
   });
 
+  test('encodes Unicode filenames and custom header values as UTF-8', () {
+    final body = TonikMultipartBody([
+      TonikMultipartPart(
+        name: 'upload',
+        bytes: const [72, 105],
+        contentType: 'application/octet-stream',
+        filename: '報告.txt',
+        headers: const {'X-Part-Meta': 'café'},
+      ),
+    ], boundary: 'test');
+
+    expect(
+      utf8.decode(body.bodyBytes),
+      '--test\r\n'
+      'content-disposition: form-data; name="upload"; filename="報告.txt"\r\n'
+      'content-type: application/octet-stream\r\n'
+      'X-Part-Meta: café\r\n'
+      '\r\n'
+      'Hi\r\n'
+      '--test--\r\n',
+    );
+  });
+
   test('rejects line breaks in custom header values', () {
     final body = TonikMultipartBody([
       TonikMultipartPart(


### PR DESCRIPTION
Multipart base64 fields sent decoded binary bytes instead of base64 transfer data. Emit ASCII base64 for Base64Model scalars and array items, add one Content-Transfer-Encoding: base64 header, and use the custom HTTP multipart writer when needed to carry it. Preserve filenames, declared media types, and unrelated custom headers; reject conflicting transfer headers while keeping binary fields raw.

Canonical OpenAPI 3.1 scalar and array-item fixtures use `type: string` with `contentEncoding: base64` and no `format`. Explicit wire tests verify base64 bytes, repeated same-name array parts, one transfer header per encoded part, filenames, and the array's declared `image/png` media type. The existing OpenAPI 3.1 `format: byte` fixture remains legacy Tonik compatibility coverage; its descriptions no longer present that behavior as a specification requirement. See [OAS 3.1.2 file upload considerations](https://spec.openapis.org/oas/v3.1.2.html#considerations-for-file-uploads).

Encode custom multipart headers as UTF-8, matching the native HTTP writer, so Unicode filenames such as `報告.txt` remain valid on both base64 fields and other parts in the same request.

Validation: all 3,259 generator and 1,630 utility unit tests passed. Regenerated all 44 integration APIs through `scripts/setup_integration_tests.sh` for each of Dio and HTTP, then passed the full 63-test multipart suite on each backend and analyzed both generated multipart APIs and their test package. The wire checks include canonical contentEncoding fixtures, legacy format-byte compatibility, UTF-8 filenames, backslash escaping, and unchanged binary payloads. Independent code and scope reviews found no blockers.

