### PR TITLE
perf: reduce integration test startup overhead

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,23 @@ jobs:
           melos bootstrap
 
       - name: Run tests with coverage
+        if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'
         run: melos run coverage-ci
+
+      - name: Run tests
+        if: matrix.sdk != 'stable' || matrix.os != 'ubuntu-latest'
+        shell: bash
+        run: |
+          set -e
+          (cd packages/tonik_util && dart test)
+          (cd packages/tonik_core && dart test)
+          (cd packages/tonik_parse && dart test)
+          (cd packages/tonik_generate && dart test)
+          (cd packages/tonik && dart test)
+
+      - name: Test integration setup scheduling
+        shell: bash
+        run: bash scripts/test_integration_setup.sh
 
       - name: Run fixed-offset tests in a DST timezone
         if: matrix.sdk == 'stable' && matrix.os == 'ubuntu-latest'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -40,6 +40,32 @@ The same setting applies to `melos run test-integration-current` and
 override. Each worker resolves a package's dependencies before analyzing it;
 failures are collected with their package diagnostics.
 
+Integration setup always recompiles Tonik and freshly generates all 44 clients.
+It runs up to four generators at once, starting the next whenever a slot becomes
+free. The default `TONIK_WORKERS` splits available CPUs between those generators.
+An explicit `TONIK_WORKERS` reduces the default number of concurrent generators;
+`INTEGRATION_SETUP_JOBS` overrides that number. Nonzero `workerCount` values in
+fixture configuration files still take precedence over `TONIK_WORKERS`. Explicit
+overrides can exceed the machine's CPU budget, so adjust both limits together:
+
+```bash
+INTEGRATION_SETUP_JOBS=2 TONIK_WORKERS=2 melos run generate-integration-tests
+bash scripts/test_integration_setup.sh # verify the setup scheduler
+```
+
+CI runs all five unit suites on every existing OS/SDK variant and collects
+coverage on Linux with stable Dart. Before every push or pull request, run all
+unit suites and the complete integration suites on both backends with
+`melos run test`.
+
+Complete integration runs use one Dart runner for all packages. It starts one
+fresh Imposter JVM per package and runs that package's test files sequentially.
+Each file clears the fixture's request store before
+using that server; a failed reset fails the file. The runner stops the JVM when
+the package ends or the run is cancelled. Fixtures must finish their requests
+before completing a test. Individual `dart test` and VS Code runs continue to
+start their own servers and need no wrapper or extra setup.
+
 ## Architecture
 
 For an overview of which package does what and how changes propagate, see [.github/copilot-instructions.md](.github/copilot-instructions.md).

--- a/integration_test/test_helpers/bin/run_integration_tests.dart
+++ b/integration_test/test_helpers/bin/run_integration_tests.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test_helpers/src/imposter_server.dart';
+
+/// Runs complete packages in one process, owning one fresh JVM at a time.
+Future<void> main(List<String> arguments) async {
+  final separator = arguments.indexOf('--');
+  final packageArguments = separator < 0
+      ? arguments
+      : arguments.take(separator);
+  final testArguments = separator < 0
+      ? <String>[]
+      : arguments.skip(separator + 1).toList();
+  if (packageArguments.isEmpty) {
+    stderr.writeln(
+      'Usage: run_integration_tests.dart <package>... [-- <dart test arguments>...]',
+    );
+    exitCode = 64;
+    return;
+  }
+
+  final initialDirectory = Directory.current;
+  final packages = [
+    for (final package in packageArguments)
+      path.normalize(path.absolute(package)),
+  ];
+  try {
+    for (final package in packages) {
+      Directory.current = package;
+      stdout.writeln(
+        'Testing ${path.relative(package, from: initialDirectory.path)}',
+      );
+      await _runPackage(testArguments);
+      if (exitCode != 0) return;
+    }
+  } finally {
+    Directory.current = initialDirectory;
+  }
+}
+
+/// Runs the current package with serial files and cleans up before returning.
+Future<void> _runPackage(List<String> arguments) async {
+  final server = ImposterServer();
+  Process? tests;
+  var cancelled = false;
+  Future<void>? stopping;
+
+  Future<void> cancel() => stopping ??= () async {
+    cancelled = true;
+    exitCode = 130;
+    final child = tests;
+    if (child != null) {
+      child.kill(
+        Platform.isWindows ? ProcessSignal.sigterm : ProcessSignal.sigint,
+      );
+      try {
+        await child.exitCode.timeout(const Duration(seconds: 5));
+      } on TimeoutException {
+        child.kill(ProcessSignal.sigkill);
+        await child.exitCode;
+      }
+    }
+    await server.stop();
+  }();
+
+  final interrupt = ProcessSignal.sigint.watch().listen(
+    (_) => unawaited(cancel()),
+  );
+  final terminate = Platform.isWindows
+      ? null
+      : ProcessSignal.sigterm.watch().listen((_) => unawaited(cancel()));
+  final environment = <String, String>{};
+  final elapsed = Stopwatch()..start();
+  try {
+    if (Directory('imposter').existsSync()) {
+      await server.start();
+      if (cancelled) return;
+      environment.addAll({
+        'TONIK_IMPOSTER_PORT': '${server.port}',
+        'TONIK_IMPOSTER_PACKAGE': path.normalize(Directory.current.path),
+      });
+      stdout.writeln('Imposter started in ${elapsed.elapsedMilliseconds}ms');
+    }
+    tests = await Process.start(
+      Platform.resolvedExecutable,
+      ['test', ...arguments, '--concurrency=1'],
+      environment: environment,
+      mode: ProcessStartMode.inheritStdio,
+    );
+    if (cancelled) tests.kill();
+    final result = await tests.exitCode;
+    if (!cancelled) {
+      exitCode = result;
+      stdout.writeln(
+        'Tests finished in ${elapsed.elapsedMilliseconds}ms (exit $result)',
+      );
+    }
+  } on Object {
+    if (!cancelled) rethrow;
+  } finally {
+    await stopping;
+    await server.stop();
+    await interrupt.cancel();
+    await terminate?.cancel();
+  }
+}

--- a/integration_test/test_helpers/lib/src/imposter_server.dart
+++ b/integration_test/test_helpers/lib/src/imposter_server.dart
@@ -5,8 +5,8 @@ import 'dart:io';
 import 'package:path/path.dart' as path;
 import 'package:test/test.dart';
 
-/// Fast JVM cold-start flags. Each suite spins up a fresh JVM in `setUpAll`,
-/// so start-up latency dominates over peak throughput: C1-only JIT and the
+/// Fast JVM cold-start flags. Start-up latency dominates over peak throughput
+/// for these fixture servers: C1-only JIT and the
 /// serial collector shave seconds off boot for these short-lived servers.
 const _fastStartJvmArgs = ['-XX:TieredStopAtLevel=1', '-XX:+UseSerialGC'];
 
@@ -20,12 +20,34 @@ final class const RecordedRequest(
 
 /// Manages the lifecycle of an Imposter mock server for integration
 /// tests.
-class ImposterServer() {
+class ImposterServer({final int? sharedPort}) {
   Process? _process;
-  int _port = 0;
+  int _port = sharedPort ?? 0;
   Completer<void> _readyCompleter = Completer<void>();
+  bool _stopRequested = false;
 
   int get port => _port;
+
+  /// Clears all request state before a sequential test file uses a shared JVM.
+  Future<void> resetRequests() async {
+    final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
+    try {
+      final request = await client.deleteUrl(
+        Uri.parse('http://localhost:$_port/system/store/tonik'),
+      );
+      final response = await request.close().timeout(
+        const Duration(seconds: 5),
+      );
+      await response.drain<void>().timeout(const Duration(seconds: 5));
+      if (response.statusCode != HttpStatus.noContent) {
+        throw StateError(
+          'Unable to reset Imposter request state: ${response.statusCode}',
+        );
+      }
+    } finally {
+      client.close(force: true);
+    }
+  }
 
   /// Returns and removes the last request recorded by the Imposter fixture.
   Future<RecordedRequest> takeRequest() async {
@@ -117,6 +139,12 @@ class ImposterServer() {
     int maxAttempts = 2,
     List<String> jvmArgs = _fastStartJvmArgs,
   }) async {
+    if (sharedPort != null) {
+      await resetRequests();
+      return;
+    }
+    _stopRequested = false;
+    _readyCompleter = Completer<void>();
     final imposterJar = path.join(
       Directory.current.parent.parent.path,
       'imposter.jar',
@@ -139,8 +167,8 @@ class ImposterServer() {
         return;
       } on Exception catch (e) {
         lastError = e;
-        _process?.kill();
-        _process = null;
+        await _stopProcess();
+        if (_stopRequested) rethrow;
         _readyCompleter = Completer<void>();
         if (attempt < maxAttempts) {
           print(
@@ -159,6 +187,7 @@ class ImposterServer() {
     required int timeoutSec,
   }) async {
     _port = await _findAvailablePort();
+    if (_stopRequested) throw Exception('Imposter startup was cancelled.');
 
     _process = await Process.start(
       'java',
@@ -178,6 +207,11 @@ class ImposterServer() {
       environment: {...Platform.environment, 'IMPOSTER_LOG_LEVEL': 'INFO'},
     );
 
+    if (_stopRequested) {
+      await stop();
+      throw Exception('Imposter startup was cancelled.');
+    }
+
     _process!.stdout.transform(const Utf8Decoder()).listen((data) {
       // Signal readiness when we see the startup message.
       if (data.contains('Mock engine up and running') &&
@@ -190,7 +224,7 @@ class ImposterServer() {
     });
 
     final ready = await _waitForImposterReady(timeoutSec: timeoutSec);
-    if (!ready) {
+    if (!ready || _stopRequested) {
       throw Exception(
         'Imposter server failed to start within $timeoutSec seconds '
         'on port $_port. Check Java/Imposter logs above for details.',
@@ -217,37 +251,58 @@ class ImposterServer() {
 
     // Add a small delay to allow OpenAPI plugin to fully initialize
     await Future<void>.delayed(const Duration(milliseconds: 500));
+    if (_stopRequested) return false;
 
     // Then verify the server is actually responding
     final deadline = DateTime.now().add(const Duration(seconds: 5));
-    final client = HttpClient();
+    final client = HttpClient()..connectionTimeout = const Duration(seconds: 5);
 
-    while (DateTime.now().isBefore(deadline)) {
-      try {
-        final request = await client.getUrl(
-          Uri.parse('http://localhost:$_port'),
-        );
-        final response = await request.close();
-        await response.drain<void>();
+    try {
+      while (DateTime.now().isBefore(deadline) && !_stopRequested) {
+        try {
+          final request = await client
+              .getUrl(Uri.parse('http://localhost:$_port'))
+              .timeout(const Duration(seconds: 5));
+          final response = await request.close().timeout(
+            const Duration(seconds: 5),
+          );
+          await response.drain<void>().timeout(const Duration(seconds: 5));
 
-        return true; // Server is ready and responding
-      } on SocketException catch (_) {
-        // ignore
-      } on HttpException catch (_) {
-        // ignore
+          return true; // Server is ready and responding
+        } on SocketException catch (_) {
+          // ignore
+        } on HttpException catch (_) {
+          // ignore
+        } on TimeoutException {
+          return false;
+        }
+        await Future<void>.delayed(const Duration(milliseconds: 100));
       }
-      await Future<void>.delayed(const Duration(milliseconds: 100));
+      return false;
+    } finally {
+      client.close(force: true);
     }
-    return false;
   }
 
   /// Stops the Imposter server process.
   ///
   /// Kills the process and waits for it to exit. Safe to call multiple times.
   Future<void> stop() async {
-    if (_process != null) {
-      _process!.kill();
-      await _process!.exitCode;
+    _stopRequested = true;
+    if (!_readyCompleter.isCompleted) _readyCompleter.complete();
+    await _stopProcess();
+  }
+
+  Future<void> _stopProcess() async {
+    final process = _process;
+    if (process != null) {
+      process.kill();
+      try {
+        await process.exitCode.timeout(const Duration(seconds: 5));
+      } on TimeoutException {
+        process.kill(ProcessSignal.sigkill);
+        await process.exitCode;
+      }
       _process = null;
     }
   }
@@ -263,7 +318,11 @@ Future<ImposterServer> setupImposterServer({
   int maxAttempts = 2,
   List<String> jvmArgs = _fastStartJvmArgs,
 }) async {
-  final server = ImposterServer();
+  final sharedPort = sharedImposterPort(
+    Platform.environment,
+    Directory.current.path,
+  );
+  final server = ImposterServer(sharedPort: sharedPort);
   await server.start(
     timeoutSec: timeoutSec,
     maxAttempts: maxAttempts,
@@ -271,4 +330,18 @@ Future<ImposterServer> setupImposterServer({
   );
   addTearDown(() => server.stop());
   return server;
+}
+
+/// Accepts a run-owned server only for its matching package.
+int? sharedImposterPort(Map<String, String> environment, String directory) {
+  final rawPort = environment['TONIK_IMPOSTER_PORT'];
+  if (rawPort == null) return null;
+  final port = int.tryParse(rawPort);
+  if (port == null ||
+      port < 1 ||
+      port > 65535 ||
+      environment['TONIK_IMPOSTER_PACKAGE'] != path.normalize(directory)) {
+    throw StateError('Invalid shared Imposter server configuration.');
+  }
+  return port;
 }

--- a/integration_test/test_helpers/test/fixtures/failure.dart
+++ b/integration_test/test_helpers/test/fixtures/failure.dart
@@ -1,0 +1,7 @@
+import 'package:test/test.dart';
+
+void main() {
+  test('intentional runner failure', () {
+    fail('intentional runner failure');
+  });
+}

--- a/integration_test/test_helpers/test/fixtures/hold.dart
+++ b/integration_test/test_helpers/test/fixtures/hold.dart
@@ -1,0 +1,15 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  test('hold the shared server until cancellation', () async {
+    final server = await setupImposterServer();
+    await File(Platform.environment['TONIK_TEST_PORT_FILE']!)
+        .writeAsString('${server.port}');
+    print('READY TO CANCEL');
+    await Completer<void>().future;
+  });
+}

--- a/integration_test/test_helpers/test/fixtures/retry_cancellation.dart
+++ b/integration_test/test_helpers/test/fixtures/retry_cancellation.dart
@@ -1,0 +1,21 @@
+import 'dart:async';
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  test('do not retry when cancelled during process cleanup', () async {
+    final server = ImposterServer();
+    addTearDown(server.stop);
+    final starting = expectLater(server.start(timeoutSec: 1), throwsException);
+    final stopping = File(Platform.environment['TONIK_TEST_STOPPING']!);
+    final deadline = DateTime.now().add(const Duration(seconds: 10));
+    while (!stopping.existsSync() && DateTime.now().isBefore(deadline)) {
+      await Future<void>.delayed(const Duration(milliseconds: 10));
+    }
+    expect(stopping.existsSync(), isTrue);
+    await server.stop();
+    await starting;
+  });
+}

--- a/integration_test/test_helpers/test/fixtures/reuse_first.dart
+++ b/integration_test/test_helpers/test/fixtures/reuse_first.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  late ImposterServer server;
+  setUpAll(() async {
+    server = await setupImposterServer();
+  });
+  tearDownAll(() async {
+    await File(Platform.environment['TONIK_TEST_PORT_FILE']!)
+        .writeAsString('${server.port}');
+  });
+  test('leave a request record for the next file', () async {
+    final client = HttpClient();
+    addTearDown(() => client.close(force: true));
+    final request = await client.putUrl(
+      Uri.parse('http://localhost:${server.port}/system/store/tonik/last'),
+    );
+    request.headers.contentType = ContentType.json;
+    request.write('{"leftBy":"first file"}');
+    final response = await request.close();
+    await response.drain<void>();
+    expect(response.statusCode, 201);
+    // Keep this file active long enough to expose accidental parallel startup.
+    await Future<void>.delayed(const Duration(milliseconds: 200));
+  });
+}

--- a/integration_test/test_helpers/test/fixtures/reuse_second.dart
+++ b/integration_test/test_helpers/test/fixtures/reuse_second.dart
@@ -1,0 +1,29 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  late ImposterServer server;
+  setUpAll(() async {
+    expect(
+      File(Platform.environment['TONIK_TEST_PORT_FILE']!).existsSync(),
+      isTrue,
+    );
+    server = await setupImposterServer();
+  });
+  test('reuse the same server with no previous request', () async {
+    expect(
+      '${server.port}',
+      await File(Platform.environment['TONIK_TEST_PORT_FILE']!).readAsString(),
+    );
+    final client = HttpClient();
+    addTearDown(() => client.close(force: true));
+    final request = await client.getUrl(
+      Uri.parse('http://localhost:${server.port}/system/store/tonik/last'),
+    );
+    final response = await request.close();
+    await response.drain<void>();
+    expect(response.statusCode, 404);
+  });
+}

--- a/integration_test/test_helpers/test/fixtures/standalone.dart
+++ b/integration_test/test_helpers/test/fixtures/standalone.dart
@@ -1,0 +1,19 @@
+import 'dart:io';
+
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  test('start a private server for a direct test invocation', () async {
+    expect(Platform.environment['TONIK_IMPOSTER_PORT'], isNull);
+    final server = await setupImposterServer();
+    expect(server.sharedPort, isNull);
+    final socket = await Socket.connect('localhost', server.port);
+    socket.destroy();
+    await server.stop();
+    await expectLater(
+      Socket.connect('localhost', server.port),
+      throwsA(isA<SocketException>()),
+    );
+  });
+}

--- a/integration_test/test_helpers/test/imposter_server_test.dart
+++ b/integration_test/test_helpers/test/imposter_server_test.dart
@@ -1,0 +1,263 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:path/path.dart' as path;
+import 'package:test/test.dart';
+import 'package:test_helpers/src/imposter_server.dart';
+
+void main() {
+  test('ordinary test runs do not attach to a shared server', () {
+    expect(sharedImposterPort({}, '/fixture'), isNull);
+  });
+
+  test('a matching package can attach', () {
+    expect(
+      sharedImposterPort({
+        'TONIK_IMPOSTER_PORT': '8123',
+        'TONIK_IMPOSTER_PACKAGE': path.normalize('/fixture'),
+      }, '/fixture'),
+      8123,
+    );
+  });
+
+  test('a different package cannot attach', () {
+    expect(
+      () => sharedImposterPort({
+        'TONIK_IMPOSTER_PORT': '8123',
+        'TONIK_IMPOSTER_PACKAGE': path.normalize('/other'),
+      }, '/fixture'),
+      throwsStateError,
+    );
+  });
+
+  test('shared setup refuses a failed state reset', () async {
+    final http = await HttpServer.bind(InternetAddress.loopbackIPv4, 0);
+    addTearDown(() => http.close(force: true));
+    http.listen((request) async {
+      expect(request.method, 'DELETE');
+      expect(request.uri.path, '/system/store/tonik');
+      request.response.statusCode = HttpStatus.internalServerError;
+      await request.response.close();
+    });
+    final server = ImposterServer(sharedPort: http.port);
+    await expectLater(server.start(), throwsStateError);
+  });
+
+  test(
+    'wrapper forces serial files and resets the shared JVM between them',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'imposter-reuse-',
+      );
+      addTearDown(() => temporary.delete(recursive: true));
+      final fixture = path.join(
+        Directory.current.parent.path,
+        'simple_encoding',
+        'simple_encoding_test',
+      );
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        [
+          path.join(
+            Directory.current.path,
+            'bin',
+            'run_integration_tests.dart',
+          ),
+          fixture,
+          '--',
+          path.join(
+            Directory.current.path,
+            'test',
+            'fixtures',
+            'reuse_first.dart',
+          ),
+          path.join(
+            Directory.current.path,
+            'test',
+            'fixtures',
+            'reuse_second.dart',
+          ),
+          '--reporter=expanded',
+          '--concurrency=2',
+        ],
+        environment: {
+          'TONIK_TEST_PORT_FILE': path.join(temporary.path, 'port'),
+        },
+      );
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+      expect(result.stdout, contains('+2: All tests passed!'));
+      final port = int.parse(
+        await File(path.join(temporary.path, 'port')).readAsString(),
+      );
+      await expectLater(
+        Socket.connect('localhost', port),
+        throwsA(isA<SocketException>()),
+      );
+    },
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('one file still runs directly with a private server', () async {
+    final fixture = path.join(
+      Directory.current.parent.path,
+      'simple_encoding',
+      'simple_encoding_test',
+    );
+    final result = await Process.run(Platform.resolvedExecutable, [
+      'test',
+      path.join(Directory.current.path, 'test', 'fixtures', 'standalone.dart'),
+      '--plain-name',
+      'start a private server for a direct test invocation',
+      '--reporter=expanded',
+    ], workingDirectory: fixture);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, contains('+1: All tests passed!'));
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'cancelling during failed-start cleanup prevents another JVM attempt',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'imposter-retry-',
+      );
+      addTearDown(() => temporary.delete(recursive: true));
+      final java = File(path.join(temporary.path, 'java'));
+      await java.writeAsString(r'''#!/bin/sh
+printf 'start\n' >> "$TONIK_TEST_STARTS"
+trap 'touch "$TONIK_TEST_STOPPING"; sleep 1; exit 0' TERM
+while :; do sleep 0.05; done
+''');
+      expect((await Process.run('chmod', ['+x', java.path])).exitCode, 0);
+      final result = await Process.run(
+        Platform.resolvedExecutable,
+        [
+          'test',
+          path.join(
+            Directory.current.path,
+            'test',
+            'fixtures',
+            'retry_cancellation.dart',
+          ),
+          '--reporter=expanded',
+        ],
+        workingDirectory: path.join(
+          Directory.current.parent.path,
+          'simple_encoding',
+          'simple_encoding_test',
+        ),
+        environment: {
+          'PATH': '${temporary.path}:${Platform.environment['PATH']}',
+          'TONIK_TEST_STARTS': path.join(temporary.path, 'starts'),
+          'TONIK_TEST_STOPPING': path.join(temporary.path, 'stopping'),
+        },
+      );
+      expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+      expect(
+        await File(path.join(temporary.path, 'starts')).readAsString(),
+        'start\n',
+      );
+    },
+    skip: Platform.isWindows
+        ? 'This regression requires POSIX process signals.'
+        : false,
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('runner preserves a failing test exit status', () async {
+    final fixture = path.join(
+      Directory.current.parent.path,
+      'simple_encoding',
+      'simple_encoding_test',
+    );
+    final result = await Process.run(Platform.resolvedExecutable, [
+      path.join(Directory.current.path, 'bin', 'run_integration_tests.dart'),
+      fixture,
+      '.',
+      '--',
+      path.join(Directory.current.path, 'test', 'fixtures', 'failure.dart'),
+      '--reporter=expanded',
+    ]);
+    expect(result.exitCode, 1);
+    expect(result.stdout, contains('intentional runner failure'));
+    expect(result.stdout, isNot(contains('\nTesting .\n')));
+  }, timeout: const Timeout(Duration(seconds: 60)));
+
+  test(
+    'cancelling a run stops its owned server',
+    () async {
+      final temporary = await Directory.systemTemp.createTemp(
+        'imposter-cancel-',
+      );
+      addTearDown(() => temporary.delete(recursive: true));
+      final fixture = path.join(
+        Directory.current.parent.path,
+        'simple_encoding',
+        'simple_encoding_test',
+      );
+      final runner = await Process.start(
+        Platform.resolvedExecutable,
+        [
+          path.join(
+            Directory.current.path,
+            'bin',
+            'run_integration_tests.dart',
+          ),
+          fixture,
+          '--',
+          path.join(Directory.current.path, 'test', 'fixtures', 'hold.dart'),
+          '--reporter=expanded',
+        ],
+        environment: {
+          'TONIK_TEST_PORT_FILE': path.join(temporary.path, 'port'),
+        },
+      );
+      addTearDown(() async {
+        runner.kill(ProcessSignal.sigterm);
+        await runner.exitCode;
+      });
+      final errors = runner.stderr.transform(utf8.decoder).join();
+      final ready = Completer<void>();
+      final output = runner.stdout
+          .transform(utf8.decoder)
+          .transform(const LineSplitter())
+          .listen((line) {
+            if (line.contains('READY TO CANCEL') && !ready.isCompleted) {
+              ready.complete();
+            }
+          });
+      addTearDown(output.cancel);
+      await ready.future.timeout(const Duration(seconds: 30));
+      final port = int.parse(
+        await File(path.join(temporary.path, 'port')).readAsString(),
+      );
+      runner.kill(ProcessSignal.sigterm);
+      expect(
+        await runner.exitCode.timeout(const Duration(seconds: 15)),
+        130,
+        reason: await errors,
+      );
+      await expectLater(
+        Socket.connect('localhost', port),
+        throwsA(isA<SocketException>()),
+      );
+    },
+    skip: Platform.isWindows
+        ? 'Process.kill does not deliver console signals on Windows.'
+        : false,
+    timeout: const Timeout(Duration(seconds: 60)),
+  );
+
+  test('relative package paths resolve before changing directories', () async {
+    final result = await Process.run(Platform.resolvedExecutable, [
+      'bin/run_integration_tests.dart',
+      '../../packages/tonik_core',
+      '.',
+      '--',
+      '--help',
+    ]);
+    expect(result.exitCode, 0, reason: '${result.stdout}\n${result.stderr}');
+    expect(result.stdout, contains('tonik_core\n'));
+    expect(result.stdout, contains('\nTesting .\n'));
+  }, timeout: const Timeout(Duration(seconds: 60)));
+}

--- a/scripts/integration_package_utils.sh
+++ b/scripts/integration_package_utils.sh
@@ -6,6 +6,18 @@ INTEGRATION_TEST_ROOT="$INTEGRATION_REPO_ROOT/integration_test"
 EXPECTED_GENERATED_INTEGRATION_PACKAGES=44
 EXPECTED_INTEGRATION_TEST_PACKAGES=40
 
+run_integration_package_tests() (
+  cd "$INTEGRATION_REPO_ROOT"
+  (
+    cd integration_test/test_helpers
+    dart pub get
+    dart test
+  )
+  dart --packages=integration_test/test_helpers/.dart_tool/package_config.json \
+    integration_test/test_helpers/bin/run_integration_tests.dart \
+    "${INTEGRATION_TEST_PACKAGES[@]}"
+)
+
 validate_integration_backend() {
   local backend="$1"
   if [ "$backend" != "dio" ] && [ "$backend" != "http" ]; then

--- a/scripts/integration_setup_utils.sh
+++ b/scripts/integration_setup_utils.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+# Share the available CPUs between simultaneous generators and their model
+# workers. A nonzero workerCount in a fixture's config still takes precedence
+# over this environment fallback, just as it does when invoking Tonik directly.
+configure_setup_workers() {
+  local cpu_count="$1"
+  local worker_budget=1
+
+  if [[ -n "${INTEGRATION_SETUP_JOBS+x}" && ! "$INTEGRATION_SETUP_JOBS" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: INTEGRATION_SETUP_JOBS must be a positive integer." >&2
+    return 64
+  fi
+  if [[ -n "${TONIK_WORKERS:-}" && ! "$TONIK_WORKERS" =~ ^(0|[1-9][0-9]*)$ ]]; then
+    echo "Error: TONIK_WORKERS must be a non-negative integer." >&2
+    return 64
+  fi
+
+  if [ "${TONIK_WORKERS:-}" = 0 ]; then
+    worker_budget=$((cpu_count - 1))
+    [ "$worker_budget" -ge 1 ] || worker_budget=1
+    [ "$worker_budget" -le 16 ] || worker_budget=16
+  elif [ -n "${TONIK_WORKERS:-}" ]; then
+    # Compare lengths first to avoid overflowing shell arithmetic for a large
+    # override. Tonik itself validates its supported integer range.
+    if [ "${#TONIK_WORKERS}" -gt "${#cpu_count}" ] || [ "$TONIK_WORKERS" -ge "$cpu_count" ]; then
+      worker_budget="$cpu_count"
+    else
+      worker_budget="$TONIK_WORKERS"
+    fi
+  fi
+
+  SETUP_JOBS=$((cpu_count / worker_budget))
+  [ "$SETUP_JOBS" -le 4 ] || SETUP_JOBS=4
+  SETUP_JOBS="${INTEGRATION_SETUP_JOBS-$SETUP_JOBS}"
+
+  if [ -z "${TONIK_WORKERS:-}" ]; then
+    if [ "${#SETUP_JOBS}" -gt "${#cpu_count}" ] || [ "$SETUP_JOBS" -ge "$cpu_count" ]; then
+      TONIK_WORKERS=1
+    else
+      TONIK_WORKERS=$((cpu_count / SETUP_JOBS))
+    fi
+  fi
+  export TONIK_WORKERS
+}
+
+# xargs maintains a rolling pool without wait -n, which macOS Bash 3.2 lacks.
+# Run every command and wait for every child even if one command fails.
+run_commands() {
+  local max_jobs="$1"
+  shift
+  local command_count="$#"
+
+  if [[ ! "$max_jobs" =~ ^[1-9][0-9]*$ ]]; then
+    echo "Error: command concurrency must be a positive integer." >&2
+    return 64
+  fi
+  [ "$command_count" -gt 0 ] || return 0
+  if [ "${#max_jobs}" -gt "${#command_count}" ] || [ "$max_jobs" -gt "$command_count" ]; then
+    max_jobs="$command_count"
+  fi
+
+  printf '%s\0' "$@" | xargs -0 -n 1 -P "$max_jobs" bash -c '
+    SECONDS=0
+    if bash -c "$1"; then
+      echo "Completed (${SECONDS}s): $1"
+    else
+      status=$?
+      echo "Error: command failed (exit $status, ${SECONDS}s): $1" >&2
+      # In particular, never forward exit 255: that makes xargs stop early.
+      exit 1
+    fi
+  ' integration-setup
+}

--- a/scripts/setup_integration_tests.sh
+++ b/scripts/setup_integration_tests.sh
@@ -30,52 +30,19 @@ if [ "$BACKEND" != "dio" ] && [ "$BACKEND" != "http" ]; then
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_setup_utils.sh"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 INTEGRATION_TEST_DIR="$REPO_ROOT/integration_test"
 TONIK_BINARY="$REPO_ROOT/.dart_tool/tonik_compiled"
 
 if command -v nproc >/dev/null 2>&1; then
-  SETUP_JOBS="$(nproc)"
+  SETUP_CPUS="$(nproc)"
 elif command -v sysctl >/dev/null 2>&1; then
-  SETUP_JOBS="$(sysctl -n hw.ncpu)"
+  SETUP_CPUS="$(sysctl -n hw.ncpu)"
 else
-  SETUP_JOBS=4
+  SETUP_CPUS=4
 fi
-SETUP_JOBS="${INTEGRATION_SETUP_JOBS:-$SETUP_JOBS}"
-
-run_commands() {
-  local max_jobs="$1"
-  shift
-  local command
-  local failed=0
-  local -a pids=()
-  local -a batch_commands=()
-
-  for command in "$@"; do
-    bash -c "$command" &
-    pids+=("$!")
-    batch_commands+=("$command")
-    if [ "${#pids[@]}" -ge "$max_jobs" ]; then
-      for index in "${!pids[@]}"; do
-        if ! wait "${pids[$index]}"; then
-          echo "Error: command failed: ${batch_commands[$index]}" >&2
-          failed=1
-        fi
-      done
-      [ "$failed" -eq 0 ] || return 1
-      pids=()
-      batch_commands=()
-    fi
-  done
-
-  for index in "${!pids[@]}"; do
-    if ! wait "${pids[$index]}"; then
-      echo "Error: command failed: ${batch_commands[$index]}" >&2
-      failed=1
-    fi
-  done
-  [ "$failed" -eq 0 ]
-}
+configure_setup_workers "$SETUP_CPUS"
 
 add_tonik_util_override() {
   local pubspec="$1"
@@ -200,7 +167,7 @@ for directory in "${GENERATED_DIRS[@]}"; do
   rm -rf "$directory"
 done
 
-echo "Generating 44 API packages for $BACKEND (max $SETUP_JOBS jobs)..."
+echo "Generating 44 API packages for $BACKEND (max $SETUP_JOBS jobs, TONIK_WORKERS=$TONIK_WORKERS)..."
 run_commands "$SETUP_JOBS" "${GENERATION_COMMANDS[@]}"
 
 generated_count=0

--- a/scripts/test_current_integration.sh
+++ b/scripts/test_current_integration.sh
@@ -7,10 +7,4 @@ source "$SCRIPT_DIR/integration_package_utils.sh"
 discover_integration_packages current
 analyze_integration_packages current "${INTEGRATION_ANALYSIS_JOBS-4}"
 
-for package_dir in "${INTEGRATION_TEST_PACKAGES[@]}"; do
-  echo "Testing $package_dir"
-  (
-    cd "$INTEGRATION_REPO_ROOT/$package_dir"
-    dart test
-  )
-done
+run_integration_package_tests

--- a/scripts/test_integration_packages.sh
+++ b/scripts/test_integration_packages.sh
@@ -15,10 +15,9 @@ discover_integration_packages "$backend"
 
 echo "Tests: backend=$backend packages=${#INTEGRATION_TEST_PACKAGES[@]}"
 for package_dir in "${INTEGRATION_TEST_PACKAGES[@]}"; do
-  echo "Testing $package_dir"
   (
     cd "$INTEGRATION_REPO_ROOT/$package_dir"
     dart pub get
-    dart test --concurrency=2
   )
 done
+run_integration_package_tests

--- a/scripts/test_integration_setup.sh
+++ b/scripts/test_integration_setup.sh
@@ -1,0 +1,105 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/integration_setup_utils.sh"
+
+TEST_DIRECTORY="$(mktemp -d "${TMPDIR:-/tmp}/tonik-setup-test.XXXXXX")"
+trap 'rm -rf "$TEST_DIRECTORY"' EXIT
+trap 'echo "Setup script test failed at line $LINENO" >&2' ERR
+unset INTEGRATION_SETUP_JOBS TONIK_WORKERS
+
+# Defaults share ten CPUs between four generators, with serial operation on a
+# single-core runner.
+(
+  configure_setup_workers 10
+  [ "$SETUP_JOBS" = 4 ]
+  [ "$TONIK_WORKERS" = 2 ]
+)
+(
+  configure_setup_workers 1
+  [ "$SETUP_JOBS" = 1 ]
+  [ "$TONIK_WORKERS" = 1 ]
+)
+
+# Explicit generator workers reduce the default number of outer jobs. Explicit
+# outer jobs instead determine the default per-generator worker count.
+(
+  TONIK_WORKERS=3
+  configure_setup_workers 10
+  [ "$SETUP_JOBS" = 3 ]
+  [ "$TONIK_WORKERS" = 3 ]
+)
+(
+  INTEGRATION_SETUP_JOBS=2
+  configure_setup_workers 10
+  [ "$SETUP_JOBS" = 2 ]
+  [ "$TONIK_WORKERS" = 5 ]
+)
+(
+  INTEGRATION_SETUP_JOBS=6
+  TONIK_WORKERS=3
+  configure_setup_workers 10
+  [ "$SETUP_JOBS" = 6 ]
+  [ "$TONIK_WORKERS" = 3 ]
+)
+(
+  TONIK_WORKERS=0
+  configure_setup_workers 10
+  [ "$SETUP_JOBS" = 1 ]
+  [ "$TONIK_WORKERS" = 0 ]
+)
+
+# Reject invalid settings before compiling or deleting generated clients.
+status=0
+(INTEGRATION_SETUP_JOBS=0; configure_setup_workers 10) 2>"$TEST_DIRECTORY/invalid-jobs" || status=$?
+[ "$status" = 64 ]
+grep -q 'INTEGRATION_SETUP_JOBS must be a positive integer' "$TEST_DIRECTORY/invalid-jobs"
+status=0
+(TONIK_WORKERS=invalid; configure_setup_workers 10) 2>"$TEST_DIRECTORY/invalid-workers" || status=$?
+[ "$status" = 64 ]
+grep -q 'TONIK_WORKERS must be a non-negative integer' "$TEST_DIRECTORY/invalid-workers"
+
+mkdir "$TEST_DIRECTORY/commands with spaces"
+cd "$TEST_DIRECTORY/commands with spaces"
+
+# With one slot, the second command must wait for the first to finish.
+run_commands 1 \
+  'sleep 0.1; printf "first\n" > order' \
+  'test "$(cat order)" = first && printf "second\n" >> order'
+[ "$(cat order)" = "$(printf 'first\nsecond')" ]
+
+# The first command waits for the third. A fixed batch cannot satisfy this;
+# the deadline keeps a broken scheduler from hanging the test run.
+status=0
+run_commands 2 \
+  'SECONDS=0; while [ ! -f third-started ] && [ "$SECONDS" -lt 10 ]; do sleep 0.05; done; test -f third-started' \
+  'touch second-finished' \
+  'test -f second-finished && touch third-started' || status=$?
+[ "$status" = 0 ]
+[ -f third-started ]
+
+# An exit of 255 must be reported and must not make xargs abandon later work.
+status=0
+run_commands 1 'exit 255' 'touch finished-after-failure' 2>failure-log || status=$?
+[ "$status" -ne 0 ]
+[ -f finished-after-failure ]
+grep -q 'command failed (exit 255,' failure-log
+
+# Large overrides are bounded by the actual number of commands, without integer
+# overflow. NUL-delimited dispatch preserves a command containing newlines.
+(
+  INTEGRATION_SETUP_JOBS=999999999999999999999999
+  configure_setup_workers 10
+  [ "$TONIK_WORKERS" = 1 ]
+  run_commands "$SETUP_JOBS" 'printf "line one\nline two\n" > "multiline output"'
+)
+[ "$(cat 'multiline output')" = "$(printf 'line one\nline two')" ]
+
+status=0
+run_commands 0 'touch should-not-run' 2>invalid-pool || status=$?
+[ "$status" = 64 ]
+[ ! -f should-not-run ]
+run_commands 2
+
+echo "Integration setup tests passed."


### PR DESCRIPTION
Integration verification repeatedly starts a JVM for each test file and leaves generator workers idle at batch boundaries. Reuse one fresh Imposter server per package, reset request state between sequential files, and keep generation workers busy with a bounded rolling pool. Collect unit coverage on Linux/stable and run ordinary unit tests on the other existing variants.

The runner uses one Dart process with separate package sequencing and server cleanup. Full-client generation, analysis, both-backend integration coverage, individual VS Code tests, and the existing CI layout remain intact.

Verified locally on macOS with Dart 3.13.2 after rebasing onto current main:

- All five unit suites: 6,062 tests passed.
- Fresh generation through `scripts/setup_integration_tests.sh` for both Dio and HTTP: 44 clients per backend.
- Complete integration verification on each backend: all 85 package analyses, all 40 test packages (4,185 tests), and all 10 helper regressions passed.
- Dependency isolation passed on both backends; source/helper analysis, formatting, Bash 3.2 scheduler tests, and shell syntax checks passed.
