### PR TITLE
perf: generate copyWith as typed functions

### DIFF
--- a/integration_test/boolean_schemas/boolean_schemas_test/test/type_verification_test.dart
+++ b/integration_test/boolean_schemas/boolean_schemas_test/test/type_verification_test.dart
@@ -20,6 +20,22 @@ void main() {
       expect(obj.anyData, isA<Object?>());
       expect(obj.anyData, 'string value');
     });
+
+    test(
+      'copyWith clears a required nullable alias and preserves the name',
+      () {
+        const original = ObjectWithAny(name: 'test', anyData: 'string value');
+
+        final omitted = original.copyWith();
+        final cleared = original.copyWith(name: null, anyData: null);
+
+        expect(omitted.name, 'test');
+        expect(omitted.anyData, 'string value');
+        expect(cleared.name, 'test');
+        expect(cleared.anyData, isNull);
+        expect(original.anyData, 'string value');
+      },
+    );
   });
 
   group('NeverModel type verification', () {

--- a/integration_test/composition/composition_test/test/copy_with_test.dart
+++ b/integration_test/composition/composition_test/test/copy_with_test.dart
@@ -2,6 +2,30 @@ import 'package:composition_api/composition_api.dart';
 import 'package:test/test.dart';
 
 void main() {
+  test(
+    'typed copyWith functions preserve omitted and explicit null values',
+    () {
+      const original = AllOfPrimitiveModel(count: 42);
+      // Verify the hidden sentinel survives an explicitly typed function.
+      // ignore: omit_local_variable_types
+      final AllOfPrimitiveModel Function({int? count}) copy = original.copyWith;
+
+      expect(copy().count, 42);
+      // Null is not redundant: the closure defaults to a sentinel.
+      // ignore: avoid_redundant_argument_values
+      expect(copy.call(count: null).count, isNull);
+      expect(copy(count: 7).count, 7);
+      expect(original.count, 42);
+    },
+  );
+
+  test('copyWith rejects null for a nonnullable field', () {
+    const original = Class1(name: 'Alice');
+
+    expect(() => original.copyWith(name: null), throwsA(isA<TypeError>()));
+    expect(original.name, 'Alice');
+  });
+
   group('copyWith - Class models', () {
     group('Class1', () {
       test('copyWith creates new instance with changed values', () {

--- a/integration_test/composition/composition_test/test/copy_with_test.dart
+++ b/integration_test/composition/composition_test/test/copy_with_test.dart
@@ -2,28 +2,30 @@ import 'package:composition_api/composition_api.dart';
 import 'package:test/test.dart';
 
 void main() {
-  test(
-    'typed copyWith functions preserve omitted and explicit null values',
-    () {
-      const original = AllOfPrimitiveModel(count: 42);
-      // Verify the hidden sentinel survives an explicitly typed function.
-      // ignore: omit_local_variable_types
-      final AllOfPrimitiveModel Function({int? count}) copy = original.copyWith;
-
-      expect(copy().count, 42);
-      // Null is not redundant: the closure defaults to a sentinel.
-      // ignore: avoid_redundant_argument_values
-      expect(copy.call(count: null).count, isNull);
-      expect(copy(count: 7).count, 7);
-      expect(original.count, 42);
-    },
-  );
-
-  test('copyWith rejects null for a nonnullable field', () {
+  test('copyWith preserves a nonnullable field when passed null', () {
     const original = Class1(name: 'Alice');
 
-    expect(() => original.copyWith(name: null), throwsA(isA<TypeError>()));
+    final copy = original.copyWith(name: null);
+
+    expect(copy.name, 'Alice');
     expect(original.name, 'Alice');
+    expect(copy, isNot(same(original)));
+  });
+
+  test('copyWith preserves a nonnullable composite field when passed null', () {
+    const original = AllOfComplex(
+      class1: Class1(name: 'Alice'),
+      class2: Class2(number: 42),
+    );
+
+    final copy = original.copyWith(
+      class1: null,
+      class2: const Class2(number: 7),
+    );
+
+    expect(copy.class1, const Class1(name: 'Alice'));
+    expect(copy.class2, const Class2(number: 7));
+    expect(original.class2, const Class2(number: 42));
   });
 
   group('copyWith - Class models', () {

--- a/integration_test/naming/naming_test/test/copy_with_test.dart
+++ b/integration_test/naming/naming_test/test/copy_with_test.dart
@@ -1,0 +1,23 @@
+import 'package:naming_api/naming_api.dart';
+import 'package:test/test.dart';
+
+void main() {
+  test('response copyWith distinguishes the body from a normalized header', () {
+    const original = ResponseBodyCollisionHeaderNormalizedGet200Response(
+      body: 'header',
+      body2: SimpleResult(id: 'body'),
+    );
+
+    final headerCopy = original.copyWith(body: 'updated-header');
+    final bodyCopy = original.copyWith.call(
+      body2: const SimpleResult(id: 'updated-body'),
+    );
+
+    expect(headerCopy.body, 'updated-header');
+    expect(headerCopy.body2, const SimpleResult(id: 'body'));
+    expect(bodyCopy.body, 'header');
+    expect(bodyCopy.body2, const SimpleResult(id: 'updated-body'));
+    expect(original.body, 'header');
+    expect(original.body2, const SimpleResult(id: 'body'));
+  });
+}

--- a/integration_test/naming/naming_test/test/copy_with_test.dart
+++ b/integration_test/naming/naming_test/test/copy_with_test.dart
@@ -20,4 +20,30 @@ void main() {
     expect(original.body, 'header');
     expect(original.body2, const SimpleResult(id: 'body'));
   });
+
+  test(
+    'response copyWith preserves nonnullable headers and bodies on null',
+    () {
+      const original = ResponseBodyCollisionHeaderNormalizedGet200Response(
+        body: 'header',
+        body2: SimpleResult(id: 'body'),
+      );
+
+      final copy = original.copyWith(body: null, body2: null);
+
+      expect(copy.body, 'header');
+      expect(copy.body2, const SimpleResult(id: 'body'));
+      expect(copy, isNot(same(original)));
+    },
+  );
+
+  test('copyWith preserves required values while clearing nullable values', () {
+    const original = SimpleResult(id: 'body', message: 'message');
+
+    final copy = original.copyWith(id: null, message: null);
+
+    expect(copy.id, 'body');
+    expect(copy.message, isNull);
+    expect(original.message, 'message');
+  });
 }

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -2564,6 +2564,10 @@ class const AllOfGenerator({
       return (
         normalizedName: normalized.normalizedName,
         typeRef: typeRef,
+        isNullable:
+            (typeRef.isNullable ?? false) ||
+            propModel.isEffectivelyNullable ||
+            resolvedModel is AnyModel,
         // Skip cast for AnyModel since its typedef is Object?
         skipCast: resolvedModel is AnyModel,
       );
@@ -2582,6 +2586,7 @@ class const AllOfGenerator({
           package,
           useImmutableCollections: useImmutableCollections,
         ),
+        isNullable: false,
         skipCast: false,
       ));
     }

--- a/packages/tonik_generate/lib/src/model/all_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/all_of_generator.dart
@@ -47,7 +47,6 @@ class const AllOfGenerator({
     );
   }
 
-  /// Generates the main class and the copyWith infrastructure classes.
   @visibleForTesting
   List<Spec> generateClasses(AllOfModel model, [String? className]) {
     final actualClassName = className ?? nameManager.modelName(model);
@@ -74,19 +73,13 @@ class const AllOfGenerator({
 
     final normalizedProperties = _normalizeModelProperties(pseudoProperties);
 
-    final copyWithResult = _buildCopyWith(
+    final copyWithGetter = _buildCopyWith(
       actualClassName,
       normalizedProperties,
       model,
     );
 
-    return [
-      generateClass(model, copyWithResult?.getter, actualClassName),
-      if (copyWithResult != null) ...[
-        copyWithResult.interfaceClass,
-        copyWithResult.implClass,
-      ],
-    ];
+    return [generateClass(model, copyWithGetter, actualClassName)];
   }
 
   @visibleForTesting
@@ -142,7 +135,7 @@ class const AllOfGenerator({
 
     final effectiveCopyWithGetter =
         copyWithGetter ??
-        _buildCopyWith(actualClassName, normalizedProperties, model)?.getter;
+        _buildCopyWith(actualClassName, normalizedProperties, model);
 
     return Class((b) {
       b
@@ -2548,7 +2541,7 @@ class const AllOfGenerator({
     );
   }
 
-  CopyWithResult? _buildCopyWith(
+  Method? _buildCopyWith(
     String className,
     List<({String normalizedName, Property property})> normalizedProperties,
     AllOfModel model,

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -86,15 +86,20 @@ class const AnyOfGenerator({
       properties: normalized.map((n) {
         final model = n.property.model;
         final resolvedModel = model.resolved;
+        final typeRef = typeReference(
+          n.property.model,
+          nameManager,
+          package,
+          isNullableOverride: n.property.isNullable || !n.property.isRequired,
+          useImmutableCollections: useImmutableCollections,
+        );
         return (
           normalizedName: n.normalizedName,
-          typeRef: typeReference(
-            n.property.model,
-            nameManager,
-            package,
-            isNullableOverride: n.property.isNullable || !n.property.isRequired,
-            useImmutableCollections: useImmutableCollections,
-          ),
+          typeRef: typeRef,
+          isNullable:
+              (typeRef.isNullable ?? false) ||
+              model.isEffectivelyNullable ||
+              resolvedModel is AnyModel,
           skipCast: resolvedModel is AnyModel,
         );
       }).toList(),

--- a/packages/tonik_generate/lib/src/model/any_of_generator.dart
+++ b/packages/tonik_generate/lib/src/model/any_of_generator.dart
@@ -72,18 +72,12 @@ class const AnyOfGenerator({
 
     final normalized = normalizeProperties(pseudoProperties);
 
-    final copyWithResult = _buildCopyWith(actualClassName, normalized);
+    final copyWithGetter = _buildCopyWith(actualClassName, normalized);
 
-    return [
-      generateClass(model, copyWithResult?.getter, actualClassName),
-      if (copyWithResult != null) ...[
-        copyWithResult.interfaceClass,
-        copyWithResult.implClass,
-      ],
-    ];
+    return [generateClass(model, copyWithGetter, actualClassName)];
   }
 
-  CopyWithResult? _buildCopyWith(
+  Method? _buildCopyWith(
     String className,
     List<({String normalizedName, Property property})> normalized,
   ) {
@@ -155,7 +149,7 @@ class const AnyOfGenerator({
     final semanticProperties = _semanticProperties(normalized);
 
     final effectiveCopyWithGetter =
-        copyWithGetter ?? _buildCopyWith(actualClassName, normalized)?.getter;
+        copyWithGetter ?? _buildCopyWith(actualClassName, normalized);
 
     final fields = normalized.map((n) {
       final ref = typeReference(

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -377,9 +377,14 @@ class const ClassGenerator({
     final copyWithProps = properties.map((prop) {
       final propModel = prop.property.model;
       final resolvedModel = propModel.resolved;
+      final typeRef = _getSchemaAwareTypeReference(prop.property, model);
       return (
         normalizedName: prop.normalizedName,
-        typeRef: _getSchemaAwareTypeReference(prop.property, model),
+        typeRef: typeRef,
+        isNullable:
+            (typeRef.isNullable ?? false) ||
+            propModel.isEffectivelyNullable ||
+            resolvedModel is AnyModel,
         skipCast: resolvedModel is AnyModel,
       );
     }).toList();
@@ -395,6 +400,7 @@ class const ClassGenerator({
           package,
           useImmutableCollections: useImmutableCollections,
         ),
+        isNullable: false,
         skipCast: false,
       ));
     }

--- a/packages/tonik_generate/lib/src/model/class_generator.dart
+++ b/packages/tonik_generate/lib/src/model/class_generator.dart
@@ -91,7 +91,7 @@ class const ClassGenerator({
 
     final normalizedProperties = normalizeProperties(model.properties.toList());
 
-    final copyWithResult = _buildCopyWith(
+    final copyWithGetter = _buildCopyWith(
       actualClassName,
       normalizedProperties,
       model,
@@ -101,12 +101,8 @@ class const ClassGenerator({
       _generateClassWithName(
         model,
         actualClassName,
-        copyWithGetter: copyWithResult?.getter,
+        copyWithGetter: copyWithGetter,
       ),
-      if (copyWithResult != null) ...[
-        copyWithResult.interfaceClass,
-        copyWithResult.implClass,
-      ],
       if (model.isNullable)
         TypeDef(
           (b) => b
@@ -144,7 +140,7 @@ class const ClassGenerator({
 
     final effectiveCopyWithGetter =
         copyWithGetter ??
-        _buildCopyWith(className, normalizedProperties, model)?.getter;
+        _buildCopyWith(className, normalizedProperties, model);
 
     bool hasConstDefault(({String normalizedName, Property property}) p) =>
         defaultsByName[p.normalizedName] is ConstDefaultBinding;
@@ -373,7 +369,7 @@ class const ClassGenerator({
           .call([specLiteralString(key)])
           .conditional(decoded, refer(defaulted.memberName));
 
-  CopyWithResult? _buildCopyWith(
+  Method? _buildCopyWith(
     String className,
     List<({String normalizedName, Property property})> properties,
     ObjectDeclaration model,

--- a/packages/tonik_generate/lib/src/response/response_generator.dart
+++ b/packages/tonik_generate/lib/src/response/response_generator.dart
@@ -89,16 +89,21 @@ class const ResponseGenerator({
       properties: properties.map((prop) {
         final model = prop.property.model;
         final resolvedModel = model.resolved;
+        final typeRef = typeReference(
+          prop.property.model,
+          nameManager,
+          package,
+          isNullableOverride:
+              prop.property.isNullable || !prop.property.isRequired,
+          useImmutableCollections: useImmutableCollections,
+        );
         return (
           normalizedName: prop.normalizedName,
-          typeRef: typeReference(
-            prop.property.model,
-            nameManager,
-            package,
-            isNullableOverride:
-                prop.property.isNullable || !prop.property.isRequired,
-            useImmutableCollections: useImmutableCollections,
-          ),
+          typeRef: typeRef,
+          isNullable:
+              (typeRef.isNullable ?? false) ||
+              model.isEffectivelyNullable ||
+              resolvedModel is AnyModel,
           skipCast: resolvedModel is AnyModel,
         );
       }).toList(),

--- a/packages/tonik_generate/lib/src/response/response_generator.dart
+++ b/packages/tonik_generate/lib/src/response/response_generator.dart
@@ -74,18 +74,12 @@ class const ResponseGenerator({
     final className = nameManager.responseNames(response).baseName;
     final properties = normalizeResponseProperties(response);
 
-    final copyWithResult = _buildCopyWith(className, properties);
+    final copyWithGetter = _buildCopyWith(className, properties);
 
-    return [
-      generateResponseClass(response, copyWithResult?.getter),
-      if (copyWithResult != null) ...[
-        copyWithResult.interfaceClass,
-        copyWithResult.implClass,
-      ],
-    ];
+    return [generateResponseClass(response, copyWithGetter)];
   }
 
-  CopyWithResult? _buildCopyWith(
+  Method? _buildCopyWith(
     String className,
     List<({ResponseHeader? header, String normalizedName, Property property})>
     properties,
@@ -121,7 +115,7 @@ class const ResponseGenerator({
 
     // If no copyWithGetter provided, generate one
     final effectiveCopyWithGetter =
-        copyWithGetter ?? _buildCopyWith(className, properties)?.getter;
+        copyWithGetter ?? _buildCopyWith(className, properties);
 
     final equalsMethod = generateEqualsMethod(
       className: className,
@@ -294,75 +288,62 @@ class const ResponseGenerator({
 
       final methods = [equalsMethod, hashCodeMethod];
 
-      var copyWithInfrastructure = <Spec>[];
       if (response.headers.isNotEmpty) {
-        final copyWithResult = _buildCopyWith(
+        final copyWithGetter = _buildCopyWith(
           implementationName,
           allProperties,
         );
-        if (copyWithResult != null) {
-          methods.add(copyWithResult.getter);
-          copyWithInfrastructure = [
-            copyWithResult.interfaceClass,
-            copyWithResult.implClass,
-          ];
+        if (copyWithGetter != null) {
+          methods.add(copyWithGetter);
         }
       }
 
-      return (
-        mainClass: Class(
-          (b) => b
-            ..name = implementationName
-            ..extend = refer(className)
-            ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
-            ..constructors.add(
-              Constructor(
-                (b) => b
-                  ..constant = true
-                  ..optionalParameters.addAll([
-                    ...normalizedBaseProperties.map(
-                      (prop) => Parameter(
-                        (b) => b
-                          ..name = prop.normalizedName
-                          ..named = true
-                          ..required = prop.property.isRequired
-                          ..toSuper = true,
-                      ),
-                    ),
-                    Parameter(
+      return Class(
+        (b) => b
+          ..name = implementationName
+          ..extend = refer(className)
+          ..annotations.add(refer('immutable', 'package:meta/meta.dart'))
+          ..constructors.add(
+            Constructor(
+              (b) => b
+                ..constant = true
+                ..optionalParameters.addAll([
+                  ...normalizedBaseProperties.map(
+                    (prop) => Parameter(
                       (b) => b
-                        ..name = bodyProperty.normalizedName
+                        ..name = prop.normalizedName
                         ..named = true
-                        ..required = true
-                        ..toThis = true,
+                        ..required = prop.property.isRequired
+                        ..toSuper = true,
                     ),
-                  ]),
-              ),
-            )
-            ..methods.addAll(methods)
-            ..fields.add(
-              Field(
-                (b) => b
-                  ..name = bodyProperty.normalizedName
-                  ..modifier = FieldModifier.final$
-                  ..type = typeReference(
-                    body.model,
-                    nameManager,
-                    package,
-                    useImmutableCollections: useImmutableCollections,
                   ),
-              ),
+                  Parameter(
+                    (b) => b
+                      ..name = bodyProperty.normalizedName
+                      ..named = true
+                      ..required = true
+                      ..toThis = true,
+                  ),
+                ]),
             ),
-        ),
-        copyWithInfrastructure: copyWithInfrastructure,
+          )
+          ..methods.addAll(methods)
+          ..fields.add(
+            Field(
+              (b) => b
+                ..name = bodyProperty.normalizedName
+                ..modifier = FieldModifier.final$
+                ..type = typeReference(
+                  body.model,
+                  nameManager,
+                  package,
+                  useImmutableCollections: useImmutableCollections,
+                ),
+            ),
+          ),
       );
     }).toList();
 
-    return [
-      baseClass,
-      ...implementationClasses.expand(
-        (item) => [item.mainClass, ...item.copyWithInfrastructure],
-      ),
-    ];
+    return [baseClass, ...implementationClasses];
   }
 }

--- a/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
+++ b/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
@@ -1,250 +1,71 @@
 import 'package:code_builder/code_builder.dart';
 
-/// A property for copyWith generation.
 typedef CopyWithProperty = ({
   String normalizedName,
   TypeReference typeRef,
   bool skipCast,
 });
 
-/// Generates freezed-like copyWith infrastructure for a class.
-///
-/// This generates:
-/// - A getter that returns the copyWith interface
-/// - An abstract class (`$$<ClassName>CopyWith`)
-/// - An implementation class (`_<ClassName>CopyWith`)
-CopyWithResult? generateCopyWith({
+Method? generateCopyWith({
   required String className,
   required List<CopyWithProperty> properties,
 }) {
-  if (properties.isEmpty) {
-    return null;
-  }
-
-  final interfaceClassName = '\$\$${className}CopyWith';
-  final implClassName = '_${className}CopyWith';
-
-  return CopyWithResult(
-    getter: _generateCopyWithGetter(
-      className,
-      interfaceClassName,
-      implClassName,
-    ),
-    interfaceClass: _generateCopyWithInterface(
-      className,
-      interfaceClassName,
-      implClassName,
-      properties,
-    ),
-    implClass: _generateCopyWithImpl(
-      className,
-      interfaceClassName,
-      implClassName,
-      properties,
-    ),
-  );
-}
-
-/// Result of generating copyWith infrastructure.
-class const CopyWithResult({
-  /// The getter method to add to the main class.
-  required final Method getter,
-
-  /// The abstract interface class.
-  required final Class interfaceClass,
-
-  /// The implementation class.
-  required final Class implClass,
-});
-
-Method _generateCopyWithGetter(
-  String className,
-  String interfaceClassName,
-  String implClassName,
-) {
-  return Method(
-    (b) => b
-      ..name = 'copyWith'
-      ..type = MethodType.getter
-      ..returns = TypeReference(
-        (b) => b
-          ..symbol = interfaceClassName
-          ..types.add(refer(className)),
-      )
-      ..lambda = true
-      ..body = Code('$implClassName(this)'),
-  );
-}
-
-Class _generateCopyWithInterface(
-  String className,
-  String interfaceClassName,
-  String implClassName,
-  List<CopyWithProperty> properties,
-) {
-  final callParams = properties.map(
-    (prop) => Parameter(
-      (b) => b
-        ..name = prop.normalizedName
-        ..named = true
-        ..type = prop.typeRef.rebuild((b) => b..isNullable = true),
-    ),
-  );
-
-  final getters = properties.map(
-    (prop) => Method(
-      (b) => b
-        ..name = prop.normalizedName
-        ..type = MethodType.getter
-        ..returns = prop.typeRef,
-    ),
-  );
-
-  return Class(
-    (b) => b
-      ..name = interfaceClassName
-      ..abstract = true
-      ..types.add(refer(r'$Res'))
-      ..constructors.add(
-        Constructor(
-          (b) => b
-            ..factory = true
-            ..requiredParameters.add(
-              Parameter(
-                (b) => b
-                  ..name = 'value'
-                  ..type = refer(className),
-              ),
-            )
-            ..redirect = TypeReference(
-              (b) => b
-                ..symbol = implClassName
-                ..types.add(refer(r'$Res')),
-            ),
-        ),
-      )
-      ..methods.add(
-        Method(
-          (b) => b
-            ..name = 'call'
-            ..returns = refer(r'$Res')
-            ..optionalParameters.addAll(callParams),
-        ),
-      )
-      ..methods.addAll(getters),
-  );
-}
-
-Class _generateCopyWithImpl(
-  String className,
-  String interfaceClassName,
-  String implClassName,
-  List<CopyWithProperty> properties,
-) {
-  final callParams = properties.map(
-    (prop) => Parameter(
-      (b) => b
-        ..name = prop.normalizedName
-        ..named = true
-        ..type = refer('Object?', 'dart:core')
-        ..defaultTo = const Code('_sentinel'),
-    ),
-  );
-
-  final getters = properties.map(
-    (prop) => Method(
-      (b) => b
-        ..name = prop.normalizedName
-        ..type = MethodType.getter
-        ..annotations.add(refer('override', 'dart:core'))
-        ..returns = prop.typeRef
-        ..lambda = true
-        ..body = Code('_value.${prop.normalizedName}'),
-    ),
-  );
-
-  // Code.scope keeps type references routed through the import allocator.
-  final callBody = _buildCallMethodBody(className, properties);
-
-  return Class(
-    (b) => b
-      ..name = implClassName
-      ..types.add(refer(r'$Res'))
-      ..implements.add(
-        TypeReference(
-          (b) => b
-            ..symbol = interfaceClassName
-            ..types.add(refer(r'$Res')),
-        ),
-      )
-      ..constructors.add(
-        Constructor(
-          (b) => b
-            ..requiredParameters.add(
-              Parameter((b) => b..name = '_value')
-                  .rebuild((b) => b..toThis = true),
-            ),
-        ),
-      )
-      ..fields.addAll([
-        Field(
-          (b) => b
-            ..name = '_sentinel'
-            ..static = true
-            ..modifier = FieldModifier.constant
-            ..assignment = refer('Object', 'dart:core').newInstance([]).code,
-        ),
-        Field(
-          (b) => b
-            ..name = '_value'
-            ..modifier = FieldModifier.final$
-            ..type = refer(className),
-        ),
-      ])
-      ..methods.addAll(getters)
-      ..methods.add(
-        Method(
-          (b) => b
-            ..name = 'call'
-            ..annotations.add(refer('override', 'dart:core'))
-            ..returns = refer(r'$Res')
-            ..optionalParameters.addAll(callParams)
-            ..body = callBody,
-        ),
-      ),
-  );
-}
-
-Code _buildCallMethodBody(String className, List<CopyWithProperty> properties) {
-  if (properties.isEmpty) {
-    return refer(className).call([]).asA(refer(r'$Res')).returned.statement;
-  }
+  if (properties.isEmpty) return null;
 
   final namedArgs = <String, Expression>{};
   for (final prop in properties) {
-    final name = prop.normalizedName;
-    // Sentinel parameters are Object?, so constructor arguments cast back to
-    // the original type.
     final originalType = prop.typeRef;
-
     final isDartCoreObjectNullable =
         originalType.symbol == 'Object' &&
         originalType.url == 'dart:core' &&
         (originalType.isNullable ?? false);
-    final shouldSkipCast = prop.skipCast || isDartCoreObjectNullable;
-
-    final valueExpression = shouldSkipCast
-        ? refer(name)
-        : refer(name).asA(originalType);
-
-    namedArgs[name] = refer('identical', 'dart:core')
-        .call([refer(name), refer('_sentinel')])
-        .conditional(refer('this').property(name), valueExpression);
+    final value = prop.skipCast || isDartCoreObjectNullable
+        ? refer(prop.normalizedName)
+        : refer(prop.normalizedName).asA(originalType);
+    namedArgs[prop.normalizedName] = refer('identical', 'dart:core')
+        .call([refer(prop.normalizedName), refer('_sentinel')])
+        .conditional(refer('this').property(prop.normalizedName), value);
   }
 
-  return refer(className)
-      .call([], namedArgs)
-      .asA(refer(r'$Res'))
-      .returned
-      .statement;
+  final closure = Method(
+    (b) => b
+      ..optionalParameters.addAll(
+        properties.map(
+          (prop) => Parameter(
+            (b) => b
+              ..name = prop.normalizedName
+              ..named = true
+              ..type = refer('Object?', 'dart:core')
+              ..defaultTo = refer('_sentinel').code,
+          ),
+        ),
+      )
+      ..lambda = true
+      ..body = refer(className).call([], namedArgs).code,
+  );
+
+  return Method(
+    (b) => b
+      ..name = 'copyWith'
+      ..type = MethodType.getter
+      ..returns = FunctionType(
+        (b) => b
+          ..returnType = refer(className)
+          ..namedParameters.addEntries(
+            properties.map(
+              (prop) => MapEntry(
+                prop.normalizedName,
+                prop.typeRef.rebuild((b) => b..isNullable = true),
+              ),
+            ),
+          ),
+      )
+      ..body = Block.of([
+        declareConst(
+          '_sentinel',
+          type: refer('Object', 'dart:core'),
+        ).assign(refer('Object', 'dart:core').constInstance([])).statement,
+        closure.closure.returned.statement,
+      ]),
+  );
 }

--- a/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
+++ b/packages/tonik_generate/lib/src/util/copy_with_method_generator.dart
@@ -3,6 +3,7 @@ import 'package:code_builder/code_builder.dart';
 typedef CopyWithProperty = ({
   String normalizedName,
   TypeReference typeRef,
+  bool isNullable,
   bool skipCast,
 });
 
@@ -14,6 +15,12 @@ Method? generateCopyWith({
 
   final namedArgs = <String, Expression>{};
   for (final prop in properties) {
+    if (!prop.isNullable) {
+      namedArgs[prop.normalizedName] = refer(prop.normalizedName)
+          .ifNullThen(refer('this').property(prop.normalizedName));
+      continue;
+    }
+
     final originalType = prop.typeRef;
     final isDartCoreObjectNullable =
         originalType.symbol == 'Object' &&
@@ -35,8 +42,10 @@ Method? generateCopyWith({
             (b) => b
               ..name = prop.normalizedName
               ..named = true
-              ..type = refer('Object?', 'dart:core')
-              ..defaultTo = refer('_sentinel').code,
+              ..type = prop.isNullable
+                  ? refer('Object?', 'dart:core')
+                  : prop.typeRef.rebuild((b) => b..isNullable = true)
+              ..defaultTo = prop.isNullable ? refer('_sentinel').code : null,
           ),
         ),
       )
@@ -61,10 +70,11 @@ Method? generateCopyWith({
           ),
       )
       ..body = Block.of([
-        declareConst(
-          '_sentinel',
-          type: refer('Object', 'dart:core'),
-        ).assign(refer('Object', 'dart:core').constInstance([])).statement,
+        if (properties.any((prop) => prop.isNullable))
+          declareConst(
+            '_sentinel',
+            type: refer('Object', 'dart:core'),
+          ).assign(refer('Object', 'dart:core').constInstance([])).statement,
         closure.closure.returned.statement,
       ]),
   );

--- a/packages/tonik_generate/test/src/model/any_of_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/any_of_generator_test.dart
@@ -446,7 +446,7 @@ void main() {
       );
     });
 
-    test('generates copyWith getter returning interface type', () {
+    test('generates copyWith getter returning a typed function', () {
       final model = AnyOfModel(
         isDeprecated: false,
         name: 'ValueChoice',
@@ -462,9 +462,14 @@ void main() {
 
       final copyWith = klass.methods.firstWhere((m) => m.name == 'copyWith');
       expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'ValueChoice');
+      expect(functionType.namedParameters.keys, ['string', 'int']);
       expect(
-        copyWith.returns?.accept(emitter).toString(),
-        r'$$ValueChoiceCopyWith<ValueChoice>',
+        functionType.namedParameters.values.map(
+          (type) => type.accept(emitter).toString(),
+        ),
+        ['String?', 'int?'],
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/class_copy_with_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_copy_with_generator_test.dart
@@ -45,7 +45,7 @@ void main() {
       expect(hasCopyWith, isFalse);
     });
 
-    test('generates freezed-like copyWith for simple properties', () {
+    test('generates typed copyWith for simple properties', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'User',
@@ -74,91 +74,25 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      expect(generatedSpecs.length, 3);
-      final mainClass = generatedSpecs[0] as Class;
-      final copyWithGetter = mainClass.methods.firstWhere(
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
         (m) => m.name == 'copyWith',
       );
-      expect(copyWithGetter.type, MethodType.getter);
-      expect(
-        copyWithGetter.returns?.accept(emitter).toString(),
-        r'$$UserCopyWith<User>',
-      );
-      expect(copyWithGetter.lambda, isTrue);
-      expect(
-        copyWithGetter.body?.accept(emitter).toString(),
-        '_UserCopyWith(this)',
-      );
-      final interfaceClass = generatedSpecs[1] as Class;
-      expect(interfaceClass.name, r'$$UserCopyWith');
-      expect(interfaceClass.abstract, isTrue);
-      expect(interfaceClass.types.length, 1);
-      expect(interfaceClass.types.first.symbol, r'$Res');
-      final interfaceFactory = interfaceClass.constructors.firstWhere(
-        (c) => c.factory,
-      );
-      expect(interfaceFactory.requiredParameters.length, 1);
-      expect(interfaceFactory.requiredParameters.first.name, 'value');
-      expect(
-        interfaceFactory.requiredParameters.first.type
-            ?.accept(emitter)
-            .toString(),
-        'User',
-      );
-      final callMethod = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'call',
-      );
-      expect(callMethod.optionalParameters.length, 2);
-      expect(callMethod.optionalParameters[0].name, 'name');
-      expect(
-        callMethod.optionalParameters[0].type?.accept(emitter).toString(),
-        'String?',
-      );
-      expect(callMethod.optionalParameters[1].name, 'age');
-      expect(
-        callMethod.optionalParameters[1].type?.accept(emitter).toString(),
-        'int?',
-      );
-      final nameGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'name',
-      );
-      expect(nameGetter.type, MethodType.getter);
-      expect(nameGetter.returns?.accept(emitter).toString(), 'String');
-
-      final ageGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'age',
-      );
-      expect(ageGetter.type, MethodType.getter);
-      expect(ageGetter.returns?.accept(emitter).toString(), 'int');
-      final implClass = generatedSpecs[2] as Class;
-      expect(implClass.name, '_UserCopyWith');
-      expect(implClass.implements.length, 1);
-      expect(
-        implClass.implements.first.accept(emitter).toString(),
-        r'$$UserCopyWith<$Res>',
-      );
-      final sentinelField = implClass.fields.firstWhere(
-        (f) => f.name == '_sentinel',
-      );
-      expect(sentinelField.static, isTrue);
-      expect(sentinelField.modifier, FieldModifier.constant);
-      final valueField = implClass.fields.firstWhere((f) => f.name == '_value');
-      expect(valueField.modifier, FieldModifier.final$);
-      expect(valueField.type?.accept(emitter).toString(), 'User');
-      final implCallMethod = implClass.methods.firstWhere(
-        (m) => m.name == 'call',
-      );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? name = _sentinel, Object? age = _sentinel, }) {
-          return (User(name: identical(name, _sentinel, ) ? this.name : (name as String),
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'User');
+      const expectedCopyWith = '''
+        User Function({String? name, int? age}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? name = _sentinel, Object? age = _sentinel, }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
             age: identical(age, _sentinel, ) ? this.age : (age as int),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
 
@@ -191,27 +125,25 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      final interfaceClass = generatedSpecs[1] as Class;
-      final bioGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'bio',
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
+        (m) => m.name == 'copyWith',
       );
-      expect(bioGetter.type, MethodType.getter);
-      expect(bioGetter.returns?.accept(emitter).toString(), 'String?');
-      final implClass = generatedSpecs[2] as Class;
-      final implCallMethod = implClass.methods.firstWhere(
-        (m) => m.name == 'call',
-      );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? name = _sentinel, Object? bio = _sentinel, }) {
-          return (User(name: identical(name, _sentinel, ) ? this.name : (name as String),
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'User');
+      const expectedCopyWith = '''
+        User Function({String? name, String? bio}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? name = _sentinel, Object? bio = _sentinel, }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
             bio: identical(bio, _sentinel, ) ? this.bio : (bio as String?),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
 
@@ -271,35 +203,29 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      final interfaceClass = generatedSpecs[1] as Class;
-      final homeAddressGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'homeAddress',
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
+        (m) => m.name == 'copyWith',
       );
-      expect(homeAddressGetter.returns?.accept(emitter).toString(), 'Address?');
-
-      final workAddressGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'workAddress',
-      );
-      expect(workAddressGetter.returns?.accept(emitter).toString(), 'Address');
-      final implClass = generatedSpecs[2] as Class;
-      final implCallMethod = implClass.methods.firstWhere(
-        (m) => m.name == 'call',
-      );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? name = _sentinel,
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'User');
+      const expectedCopyWith = '''
+        User Function({String? name, Address? homeAddress, Address? workAddress}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? name = _sentinel,
           Object? homeAddress = _sentinel,
           Object? workAddress = _sentinel,
-        }) {
-          return (User(name: identical(name, _sentinel, ) ? this.name : (name as String),
+        }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
             homeAddress: identical(homeAddress, _sentinel, ) ? this.homeAddress : (homeAddress as Address?),
             workAddress: identical(workAddress, _sentinel, ) ? this.workAddress : (workAddress as Address),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
 
@@ -340,36 +266,27 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      final interfaceClass = generatedSpecs[1] as Class;
-      final tagsGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'tags',
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
+        (m) => m.name == 'copyWith',
       );
-      expect(tagsGetter.returns?.accept(emitter).toString(), 'List<String>');
-
-      final optionalTagsGetter = interfaceClass.methods.firstWhere(
-        (m) => m.name == 'optionalTags',
-      );
-      expect(
-        optionalTagsGetter.returns?.accept(emitter).toString(),
-        'List<String>?',
-      );
-      final implClass = generatedSpecs[2] as Class;
-      final implCallMethod = implClass.methods.firstWhere(
-        (m) => m.name == 'call',
-      );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? tags = _sentinel,
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'User');
+      const expectedCopyWith = '''
+        User Function({List<String>? tags, List<String>? optionalTags}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? tags = _sentinel,
           Object? optionalTags = _sentinel,
-        }) {
-          return (User(tags: identical(tags, _sentinel, ) ? this.tags : (tags as List<String>),
+        }) => User(tags: identical(tags, _sentinel, ) ? this.tags : (tags as List<String>),
             optionalTags: identical(optionalTags, _sentinel, ) ? this.optionalTags : (optionalTags as List<String>?),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
 
@@ -411,35 +328,33 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      final interfaceClass = generatedSpecs[1] as Class;
-      final getterNames = interfaceClass.methods
-          .where((m) => m.type == MethodType.getter)
-          .map((m) => m.name)
-          .toList();
-      expect(getterNames, containsAll(['firstName', 'lastName', 'id']));
-      final implClass = generatedSpecs[2] as Class;
-      final implCallMethod = implClass.methods.firstWhere(
-        (m) => m.name == 'call',
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
+        (m) => m.name == 'copyWith',
       );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? firstName = _sentinel,
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'User');
+      const expectedCopyWith = '''
+        User Function({String? firstName, String? lastName, String? id}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? firstName = _sentinel,
           Object? lastName = _sentinel,
           Object? id = _sentinel,
-        }) {
-          return (User(firstName: identical(firstName, _sentinel, ) ? this.firstName : (firstName as String),
+        }) => User(firstName: identical(firstName, _sentinel, ) ? this.firstName : (firstName as String),
             lastName: identical(lastName, _sentinel, ) ? this.lastName : (lastName as String),
             id: identical(id, _sentinel, ) ? this.id : (id as String),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
 
-    test('escapes call property throughout copyWith infrastructure', () {
+    test('escapes call property in copyWith', () {
       final model = ClassModel(
         isDeprecated: false,
         name: 'Widget',
@@ -468,51 +383,29 @@ void main() {
       );
 
       final generatedSpecs = generator.generateClasses(model);
-      final mainClass = generatedSpecs[0] as Class;
-      final interfaceClass = generatedSpecs[1] as Class;
-      final implClass = generatedSpecs[2] as Class;
-
-      expect(mainClass.fields.map((field) => field.name), contains(r'$call'));
-      expect(
-        interfaceClass.methods.where((method) => method.name == 'call'),
-        hasLength(1),
+      expect(generatedSpecs, hasLength(1));
+      final mainClass = generatedSpecs.single as Class;
+      final copyWith = mainClass.methods.singleWhere(
+        (m) => m.name == 'copyWith',
       );
-      expect(
-        interfaceClass.methods
-            .singleWhere((method) => method.name == r'$call')
-            .type,
-        MethodType.getter,
-      );
-      expect(
-        interfaceClass.methods
-            .singleWhere((method) => method.name == 'call')
-            .optionalParameters
-            .map((parameter) => parameter.name),
-        [r'$call', 'name'],
-      );
-      expect(
-        implClass.methods.where((method) => method.name == 'call'),
-        hasLength(1),
-      );
-
-      final implCallMethod = implClass.methods.singleWhere(
-        (method) => method.name == 'call',
-      );
-      const expectedCallMethod = r'''
-        @override
-        $Res call({Object? $call = _sentinel, Object? name = _sentinel, }) {
-          return (Widget($call: identical($call, _sentinel, )
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'Widget');
+      const expectedCopyWith = r'''
+        Widget Function({String? $call, String? name}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? $call = _sentinel, Object? name = _sentinel, }) => Widget($call: identical($call, _sentinel, )
               ? this.$call
               : ($call as String),
             name: identical(name, _sentinel, )
               ? this.name
               : (name as String),
-          ) as $Res);
+          );
         }
       ''';
       expect(
-        collapseWhitespace(format(implCallMethod.accept(emitter).toString())),
-        collapseWhitespace(format(expectedCallMethod)),
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expectedCopyWith)),
       );
     });
   });

--- a/packages/tonik_generate/test/src/model/class_copy_with_generator_test.dart
+++ b/packages/tonik_generate/test/src/model/class_copy_with_generator_test.dart
@@ -84,9 +84,8 @@ void main() {
       expect(functionType.returnType?.symbol, 'User');
       const expectedCopyWith = '''
         User Function({String? name, int? age}) get copyWith {
-          const Object _sentinel = Object();
-          return ({Object? name = _sentinel, Object? age = _sentinel, }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
-            age: identical(age, _sentinel, ) ? this.age : (age as int),
+          return ({String? name, int? age, }) => User(name: name ?? this.name,
+            age: age ?? this.age,
           );
         }
       ''';
@@ -136,7 +135,7 @@ void main() {
       const expectedCopyWith = '''
         User Function({String? name, String? bio}) get copyWith {
           const Object _sentinel = Object();
-          return ({Object? name = _sentinel, Object? bio = _sentinel, }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
+          return ({String? name, Object? bio = _sentinel, }) => User(name: name ?? this.name,
             bio: identical(bio, _sentinel, ) ? this.bio : (bio as String?),
           );
         }
@@ -144,6 +143,69 @@ void main() {
       expect(
         collapseWhitespace(format(copyWith.accept(emitter).toString())),
         collapseWhitespace(format(expectedCopyWith)),
+      );
+    });
+
+    test('preserves nullable typedef semantics for required properties', () {
+      final nullableName = AliasModel(
+        name: 'NullableName',
+        model: StringModel(context: context),
+        isNullable: true,
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final anyValue = AliasModel(
+        name: 'AnyValue',
+        model: AnyModel(context: context),
+        context: context,
+        examples: const [],
+        defaultValue: null,
+      );
+      final model = ClassModel(
+        isDeprecated: false,
+        name: 'User',
+        properties: [
+          Property(
+            name: 'name',
+            model: nullableName,
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+          Property(
+            name: 'data',
+            model: anyValue,
+            isRequired: true,
+            isNullable: false,
+            isDeprecated: false,
+            examples: const [],
+            defaultValue: null,
+          ),
+        ],
+        context: context,
+        examples: const [],
+      );
+
+      final generated = generator.generateClasses(model).single as Class;
+      final copyWith = generated.methods.singleWhere(
+        (method) => method.name == 'copyWith',
+      );
+      const expected = '''
+        User Function({NullableName? name, AnyValue? data}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? name = _sentinel, Object? data = _sentinel}) =>
+            User(
+              name: identical(name, _sentinel) ? this.name : (name as NullableName),
+              data: identical(data, _sentinel) ? this.data : data,
+            );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
       );
     });
 
@@ -214,12 +276,12 @@ void main() {
       const expectedCopyWith = '''
         User Function({String? name, Address? homeAddress, Address? workAddress}) get copyWith {
           const Object _sentinel = Object();
-          return ({Object? name = _sentinel,
+          return ({String? name,
           Object? homeAddress = _sentinel,
-          Object? workAddress = _sentinel,
-        }) => User(name: identical(name, _sentinel, ) ? this.name : (name as String),
+          Address? workAddress,
+        }) => User(name: name ?? this.name,
             homeAddress: identical(homeAddress, _sentinel, ) ? this.homeAddress : (homeAddress as Address?),
-            workAddress: identical(workAddress, _sentinel, ) ? this.workAddress : (workAddress as Address),
+            workAddress: workAddress ?? this.workAddress,
           );
         }
       ''';
@@ -277,9 +339,9 @@ void main() {
       const expectedCopyWith = '''
         User Function({List<String>? tags, List<String>? optionalTags}) get copyWith {
           const Object _sentinel = Object();
-          return ({Object? tags = _sentinel,
+          return ({List<String>? tags,
           Object? optionalTags = _sentinel,
-        }) => User(tags: identical(tags, _sentinel, ) ? this.tags : (tags as List<String>),
+        }) => User(tags: tags ?? this.tags,
             optionalTags: identical(optionalTags, _sentinel, ) ? this.optionalTags : (optionalTags as List<String>?),
           );
         }
@@ -338,13 +400,12 @@ void main() {
       expect(functionType.returnType?.symbol, 'User');
       const expectedCopyWith = '''
         User Function({String? firstName, String? lastName, String? id}) get copyWith {
-          const Object _sentinel = Object();
-          return ({Object? firstName = _sentinel,
-          Object? lastName = _sentinel,
-          Object? id = _sentinel,
-        }) => User(firstName: identical(firstName, _sentinel, ) ? this.firstName : (firstName as String),
-            lastName: identical(lastName, _sentinel, ) ? this.lastName : (lastName as String),
-            id: identical(id, _sentinel, ) ? this.id : (id as String),
+          return ({String? firstName,
+          String? lastName,
+          String? id,
+        }) => User(firstName: firstName ?? this.firstName,
+            lastName: lastName ?? this.lastName,
+            id: id ?? this.id,
           );
         }
       ''';
@@ -393,13 +454,8 @@ void main() {
       expect(functionType.returnType?.symbol, 'Widget');
       const expectedCopyWith = r'''
         Widget Function({String? $call, String? name}) get copyWith {
-          const Object _sentinel = Object();
-          return ({Object? $call = _sentinel, Object? name = _sentinel, }) => Widget($call: identical($call, _sentinel, )
-              ? this.$call
-              : ($call as String),
-            name: identical(name, _sentinel, )
-              ? this.name
-              : (name as String),
+          return ({String? $call, String? name, }) => Widget($call: $call ?? this.$call,
+            name: name ?? this.name,
           );
         }
       ''';

--- a/packages/tonik_generate/test/src/response/response_class_generator_test.dart
+++ b/packages/tonik_generate/test/src/response/response_class_generator_test.dart
@@ -431,7 +431,7 @@ void main() {
     });
 
     group('copyWith method generation', () {
-      test('generates copyWith getter returning interface type', () {
+      test('generates copyWith getter returning a typed function', () {
         final response = ResponseObject(
           name: 'CopyWithResponse',
           context: testContext,
@@ -475,9 +475,18 @@ void main() {
           (m) => m.name == 'copyWith',
         );
         expect(copyWith.type, MethodType.getter);
+        final functionType = copyWith.returns! as FunctionType;
+        expect(functionType.returnType?.symbol, 'CopyWithResponse');
+        expect(functionType.namedParameters.keys, [
+          'xRequired',
+          'body',
+          'xOptional',
+        ]);
         expect(
-          copyWith.returns?.accept(emitter).toString(),
-          r'$$CopyWithResponseCopyWith<CopyWithResponse>',
+          functionType.namedParameters.values.map(
+            (type) => type.accept(emitter).toString(),
+          ),
+          ['String?', 'String?', 'int?'],
         );
       });
 
@@ -514,9 +523,14 @@ void main() {
           (m) => m.name == 'copyWith',
         );
         expect(copyWith.type, MethodType.getter);
+        final functionType = copyWith.returns! as FunctionType;
+        expect(functionType.returnType?.symbol, 'SimpleCopyWithResponse');
+        expect(functionType.namedParameters.keys, ['xTest', 'body']);
         expect(
-          copyWith.returns?.accept(emitter).toString(),
-          r'$$SimpleCopyWithResponseCopyWith<SimpleCopyWithResponse>',
+          functionType.namedParameters.values.map(
+            (type) => type.accept(emitter).toString(),
+          ),
+          ['String?', 'String?'],
         );
       });
     });

--- a/packages/tonik_generate/test/src/response/response_multi_body_generator_test.dart
+++ b/packages/tonik_generate/test/src/response/response_multi_body_generator_test.dart
@@ -100,10 +100,13 @@ void main() {
   });
 
   group('response with headers', () {
-    test('generates correct number of classes (main + copyWith helpers)', () {
-      // 3 main classes + 4 copyWith helpers (interface + impl for
-      // each subclass)
-      expect(classesWithHeaders.whereType<Class>().length, 7);
+    test('generates only the base and response variant classes', () {
+      expect(classesWithHeaders, hasLength(3));
+      expect(classesWithHeaders.whereType<Class>().map((c) => c.name), [
+        'TestResponse',
+        'TestResponsePlain',
+        'TestResponseJson',
+      ]);
     });
 
     group('base sealed class', () {
@@ -223,13 +226,22 @@ void main() {
           expect(hashCode.returns?.accept(emitter).toString(), 'int');
         });
 
-        test('has copyWith getter returning interface type', () {
+        test('has copyWith getter returning a typed function', () {
           final copyWith = methods.firstWhere((m) => m.name == 'copyWith');
           expect(copyWith, isNotNull);
           expect(copyWith.type, MethodType.getter);
+          final functionType = copyWith.returns! as FunctionType;
+          expect(functionType.returnType?.symbol, 'TestResponsePlain');
+          expect(functionType.namedParameters.keys, [
+            'contentType',
+            'body',
+            'body2',
+          ]);
           expect(
-            copyWith.returns?.accept(emitter).toString(),
-            r'$$TestResponsePlainCopyWith<TestResponsePlain>',
+            functionType.namedParameters.values.map(
+              (type) => type.accept(emitter).toString(),
+            ),
+            ['String?', 'String?', 'String?'],
           );
         });
       });
@@ -300,13 +312,22 @@ void main() {
           expect(hashCode.returns?.accept(emitter).toString(), 'int');
         });
 
-        test('has copyWith getter returning interface type', () {
+        test('has copyWith getter returning a typed function', () {
           final copyWith = methods.firstWhere((m) => m.name == 'copyWith');
           expect(copyWith, isNotNull);
           expect(copyWith.type, MethodType.getter);
+          final functionType = copyWith.returns! as FunctionType;
+          expect(functionType.returnType?.symbol, 'TestResponseJson');
+          expect(functionType.namedParameters.keys, [
+            'contentType',
+            'body',
+            'body2',
+          ]);
           expect(
-            copyWith.returns?.accept(emitter).toString(),
-            r'$$TestResponseJsonCopyWith<TestResponseJson>',
+            functionType.namedParameters.values.map(
+              (type) => type.accept(emitter).toString(),
+            ),
+            ['String?', 'String?', 'int?'],
           );
         });
       });
@@ -315,7 +336,6 @@ void main() {
 
   group('response without headers', () {
     test('generates correct number of classes (main only, no copyWith)', () {
-      // 3 main classes, no copyWith helpers since there are no header fields
       expect(classesWithoutHeaders.whereType<Class>().length, 3);
     });
 

--- a/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
@@ -7,7 +7,6 @@ void main() {
   final format = DartFormatter(
     languageVersion: DartFormatter.latestLanguageVersion,
   ).format;
-
   final emitter = DartEmitter(useNullSafetySyntax: true);
 
   group('generateCopyWith', () {
@@ -20,511 +19,216 @@ void main() {
       expect(result, isNull);
     });
 
-    group('getter', () {
-      test('has correct name and type', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
+    test('returns a getter with typed nullable named parameters', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'name',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'String'
+                ..url = 'dart:core',
             ),
-          ],
-        );
-
-        expect(result!.getter.name, 'copyWith');
-        expect(result.getter.type, MethodType.getter);
-      });
-
-      test('returns interface type with class as type parameter', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
+            skipCast: false,
+          ),
+          (
+            normalizedName: 'count',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'int'
+                ..url = 'dart:core'
+                ..isNullable = true,
             ),
-          ],
-        );
+            skipCast: false,
+          ),
+        ],
+      )!;
 
-        final returnType = result!.getter.returns;
-        expect(returnType, isA<TypeReference>());
-        final typeRef = returnType! as TypeReference;
-        expect(typeRef.symbol, r'$$TestClassCopyWith');
-        expect(typeRef.types.first.symbol, 'TestClass');
-      });
-
-      test('returns implementation instance', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        expect(result!.getter.lambda, isTrue);
-        expect(result.getter.body.toString(), '_TestClassCopyWith(this)');
-      });
+      expect(copyWith.name, 'copyWith');
+      expect(copyWith.type, MethodType.getter);
+      final functionType = copyWith.returns! as FunctionType;
+      expect(functionType.returnType?.symbol, 'TestClass');
+      expect(functionType.namedParameters.keys, ['name', 'count']);
+      expect(functionType.requiredParameters, isEmpty);
+      expect(functionType.namedRequiredParameters, isEmpty);
+      expect(
+        functionType.namedParameters['name']?.accept(emitter).toString(),
+        'String?',
+      );
+      expect(
+        functionType.namedParameters['count']?.accept(emitter).toString(),
+        'int?',
+      );
+      const expected = '''
+        TestClass Function({String? name, int? count}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? name = _sentinel, Object? count = _sentinel}) =>
+            TestClass(
+              name: identical(name, _sentinel) ? this.name : (name as String),
+              count: identical(count, _sentinel) ? this.count : (count as int?),
+            );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
     });
 
-    group('interface class', () {
-      test(r'has correct name with $$ prefix', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
+    test('skips the cast when requested for an any model', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'anyValue',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'AnyValue'
+                ..url = 'package:my_api/src/model/any_value.dart'
+                ..isNullable = true,
             ),
-          ],
-        );
+            skipCast: true,
+          ),
+        ],
+      )!;
 
-        expect(result!.interfaceClass.name, r'$$TestClassCopyWith');
-      });
-
-      test('is abstract', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        expect(result!.interfaceClass.abstract, isTrue);
-      });
-
-      test(r'has generic type parameter $Res', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        expect(result!.interfaceClass.types.length, 1);
-        expect(result.interfaceClass.types.first.symbol, r'$Res');
-      });
-
-      test('has factory constructor redirecting to implementation', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final factory = result!.interfaceClass.constructors.first;
-        expect(factory.factory, isTrue);
-        expect(factory.requiredParameters.length, 1);
-        expect(factory.requiredParameters.first.name, 'value');
-        expect(factory.requiredParameters.first.type?.symbol, 'TestClass');
-        expect(factory.redirect?.symbol, '_TestClassCopyWith');
-      });
-
-      test(r'has call method returning $Res', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.interfaceClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        expect(callMethod.returns?.symbol, r'$Res');
-      });
-
-      test('call method has nullable parameters for each property', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-            (
-              normalizedName: 'age',
-              typeRef: TypeReference((b) => b..symbol = 'int'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.interfaceClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        expect(callMethod.optionalParameters.length, 2);
-        expect(callMethod.optionalParameters[0].name, 'name');
-        expect(callMethod.optionalParameters[0].named, isTrue);
-        expect(
-          (callMethod.optionalParameters[0].type as TypeReference?)?.isNullable,
-          isTrue,
-        );
-        expect(callMethod.optionalParameters[1].name, 'age');
-      });
-
-      test('has getter for each property', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final getters = result!.interfaceClass.methods
-            .where((m) => m.type == MethodType.getter)
-            .toList();
-        expect(getters.length, 1);
-        expect(getters.first.name, 'name');
-        // Getter preserves original nullability
-        // (String is non-nullable)
-        // When isNullable is not set, it defaults to null
-        // (which means non-nullable)
-        expect(
-          (getters.first.returns as TypeReference?)?.isNullable,
-          isNot(isTrue),
-        );
-      });
+      const expected = '''
+        TestClass Function({AnyValue? anyValue}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? anyValue = _sentinel}) => TestClass(
+            anyValue: identical(anyValue, _sentinel) ? this.anyValue : anyValue,
+          );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
     });
 
-    group('implementation class', () {
-      test('has correct name with _ prefix', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
+    test('skips the cast for dart:core Object?', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'value',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'Object'
+                ..url = 'dart:core'
+                ..isNullable = true,
             ),
-          ],
-        );
+            skipCast: false,
+          ),
+        ],
+      )!;
 
-        expect(result!.implClass.name, '_TestClassCopyWith');
-      });
-
-      test('implements interface class', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        expect(result!.implClass.implements.length, 1);
-        final impl = result.implClass.implements.first;
-        expect(impl.symbol, r'$$TestClassCopyWith');
-      });
-
-      test('has static const _sentinel field', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final sentinel = result!.implClass.fields.firstWhere(
-          (f) => f.name == '_sentinel',
-        );
-        expect(sentinel.static, isTrue);
-        expect(sentinel.modifier, FieldModifier.constant);
-      });
-
-      test('has _value field of class type', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final valueField = result!.implClass.fields.firstWhere(
-          (f) => f.name == '_value',
-        );
-        expect(valueField.modifier, FieldModifier.final$);
-        expect(valueField.type?.symbol, 'TestClass');
-      });
-
-      test('has constructor that takes _value', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final ctor = result!.implClass.constructors.first;
-        expect(ctor.requiredParameters.length, 1);
-        expect(ctor.requiredParameters.first.toThis, isTrue);
-      });
-
-      test('getters delegate to _value', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final getter = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'name' && m.type == MethodType.getter,
-        );
-        expect(getter.lambda, isTrue);
-        expect(getter.body.toString(), '_value.name');
-      });
-
-      test('call method uses Object? parameters with sentinel default', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        expect(callMethod.optionalParameters.length, 1);
-        final param = callMethod.optionalParameters.first;
-        expect(param.type, isA<Reference>());
-        expect(param.type?.accept(emitter).toString(), 'Object?');
-        expect(param.defaultTo.toString(), '_sentinel');
-      });
-
-      test('call method body uses identical check with sentinel', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'name',
-              typeRef: TypeReference((b) => b..symbol = 'String'),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        const expectedCallMethod = r'''
-          @override
-          $Res call({Object? name = _sentinel}) {
-            return (TestClass(name: identical(name, _sentinel, ) ? this.name : (name as String)) as $Res);
-          }
-        ''';
-        expect(
-          collapseWhitespace(format(callMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedCallMethod)),
-        );
-      });
-
-      test('call method skips cast when skipCast is true', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'anyValue',
-              typeRef: TypeReference(
-                (b) => b
-                  ..symbol = 'AnyValue'
-                  ..isNullable = true,
-              ),
-              skipCast: true, // Skip cast for AnyModel properties
-            ),
-          ],
-        );
-
-        final callMethod = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        const expectedCallMethod = r'''
-          @override
-          $Res call({Object? anyValue = _sentinel}) {
-            return (TestClass(anyValue: identical(anyValue, _sentinel, ) ? this.anyValue : anyValue) as $Res);
-          }
-        ''';
-        expect(
-          collapseWhitespace(format(callMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedCallMethod)),
-        );
-      });
-
-      test('call method skips cast for dart:core Object? type', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'value',
-              typeRef: TypeReference(
-                (b) => b
-                  ..symbol = 'Object'
-                  ..url = 'dart:core'
-                  ..isNullable = true,
-              ),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        const expectedCallMethod = r'''
-          @override
-          $Res call({Object? value = _sentinel}) {
-            return (TestClass(value: identical(value, _sentinel, ) ? this.value : value) as $Res);
-          }
-        ''';
-        expect(
-          collapseWhitespace(format(callMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedCallMethod)),
-        );
-      });
-
-      test('call method casts user-defined Object? type (not dart:core)', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'object',
-              typeRef: TypeReference(
-                (b) => b
-                  ..symbol = 'Object'
-                  ..url = 'package:my_api/src/model/object.dart'
-                  ..isNullable = true,
-              ),
-              skipCast: false,
-            ),
-          ],
-        );
-
-        final callMethod = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        const expectedCallMethod = r'''
-          @override
-          $Res call({Object? object = _sentinel}) {
-            return (TestClass(object: identical(object, _sentinel, ) ? this.object : (object as Object?)) as $Res);
-          }
-        ''';
-        expect(
-          collapseWhitespace(format(callMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedCallMethod)),
-        );
-      });
+      const expected = '''
+        TestClass Function({Object? value}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? value = _sentinel}) => TestClass(
+            value: identical(value, _sentinel) ? this.value : value,
+          );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
     });
 
-    group('complex types', () {
-      test('handles generic types correctly', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'items',
-              typeRef: TypeReference(
-                (b) => b
-                  ..symbol = 'List'
-                  ..types.add(refer('String')),
-              ),
-              skipCast: false,
+    test('retains the cast for an imported class named Object', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'object',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'Object'
+                ..url = 'package:my_api/src/model/object.dart'
+                ..isNullable = true,
             ),
-          ],
-        );
-        final getter = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'items' && m.type == MethodType.getter,
-        );
-        expect(getter.returns?.accept(emitter).toString(), 'List<String>');
-        final callMethod = result.implClass.methods.firstWhere(
-          (m) => m.name == 'call',
-        );
-        const expectedCallMethod = r'''
-          @override
-          $Res call({Object? items = _sentinel}) {
-            return (TestClass(items: identical(items, _sentinel, ) ? this.items : (items as List<String>)) as $Res);
-          }
-        ''';
-        expect(
-          collapseWhitespace(format(callMethod.accept(emitter).toString())),
-          collapseWhitespace(format(expectedCallMethod)),
-        );
-      });
+            skipCast: false,
+          ),
+        ],
+      )!;
 
-      test('handles already nullable types correctly', () {
-        final result = generateCopyWith(
-          className: 'TestClass',
-          properties: [
-            (
-              normalizedName: 'value',
-              typeRef: TypeReference(
-                (b) => b
-                  ..symbol = 'int'
-                  ..isNullable = true,
-              ),
-              skipCast: false,
+      const expected = '''
+        TestClass Function({Object? object}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? object = _sentinel}) => TestClass(
+            object: identical(object, _sentinel) ? this.object : (object as Object?),
+          );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('preserves generic collection types', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'items',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'List'
+                ..url = 'dart:core'
+                ..types.add(refer('String', 'dart:core')),
             ),
-          ],
-        );
-        final getter = result!.implClass.methods.firstWhere(
-          (m) => m.name == 'value' && m.type == MethodType.getter,
-        );
-        final returnType = getter.returns as TypeReference?;
-        expect(returnType?.symbol, 'int');
-        expect(returnType?.isNullable, isTrue);
-      });
+            skipCast: false,
+          ),
+        ],
+      )!;
+
+      const expected = '''
+        TestClass Function({List<String>? items}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? items = _sentinel}) => TestClass(
+            items: identical(items, _sentinel) ? this.items : (items as List<String>),
+          );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
+    });
+
+    test('preserves Never? in the signature and cast', () {
+      final copyWith = generateCopyWith(
+        className: 'TestClass',
+        properties: [
+          (
+            normalizedName: 'impossible',
+            typeRef: TypeReference(
+              (b) => b
+                ..symbol = 'Never'
+                ..url = 'dart:core'
+                ..isNullable = true,
+            ),
+            skipCast: false,
+          ),
+        ],
+      )!;
+
+      const expected = '''
+        TestClass Function({Never? impossible}) get copyWith {
+          const Object _sentinel = Object();
+          return ({Object? impossible = _sentinel}) => TestClass(
+            impossible: identical(impossible, _sentinel) ? this.impossible : (impossible as Never?),
+          );
+        }
+      ''';
+      expect(
+        collapseWhitespace(format(copyWith.accept(emitter).toString())),
+        collapseWhitespace(format(expected)),
+      );
     });
   });
 }

--- a/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
+++ b/packages/tonik_generate/test/src/util/copy_with_method_generator_test.dart
@@ -30,6 +30,7 @@ void main() {
                 ..symbol = 'String'
                 ..url = 'dart:core',
             ),
+            isNullable: false,
             skipCast: false,
           ),
           (
@@ -40,6 +41,7 @@ void main() {
                 ..url = 'dart:core'
                 ..isNullable = true,
             ),
+            isNullable: true,
             skipCast: false,
           ),
         ],
@@ -63,9 +65,9 @@ void main() {
       const expected = '''
         TestClass Function({String? name, int? count}) get copyWith {
           const Object _sentinel = Object();
-          return ({Object? name = _sentinel, Object? count = _sentinel}) =>
+          return ({String? name, Object? count = _sentinel}) =>
             TestClass(
-              name: identical(name, _sentinel) ? this.name : (name as String),
+              name: name ?? this.name,
               count: identical(count, _sentinel) ? this.count : (count as int?),
             );
         }
@@ -76,24 +78,26 @@ void main() {
       );
     });
 
-    test('skips the cast when requested for an any model', () {
-      final copyWith = generateCopyWith(
-        className: 'TestClass',
-        properties: [
-          (
-            normalizedName: 'anyValue',
-            typeRef: TypeReference(
-              (b) => b
-                ..symbol = 'AnyValue'
-                ..url = 'package:my_api/src/model/any_value.dart'
-                ..isNullable = true,
+    test(
+      'preserves null for an any alias without an explicit nullable type',
+      () {
+        final copyWith = generateCopyWith(
+          className: 'TestClass',
+          properties: [
+            (
+              normalizedName: 'anyValue',
+              typeRef: TypeReference(
+                (b) => b
+                  ..symbol = 'AnyValue'
+                  ..url = 'package:my_api/src/model/any_value.dart',
+              ),
+              isNullable: true,
+              skipCast: true,
             ),
-            skipCast: true,
-          ),
-        ],
-      )!;
+          ],
+        )!;
 
-      const expected = '''
+        const expected = '''
         TestClass Function({AnyValue? anyValue}) get copyWith {
           const Object _sentinel = Object();
           return ({Object? anyValue = _sentinel}) => TestClass(
@@ -101,11 +105,12 @@ void main() {
           );
         }
       ''';
-      expect(
-        collapseWhitespace(format(copyWith.accept(emitter).toString())),
-        collapseWhitespace(format(expected)),
-      );
-    });
+        expect(
+          collapseWhitespace(format(copyWith.accept(emitter).toString())),
+          collapseWhitespace(format(expected)),
+        );
+      },
+    );
 
     test('skips the cast for dart:core Object?', () {
       final copyWith = generateCopyWith(
@@ -119,6 +124,7 @@ void main() {
                 ..url = 'dart:core'
                 ..isNullable = true,
             ),
+            isNullable: true,
             skipCast: false,
           ),
         ],
@@ -150,6 +156,7 @@ void main() {
                 ..url = 'package:my_api/src/model/object.dart'
                 ..isNullable = true,
             ),
+            isNullable: true,
             skipCast: false,
           ),
         ],
@@ -181,6 +188,7 @@ void main() {
                 ..url = 'dart:core'
                 ..types.add(refer('String', 'dart:core')),
             ),
+            isNullable: false,
             skipCast: false,
           ),
         ],
@@ -188,9 +196,8 @@ void main() {
 
       const expected = '''
         TestClass Function({List<String>? items}) get copyWith {
-          const Object _sentinel = Object();
-          return ({Object? items = _sentinel}) => TestClass(
-            items: identical(items, _sentinel) ? this.items : (items as List<String>),
+          return ({List<String>? items}) => TestClass(
+            items: items ?? this.items,
           );
         }
       ''';
@@ -212,6 +219,7 @@ void main() {
                 ..url = 'dart:core'
                 ..isNullable = true,
             ),
+            isNullable: true,
             skipCast: false,
           ),
         ],


### PR DESCRIPTION
Generated `copyWith` previously added two helper classes per model or response. This change emits a typed function getter, reducing generated declarations while keeping the normal `object.copyWith(...)` API.

Omitted arguments preserve their current values. Explicit null preserves nonnullable fields and clears nullable fields, including nullable typedefs and aliases to `Object?`. Nonnullable parameters use `value ?? this.value`; nullable parameters retain sentinel defaults to distinguish omission from null. Models with only nonnullable fields no longer emit a sentinel.

This removes the generated `$$ModelCopyWith<R>` helper types, their factories, and property getters exposed through the old helper objects. Code using those helper APIs must migrate to the function getter.

Validation passed on the final change: all five unit suites (6,047 tests), fatal package analysis, fresh generation of all 44 clients per backend, all 85 integration package analyses per backend, and all 40 integration suites on both Dio and HTTP (4,195 tests plus 10 helper tests per backend). Direct public `object.copyWith(field: null)` calls analyze without lint suppressions and cover nonnullable preservation, nullable clearing, aliases, composites, and response headers/bodies. CI unit tests and lint passed; the complete integration workflow passed twice, all 20 jobs each time.

CI timing comparison: two complete runs per commit, baseline `98eda1f` and candidate `2843ea3`, with the unchanged workflow and matching Dart versions for every measured job. All runs regenerated the full fixture set.

| Measurement | Baseline average | Candidate average | Reduction |
|---|---:|---:|---:|
| Full integration workflow | 23m47s | 18m33s | 22.0% |
| Generate all 44 clients | 1m49s | 1m33s | 14.7% |
| Analyze all 85 packages | 8m37s | 6m31s | 24.4% |
| Run all 40 integration suites | 13m32s | 12m06s | 10.6% |

Individual workflow times were 24m09s and 23m24s before, then 19m21s and 17m45s after. Workflow time spans the first job starting to the last completing. Phase rows are averages per matched job and are not additive because jobs run concurrently. Generation includes parsing, emission, and formatting; analysis includes dependency resolution; test time includes fresh test compilation, server lifecycle, and execution. Two runs still leave hosted-runner variance: Dio analysis averaged 40.2% lower and HTTP analysis 4.3% lower, with substantial variation in the HTTP baseline.

The deterministic source comparison across all 44 HTTP clients retains 65,086 Dart files while reducing generated bytes from 411,792,909 to 365,852,559 (11.2%). Removing all 59,462 copyWith helper classes reduces class declarations from 122,485 to 63,023.

Runs: [baseline 1](https://github.com/t-unit/tonik/actions/runs/34337551137/attempts/2), [baseline 2](https://github.com/t-unit/tonik/actions/runs/34337551137/attempts/3), [candidate 1](https://github.com/t-unit/tonik/actions/runs/34708926233/attempts/1), [candidate 2](https://github.com/t-unit/tonik/actions/runs/34708926233/attempts/2).
