### PR TITLE
fix: omit absent forbidden query properties

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/absent_forbidden_query_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/absent_forbidden_query_test.dart
@@ -1,0 +1,83 @@
+import 'package:boolean_schemas_api/boolean_schemas_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+import 'package:tonik_util/tonik_util.dart';
+
+void main() {
+  test(
+    'dispatches a valid filter with its forbidden property absent',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = BooleanSchemasApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+      final filter = ProfileFilter.fromJson(const {'name': 'alice'});
+      expect(filter.password, isNull);
+      expect(filter.toJson(), {'name': 'alice'});
+
+      final response = await api.searchProfiles(filter: filter);
+      expect(response, isTonikSuccess);
+
+      final request = await server.takeRequest();
+      expect(request.method, 'GET');
+      expect(request.uri.path, '/profiles');
+      expect(request.uri.query, 'name=alice');
+    },
+  );
+
+  test('preserves list query values beside a forbidden alias', () async {
+    final server = await RawRequestServer.start();
+    final api = BooleanSchemasApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+    final filter = ProfileListFilter.fromJson(const {
+      'tags': ['daily', 'weekly'],
+    });
+    expect(filter.password, isNull);
+    expect(filter.toJson(), {
+      'tags': ['daily', 'weekly'],
+    });
+
+    final response = await api.searchProfilesByTags(filter: filter);
+    expect(response, isTonikSuccess);
+
+    final request = await server.takeRequest();
+    expect(request.uri.path, '/profiles/tags');
+    expect(request.uri.query, 'tags=daily,weekly');
+  });
+
+  test(
+    'preserves Any scalar query encoding beside a forbidden property',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = BooleanSchemasApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+      final filter = ProfileMixedFilter.fromJson(const {'data': 42});
+      expect(filter.password, isNull);
+      expect(filter.toJson(), {'data': 42});
+
+      final response = await api.searchProfilesByData(filter: filter);
+      expect(response, isTonikSuccess);
+
+      final request = await server.takeRequest();
+      expect(request.uri.path, '/profiles/data');
+      expect(request.uri.query, 'data=42');
+    },
+  );
+
+  test('still rejects a present forbidden JSON value', () {
+    expect(
+      () =>
+          ProfileFilter.fromJson(const {'name': 'alice', 'password': 'secret'}),
+      throwsA(isA<JsonDecodingException>()),
+    );
+  });
+
+  test('retains the existing rejection for List of Never parameter values', () {
+    final shape = Shape.fromJson(const {'corner': <Object?>[]});
+
+    expect(shape.parameterProperties, throwsA(isA<EncodingException>()));
+    expect(shape.toJson(), {'corner': <Object?>[]});
+  });
+}

--- a/integration_test/boolean_schemas/openapi.yaml
+++ b/integration_test/boolean_schemas/openapi.yaml
@@ -16,6 +16,57 @@ tags:
     description: Operations testing boolean schemas (AnyModel and NeverModel)
 
 paths:
+  /profiles:
+    get:
+      operationId: searchProfiles
+      tags:
+        - boolean-schemas
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/ProfileFilter'
+      responses:
+        '204':
+          description: Search accepted
+
+  /profiles/tags:
+    get:
+      operationId: searchProfilesByTags
+      tags:
+        - boolean-schemas
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/ProfileListFilter'
+      responses:
+        '204':
+          description: Search accepted
+
+  /profiles/data:
+    get:
+      operationId: searchProfilesByData
+      tags:
+        - boolean-schemas
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          style: form
+          explode: true
+          schema:
+            $ref: '#/components/schemas/ProfileMixedFilter'
+      responses:
+        '204':
+          description: Search accepted
+
   /json/any/echo:
     post:
       operationId: echoJsonAny
@@ -1166,6 +1217,35 @@ paths:
 
 components:
   schemas:
+    ProfileFilter:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+        password: false
+
+    ProfileListFilter:
+      type: object
+      required:
+        - tags
+      properties:
+        tags:
+          type: array
+          items:
+            type: string
+        password:
+          $ref: '#/components/schemas/NeverValid'
+
+    ProfileMixedFilter:
+      type: object
+      required:
+        - data
+      properties:
+        data: true
+        password: false
+
     AnyValue: true
 
     NeverValid: false

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -1237,6 +1237,7 @@ class const ClassGenerator({
       final resolvedModel = model.resolved;
 
       if (resolvedModel is NeverModel) {
+        if (!isRequired) continue;
         propertyAssignments.add(
           generateEncodingExceptionExpression(
             'Cannot encode NeverModel property $propertyName: '
@@ -1292,6 +1293,19 @@ class const ClassGenerator({
       final isNullable =
           prop.property.isNullable || fieldModel.isEffectivelyNullable;
       final isFieldNullable = isNullable || prop.property.isWriteOnly;
+
+      if (fieldModel.resolved is NeverModel) {
+        if (isRequired) {
+          propertyAssignments.add(
+            generateEncodingExceptionExpression(
+              'Cannot encode NeverModel property $propertyName: '
+              'this type does not permit any value',
+              raw: true,
+            ).statement,
+          );
+        }
+        continue;
+      }
 
       if (fieldModel.encodingShape == EncodingShape.simple) {
         propertyAssignments.addAll(
@@ -1415,6 +1429,7 @@ class const ClassGenerator({
       }
 
       if (resolvedModel is NeverModel) {
+        if (!isRequired) continue;
         propertyAssignments.add(
           generateEncodingExceptionExpression(
             'Cannot encode NeverModel property $propertyName: '

--- a/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
+++ b/packages/tonik_generate/test/src/model/class_generator_parameter_encoding_test.dart
@@ -1642,6 +1642,212 @@ Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
       );
     });
 
+    test('omits an optional forbidden property from a simple query object', () {
+      final model = ClassModel(
+        name: 'ProfileFilter',
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        properties: [
+          Property(
+            name: 'name',
+            model: StringModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'password',
+            model: NeverModel(context: context, isNullable: false),
+            isRequired: false,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+      );
+
+      final method = generator
+          .generateClass(model)
+          .methods
+          .singleWhere((method) => method.name == 'parameterProperties');
+      const expected = r'''
+@override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  _$result[r'name'] = PropertyValue.scalar(name);
+  return _$result;
+}
+''';
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('omits an optional forbidden alias beside a string list', () {
+      final model = ClassModel(
+        name: 'ProfileListFilter',
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        properties: [
+          Property(
+            name: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'password',
+            model: AliasModel(
+              name: 'Forbidden',
+              model: NeverModel(context: context, isNullable: false),
+              context: context,
+              examples: const [],
+              defaultValue: null,
+            ),
+            isRequired: false,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+      );
+
+      final method = generator
+          .generateClass(model)
+          .methods
+          .singleWhere((method) => method.name == 'parameterProperties');
+      const expected = r'''
+@override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  _$result[r'tags'] = PropertyValue.array(tags);
+  return _$result;
+}
+''';
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('omits an optional forbidden property beside an Any scalar', () {
+      final model = ClassModel(
+        name: 'ProfileMixedFilter',
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        properties: [
+          Property(
+            name: 'data',
+            model: AnyModel(context: context),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'password',
+            model: NeverModel(context: context, isNullable: false),
+            isRequired: false,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+      );
+
+      final method = generator
+          .generateClass(model)
+          .methods
+          .singleWhere((method) => method.name == 'parameterProperties');
+      const expected = r'''
+@override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  if (data != null) {
+    _$result[r'data'] = PropertyValue.scalar(
+      encodeUnknownFlatScalar(data!, context: 'ProfileMixedFilter.data'),
+    );
+  }
+  return _$result;
+}
+''';
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('rejects a required write-only forbidden property beside a list', () {
+      final model = ClassModel(
+        name: 'RequiredForbiddenFilter',
+        isDeprecated: false,
+        context: context,
+        examples: const [],
+        properties: [
+          Property(
+            name: 'tags',
+            model: ListModel(
+              content: StringModel(context: context),
+              context: context,
+              examples: const [],
+            ),
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'password',
+            model: NeverModel(context: context, isNullable: false),
+            isRequired: true,
+            isNullable: false,
+            isWriteOnly: true,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+      );
+
+      final method = generator
+          .generateClass(model)
+          .methods
+          .singleWhere((method) => method.name == 'parameterProperties');
+      const expected = r'''
+@override
+Map<String, PropertyValue> parameterProperties({bool allowEmpty = true}) {
+  final _$result = <String, PropertyValue>{};
+  _$result[r'tags'] = PropertyValue.array(tags);
+  throw EncodingException(
+    r'Cannot encode NeverModel property password: this type does not permit any value',
+  );
+  return _$result;
+}
+''';
+      expect(
+        collapseWhitespace(format(method.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
     test(
       'mixed model NeverModel property throws that no value is permitted',
       () {


### PR DESCRIPTION
A valid query object could not be sent when it declared an absent optional property with a false schema: encoding threw before dispatching the request. Omit optional forbidden properties in simple, mixed, and list-shaped parameter objects, so a filter containing only `name: alice` sends `/profiles?name=alice`. Required forbidden properties retain their encoding errors.

Validation: all 3,251 generator unit tests passed. Five explicit regression cases and the existing query/list/forbidden-schema checks passed with each generated backend. Generator and generated API/test analyzers passed. Independent code and scope reviews found no blockers.
