### PR TITLE
fix: support JSON content query parameters

### DIFF
--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -30,7 +30,7 @@
 - `contains`, `minContains`, `maxContains`
 
 **Encoding & Content:**
-- Parameter encoding via content - only `schema` supported (see [schema vs content](https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content))
+- Parameter encoding via non-JSON content, and content on header, path, or cookie parameters (JSON query content is supported; see [schema vs content](https://swagger.io/docs/specification/v3_0/describing-parameters/#schema-vs-content))
 - XML de- and encoding
 
 **References:**

--- a/docs/uri_encoding.md
+++ b/docs/uri_encoding.md
@@ -11,6 +11,21 @@ When `allowReserved` is not set (the default), tonik percent-encodes reserved ch
 following RFC 3986. This is the standard, safe behavior and is byte-for-byte identical to
 earlier tonik releases.
 
+## JSON query content
+
+Query parameters with `content: application/json` serialize their value as JSON and
+send it as one percent-encoded query parameter. JSON media types with a `+json`
+suffix are also supported. For example, `filter: {"status": "active"}` is sent as:
+
+```
+?filter=%7B%22status%22%3A%22active%22%7D
+```
+
+Generated models use their JSON representation, including nested models and formatted
+values. Optional parameters are omitted when no value or default is provided. Style,
+explode, and allowReserved settings apply to schema-based serialization; JSON content
+is always encoded as a single value.
+
 ## `allowReserved: true`
 
 OpenAPI lets a query parameter — or a property of an `application/x-www-form-urlencoded`

--- a/integration_test/query_parameters/openapi.yaml
+++ b/integration_test/query_parameters/openapi.yaml
@@ -16,6 +16,97 @@ tags:
     description: Operations demonstrating query parameters
 
 paths:
+  /items:
+    get:
+      tags:
+        - query
+      parameters:
+        - name: filter
+          in: query
+          content:
+            application/json:
+              schema:
+                type: object
+      responses:
+        '204':
+          description: No content
+  /json-content-filter:
+    get:
+      operationId: testJsonContentFilter
+      tags:
+        - query
+      parameters:
+        - $ref: '#/components/parameters/JsonFilter'
+      responses:
+        '204':
+          description: No content
+  /json-content-recursive:
+    get:
+      operationId: testJsonContentRecursive
+      tags:
+        - query
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonRecursiveFilter'
+        - name: other
+          in: query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JsonRecursiveFilter'
+      responses:
+        '204':
+          description: No content
+  /json-content-nullable:
+    get:
+      operationId: testJsonContentNullable
+      tags:
+        - query
+      parameters:
+        - name: filter
+          in: query
+          required: true
+          content:
+            application/json:
+              schema:
+                type: array
+                nullable: true
+                items:
+                  type: string
+                  format: date-time
+        - name: other
+          in: query
+          content:
+            application/json:
+              schema:
+                type: array
+                nullable: true
+                items:
+                  type: string
+                  format: date-time
+      responses:
+        '204':
+          description: No content
+  /json-content-default:
+    get:
+      operationId: testJsonContentDefault
+      tags:
+        - query
+      parameters:
+        - name: status
+          in: query
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DefaultJsonStatus'
+      responses:
+        '204':
+          description: No content
   /form-primitive:
     get:
       operationId: testFormPrimitive
@@ -1857,7 +1948,31 @@ paths:
           description: OK
 
 components:
+  parameters:
+    JsonFilter:
+      name: filter
+      in: query
+      required: true
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/JsonFilter'
   schemas:
+    JsonRecursiveFilter:
+      type: object
+      nullable: true
+      additionalProperties:
+        $ref: '#/components/schemas/JsonRecursiveFilter'
+    JsonFilter:
+      type: object
+      required:
+        - status
+      properties:
+        status:
+          type: string
+    DefaultJsonStatus:
+      type: string
+      default: active
     PartialFilter:
       type: object
       required:

--- a/integration_test/query_parameters/query_parameters_test/test/json_content_test.dart
+++ b/integration_test/query_parameters/query_parameters_test/test/json_content_test.dart
@@ -1,0 +1,160 @@
+import 'package:query_parameters_api/query_parameters_api.dart';
+import 'package:test/test.dart';
+import 'package:test_helpers/test_helpers.dart';
+
+void main() {
+  test('sends arbitrary JSON objects as one query parameter', () async {
+    final server = await RawRequestServer.start();
+    final api = QueryApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.itemsGet(
+      filter: const {
+        'nested': {'status': 'active'},
+        'tags': [1, true, null],
+      },
+    );
+
+    requireSuccess(response);
+    final request = await server.takeRequest();
+    expect(request.method, 'GET');
+    expect(request.uri.path, '/items');
+    expect(
+      request.uri.query,
+      'filter=%7B%22nested%22%3A%7B%22status%22%3A%22active%22%7D%2C'
+      '%22tags%22%3A%5B1%2Ctrue%2Cnull%5D%7D',
+    );
+    expect(request.uri.queryParametersAll, {
+      'filter': ['{"nested":{"status":"active"},"tags":[1,true,null]}'],
+    });
+  });
+
+  test('omits an optional JSON query parameter when absent', () async {
+    final server = await RawRequestServer.start();
+    final api = QueryApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.itemsGet();
+
+    requireSuccess(response);
+    final request = await server.takeRequest();
+    expect(request.uri.hasQuery, isFalse);
+    expect(request.uri.queryParametersAll, isEmpty);
+  });
+
+  test(
+    'escapes reserved and Unicode values in a required typed filter',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testJsonContentFilter(
+        filter: const JsonFilter(status: 'a&b=+%/# ü東京'),
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(
+        request.uri.query,
+        'filter=%7B%22status%22%3A%22a%26b%3D%2B%25%2F%23%20'
+        '%C3%BC%E6%9D%B1%E4%BA%AC%22%7D',
+      );
+      expect(request.uri.queryParametersAll, {
+        'filter': ['{"status":"a&b=+%/# ü東京"}'],
+      });
+      expect(request.uri.hasFragment, isFalse);
+    },
+  );
+
+  test('serializes a referenced schema default as JSON', () async {
+    final server = await RawRequestServer.start();
+    final api = QueryApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.testJsonContentDefault();
+
+    requireSuccess(response);
+    final request = await server.takeRequest();
+    expect(request.uri.query, 'status=%22active%22');
+    expect(request.uri.queryParametersAll, {
+      'status': ['"active"'],
+    });
+  });
+
+  test(
+    'sends JSON null for required nullable content and omits optional null',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testJsonContentNullable(filter: null);
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(request.uri.query, 'filter=null');
+      expect(request.uri.queryParametersAll, {
+        'filter': ['null'],
+      });
+    },
+  );
+
+  test(
+    'uses JSON date conversion for required and optional nullable lists',
+    () async {
+      final server = await RawRequestServer.start();
+      final api = QueryApi(
+        CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+      );
+
+      final response = await api.testJsonContentNullable(
+        filter: [DateTime.utc(2026, 9, 7)],
+        other: [DateTime.utc(2026, 9, 8)],
+      );
+
+      requireSuccess(response);
+      final request = await server.takeRequest();
+      expect(
+        request.uri.query,
+        'filter=%5B%222026-09-07T00%3A00%3A00.000Z%22%5D&'
+        'other=%5B%222026-09-08T00%3A00%3A00.000Z%22%5D',
+      );
+      expect(request.uri.queryParametersAll, {
+        'filter': ['["2026-09-07T00:00:00.000Z"]'],
+        'other': ['["2026-09-08T00:00:00.000Z"]'],
+      });
+    },
+  );
+
+  test('serializes shared recursive nullable content schemas', () async {
+    final server = await RawRequestServer.start();
+    final api = QueryApi(
+      CustomServer(baseUrl: server.baseUrl, serverConfig: testServerConfig()),
+    );
+
+    final response = await api.testJsonContentRecursive(
+      filter: const {
+        'child': {'leaf': null},
+      },
+      other: const {'child': null},
+    );
+
+    requireSuccess(response);
+    final request = await server.takeRequest();
+    expect(
+      request.uri.query,
+      'filter=%7B%22child%22%3A%7B%22leaf%22%3Anull%7D%7D&'
+      'other=%7B%22child%22%3Anull%7D',
+    );
+    expect(request.uri.queryParametersAll, {
+      'filter': ['{"child":{"leaf":null}}'],
+      'other': ['{"child":null}'],
+    });
+  });
+}

--- a/packages/tonik_core/lib/src/model/query_parameter.dart
+++ b/packages/tonik_core/lib/src/model/query_parameter.dart
@@ -20,6 +20,10 @@ enum QueryParameterEncoding() {
   /// Objects are serialized as `paramName[property]=value`.
   /// Example: `?id[role]=admin&id[firstName]=Alex`
   deepObject,
+
+  /// A JSON content value serialized as one percent-encoded query parameter.
+  /// Example: `?filter=%7B%22status%22%3A%22active%22%7D`
+  json,
 }
 
 sealed class const QueryParameter({required final Context context}) {

--- a/packages/tonik_generate/lib/src/operation/query_generator.dart
+++ b/packages/tonik_generate/lib/src/operation/query_generator.dart
@@ -1,10 +1,14 @@
 import 'package:code_builder/code_builder.dart';
 import 'package:tonik_core/tonik_core.dart';
 import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/util/built_expression.dart';
 import 'package:tonik_generate/src/util/form_entries_expression_builder.dart';
+import 'package:tonik_generate/src/util/inline_helper_context.dart';
+import 'package:tonik_generate/src/util/spec_literal_string.dart';
 import 'package:tonik_generate/src/util/to_deep_object_query_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_delimited_query_parameter_expression_generator.dart';
 import 'package:tonik_generate/src/util/to_form_query_parameter_expression_generator.dart';
+import 'package:tonik_generate/src/util/to_json_value_expression_generator.dart';
 import 'package:tonik_generate/src/util/type_reference_generator.dart';
 
 /// Generator for creating query parameters method for operations.
@@ -20,6 +24,8 @@ class const QueryGenerator({
     queryParameters,
   ) {
     final parameters = <Parameter>[];
+    final helperContext = InlineHelperContext(nameManager: nameManager);
+    final helpers = <InlineHelper>[];
     final body = <Code>[
       declareFinal(r'_$entries')
           .assign(
@@ -53,11 +59,23 @@ class const QueryGenerator({
         ),
       );
 
-      final encodingCode = _generateEncodingCode(paramName, resolvedParam);
-      _addCodeWithNullCheck(body, encodingCode, paramName, resolvedParam);
+      final encodingCode = _generateEncodingCode(
+        paramName,
+        resolvedParam,
+        helperContext: helperContext,
+      );
+      helpers.addAll(encodingCode.inlineFunctions);
+      _addCodeWithNullCheck(
+        body,
+        encodingCode.unsafeRawStatements,
+        paramName,
+        resolvedParam,
+      );
     }
 
-    body.add(_generateReturnStatement());
+    body
+      ..insertAll(0, spliceInlineHelpers(helpers))
+      ..add(_generateReturnStatement());
 
     return Method(
       (b) => b
@@ -69,11 +87,41 @@ class const QueryGenerator({
     );
   }
 
-  List<Code> _generateEncodingCode(
+  BuiltStatements _generateEncodingCode(
     String paramName,
-    QueryParameterObject resolvedParam,
-  ) {
+    QueryParameterObject resolvedParam, {
+    required InlineHelperContext helperContext,
+  }) {
     final encoding = resolvedParam.encoding;
+
+    if (encoding == QueryParameterEncoding.json) {
+      final value = buildToJsonQueryParameterExpression(
+        paramName,
+        resolvedParam,
+        nameManager: nameManager,
+        package: package,
+        helperContext: helperContext,
+        useImmutableCollections: useImmutableCollections,
+        receiverIsPromotedNonNull: !resolvedParam.isRequired,
+      );
+      final entries = refer('jsonEncode', 'dart:convert')
+          .call([value.unsafeRawBody])
+          .property('toForm')
+          .call(
+            [specLiteralString(resolvedParam.rawName)],
+            {
+              'explode': literalBool(false),
+              'allowEmpty': literalBool(false),
+              'textEncoding': refer('utf8', 'dart:convert'),
+            },
+          );
+      return BuiltStatements(
+        statements: [
+          refer(r'_$entries').property('addAll').call([entries]).statement,
+        ],
+        inlineFunctions: value.inlineFunctions,
+      );
+    }
 
     if (encoding == QueryParameterEncoding.form) {
       return buildToFormQueryParameterCode(
@@ -82,7 +130,7 @@ class const QueryGenerator({
         explode: resolvedParam.explode,
         allowEmpty: resolvedParam.allowEmptyValue,
         allowReserved: resolvedParam.allowReserved,
-      ).statements;
+      );
     }
 
     if (encoding == QueryParameterEncoding.spaceDelimited ||
@@ -94,10 +142,12 @@ class const QueryGenerator({
         explode: resolvedParam.explode,
         allowEmpty: resolvedParam.allowEmptyValue,
         allowReserved: resolvedParam.allowReserved,
-      ).statements;
+      );
     }
 
-    return [_generateDeepObjectEncodingStatement(paramName, resolvedParam)];
+    return BuiltStatements.simple([
+      _generateDeepObjectEncodingStatement(paramName, resolvedParam),
+    ]);
   }
 
   Code _generateDeepObjectEncodingStatement(

--- a/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
+++ b/packages/tonik_generate/lib/src/util/to_json_value_expression_generator.dart
@@ -73,22 +73,27 @@ BuiltExpression buildToJsonPathParameterExpression(
 
 /// Creates a [BuiltExpression] that correctly serializes a query parameter
 /// to its JSON representation.
+/// Set [receiverIsPromotedNonNull] when an optional parameter has been guarded.
 BuiltExpression buildToJsonQueryParameterExpression(
   String parameterName,
   QueryParameterObject parameter, {
   required NameManager nameManager,
   String? package,
   InlineHelperContext? helperContext,
+  bool useImmutableCollections = false,
+  bool receiverIsPromotedNonNull = false,
 }) {
   final model = parameter.model;
   return _buildSerializationExpression(
     refer(parameterName),
     model,
-    false,
+    model.isEffectivelyNullable,
     nameManager: nameManager,
     package: package,
     helperContext:
         helperContext ?? InlineHelperContext(nameManager: nameManager),
+    useImmutableCollections: useImmutableCollections,
+    receiverIsPromotedNonNull: receiverIsPromotedNonNull,
   );
 }
 
@@ -596,7 +601,7 @@ BuiltExpression _buildNamedTypedefEncodeHelperCall({
           MapModel() => _handleMapExpressionBody(
             paramRef,
             model,
-            false,
+            model.isNullable,
             nameManager: nameManager,
             package: resolvedPackage,
             helperContext: helperContext,
@@ -607,7 +612,7 @@ BuiltExpression _buildNamedTypedefEncodeHelperCall({
           ListModel() => _handleListExpressionBody(
             paramRef,
             model,
-            false,
+            model.isNullable,
             nameManager: nameManager,
             package: resolvedPackage,
             helperContext: helperContext,

--- a/packages/tonik_generate/test/src/operation/json_content_query_generator_test.dart
+++ b/packages/tonik_generate/test/src/operation/json_content_query_generator_test.dart
@@ -1,0 +1,289 @@
+import 'package:code_builder/code_builder.dart';
+import 'package:dart_style/dart_style.dart';
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_generate/src/naming/name_generator.dart';
+import 'package:tonik_generate/src/naming/name_manager.dart';
+import 'package:tonik_generate/src/operation/query_generator.dart';
+
+void main() {
+  late NameManager nameManager;
+  late QueryGenerator generator;
+  late Operation operation;
+  final context = Context.initial();
+  final emitter = DartEmitter(useNullSafetySyntax: true);
+  final format = DartFormatter(
+    languageVersion: DartFormatter.latestLanguageVersion,
+  ).format;
+
+  setUp(() {
+    nameManager = NameManager(
+      generator: NameGenerator(),
+      stableModelSorter: StableModelSorter(),
+    );
+    generator = QueryGenerator(nameManager: nameManager, package: 'api');
+    operation = Operation(
+      context: context,
+      path: '/items',
+      method: HttpMethod.get,
+      tags: const {},
+      isDeprecated: false,
+      headers: const {},
+      queryParameters: const {},
+      pathParameters: const {},
+      cookieParameters: const {},
+      responses: const {},
+      securitySchemes: const {},
+    );
+  });
+
+  test('encodes a required model as one JSON string parameter', () {
+    final parameter = QueryParameterObject(
+      name: 'filter',
+      rawName: 'filter',
+      description: null,
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      allowReserved: false,
+      explode: true,
+      model: ClassModel(
+        name: 'Filter',
+        isDeprecated: false,
+        context: context,
+        properties: const [],
+        examples: const [],
+      ),
+      encoding: QueryParameterEncoding.json,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    final method = generator.generateQueryParametersMethod(operation, [
+      (normalizedName: 'filter', parameter: parameter),
+    ]);
+
+    const expected = r'''
+String? _queryParameters({required Filter filter}) {
+      final _$entries = <ParameterEntry>[];
+      _$entries.addAll(jsonEncode(filter.toJson()).toForm(
+        r'filter', explode: false, allowEmpty: false, textEncoding: utf8,
+      ));
+      if (_$entries.isEmpty) {
+        return null;
+      }
+      return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+    }''';
+    expect(format(method.accept(emitter).toString()), format(expected));
+  });
+
+  test('guards optional immutable maps and converts formatted JSON values', () {
+    generator = QueryGenerator(
+      nameManager: nameManager,
+      package: 'api',
+      useImmutableCollections: true,
+    );
+    final parameter = QueryParameterObject(
+      name: 'filter',
+      rawName: r'filter&$name',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      allowReserved: false,
+      explode: false,
+      model: MapModel(
+        valueModel: DateTimeModel(context: context),
+        context: context,
+        examples: const [],
+      ),
+      encoding: QueryParameterEncoding.json,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    final method = generator.generateQueryParametersMethod(operation, [
+      (normalizedName: 'filter', parameter: parameter),
+    ]);
+
+    const expected = r'''
+String? _queryParameters({IMap<String, DateTime>? filter}) {
+      final _$entries = <ParameterEntry>[];
+      if (filter != null) {
+        _$entries.addAll(jsonEncode(filter.unlock.map((k, v) => MapEntry(k, v.toTimeZonedIso8601String()))).toForm(
+          r'filter&$name', explode: false, allowEmpty: false, textEncoding: utf8,
+        ));
+      }
+      if (_$entries.isEmpty) {
+        return null;
+      }
+      return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+    }''';
+    expect(format(method.accept(emitter).toString()), format(expected));
+  });
+
+  test(
+    'shares recursive helpers across required and optional JSON parameters',
+    () {
+      final model = MapModel(
+        name: 'Filter',
+        isNullable: true,
+        valueModel: StringModel(context: context),
+        context: context,
+        examples: const [],
+      );
+      model.valueModel = model;
+      final requiredFilter = QueryParameterObject(
+        name: 'filter',
+        rawName: 'filter',
+        description: null,
+        isRequired: true,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        allowReserved: false,
+        explode: false,
+        model: model,
+        encoding: QueryParameterEncoding.json,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final optionalFilter = QueryParameterObject(
+        name: 'other',
+        rawName: 'other',
+        description: null,
+        isRequired: false,
+        isDeprecated: false,
+        allowEmptyValue: false,
+        allowReserved: false,
+        explode: false,
+        model: model,
+        encoding: QueryParameterEncoding.json,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+
+      final method = generator.generateQueryParametersMethod(operation, [
+        (normalizedName: 'filter', parameter: requiredFilter),
+        (normalizedName: 'other', parameter: optionalFilter),
+      ]);
+
+      const expected = r'''
+String? _queryParameters({required Filter filter, Filter? other}) {
+        late final Object? Function(Object?) _$encodeFilter;
+        _$encodeFilter = (Object? raw) {
+          if (raw is! Filter) {
+            throw EncodingException(
+              'Cannot encode value as Filter; got: '
+              '${raw.runtimeType}',
+            );
+          }
+          final v = raw;
+          return v?.map((k, v) => MapEntry(
+            k, v == null ? null : _$encodeFilter(v),
+          ));
+        };
+        final _$entries = <ParameterEntry>[];
+        _$entries.addAll(jsonEncode(
+          filter == null ? null : _$encodeFilter(filter),
+        ).toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8));
+        if (other != null) {
+          _$entries.addAll(jsonEncode(
+            _$encodeFilter(other),
+          ).toForm(r'other', explode: false, allowEmpty: false, textEncoding: utf8));
+        }
+        if (_$entries.isEmpty) {
+          return null;
+        }
+        return _$entries.map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+      }''';
+      expect(format(method.accept(emitter).toString()), format(expected));
+    },
+  );
+  test('serializes a required nullable list as JSON null or an array', () {
+    final parameter = QueryParameterObject(
+      name: 'filter',
+      rawName: 'filter',
+      description: null,
+      isRequired: true,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      allowReserved: false,
+      explode: false,
+      model: ListModel(
+        content: DateTimeModel(context: context),
+        context: context,
+        examples: const [],
+        isNullable: true,
+      ),
+      encoding: QueryParameterEncoding.json,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    final method = generator.generateQueryParametersMethod(operation, [
+      (normalizedName: 'filter', parameter: parameter),
+    ]);
+
+    const expected = r'''
+    String? _queryParameters({required List<DateTime>? filter}) {
+      final _$entries = <ParameterEntry>[];
+      _$entries.addAll(jsonEncode(
+        filter?.map((e) => e.toTimeZonedIso8601String()).toList(),
+      ).toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8));
+      if (_$entries.isEmpty) {
+        return null;
+      }
+      return _$entries
+          .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+    }''';
+    expect(format(method.accept(emitter).toString()), format(expected));
+  });
+
+  test('promotes optional nullable lists before JSON conversion', () {
+    final parameter = QueryParameterObject(
+      name: 'filter',
+      rawName: 'filter',
+      description: null,
+      isRequired: false,
+      isDeprecated: false,
+      allowEmptyValue: false,
+      allowReserved: false,
+      explode: false,
+      model: ListModel(
+        content: DateTimeModel(context: context),
+        context: context,
+        examples: const [],
+        isNullable: true,
+      ),
+      encoding: QueryParameterEncoding.json,
+      context: context,
+      examples: const [],
+      defaultValue: null,
+    );
+
+    final method = generator.generateQueryParametersMethod(operation, [
+      (normalizedName: 'filter', parameter: parameter),
+    ]);
+
+    const expected = r'''
+    String? _queryParameters({List<DateTime>? filter}) {
+      final _$entries = <ParameterEntry>[];
+      if (filter != null) {
+        _$entries.addAll(jsonEncode(
+          filter.map((e) => e.toTimeZonedIso8601String()).toList(),
+        ).toForm(r'filter', explode: false, allowEmpty: false, textEncoding: utf8));
+      }
+      if (_$entries.isEmpty) {
+        return null;
+      }
+      return _$entries
+          .map((e) => e.name.isEmpty ? e.value : '${e.name}=${e.value}').join('&');
+    }''';
+    expect(format(method.accept(emitter).toString()), format(expected));
+  });
+}

--- a/packages/tonik_parse/lib/src/request_parameter_importer.dart
+++ b/packages/tonik_parse/lib/src/request_parameter_importer.dart
@@ -1,9 +1,11 @@
 import 'package:logging/logging.dart';
 import 'package:tonik_core/tonik_core.dart' as core;
+import 'package:tonik_parse/src/content_type_resolver.dart';
 import 'package:tonik_parse/src/example_importer.dart';
 import 'package:tonik_parse/src/model/open_api_object.dart';
 import 'package:tonik_parse/src/model/parameter.dart';
 import 'package:tonik_parse/src/model/reference.dart';
+import 'package:tonik_parse/src/model/schema.dart';
 import 'package:tonik_parse/src/model/serialization_style.dart';
 import 'package:tonik_parse/src/model_importer.dart';
 
@@ -224,16 +226,9 @@ class RequestParameterImporter({
           return null;
         }
 
-        if (parameter.schema == null) {
-          throw ArgumentError(
-            'Parameter ${name ?? context.path} must have a schema. '
-            'Complex parameters via content are not supported.',
-          );
-        }
-
-        final model = modelImporter.importSchema(parameter.schema!, context);
-
-        final rawDefault = parameter.schema!.rawDefault;
+        final schema = _parameterSchema(parameter);
+        final model = modelImporter.importSchema(schema, context);
+        final rawDefault = schema.rawDefault;
 
         switch (parameter.location) {
           case ParameterLocation.header:
@@ -261,7 +256,9 @@ class RequestParameterImporter({
               name: name,
               rawName: parameter.name,
               description: parameter.description,
-              encoding: _queryEncoding(parameter.style),
+              encoding: parameter.content == null
+                  ? _queryEncoding(parameter.style)
+                  : core.QueryParameterEncoding.json,
               explode:
                   parameter.explode ??
                   _defaultExplodeForQueryParameter(parameter.style),
@@ -271,7 +268,11 @@ class RequestParameterImporter({
               allowEmptyValue: parameter.allowEmptyValue ?? false,
               allowReserved: parameter.allowReserved ?? false,
               context: context,
-              examples: exampleImporter.fromParameter(parameter),
+              examples: parameter.content == null
+                  ? exampleImporter.fromParameter(parameter)
+                  : exampleImporter.fromMediaType(
+                      parameter.content!.values.single,
+                    ),
               defaultValue: rawDefault,
             );
             if (parameter.xDartName != null) {
@@ -319,6 +320,45 @@ class RequestParameterImporter({
             return cookieParam;
         }
     }
+  }
+
+  Schema _parameterSchema(Parameter parameter) {
+    final schema = parameter.schema;
+    final content = parameter.content;
+    if ((schema == null) == (content == null)) {
+      throw ArgumentError(
+        'Parameter ${parameter.name} must have exactly one of '
+        'schema or content.',
+      );
+    }
+    if (schema != null) return schema;
+
+    if (content!.length != 1) {
+      throw ArgumentError(
+        'Parameter ${parameter.name} content must have exactly one media type.',
+      );
+    }
+    if (parameter.location != ParameterLocation.query) {
+      throw UnimplementedError(
+        'Parameter content is only supported for query parameters, '
+        'found ${parameter.location.name} parameter ${parameter.name}.',
+      );
+    }
+    final mediaType = content.entries.single;
+    if (resolveContentType(mediaType.key, contentTypes: const {}, log: log) !=
+        core.ContentType.json) {
+      throw UnimplementedError(
+        'Unsupported content media type ${mediaType.key} for query parameter '
+        '${parameter.name}. Only JSON content is supported.',
+      );
+    }
+    final contentSchema = mediaType.value.schema;
+    if (contentSchema == null) {
+      throw ArgumentError(
+        'Content for query parameter ${parameter.name} must have a schema.',
+      );
+    }
+    return contentSchema;
   }
 
   // OpenAPI reserves these headers for media types and security schemes.

--- a/packages/tonik_parse/test/json_content_query_parameter_test.dart
+++ b/packages/tonik_parse/test/json_content_query_parameter_test.dart
@@ -1,0 +1,384 @@
+import 'package:test/test.dart';
+import 'package:tonik_core/tonik_core.dart';
+import 'package:tonik_parse/tonik_parse.dart';
+
+void main() {
+  const document = {
+    'openapi': '3.0.3',
+    'info': {'title': 'JSON query parameters', 'version': '1.0.0'},
+    'paths': <String, dynamic>{},
+  };
+
+  test('imports the minimal optional arbitrary object query parameter', () {
+    final api = Importer().import({
+      ...document,
+      'paths': {
+        '/items': {
+          'get': {
+            'parameters': [
+              {
+                'name': 'filter',
+                'in': 'query',
+                'content': {
+                  'application/json': {
+                    'schema': {'type': 'object'},
+                  },
+                },
+              },
+            ],
+            'responses': {
+              '204': {'description': 'No content'},
+            },
+          },
+        },
+      },
+    });
+
+    final parameter = api.operations.single.queryParameters.single.resolve();
+    expect(parameter.rawName, 'filter');
+    expect(parameter.isRequired, isFalse);
+    expect(parameter.encoding, QueryParameterEncoding.json);
+    expect(parameter.model, isA<MapModel>());
+    expect((parameter.model as MapModel).valueModel, isA<AnyModel>());
+    expect(parameter.defaultValue, isNull);
+  });
+
+  test('imports a required inline object and media type example', () {
+    final api = Importer().import({
+      ...document,
+      'components': {
+        'parameters': {
+          'Filter': {
+            'name': 'filter',
+            'in': 'query',
+            'required': true,
+            'content': {
+              'application/json': {
+                'schema': {
+                  'type': 'object',
+                  'properties': {
+                    'status': {'type': 'string'},
+                  },
+                },
+                'example': {'status': 'active'},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    final parameter = api.queryParameters.single.resolve();
+    final model = parameter.model as ClassModel;
+    expect(parameter.isRequired, isTrue);
+    expect(parameter.encoding, QueryParameterEncoding.json);
+    expect(model.properties.single.name, 'status');
+    expect(model.properties.single.model, isA<StringModel>());
+    expect(parameter.examples.single.value, {'status': 'active'});
+  });
+
+  test('preserves JSON encoding through parameter and schema references', () {
+    final api = Importer().import({
+      ...document,
+      'paths': {
+        '/items': {
+          'get': {
+            'parameters': [
+              {r'$ref': '#/components/parameters/Filter'},
+            ],
+            'responses': {
+              '204': {'description': 'No content'},
+            },
+          },
+        },
+      },
+      'components': {
+        'parameters': {
+          'Filter': {
+            'name': 'filter',
+            'in': 'query',
+            'required': true,
+            'content': {
+              'application/json': {
+                'schema': {r'$ref': '#/components/schemas/Filter'},
+              },
+            },
+          },
+        },
+        'schemas': {
+          'Filter': {
+            'type': 'object',
+            'properties': {
+              'status': {'type': 'string'},
+            },
+          },
+        },
+      },
+    });
+
+    final parameter = api.operations.single.queryParameters.single.resolve();
+    expect(parameter.encoding, QueryParameterEncoding.json);
+    expect(parameter.isRequired, isTrue);
+    expect(parameter.model, same(api.models.whereType<ClassModel>().single));
+  });
+
+  test('imports a default from an inline JSON content schema', () {
+    final api = Importer().import({
+      ...document,
+      'components': {
+        'parameters': {
+          'Limit': {
+            'name': 'limit',
+            'in': 'query',
+            'content': {
+              'application/json': {
+                'schema': {'type': 'integer', 'default': 10},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    final parameter = api.queryParameters.single.resolve();
+    expect(parameter.defaultValue, 10);
+    expect(parameter.effectiveDefaultValue, 10);
+    expect(parameter.isRequired, isFalse);
+  });
+
+  test('inherits defaults from referenced JSON content schemas', () {
+    final api = Importer().import({
+      ...document,
+      'components': {
+        'parameters': {
+          'Status': {
+            'name': 'status',
+            'in': 'query',
+            'content': {
+              'application/json': {
+                'schema': {r'$ref': '#/components/schemas/Status'},
+              },
+            },
+          },
+        },
+        'schemas': {
+          'Status': {'type': 'string', 'default': 'active'},
+        },
+      },
+    });
+
+    final parameter = api.queryParameters.single.resolve();
+    expect(parameter.defaultValue, isNull);
+    expect(parameter.effectiveDefaultValue, 'active');
+    expect(parameter.isRequired, isFalse);
+  });
+
+  test('recognizes JSON suffix media types with parameters', () {
+    final api = Importer().import({
+      ...document,
+      'components': {
+        'parameters': {
+          'Filter': {
+            'name': 'filter',
+            'in': 'query',
+            'content': {
+              'application/vnd.filter+json; charset=utf-8': {
+                'schema': {'type': 'object'},
+              },
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      api.queryParameters.single.resolve().encoding,
+      QueryParameterEncoding.json,
+    );
+  });
+
+  test('rejects parameters with both schema and content', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'query',
+              'schema': {'type': 'string'},
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'object'},
+                },
+              },
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Parameter filter must have exactly one of schema or content.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects parameters with neither schema nor content', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {'name': 'filter', 'in': 'query'},
+          },
+        },
+      }),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Parameter filter must have exactly one of schema or content.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects empty parameter content', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'query',
+              'content': <String, dynamic>{},
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Parameter filter content must have exactly one media type.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects multiple parameter content media types', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'query',
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'object'},
+                },
+                'text/plain': {
+                  'schema': {'type': 'string'},
+                },
+              },
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Parameter filter content must have exactly one media type.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects non-JSON content explicitly', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'query',
+              'content': {
+                'text/plain': {
+                  'schema': {'type': 'string'},
+                },
+              },
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<UnimplementedError>().having(
+          (e) => e.message,
+          'message',
+          'Unsupported content media type text/plain for query parameter filter. Only JSON content is supported.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects content on non-query parameters explicitly', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'header',
+              'content': {
+                'application/json': {
+                  'schema': {'type': 'object'},
+                },
+              },
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<UnimplementedError>().having(
+          (e) => e.message,
+          'message',
+          'Parameter content is only supported for query parameters, '
+              'found header parameter filter.',
+        ),
+      ),
+    );
+  });
+
+  test('rejects JSON content without a schema explicitly', () {
+    expect(
+      () => Importer().import({
+        ...document,
+        'components': {
+          'parameters': {
+            'Filter': {
+              'name': 'filter',
+              'in': 'query',
+              'content': {'application/json': <String, dynamic>{}},
+            },
+          },
+        },
+      }),
+      throwsA(
+        isA<ArgumentError>().having(
+          (e) => e.message,
+          'message',
+          'Content for query parameter filter must have a schema.',
+        ),
+      ),
+    );
+  });
+}


### PR DESCRIPTION
Query parameters declared with `content: application/json` previously failed during parsing, so valid object filters could not generate a client. Import the content schema and serialize its value as one percent-encoded JSON query parameter on both Dio and HTTP.

Preserve referenced schemas, defaults, examples, and optional omission. Handle nullable and immutable collections, and share recursive serialization helpers within each generated query method. Unsupported media types and content on other parameter locations fail explicitly.

Validation:
- All five package unit suites passed: 6,068 tests.
- Generated all 44 integration clients for each backend with `scripts/setup_integration_tests.sh`; all 40 integration test packages passed on both Dio and HTTP.
- Strict analysis passed for the workspace packages and all 85 integration targets per backend.
- Added concrete parser, generator, and request-URL regressions for objects, escaping, defaults, nullable arrays, and recursive filters.
